### PR TITLE
testing/py-django-simple-captcha: use 0.4.3 tarball

### DIFF
--- a/main/py-django-simple-captcha/APKBUILD
+++ b/main/py-django-simple-captcha/APKBUILD
@@ -3,16 +3,16 @@
 _pkgname=django-simple-captcha
 pkgname=py-${_pkgname}
 pkgver=0.4.3
-pkgrel=0
+pkgrel=1
 pkgdesc="simple, yet highly customizable Django application to add captcha images to any Django"
 url="https://github.com/mbi/django-simple-captcha"
 arch="noarch"
 license="BSD"
 makedepends="python-dev py-setuptools"
 depends="python"
-source="$pkgname-$pkgver.tar.gz::https://github.com/mbi/django-simple-captcha/archive/9f2f5bfba97e931931e59d1a58a4a35d36dcce0d.tar.gz"
+source="https://github.com/mbi/django-simple-captcha/archive/0.4.3.tar.gz"
 
-_builddir="${srcdir}/${_pkgname}-9f2f5bfba97e931931e59d1a58a4a35d36dcce0d"
+_builddir="${srcdir}/${_pkgname}-${pkgver}"
 
 prepare() {
 	local pf
@@ -33,6 +33,6 @@ package() {
 	cd "${_builddir}"
 	python setup.py install --prefix=/usr --root="$pkgdir" || return 1
 }
-md5sums="9ed672fe6f248751583f815fc8224835  py-django-simple-captcha-0.4.3.tar.gz"
-sha256sums="2ddc577b9be29f4f3bc99ce1b49548fbced11238d0f1d6ba64a7f151a9fd4f24  py-django-simple-captcha-0.4.3.tar.gz"
-sha512sums="361e5e746af42ccd4c8a5bd347e7e92facbec500ad28088f07d45b54a74cf151b34037a4e5eda2313fbdd0463e60edc692a8eb990ee87c6e8423ca23210be59a  py-django-simple-captcha-0.4.3.tar.gz"
+md5sums="c86a3f76ccbfcfd0af52b1094c601320  0.4.3.tar.gz"
+sha256sums="9a12d2c35369e5cfbd6dbdfb1a64078300c44b95e4b2ad5e5cfce831d32b16d1  0.4.3.tar.gz"
+sha512sums="86fd368e85b127e6447d5b41bec362414f83bb08447a7357cf57c961542001e820ae6881ab4bd9ae20fffce84092aedd0b60f79c3adbe97f7c3bbe012c6208c2  0.4.3.tar.gz"


### PR DESCRIPTION
Proper tarball now
