### PR TITLE
Update composer to current stable release

### DIFF
--- a/testing/composer/APKBUILD
+++ b/testing/composer/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Nathan Johnson <nathan@nathanjohnson.info>
 # Maintainer: Nathan Johnson <nathan@nathanjohnson.info>
 pkgname=composer
-pkgver=1.0.0_beta1
+pkgver=1.0.2
 _pkgverreal=${pkgver/_beta/-beta}
 pkgrel=0
 pkgdesc="Dependency manager for php"
@@ -23,6 +23,6 @@ package() {
 	install -m 0755 "${pkgname}"-"${_pkgverreal}".phar $pkgdir/usr/bin/"${pkgname}"
 }
 
-md5sums="ce74af6e6ea8b4a4901e57fda4c5c4f6  composer-1.0.0-beta1.phar"
-sha256sums="4344038a546bd0e9e2c4fa53bced1c7faef1bcccab09b2276ddd5cc01e4e022a  composer-1.0.0-beta1.phar"
-sha512sums="808398d945c8c993976b289af75c96ab1bcdf745b0685f4ae567320457cd88d4433a5ba73740b3a9969feaf85f2600cd7cbab2d15e672d949376c5bfdc96e956  composer-1.0.0-beta1.phar"
+md5sums="fcce0b6badce67e98b1f444946d0d6ab  composer-1.0.2.phar"
+sha256sums="264673ccee900b22192605b8c74ecb77c45a5197347edacd142699866c478f4c  composer-1.0.2.phar"
+sha512sums="b3ec242ab73236226a6bcfbf6d6cc76bd405fb79942ff7da78369af4a536730444dfb53497cb1d1551870665bd509d4ede62be4489e86ed481af8070539f0a5e  composer-1.0.2.phar"


### PR DESCRIPTION
On 21 April composer 1.0.2 was released. beta1 is now ~8 weeks old.