### PR TITLE
main/libc6-compat: add symlink for libcrypt.so.1

### DIFF
--- a/main/musl/APKBUILD
+++ b/main/musl/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=musl
 pkgver=1.1.14
-pkgrel=7
+pkgrel=8
 pkgdesc="the musl c library (libc) implementation"
 url="http://www.musl-libc.org/"
 arch="all"
@@ -123,7 +123,7 @@ compat() {
 	mkdir -p "$subpkgdir"/lib
 	ln -sf "/lib/libc.musl-${CARCH}.so.1" "$subpkgdir/lib/$_ld"
 
-	for i in libc.so.6 libm.so.6 libpthread.so.0 librt.so.1 libutil.so.1; do
+	for i in libc.so.6 libcrypt.so.1 libm.so.6 libpthread.so.0 librt.so.1 libutil.so.1; do
 		ln -sf "/lib/libc.musl-${CARCH}.so.1" "$subpkgdir/lib/$i"
 	done
 }


### PR DESCRIPTION
http://wiki.musl-libc.org/wiki/FAQ#Q:_lib.5Bm.7Cpthread.7Ccrypt.5D.a.2Fso_are_empty.21
https://github.com/jnr/jnr-posix/issues/73#issue-145821125