### PR TITLE
testing/mednafen: new aport

### DIFF
--- a/testing/mednafen/01-fix_help.patch
+++ b/testing/mednafen/01-fix_help.patch
@@ -1,0 +1,25 @@
+--- origin/src/drivers/main.cpp
++++ mednafen/src/drivers/main.cpp
+@@ -696,7 +696,7 @@
+ 	if(argc <= 1)
+ 	{
+ 	 printf(_("No command-line arguments specified.\n\n"));
+-	 printf(usage_string, argv[0]);
++	 printf(usage_string, "/usr/bin/mednafen");
+ 	 printf(_("\tPlease refer to the documentation for option parameters and usage.\n\n"));
+ 	 return(0);
+ 	}
+@@ -713,11 +713,11 @@
+ 
+ 	 if(ShowCLHelp)
+ 	 {
+-          printf(usage_string, argv[0]);
++          printf(usage_string, "/usr/bin/mednafen");
+           ShowArgumentsHelp(MDFNArgs, false);
+ 	  printf("\n");
+ 	  printf(_("Each setting(listed in the documentation) can also be passed as an argument by prefixing the name with a hyphen,\nand specifying the value to change the setting to as the next argument.\n\n"));
+-	  printf(_("For example:\n\t%s -pce.stretch aspect -pce.pixshader autoipsharper \"Hyper Bonk Soldier.pce\"\n\n"), argv[0]);
++	  printf(_("For example:\n\t/usr/bin/mednafen -pce.stretch aspect -pce.pixshader autoipsharper \"Hyper Bonk Soldier.pce\"\n\n"));
+ 	  printf(_("Settings specified in this manner are automatically saved to the configuration file, hence they\ndo not need to be passed to future invocations of the Mednafen executable.\n"));
+ 	  printf("\n");
+ 	  return(0);

--- a/testing/mednafen/02-sdl_by_default.patch
+++ b/testing/mednafen/02-sdl_by_default.patch
@@ -1,0 +1,11 @@
+--- origin/include/mednafen/drivers/main.cpp
++++ mednafen/include/mednafen/drivers/main.cpp
+@@ -183,7 +183,7 @@
+   { "netplay.smallfont", MDFNSF_NOFLAGS, gettext_noop("Use small(tiny!) font for netplay chat console."), NULL, MDFNST_BOOL, "0" },
+ 
+   { "video.fs", MDFNSF_NOFLAGS, gettext_noop("Enable fullscreen mode."), NULL, MDFNST_BOOL, "0", },
+-  { "video.driver", MDFNSF_NOFLAGS, gettext_noop("Video output method/driver."), NULL, MDFNST_ENUM, "opengl", NULL, NULL, NULL,NULL, VDriver_List },
++  { "video.driver", MDFNSF_NOFLAGS, gettext_noop("Video output method/driver."), NULL, MDFNST_ENUM, "sdl", NULL, NULL, NULL,NULL, VDriver_List },
+   { "video.glvsync", MDFNSF_NOFLAGS, gettext_noop("Attempt to synchronize OpenGL page flips to vertical retrace period."), 
+ 			       gettext_noop("Note: Additionally, if the environment variable \"__GL_SYNC_TO_VBLANK\" does not exist, then it will be created and set to the value specified for this setting.  This has the effect of forcibly enabling or disabling vblank synchronization when running under Linux with NVidia's drivers."),
+ 				MDFNST_BOOL, "1" },

--- a/testing/mednafen/APKBUILD
+++ b/testing/mednafen/APKBUILD
@@ -1,0 +1,64 @@
+# Contributor: August Klein <amatcoder@gmail.com>
+# Maintainer: August Klein <amatcoder@gmail.com>
+pkgname=mednafen
+pkgver=0.9.36.5
+pkgrel=0
+pkgdesc="A command-line multi-system emulator"
+url="http://mednafen.sourceforge.net"
+arch="all"
+license="GPL2"
+depends=""
+depends_dev="alsa-lib-dev libcdio-dev libsndfile-dev sdl-dev zlib-dev"
+makedepends="$depends_dev mesa-dev glu-dev paxctl"
+install=""
+subpackages=""
+source="https://prdownloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.bz2
+	01-fix_help.patch
+	02-sdl_by_default.patch"
+
+_builddir="$srcdir"/$pkgname
+prepare() {
+	local i
+	cd "$_builddir"
+	for i in $source; do
+		case $i in
+		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
+		esac
+	done
+}
+
+build() {
+	cd "$_builddir"
+	./configure --prefix=/usr || return 1
+	make || return 1
+}
+
+package() {
+	cd "$_builddir"
+	make DESTDIR="$pkgdir" install || return 1
+	rm -rf "$pkgdir"/usr/lib/charset.alias
+
+	mv -f "$pkgdir"/usr/bin/mednafen "$pkgdir"/usr/bin/mednafen-bin || return 1
+	libgl=$(scanelf -qF '#F%S' /usr/lib/libGL.so)
+	cat > "$pkgdir"/usr/bin/mednafen << __EOF__
+#!/bin/sh
+
+# as a workaround for libGL's initial-exec TLS we preload libgl
+# https://bugs.freedesktop.org/show_bug.cgi?id=35268
+
+LD_PRELOAD=$libgl exec /usr/bin/mednafen-bin "\$@"
+__EOF__
+
+	chmod 755 "$pkgdir"/usr/bin/mednafen
+	paxctl -c -m "$pkgdir"/usr/bin/mednafen-bin
+}
+
+md5sums="a0841f0073322414858c22e247344502  mednafen-0.9.36.5.tar.bz2
+0eca9d6e2b75e1687c231130994e9ec6  01-fix_help.patch
+af94272d82816ca74db585c7c5f96bf6  02-sdl_by_default.patch"
+sha256sums="1f3ac7dd705e71a77ccbac0e74e07609bb90b15dfdce04d8f452d8cddd878d0e  mednafen-0.9.36.5.tar.bz2
+3428cd835d68dda2476b01facbf46d960d24deffbbaa58a70ce8b84d6081583f  01-fix_help.patch
+22744df0ece6e67d2c61d8f014e3dbe65d3f425819be742e547a07e676efc5ee  02-sdl_by_default.patch"
+sha512sums="76e8534f91f70100d0e0c0c3e490c71929cce24b47880d1271eaf7d581ec488427194c23ba96d6400ad4d0a80134479442b8a5448776d484dbf4d1940deb61da  mednafen-0.9.36.5.tar.bz2
+55110e6b3d62d716e6c572a2abbc3914d10461b90ae6a1b2a433c4508fb17bca1ac7010cb3bd25938b937744725c577dae177a598ce4142dfc4da53f3a54f6c2  01-fix_help.patch
+ab52224218c972a2f5f470ad5fe2db7fc37422466c1edd3c6170feefafbf6b55c83b5f92b09fc86648444e835a8b38b0a773b9aae462fa5d3a3c203ef534c574  02-sdl_by_default.patch"


### PR DESCRIPTION
This needs a wrapper because libGL is not loaded by dlopen() and it also needs to disable MPROTECT.
