### PR TITLE
main/uwsgi: set default plugin_dir

### DIFF
--- a/main/uwsgi/0005-uwsgiconfig-plugin_build_dir.patch
+++ b/main/uwsgi/0005-uwsgiconfig-plugin_build_dir.patch
@@ -1,0 +1,32 @@
+From 6dc5730a234f4bc8a0cbfb0bd3360e860d39e340 Mon Sep 17 00:00:00 2001
+From: Jakub Jirutka <jakub@jirutka.cz>
+Date: Sat, 26 Mar 2016 00:17:35 +0100
+Subject: [PATCH] Add variable plugin_build_dir to uwsgiconfig
+
+Package managers in Alpine Linux (APK) and Gentoo (Portage) builds
+packages in different directory than where are eventually installed.
+Therefore we need to set different plugin_dir for build and runtime.
+
+Gentoo ebuild for uWSGI solved this problem using simple workaround that
+involves patching uwsgiconfig.py (see [1]). This patch do the same
+thing; it adds build variable plugin_build_dir, but with fallback to
+plugin_dir for backward compatibility.
+
+[1]: https://github.com/gentoo/gentoo/blob/master/www-servers/uwsgi/uwsgi-2.0.11.2-r1.ebuild#L149
+---
+ uwsgiconfig.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/uwsgiconfig.py b/uwsgiconfig.py
+index 835d6b4..617d6b3 100644
+--- a/uwsgiconfig.py
++++ b/uwsgiconfig.py
+@@ -1424,7 +1424,7 @@ def build_plugin(path, uc, cflags, ldflags, libs, name=None):
+         pass
+ 
+     if uc:
+-        plugin_dest = uc.get('plugin_dir') + '/' + name + '_plugin'
++        plugin_dest = uc.get('plugin_build_dir', uc.get('plugin_dir')) + '/' + name + '_plugin'
+     else:
+         plugin_dest = name + '_plugin'
+ 

--- a/main/uwsgi/APKBUILD
+++ b/main/uwsgi/APKBUILD
@@ -1,9 +1,10 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Contributor: Kaarle Ritvanen <kaarle.ritvanen@datakunkku.fi>
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=uwsgi
 pkgver=2.0.11.2
-pkgrel=0
+pkgrel=1
 pkgdesc="uWSGI application container server"
 url=http://projects.unbit.it/uwsgi/
 arch=all
@@ -13,11 +14,13 @@ makedepends="linux-headers lua5.2-dev python python-dev zeromq-dev paxmark
 	pcre-dev"
 source="http://projects.unbit.it/downloads/uwsgi-${pkgver}.tar.gz
 	uwsgi.initd uwsgi.confd
+	alpine.buildconf
 
 	0001-use-portable-pthread-functions-instead-of-the-non-po.patch
 	0002-Check-for-GNU-libc-instead-of-linux-for-use-of-execi.patch
 	0003-always-define-_GNU_SOURCE-for-linux.patch
 	0004-define-WAIT_ANY-if-missing.patch
+	0005-uwsgiconfig-plugin_build_dir.patch
 	musl-fix-python.patch
 	musl-locking-fix.patch
 	"
