### PR TITLE
Libdir should point to /lib

### DIFF
--- a/testing/google-authenticator/APKBUILD
+++ b/testing/google-authenticator/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 pkgname=google-authenticator
 pkgver=20160207
-pkgrel=0
+pkgrel=1
 pkgdesc="Google Authenticator PAM module"
 url="https://github.com/google/google-authenticator"
 arch="all"
@@ -33,6 +33,7 @@ build() {
 			--build=$CBUILD \
 			--host=$CHOST \
 			--prefix=/usr \
+			--libdir=/lib \
 			--sysconfdir=/etc \
 			--mandir=/usr/share/man \
 			--infodir=/usr/share/info \


### PR DESCRIPTION
As in [linux-pam](https://github.com/alpinelinux/aports/blob/master/main/linux-pam/APKBUILD#L52) package libdir should be `/lib` otherwise pam module is installed in the wrong folder.