### PR TITLE
testing/elasticsearch: fix runscript (#5390) and change arch to noarch

### DIFF
--- a/testing/elasticsearch/APKBUILD
+++ b/testing/elasticsearch/APKBUILD
@@ -2,11 +2,11 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=elasticsearch
 pkgver=2.2.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Open Source, Distributed, RESTful Search Engine"
 url="https://www.elastic.co/products/elasticsearch"
 arch="x86_64 x86"
-license="ASL 2.0"
+license="ASL-2.0"
 depends="openjdk8-jre"
 makedepends=""
 install="$pkgname.pre-install"
@@ -14,6 +14,7 @@ source="https://download.elasticsearch.org/$pkgname/release/org/$pkgname/distrib
 	$pkgname.initd
 	$pkgname.confd
 	"
+builddir="$srcdir/$pkgname-$pkgver"
 
 _modules="lang-expression lang-groovy"
 for _mod in $_modules; do
@@ -21,12 +22,11 @@ for _mod in $_modules; do
 	eval "_${_mod//-/_}() { _builtin_module $_mod; }"
 done
 
-_builddir="$srcdir/$pkgname-$pkgver"
 _basedir="/usr/share/java/$pkgname"
 
 build() {
 	sed "s/@@ES_VERSION@@/$pkgver/" "$srcdir"/$pkgname.initd \
-		> "$_builddir"/$pkgname.initd
+		> "$builddir"/$pkgname.initd
 }
 
 package() {
@@ -35,7 +35,7 @@ package() {
 	local user="elastico"
 	local group="$user"
 
-	cd "$_builddir"
+	cd "$builddir"
 
 	install -dm755 "$destdir"/lib "$destdir"/modules
 	install -m644 -t "$destdir"/lib lib/* || return 1
@@ -43,15 +43,11 @@ package() {
 	install -dm755 "$confdir"
 	install -m644 -t "$confdir" config/* || return 1
 
-	install -dm750 -o $user -g $group "$pkgdir"/var/lib/$pkgname
-	install -dm755 -o $user -g $group "$pkgdir"/var/log/$pkgname
-	install -dm700 -o $user -g $group "$pkgdir"/var/tmp/$pkgname
-
 	install -m755 -D $pkgname.initd \
 		"$pkgdir"/etc/init.d/$pkgname || return 1
 
 	install -m644 -D "$srcdir"/$pkgname.confd \
-		"$pkgdir"/etc/conf.d/$pkgname || return 1
+		"$pkgdir"/etc/conf.d/$pkgname
 }
 
 _builtin_module() {
@@ -59,15 +55,15 @@ _builtin_module() {
 	local destdir="$subpkgdir/$_basedir/modules/$name"
 
 	install -dm755 "$destdir"
-	install -m644 -t "$destdir" "$_builddir"/modules/$name/* || return 1
+	install -m644 -t "$destdir" "$builddir"/modules/$name/*
 }
 
 md5sums="3bf8349cc3cc9439e7c8aa9694dfb1da  elasticsearch-2.2.1.tar.gz
-01d8bdc0fd186f2bb5e0e0672ffd9c21  elasticsearch.initd
+8588526df39a4d7fab06cf885edec731  elasticsearch.initd
 11ca8100933039b8433eac9342e9e326  elasticsearch.confd"
 sha256sums="7d43d18a8ee8d715d827ed26b4ff3d939628f5a5b654c6e8de9d99bf3a9b2e03  elasticsearch-2.2.1.tar.gz
-acaaa0e053e10d1823a742e888a4a56743d58d9d85b664c63e7000f471e6adda  elasticsearch.initd
+b4cacc84afac4f4d51cad888b0dca034a91e3aed96543d43126a86fa7c3f2bb6  elasticsearch.initd
 356989a74e111a50862712f877da1078ffbc77a4a2735090e2aa87bfa9cbf1e0  elasticsearch.confd"
 sha512sums="9254175afff5c002625465fb5f398e4e53d121925a656af13e65d90eb3b3ef7507ef094cf44002f104a84e5147a8677a05f4071248140d6b48179b9057867cb5  elasticsearch-2.2.1.tar.gz
-fd37a8883cda0ad6c065d9bf5ce06c3d62f3927bc88e81b22ca77714f0700b51f971d7c587191b340d021ca3ce3aca1ac99ac08251bcde4901ae3b791a24b1c8  elasticsearch.initd
+9fe933d6b1b53a02514d34377e6362d176148da3297edbea5902a1c4aff9762aa9c9cb00f053c9aec42db8dea22f722f8a3e16f5ed5b32f5b975e0b311a5e6ff  elasticsearch.initd
 e1e4b31f8bac2e79118e7bf9b25ca8a31eefa6fb00d35c57ccf2db718236a3255d5cbfe429009a98c6f4a8ded19d291e97e5a4d9c44fa044ed6f9961792f5d62  elasticsearch.confd"

--- a/testing/elasticsearch/elasticsearch.initd
+++ b/testing/elasticsearch/elasticsearch.initd
@@ -62,13 +62,21 @@ depend() {
 }
 
 start_pre() {
-	checkpath -d -o $user:$group -m755 "$home_dir" || die
-	checkpath -d -o $user:$group -m700 "$default_data_dir" || die
-	checkpath -d -o $user:$group -m700 "$default_work_dir" || die
-	checkpath -d "$default_script_dir" || die
+	local dir
+
+	# Note: checkpath doesn't create intermediate directories.
+	for dir in "$home_dir" "$default_data_dir" "$default_work_dir" "$default_script_dir"; do
+		mkdir -p "$(dirname "$dir")"
+	done
+
+	checkpath -d -o $user:$group -m755 "$home_dir"
+	checkpath -d -o $user:$group -m700 "$default_data_dir"
+	checkpath -d -o $user:$group -m700 "$default_work_dir"
+	checkpath -d "$default_script_dir"
 
 	if yesno "$create_logs_dir"; then
-		checkpath -d -o $user:$group -m755 "$default_logs_dir" || die
+		mkdir -p "$default_logs_dir"
+		checkpath -d -o $user:$group -m755 "$default_logs_dir"
 	fi
 
 	if [ -n "$max_fd" ]; then


### PR DESCRIPTION
* You can't "die" in runscript, it's not defined in openrc-run.
* checkpath doesn't create intermediate directories.
* Variable "builddir" is now allowed to be declared in APKBUILD.

Fixes: http://bugs.alpinelinux.org/issues/5390