### PR TITLE
Update rsyslog.conf

### DIFF
--- a/main/rsyslog/rsyslog.conf
+++ b/main/rsyslog/rsyslog.conf
@@ -40,7 +40,7 @@ mail.*                                                  -/var/log/maillog
 cron.*                                                  -/var/log/cron
 
 # Everybody gets emergency messages
-*.emerg                                                 *
+*.emerg                                                 :omusrmsg:*
 
 # Save news errors of level crit and higher in a special file.
 uucp,news.crit                                          -/var/log/spooler


### PR DESCRIPTION
Fix emergency broadcast. This prevented rsyslog from starting up.