### PR TITLE
testing/ssh-getkey-ldap: new aport

### DIFF
--- a/testing/ssh-getkey-ldap/APKBUILD
+++ b/testing/ssh-getkey-ldap/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
+# Maintainer: Jakub Jirutka <jakub@jirutka.cz>
+pkgname=ssh-getkey-ldap
+pkgver=0.1.0
+pkgrel=0
+pkgdesc="A simple script to be used as AuthorizedKeysCommand in OpenSSH server to look up user's public keys in LDAP."
+url="https://github.com/jirutka/ssh-getkey-ldap"
+arch="noarch"
+license="MIT"
+depends="lua-ldap"
+depends_dev=""
+makedepends=""
+install="$pkgname.post-install"
+subpackages=""
+source="saveas-http://github.com/jirutka/${pkgname}/archive/v${pkgver}.tar.gz/${pkgname}-${pkgver}.tar.gz"
+
+_builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$_builddir"
+}
+
+package() {
+	cd "$_builddir"
+	DESTDIR="$pkgdir" PREFIX="/usr" ./install || return 1
+}
+
+md5sums="5eb480083707e16ce05df7e5692092bb  ssh-getkey-ldap-0.1.0.tar.gz"
+sha256sums="609880ae1f0363ce6e05d8d4533ccc5472dc883e7da2b1b90dc81216558d3b59  ssh-getkey-ldap-0.1.0.tar.gz"
+sha512sums="4cf657a5a6bfde243f1db309d52d15b926c9b4c33d35336d1aa8460d62b841012696798a9913f62fa2020680eaa59954aeab449677fa990528ccae2172d9d59b  ssh-getkey-ldap-0.1.0.tar.gz"

--- a/testing/ssh-getkey-ldap/ssh-getkey-ldap.post-install
+++ b/testing/ssh-getkey-ldap/ssh-getkey-ldap.post-install
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+cat <<EOF 1>&2
+*
+* If you want OpenSSH server to look up user's public keys in LDAP,
+* add the following lines to /etc/ssh/sshd_config and reload sshd:
+*
+*     AuthorizedKeysCommand /usr/bin/ssh-getkey-ldap
+*     AuthorizedKeysCommandUser nobody
+*
+EOF
+
+exit 0


### PR DESCRIPTION
https://github.com/jirutka/ssh-getkey-ldap
A simple script to be used as AuthorizedKeysCommand in OpenSSH server to look up user's public keys in LDAP.