### PR TITLE
testing/java-jansi-native: new abuild

### DIFF
--- a/testing/java-jansi-native/APKBUILD
+++ b/testing/java-jansi-native/APKBUILD
@@ -1,0 +1,40 @@
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
+# Maintainer: Jakub Jirutka <jakub@jirutka.cz>
+pkgname=java-jansi-native
+_pkgname=${pkgname#java-}
+pkgver=1.5
+pkgrel=0
+pkgdesc="Native JNI libraries used by the Jansi project."
+url="https://github.com/fusesource/jansi-native"
+arch="all"
+license="ASL-2.0"
+depends="openjdk8-jre-base"
+makedepends="autoconf automake build-base libtool maven openjdk8"
+source="https://github.com/fusesource/$_pkgname/archive/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$_pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+
+	# We need to use newer version of hawtjni plugin, otherwise compilation
+	# of native sources fails.
+	JAVA_HOME=/usr/lib/jvm/default-jvm \
+		mvn package -Dmaven.repo.local=/tmp/m2 -Dhawtjni-version=1.11
+}
+
+package() {
+	cd "$builddir/target"
+
+	install -m644 -D $_pkgname-$pkgver.jar \
+		"$pkgdir"/usr/share/java/$_pkgname-$pkgver.jar || return 1
+	ln -sf $_pkgname-$pkgver.jar "$pkgdir"/usr/share/java/$_pkgname.jar || return 1
+
+	# Note: jansi expects file named libjansi.so or libjansi-x.y.so, not libjansi.so.x.y.
+	install -m755 -D native-build/target/lib/libjansi.so \
+		"$pkgdir"/usr/lib/libjansi-$pkgver.so || return 1
+	ln -sf libjansi-$pkgver.so "$pkgdir"/usr/lib/libjansi.so
+}
+
+md5sums="88c687bedd1e9cef1a652a05dfa2f169  jansi-native-1.5.tar.gz"
+sha256sums="dad14082250023d13d3b78b6f7d95f3157a0ed254ae7742c5b240218da9af6d0  jansi-native-1.5.tar.gz"
+sha512sums="f474df09402b86f5e534bc50a3755dfff353cb5688c93b951ffb4166ac6f83e445393d65baf50a6e93a50d1583772e56bf668a3a0b5312d59cce61493ded1453  jansi-native-1.5.tar.gz"


### PR DESCRIPTION
https://github.com/fusesource/jansi-native
Native JNI libraries used by the Jansi project.