@@ -37,6 +40,8 @@ prepare() {
 		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
 		esac
 	done
+
+	cp "$srcdir"/alpine.buildconf buildconf/alpine.ini || return 1
 }
 
 build() {
@@ -44,12 +49,12 @@ build() {
 
 	msg "building core"
 	# ccache seems to trigger some weird bug on musl
-	CC="gcc" python uwsgiconfig.py --build core || return 1
+	CC="gcc" python uwsgiconfig.py --build alpine || return 1
 
 	export UWSGICONFIG_LUAPC="lua5.2"
 	for i in ${_plugins}; do
 		msg "building $i plugin"
-		python uwsgiconfig.py --plugin plugins/$i core || return 1
+		python uwsgiconfig.py --plugin plugins/$i alpine || return 1
 	done
 }
 
@@ -86,27 +91,33 @@ done
 md5sums="1f02dcbee7f6f61de4b1fd68350cf16f  uwsgi-2.0.11.2.tar.gz
 23b476a8ad6aab93b162e8eeec50c859  uwsgi.initd
 3d6afe6a8c52556d1d6c52384fc38d9a  uwsgi.confd
+98407f45c566a2c39a34b882e1ac9fe4  alpine.buildconf
 a7f98e2775e9f38a0f16c28332745836  0001-use-portable-pthread-functions-instead-of-the-non-po.patch
 b40fe76f34674874815c39a7e611f259  0002-Check-for-GNU-libc-instead-of-linux-for-use-of-execi.patch
 43e4edbe50bde1096e8ca03297a1f271  0003-always-define-_GNU_SOURCE-for-linux.patch
 1ee8996f7cced9dc88515c69c04dd79a  0004-define-WAIT_ANY-if-missing.patch
+c1ef4825079b9b1ccfe02175617c6632  0005-uwsgiconfig-plugin_build_dir.patch
 87c16f6fe482c9b0eac0d33c51873f45  musl-fix-python.patch
 0ad5fe4340891bb9e1ee2d598add7a4a  musl-locking-fix.patch"
 sha256sums="0b889b0b4d2dd3f6625df28cb0b86ec44a68d074ede2d0dfad0b91e88914885c  uwsgi-2.0.11.2.tar.gz
 df99bc13609a526432afaeb16661086c73f49394e069a19ccb7423bbd025168f  uwsgi.initd
 4cb047e311aecd0f498da1d6a4c0947dd6dc7cc98575d54cb2ef150cacf8425c  uwsgi.confd
+31fc9c17f17aa067c3b025a3f7a84c6102d24368afcbc237f3d58041083c0875  alpine.buildconf
 b61bf4da3d022ddfd93a73196300cb86d962f8f6198079d11b727f61c0f8acb4  0001-use-portable-pthread-functions-instead-of-the-non-po.patch
 360ede589ad228f31dd06fbf8dc17d86d60e968ae76a61b3ca258a2c5ae6f007  0002-Check-for-GNU-libc-instead-of-linux-for-use-of-execi.patch
 6cefd10432900518b3c19ee7f2a20b6b1f722b6d6e7ad43e4c3ad1be3daf43ee  0003-always-define-_GNU_SOURCE-for-linux.patch
 82a2c13162387efcafa388038602d783f8a7e71c28d56ab3ac6b94abeba474d3  0004-define-WAIT_ANY-if-missing.patch
+0e85b019f005925b8026c48d772adf133cd16251e8662d9dc434160eec4ea076  0005-uwsgiconfig-plugin_build_dir.patch
 3838e8e3926a1f6271bb5aa88d309837a3bcd06cd570c499b72ca549326c682e  musl-fix-python.patch
 1540ceee3eadb4c62ca1a9d7a585cb4d4bd6cb01d206773c0a938ca6300f0b5a  musl-locking-fix.patch"
 sha512sums="627759ec9cccc8de74016c245b19069dc7e6970c398be95e707c2c9e36fa06438249f130d0c2bdee16f585b123094a9dd4977de5be276a065ddce30a9698da9a  uwsgi-2.0.11.2.tar.gz
 5d8eadba7c6ee17f86c3dbb6b7c98131ecf9db173156e3196909550954dd09be2191285f46fd4e558f0c47a0cbe7831cde71d3d4c63862d11b819660cc418131  uwsgi.initd
 9f00afb2aa574bbc59040f945475712b8c40da0c06eeb5699de5510aa116148e35ab0429fa891084cf0cd7868876d5a80e1601b7c85d0e2e9ea2a1f54cdde619  uwsgi.confd
+f3cff00926929a5bb40afafb65fd5228582af35fbf524562282020c4c4ae9c659231b2381f4b3cceb18e8f3f6c888c21bdd8ed4ddcd81e92fbc6a0891800ce38  alpine.buildconf
 d105c487d8bd0b496cfac2dad6090f0e420805a83dca514bfbea97c687be26d7a8b9545add0f999cb67eb66818b05995405f9a874b970f53aa38ff5ce3bbdc02  0001-use-portable-pthread-functions-instead-of-the-non-po.patch
 f4038ab866f445a94e155f4b73d308959c402e81227401bc7a5fe2165b888a2c8d95141245a2c10b186782934a4103c785769afaf4091fe3fe5524ed3c270fcf  0002-Check-for-GNU-libc-instead-of-linux-for-use-of-execi.patch
 fc13550528121a1c8ecd530b38ea63f3802cb6d829ec18e55e485acb592b29bed8afe4d23a5f8b9baf8076a00f72d45e8b48c5c56e8c05299b7a1ea7a0ee2e77  0003-always-define-_GNU_SOURCE-for-linux.patch
 deb9fb2f125b80534e8176d32ec7cd85d49225339ccd989cfb463f5b38aa0869841c4bf9a2a97e0ed1c38b999599edb057b9aae17bdad96dad68970362e8bbc3  0004-define-WAIT_ANY-if-missing.patch
+b74a3ccd49a45f65cac31788c78a8182a8939c949615e22694654a2dca329572832da04bf77fc639f89f9a7771ff8fb194ff22c8f6dc70c0cfad2e138ac8fdec  0005-uwsgiconfig-plugin_build_dir.patch
 de68b16b44e554a79c073c9befa10566796316dbf4c375b4d6b633d80b0282694cca233f0a70f3d6570584324f14276826bbeb8f38b550c00087a05f9ba9227f  musl-fix-python.patch
 9c786eb9c51e34cde32c9980c01bc3ebee380524d0897be1f40d85a9e0f4cafc974b58a00cc914f7275a712712d2fb12fd0f91bc8f9f48d33d6414f2ed19c0c4  musl-locking-fix.patch"

--- a/main/uwsgi/alpine.buildconf
+++ b/main/uwsgi/alpine.buildconf
@@ -1,0 +1,6 @@
+[uwsgi]
+inherit = base
+main_plugin =
+embedded_plugins = null
+plugin_dir = /usr/lib/uwsgi
+plugin_build_dir = .


### PR DESCRIPTION
Default value of plugin_dir is . (current working directory). This is
bad, because plugins can't be loaded using simple name  (e.g. uwsgi
--plugin python) and absolute path must be used instead. It also breaks
some applications that use uwsgi wrappers which expects this variable to
be set correctly.

This approach is adopted from Gentoo ebuild www-servers/uwsgi.
See also http://projects.unbit.it/uwsgi/wiki/Guide4Packagers