### PR TITLE
Move pyconfig.h from python3-dev to python3 package

### DIFF
--- a/testing/python3/APKBUILD
+++ b/testing/python3/APKBUILD
@@ -55,6 +55,14 @@ _mv_files() {
 	mv "$pkgdir"/usr/lib/python$_pkgver/test "$subpkgdir"/usr/lib/python$_pkgver
 }
 
+dev() {
+	# pyconfig.h is needed runtime so we move it back
+	default_dev
+	mkdir -p "$pkgdir"/usr/include/python${_pkgver}m
+	mv "$subpkgdir"/usr/include/python${_pkgver}m/pyconfig.h \
+		"$pkgdir"/usr/include/python${_pkgver}m/
+}
+
 tests() {
 	pkgdesc="The test modules from the main python package"
 	arch="noarch"


### PR DESCRIPTION
Here is the related commit in python (python2) package: https://github.com/alpinelinux/aports/commit/01a80be974d3c4034414bdfde057ca2ecd96601d

The lack of `pyconfig.h` breaks distutils (`/usr/lib/python3.4/distutils/sysconfig.py`):

```bash
# pip3 install -U pip
Downloading/unpacking pip from https://pypi.python.org/packages/py2.py3/p/pip/pip-6.1.0-py2.py3-none-any.whl#md5=94faa2660c3a2ebe7d015d62c8726259
  Downloading pip-6.1.0-py2.py3-none-any.whl (1.1MB): 1.1MB downloaded
Installing collected packages: pip
  Found existing installation: pip 1.5.6
    Uninstalling pip:
      Successfully uninstalled pip
  Rolling back uninstall of pip
Cleaning up...
Exception:
Traceback (most recent call last):
  File "/usr/lib/python3.4/distutils/sysconfig.py", line 442, in _init_posix
    with open(filename) as file:
FileNotFoundError: [Errno 2] No such file or directory: '/usr/include/python3.4m/pyconfig.h'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/pip/basecommand.py", line 122, in main
    status = self.run(options, args)
  File "/usr/lib/python3.4/site-packages/pip/commands/install.py", line 283, in run
    requirement_set.install(install_options, global_options, root=options.root_path)
  File "/usr/lib/python3.4/site-packages/pip/req.py", line 1435, in install
    requirement.install(install_options, global_options, *args, **kwargs)
  File "/usr/lib/python3.4/site-packages/pip/req.py", line 671, in install
    self.move_wheel_files(self.source_dir, root=root)
  File "/usr/lib/python3.4/site-packages/pip/req.py", line 901, in move_wheel_files
    pycompile=self.pycompile,
  File "/usr/lib/python3.4/site-packages/pip/wheel.py", line 141, in move_wheel_files
    scheme = distutils_scheme(name, user=user, home=home, root=root)
  File "/usr/lib/python3.4/site-packages/pip/locations.py", line 155, in distutils_scheme
    i.finalize_options()
  File "/usr/lib/python3.4/distutils/command/install.py", line 283, in finalize_options
    (prefix, exec_prefix) = get_config_vars('prefix', 'exec_prefix')
  File "/usr/lib/python3.4/distutils/sysconfig.py", line 494, in get_config_vars
    func()
  File "/usr/lib/python3.4/distutils/sysconfig.py", line 449, in _init_posix
    raise DistutilsPlatformError(my_msg)
distutils.errors.DistutilsPlatformError: invalid Python installation: unable to open /usr/include/python3.4m/pyconfig.h (No such file or directory)

Storing debug log for failure in /root/.pip/pip.log
```

Please, note that I have added suffix 'm' as since Python 3.2 it is configured with enabled `--with-pymalloc` option by default, which adds suffix 'm' (/usr/include/python3.4m/).