### PR TITLE
Introduce a metapackage for Java JDK/JRE (WIP)

### DIFF
--- a/community/java/APKBUILD
+++ b/community/java/APKBUILD
@@ -1,0 +1,39 @@
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
+# Maintainer: Jakub Jirutka <jakub@jirutka.cz>
+pkgname=java
+pkgver=8
+pkgrel=0
+pkgdesc="Metapackage for Java runtime (JRE) and development (JDK)"
+url="http://git.alpinelinux.org/aports.git"
+arch="noarch"
+license="custom"
+depends="$pkgname-jdk"
+makedepends=""
+subpackages="$pkgname-jdk $pkgname-jre $pkgname-jre-base:jre_base"
+source=""
+
+build() {
+	return 0
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+jdk() {
+	pkgdesc="Metapackage for Java Development Kit (JDK)"
+	depends="openjdk8-jdk"
+	mkdir -p "$subpkgdir"
+}
+
+jre() {
+	pkgdesc="Metapackage for Java Runtime Environment (JRE)"
+	depends="openjdk8-jre"
+	mkdir -p "$subpkgdir"
+}
+
+jre_base() {
+	pkgdesc="Metapackage for headless Java Runtime Environment (JRE)"
+	depends="openjdk8-jre-base"
+	mkdir -p "$subpkgdir"
+}

--- a/community/openjdk7/APKBUILD
+++ b/community/openjdk7/APKBUILD
@@ -1,11 +1,12 @@
 # Contributor: Timo Teras <timo.teras@iki.fi>
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Timo Teras <timo.teras@iki.fi>
 pkgname=openjdk7
 _icedteaver=2.6.3
 # pkgver is <JDK version>.<JDK update>
 # check icedtea JDK when updating
 pkgver=7.91.$_icedteaver
-pkgrel=1
+pkgrel=2
 pkgdesc="Sun OpenJDK 7 via IcedTea"
 url="http://icedtea.classpath.org/"
 arch="all"
@@ -13,12 +14,12 @@ license="GPL2 with Classpath"
 depends="$pkgname-jre"
 options="sover-namecheck"
 makedepends="bash findutils tar zip file paxmark gawk util-linux libxslt
-	     autoconf automake linux-headers
-	     ca-certificates
-	     nss-dev cups-dev jpeg-dev giflib-dev libpng-dev libxt-dev
-	     lcms2-dev libxp-dev libxtst-dev libxinerama-dev zlib-dev
-	     libxrender-dev alsa-lib-dev freetype-dev fontconfig-dev
-	     gtk+2.0-dev krb5-dev attr-dev pcsc-lite-dev lksctp-tools-dev"
+	autoconf automake linux-headers
+	ca-certificates
+	nss-dev cups-dev jpeg-dev giflib-dev libpng-dev libxt-dev
+	lcms2-dev libxp-dev libxtst-dev libxinerama-dev zlib-dev
+	libxrender-dev alsa-lib-dev freetype-dev fontconfig-dev
+	gtk+2.0-dev krb5-dev attr-dev pcsc-lite-dev lksctp-tools-dev"
 install=""
 
 # upstream binary versions
@@ -43,7 +44,7 @@ ldpath="$_jrelib:$_jrelib/native_threads:$_jrelib/headless:$_jrelib/server:$_jre
 sonameprefix="$pkgname:"
 
 subpackages="$pkgname-jre-lib:jrelib $pkgname-jre $pkgname-jre-base:jrebase
-	     $pkgname-doc:doc"
+	$pkgname-doc:doc"
 
 if [ "$BOOTSTRAP" != "no" ]; then
 	makedepends="$makedepends java-gcj-compat"
@@ -79,7 +80,7 @@ source="http://icedtea.classpath.org/download/source/icedtea-$_icedteaver.tar.gz
 
 # icedtea6-1.9.7-generate_cacerts-1.patch
 
-_builddir="$srcdir/icedtea-$_icedteaver"
+builddir="$srcdir/icedtea-$_icedteaver"
 
 unpack() {
 	if [ -z "$force" ]; then
@@ -94,28 +95,28 @@ unpack() {
 }
 
 prepare() {
-	cd "$_builddir"
+	cd "$builddir"
 
-        # Busybox sha256 does not support longopts
-        sed -e "s/--check/-c/g" -i Makefile.am
+	# Busybox sha256 does not support longopts
+	sed -e "s/--check/-c/g" -i Makefile.am
 
-        for patch in $source; do
-                case $patch in
+	for patch in $source; do
+		case $patch in
 		icedtea-*.patch)
 			cp ../$patch patches
 			;;
-                *.patch)
-                        msg "Applying patch $patch"
-                        patch -p1 -i "$srcdir"/$patch || return 1
-                        ;;
-                esac
-        done
+		*.patch)
+			msg "Applying patch $patch"
+			patch -p1 -i "$srcdir"/$patch || return 1
+			;;
+		esac
+	done
 
 	./autogen.sh
 }
 
 build() {
-	[ -z "$JOBS" ] && export JOBS=`echo $MAKEFLAGS | sed -n -e 's/.*-j\([0-9]\+\).*/\1/p'`
+	[ -z "$JOBS" ] && export JOBS=$(echo $MAKEFLAGS | sed -n -e 's/.*-j\([0-9]\+\).*/\1/p')
 	export ALT_PARALLEL_COMPILE_JOBS="${JOBS:-2}"
 	export HOTSPOT_BUILD_JOBS="${JOBS:-2}"
 
@@ -133,7 +134,7 @@ build() {
 	done
 	echo "icedtea patches: $DISTRIBUTION_PATCHES"
 
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -162,16 +163,15 @@ build() {
 	make -j1 icedtea-boot || return 1
 	msg "Icedtea boot done"
 	make || return 1
-
 }
 
 package() {
 	mkdir -p "$pkgdir"/$INSTALL_BASE
-	cp -a "$_builddir"/openjdk.build/j2sdk-image/* "$pkgdir"/$INSTALL_BASE
+	cp -a "$builddir"/openjdk.build/j2sdk-image/* "$pkgdir"/$INSTALL_BASE || return 1
 	rm "$pkgdir"/$INSTALL_BASE/src.zip
 
 	# pax mark again (due to fakeroot xattr handling bug)
-	$_builddir/pax-mark-vm "$pkgdir"/$INSTALL_BASE
+	"$builddir"/pax-mark-vm "$pkgdir"/$INSTALL_BASE
 }
 
 jrelib() {
@@ -179,12 +179,13 @@ jrelib() {
 	arch="noarch"
 	depends=""
 
-	for A in jre/lib/zi jre/lib/images jre/lib/*.jar jre/lib/security \
-		 jre/lib/ext/*.jar jre/lib/cmm jre/ASSEMBLY_EXCEPTION \
-		 jre/THIRD_PARTY_README jre/LICENSE ; do
-		dirname=${A%/*}
+	local A; for A in jre/lib/zi jre/lib/images jre/lib/*.jar \
+			jre/lib/security jre/lib/ext/*.jar jre/lib/cmm \
+			jre/ASSEMBLY_EXCEPTION jre/THIRD_PARTY_README jre/LICENSE; do
+
+		local dirname=${A%/*}
 		mkdir -p "$subpkgdir"/$INSTALL_BASE/$dirname
-		mv "$pkgdir"/$INSTALL_BASE/$A "$subpkgdir"/$INSTALL_BASE/$dirname
+		mv "$pkgdir"/$INSTALL_BASE/$A "$subpkgdir"/$INSTALL_BASE/$dirname || return 1
 	done
 }
 
@@ -194,16 +195,16 @@ jrebase() {
 
 	mkdir -p "$subpkgdir"/$INSTALL_BASE/bin
 
-	for A in java orbd rmid servertool unpack200 keytool \
-		 pack200 rmiregistry tnameserv ; do
-		mv "$pkgdir"/$INSTALL_BASE/bin/$A "$subpkgdir"/$INSTALL_BASE/bin
+	local A; for A in java orbd rmid servertool unpack200 keytool \
+			pack200 rmiregistry tnameserv; do
+		mv "$pkgdir"/$INSTALL_BASE/bin/$A "$subpkgdir"/$INSTALL_BASE/bin || return 1
 	done
 
 	# rest of the jre subdir (which were not taken by -jre subpkg)
-	mv "$pkgdir"/$INSTALL_BASE/jre "$subpkgdir"/$INSTALL_BASE
+	mv "$pkgdir"/$INSTALL_BASE/jre "$subpkgdir"/$INSTALL_BASE || return 1
 
 	# pax mark again (due to fakeroot xattr handling bug)
-	$_builddir/pax-mark-vm "$subpkgdir"/$INSTALL_BASE
+	"$builddir"/pax-mark-vm "$subpkgdir"/$INSTALL_BASE
 }
 
 jre() {
@@ -212,18 +213,19 @@ jre() {
 	depends="so:openjdk7:libjvm.so=0"
 
 	mkdir -p "$subpkgdir"
-	for A in jre/bin/policytool \
-		 bin/appletviewer \
-		 bin/policytool \
-		 jre/lib/$_jarch/xawt \
-		 jre/lib/$_jarch/libsplashscreen.so ; do
-		dirname=${A%/*}
+	local A; for A in jre/bin/policytool \
+			bin/appletviewer \
+			bin/policytool \
+			jre/lib/$_jarch/xawt \
+			jre/lib/$_jarch/libsplashscreen.so; do
+
+		local dirname=${A%/*}
 		mkdir -p "$subpkgdir"/$INSTALL_BASE/$dirname
-		mv "$pkgdir"/$INSTALL_BASE/$A "$subpkgdir"/$INSTALL_BASE/$dirname
+		mv "$pkgdir"/$INSTALL_BASE/$A "$subpkgdir"/$INSTALL_BASE/$dirname || return 1
 	done
 
 	# pax mark again (due to fakeroot xattr handling bug)
-	$_builddir/pax-mark-vm "$subpkgdir"/$INSTALL_BASE
+	"$builddir"/pax-mark-vm "$subpkgdir"/$INSTALL_BASE
 }
 
 doc() {
@@ -232,6 +234,7 @@ doc() {
 	mkdir -p "$subpkgdir"/$INSTALL_BASE/
 	mv "$pkgdir"/$INSTALL_BASE/man "$subpkgdir"/$INSTALL_BASE/
 }
+
 md5sums="7bbc8dc603bf5abc87fe8c7ffcafeabe  icedtea-2.6.3.tar.gz
 be68af0132b4d6ff4faa089dbd92d840  openjdk-2.6.3.tar.bz2
 a637ba113153688c3f1d04abd2062f3b  corba-2.6.3.tar.bz2

--- a/community/openjdk7/APKBUILD
+++ b/community/openjdk7/APKBUILD
@@ -6,11 +6,12 @@ _icedteaver=2.6.3
 # pkgver is <JDK version>.<JDK update>
 # check icedtea JDK when updating
 pkgver=7.91.$_icedteaver
-pkgrel=2
+pkgrel=3
 pkgdesc="Sun OpenJDK 7 via IcedTea"
 url="http://icedtea.classpath.org/"
 arch="all"
 license="GPL2 with Classpath"
+provides="java-jdk"
 depends="$pkgname-jre"
 options="sover-namecheck"
 makedepends="bash findutils tar zip file paxmark gawk util-linux libxslt
@@ -191,6 +192,7 @@ jrelib() {
 
 jrebase() {
 	pkgdesc="OpenJDK 7 Java Runtime (no GUI support)"
+	provides="java-jre-base"
 	depends="$pkgname-jre-lib java-common"
 
 	mkdir -p "$subpkgdir"/$INSTALL_BASE/bin
@@ -209,6 +211,7 @@ jrebase() {
 
 jre() {
 	pkgdesc="OpenJDK 7 Java Runtime"
+	provides="java-jre"
 	# manually depend to avoid clash with libgcj's libjvm.so
 	depends="so:openjdk7:libjvm.so=0"
 

--- a/community/openjdk8/APKBUILD
+++ b/community/openjdk8/APKBUILD
@@ -6,11 +6,12 @@ _java_ver=8
 _jdk_update=77
 _jdk_build=03
 pkgver=$_java_ver.$_jdk_update.$_jdk_build
-pkgrel=1
+pkgrel=2
 pkgdesc="Sun OpenJDK 8"
 url="http://openjdk.java.net"
 arch="x86_64 x86"
 license="custom"
+provides="java-jdk"
 depends="$pkgname-jre java-cacerts"
 options="sover-namecheck"
 makedepends="bash findutils tar zip file paxmark gawk util-linux libxslt
@@ -172,6 +173,7 @@ jrelib() {
 
 jrebase() {
 	pkgdesc="OpenJDK 8 Java Runtime (no GUI support)"
+	provides="java-jre-base"
 	depends="$pkgname-jre-lib java-common java-cacerts"
 
 	mkdir -p "$subpkgdir"/$INSTALL_BASE/bin
@@ -189,6 +191,7 @@ jrebase() {
 
 jre() {
 	pkgdesc="OpenJDK 8 Java Runtime"
+	provides="java-jre"
 
 	mkdir -p "$subpkgdir"
 	local A; for A in jre/bin/policytool \

--- a/community/openjdk8/APKBUILD
+++ b/community/openjdk8/APKBUILD
@@ -1,11 +1,12 @@
 # Contributor: Timo Teras <timo.teras@iki.fi>
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Timo Teras <timo.teras@iki.fi>
 pkgname=openjdk8
 _java_ver=8
 _jdk_update=77
 _jdk_build=03
 pkgver=$_java_ver.$_jdk_update.$_jdk_build
-pkgrel=0
+pkgrel=1
 pkgdesc="Sun OpenJDK 8"
 url="http://openjdk.java.net"
 arch="x86_64 x86"
@@ -13,12 +14,12 @@ license="custom"
 depends="$pkgname-jre java-cacerts"
 options="sover-namecheck"
 makedepends="bash findutils tar zip file paxmark gawk util-linux libxslt
-	     autoconf automake linux-headers sed
-	     openjdk7 ca-certificates
-	     nss-dev cups-dev jpeg-dev giflib-dev libpng-dev libxt-dev
-	     lcms2-dev libxp-dev libxtst-dev libxinerama-dev zlib-dev
-	     libxrender-dev alsa-lib-dev freetype-dev fontconfig-dev
-	     gtk+2.0-dev krb5-dev attr-dev pcsc-lite-dev lksctp-tools-dev"
+	autoconf automake linux-headers sed
+	openjdk7 ca-certificates
+	nss-dev cups-dev jpeg-dev giflib-dev libpng-dev libxt-dev
+	lcms2-dev libxp-dev libxtst-dev libxinerama-dev zlib-dev
+	libxrender-dev alsa-lib-dev freetype-dev fontconfig-dev
+	gtk+2.0-dev krb5-dev attr-dev pcsc-lite-dev lksctp-tools-dev"
 install=""
 
 case $CARCH in
@@ -37,7 +38,7 @@ ldpath="$_jrelib:$_jrelib/native_threads:$_jrelib/headless:$_jrelib/server:$_jre
 sonameprefix="$pkgname:"
 
 subpackages="$pkgname-jre-lib:jrelib $pkgname-jre $pkgname-jre-base:jrebase
-	     $pkgname-doc:doc $pkgname-demos:demos"
+	$pkgname-doc:doc $pkgname-demos:demos"
 
 _dropsurl=http://hg.openjdk.java.net/jdk8u/jdk8u
 _dropsver=jdk${_java_ver}u${_jdk_update}-b${_jdk_build}
@@ -62,29 +63,29 @@ source="jdk8u-$_dropsver.tar.bz2::$_dropsurl/archive/${_dropsver}.tar.bz2
 	build-demo-ldflags.patch
 	"
 
-_builddir="$srcdir/jdk8u-$_dropsver"
+builddir="$srcdir/jdk8u-$_dropsver"
 
 prepare() {
-	cd "$_builddir"
+	cd "$builddir"
 	update_config_sub || return 1
 
 	local module
 	for module in corba hotspot jdk jaxws jaxp langtools nashorn; do
-		ln -s ../${module}-${_dropsver} ${module}
+		ln -s ../${module}-${_dropsver} $module || return 1
 	done
 
-        for patch in $source; do
-                case $patch in
-                *.patch)
-                        msg "Applying patch $patch"
-                        busybox patch -p1 < "$srcdir"/$patch || return 1
-                        ;;
-                esac
-        done
+	for patch in $source; do
+		case $patch in
+		*.patch)
+			msg "Applying patch $patch"
+			busybox patch -p1 < "$srcdir"/$patch || return 1
+			;;
+		esac
+	done
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	unset JAVA_HOME
 	export MAKEFLAGS=${MAKEFLAGS/-j*}
 	sh ./configure \
@@ -121,22 +122,24 @@ build() {
 }
 
 list_paxables() {
-        file "$@" 2> /dev/null | grep -E 'ELF.*(executable|shared object)' | sed -e 's/: .*$//'
+	file "$@" 2> /dev/null \
+		| grep -E 'ELF.*(executable|shared object)' | sed -e 's/: .*$//'
 }
 
 pax_mark_vm() {
 	local paxflags="-mp"
-        [ "$CARCH" = "x86" ] && paxflags="-msp"
+	[ "$CARCH" = "x86" ] && paxflags="-msp"
 
+	local paxable
 	for paxable in $(list_paxables "${1}"/bin/* "${1}"/jre/bin/*); do
-                echo "PaX mark $paxflags ${paxable}"
-                paxmark $paxflags "${paxable}"
-        done
+		echo "PaX mark $paxflags ${paxable}"
+		paxmark $paxflags "${paxable}"
+	done
 }
 
 package() {
 	mkdir -p "$pkgdir"/$INSTALL_BASE
-	cp -a "$_builddir"/build/*/images/j2sdk-image/* "$pkgdir"/$INSTALL_BASE
+	cp -a "$builddir"/build/*/images/j2sdk-image/* "$pkgdir"/$INSTALL_BASE || return 1
 	rm "$pkgdir"/$INSTALL_BASE/src.zip
 
 	find "$pkgdir"/$INSTALL_BASE -iname "*.diz" -delete || return 1
@@ -157,12 +160,13 @@ jrelib() {
 	arch="noarch"
 	depends=""
 
-	for A in jre/lib/images jre/lib/*.jar jre/lib/security \
-		 jre/lib/ext/*.jar jre/lib/cmm jre/ASSEMBLY_EXCEPTION \
-		 jre/THIRD_PARTY_README jre/LICENSE ; do
-		dirname=${A%/*}
+	local A; for A in jre/lib/images jre/lib/*.jar jre/lib/security \
+			jre/lib/ext/*.jar jre/lib/cmm jre/ASSEMBLY_EXCEPTION \
+			jre/THIRD_PARTY_README jre/LICENSE; do
+
+		local dirname=${A%/*}
 		mkdir -p "$subpkgdir"/$INSTALL_BASE/$dirname
-		mv "$pkgdir"/$INSTALL_BASE/$A "$subpkgdir"/$INSTALL_BASE/$dirname
+		mv "$pkgdir"/$INSTALL_BASE/$A "$subpkgdir"/$INSTALL_BASE/$dirname || return 1
 	done
 }
 
@@ -172,13 +176,13 @@ jrebase() {
 
 	mkdir -p "$subpkgdir"/$INSTALL_BASE/bin
 
-	for A in java orbd rmid servertool unpack200 keytool \
-		 pack200 rmiregistry tnameserv ; do
-		mv "$pkgdir"/$INSTALL_BASE/bin/$A "$subpkgdir"/$INSTALL_BASE/bin
+	local A; for A in java orbd rmid servertool unpack200 keytool \
+			pack200 rmiregistry tnameserv; do
+		mv "$pkgdir"/$INSTALL_BASE/bin/$A "$subpkgdir"/$INSTALL_BASE/bin || return 1
 	done
 
 	# rest of the jre subdir (which were not taken by -jre subpkg)
-	mv "$pkgdir"/$INSTALL_BASE/jre "$subpkgdir"/$INSTALL_BASE
+	mv "$pkgdir"/$INSTALL_BASE/jre "$subpkgdir"/$INSTALL_BASE || return 1
 
 	pax_mark_vm "$subpkgdir"/$INSTALL_BASE
 }
@@ -187,16 +191,17 @@ jre() {
 	pkgdesc="OpenJDK 8 Java Runtime"
 
 	mkdir -p "$subpkgdir"
-	for A in jre/bin/policytool \
-		 bin/appletviewer \
-		 bin/policytool \
-		 jre/lib/$_jarch/libawt_xawt.so \
-		 jre/lib/$_jarch/libfontmanager.so \
-		 jre/lib/$_jarch/libjawt.so \
-		 jre/lib/$_jarch/libsplashscreen.so ; do
-		dirname=${A%/*}
+	local A; for A in jre/bin/policytool \
+			bin/appletviewer \
+			bin/policytool \
+			jre/lib/$_jarch/libawt_xawt.so \
+			jre/lib/$_jarch/libfontmanager.so \
+			jre/lib/$_jarch/libjawt.so \
+			jre/lib/$_jarch/libsplashscreen.so; do
+
+		local dirname=${A%/*}
 		mkdir -p "$subpkgdir"/$INSTALL_BASE/$dirname
-		mv "$pkgdir"/$INSTALL_BASE/$A "$subpkgdir"/$INSTALL_BASE/$dirname
+		mv "$pkgdir"/$INSTALL_BASE/$A "$subpkgdir"/$INSTALL_BASE/$dirname || return 1
 	done
 
 	pax_mark_vm "$subpkgdir"/$INSTALL_BASE


### PR DESCRIPTION
⚠️ **Do not merge it yet, we have to discuss this change!**
- Add metapackages java-jdk, java-jre and java-jre-base (headless).
- Change openjdk7 and openjdk8 packages to _provide_ the above metapackages.
- Clean-up openjdk7 and openjdk8 packages.

This patch will allow packages to depend on _any_ JDK or JRE, without specifying exact version (7, or 8) or implementation (OpenJDK). In this case, the latest OpenJDK is installed. If any JRE/JDK is already installed, then it satisfies the requirement (thanks to the directive `provides`).

OpenJDK 7 is not publicly supported by upstream anymore (but we need it to build OpenJDK 8), so it may seem that this change is unnecessary since we have just one truly supported version. Well, for **now**; OpenJDK 9 comes in a year and nightly builds are already available.

Moreover, the sad reality is, that some ~~sh*tty~~ enterprise software still doesn’t work on JRE/JDK 8, so openjdk7 is not used just for building openjdk8 in the wild. And also some people insist on installing Oracle JDK on Alpine, for whatever absurd reason (like some “security certificates”). I’m not for adding Oracle JDK to Alpine (for many reasons), but why not to allow people using their own JDK abuild with any Alpine packages depending on any JDK/JRE? Lastly, there are also [many other Java VM implementations](https://en.wikipedia.org/wiki/List_of_Java_virtual_machines); that’s why I named it java-\* and not openjdk-*.

EDIT: I don’t understand why openjdk7 fails on Travis (`tar (child): icedtea-2.6.3.tar.gz: Cannot open: No such file or directory`), it works on my machine.
