### PR TITLE
testing/py-flup: new aport

### DIFF
--- a/testing/py-flup/APKBUILD
+++ b/testing/py-flup/APKBUILD
@@ -1,0 +1,39 @@
+# Contributor: <xmingske@gmail.com>
+# Maintainer: Natanael Copa <ncopa@alpinelinux.org>
+_pkgname=flup
+pkgname=py-${_pkgname}
+pkgver=1.0.2
+pkgrel=0
+pkgdesc="WSGI modules for Python"
+url="http://www.saddi.com/software/flup/"
+arch="noarch"
+license="BSD"
+makedepends="python-dev py-setuptools"
+depends="python"
+source="$pkgname-$pkgver.tar.gz::http://www.saddi.com/software/flup/dist/${_pkgname}-${pkgver}.tar.gz"
+
+_builddir="${srcdir}/${_pkgname}-${pkgver}"
+
+prepare() {
+	local pf
+	cd "${_builddir}"
+	for pf in $source; do
+		case $pf in
+		*.patch) msg $pf; patch -p1 -i "$srcdir"/${pf} || return 1;;
+		esac
+	done
+}
+
+build() {
+	cd "${_builddir}"
+	python setup.py build || return 1
+}
+
+package() {
+	cd "${_builddir}"
+	python setup.py install --prefix=/usr --root="$pkgdir" || return 1
+}
+
+md5sums="24dad7edc5ada31dddd49456ee8d5254  py-flup-1.0.2.tar.gz"
+sha256sums="4bad317a5fc1ce3d4fe5e9b6d846ec38a8023e16876785d4f88102f2c8097dd9  py-flup-1.0.2.tar.gz"
+sha512sums="65c610f9ddc3df6ed6deb6753b2b15ce4f4579efd9dfd25166d3b6803e5d7058fee6617388c9c67c39f7db54da5c918181dcbddfbb7be4a78cf8b65501af4c4a  py-flup-1.0.2.tar.gz"


### PR DESCRIPTION
Last dependency for seafile, so seahub can be run in fcgi mode

WSGI modules for Python
http://www.saddi.com/software/flup/
