### PR TITLE
testing/elasticsearch: upgrade to 2.3.1

### DIFF
--- a/testing/elasticsearch/APKBUILD
+++ b/testing/elasticsearch/APKBUILD
@@ -1,13 +1,13 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=elasticsearch
-pkgver=2.2.1
-pkgrel=1
+pkgver=2.3.1
+pkgrel=0
 pkgdesc="Open Source, Distributed, RESTful Search Engine"
 url="https://www.elastic.co/products/elasticsearch"
-arch="x86_64 x86"
+arch="noarch"
 license="ASL-2.0"
-depends="openjdk8-jre"
+depends="java-jna-native>=4.1 openjdk8-jre"
 makedepends=""
 install="$pkgname.pre-install"
 source="https://download.elasticsearch.org/$pkgname/release/org/$pkgname/distribution/tar/$pkgname/$pkgver/$pkgname-$pkgver.tar.gz
@@ -16,7 +16,7 @@ source="https://download.elasticsearch.org/$pkgname/release/org/$pkgname/distrib
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
-_modules="lang-expression lang-groovy"
+_modules="lang-expression lang-groovy reindex"
 for _mod in $_modules; do
 	subpackages="$subpackages $pkgname-$_mod:_${_mod//-/_}"
 	eval "_${_mod//-/_}() { _builtin_module $_mod; }"
@@ -58,12 +58,12 @@ _builtin_module() {
 	install -m644 -t "$destdir" "$builddir"/modules/$name/*
 }
 
-md5sums="3bf8349cc3cc9439e7c8aa9694dfb1da  elasticsearch-2.2.1.tar.gz
+md5sums="64e2333b904c07d320f3e995a8cf1489  elasticsearch-2.3.1.tar.gz
 8588526df39a4d7fab06cf885edec731  elasticsearch.initd
 11ca8100933039b8433eac9342e9e326  elasticsearch.confd"
-sha256sums="7d43d18a8ee8d715d827ed26b4ff3d939628f5a5b654c6e8de9d99bf3a9b2e03  elasticsearch-2.2.1.tar.gz
+sha256sums="f0092e73038e0472fcdd923e5f2792e13692ea0f09ca034a54dd49b217110ebb  elasticsearch-2.3.1.tar.gz
 b4cacc84afac4f4d51cad888b0dca034a91e3aed96543d43126a86fa7c3f2bb6  elasticsearch.initd
 356989a74e111a50862712f877da1078ffbc77a4a2735090e2aa87bfa9cbf1e0  elasticsearch.confd"
-sha512sums="9254175afff5c002625465fb5f398e4e53d121925a656af13e65d90eb3b3ef7507ef094cf44002f104a84e5147a8677a05f4071248140d6b48179b9057867cb5  elasticsearch-2.2.1.tar.gz
+sha512sums="447d8824c4bfbec9b8431d213e3a8ae6720d1486e1389c271cc67cce5546861a817ef8c7db1c3c3669a50a61b5305739ac26f46b04d5674bbca203c3b5dbcf2f  elasticsearch-2.3.1.tar.gz
 9fe933d6b1b53a02514d34377e6362d176148da3297edbea5902a1c4aff9762aa9c9cb00f053c9aec42db8dea22f722f8a3e16f5ed5b32f5b975e0b311a5e6ff  elasticsearch.initd
 e1e4b31f8bac2e79118e7bf9b25ca8a31eefa6fb00d35c57ccf2db718236a3255d5cbfe429009a98c6f4a8ded19d291e97e5a4d9c44fa044ed6f9961792f5d62  elasticsearch.confd"


### PR DESCRIPTION
Depends on #56.