### PR TITLE
main/qemu: improve abuild (DRY!) and fix qemu-bridge-helper

### DIFF
--- a/main/qemu/APKBUILD
+++ b/main/qemu/APKBUILD
@@ -1,8 +1,9 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=qemu
 pkgver=2.5.1
-pkgrel=2
+pkgrel=3
 pkgdesc="QEMU is a generic machine emulator and virtualizer"
 url="http://qemu.org/"
 arch="all"
@@ -36,7 +37,9 @@ makedepends="
 	zlib-dev
 	"
 depends=""
-install="$pkgname.pre-install"
+pkggroups="qemu"
+install="$pkgname.pre-install $pkgname.post-install"
+options="suid"  # needed for qemu-bridge-helper
 subpackages="$pkgname-guest-agent:guest"
 
 _subsystems="
@@ -213,6 +216,11 @@ package() {
 	gzip "$pkgdir"/usr/share/man/man1/*
 	gzip "$pkgdir"/usr/share/man/man8/*
 
+	# qemu-bridge-helper needs suid to create tunX devices;
+	# allow only users in the qemu group to run it.
+	chmod 04710 "$pkgdir"/usr/libexec/qemu/qemu-bridge-helper
+	chgrp qemu "$pkgdir"/usr/libexec/qemu/qemu-bridge-helper
+
 	if [ -n "$_arch" ]; then
 		cd "$builddir"/build-gtk
 		install $_arch-softmmu/qemu-system-$_arch \
@@ -223,6 +231,8 @@ package() {
 _subsys() {
 	pkgdesc="Qemu ${1/-/ } emulator"
 	depends="qemu"
+	options=""
+
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/qemu-$1 "$subpkgdir"/usr/bin/ || return 1
 }
@@ -230,6 +240,7 @@ _subsys() {
 img() {
 	pkgdesc="QEMU command line tool for manipulating disk images"
 	replaces="qemu"
+	options=""
 
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/qemu-img \
@@ -251,6 +262,7 @@ img() {
 
 guest() {
 	pkgdesc="QEMU guest agent"
+	options=""
 
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/qemu-ga "$subpkgdir"/usr/bin/

--- a/main/qemu/APKBUILD
+++ b/main/qemu/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=qemu
 pkgver=2.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc="QEMU is a generic machine emulator and virtualizer"
 url="http://qemu.org/"
 arch="all"
@@ -35,83 +35,84 @@ makedepends="
 	xfsprogs-dev
 	zlib-dev
 	"
-depends=
+depends=""
 install="$pkgname.pre-install"
-subpackages="
-$pkgname-aarch64:aarch64
-$pkgname-alpha:alpha
-$pkgname-arm:arm
-$pkgname-armeb:armeb
-$pkgname-cris:cris
-$pkgname-i386:i386
-$pkgname-m68k:m68k
-$pkgname-microblaze:microblaze
-$pkgname-microblazeel:microblazeel
-$pkgname-mips:mips
-$pkgname-mips64:mips64
-$pkgname-mips64el:mips64el
-$pkgname-mipsel:mipsel
-$pkgname-mipsn32:mipsn32
-$pkgname-mipsn32el:mipsn32el
-$pkgname-or32:or32
-$pkgname-ppc:ppc
-$pkgname-ppc64:ppc64
-$pkgname-ppc64abi32:ppc64abi32
-$pkgname-ppc64le:ppc64le
-$pkgname-s390x:s390x
-$pkgname-sh4:sh4
-$pkgname-sh4eb:sh4eb
-$pkgname-sparc:sparc
-$pkgname-sparc32plus:sparc32plus
-$pkgname-sparc64:sparc64
-$pkgname-system-aarch64:system_aarch64
-$pkgname-system-alpha:system_alpha
-$pkgname-system-arm:system_arm
-$pkgname-system-cris:system_cris
-$pkgname-system-i386:system_i386
-$pkgname-system-lm32:system_lm32
-$pkgname-system-m68k:system_m68k
-$pkgname-system-microblaze:system_microblaze
-$pkgname-system-microblazeel:system_microblazeel
-$pkgname-system-mips:system_mips
-$pkgname-system-mips64:system_mips64
-$pkgname-system-mips64el:system_mips64el
-$pkgname-system-mipsel:system_mipsel
-$pkgname-system-moxie:system_moxie
-$pkgname-system-or32:system_or32
-$pkgname-system-ppc:system_ppc
-$pkgname-system-ppc64:system_ppc64
-$pkgname-system-ppcemb:system_ppcemb
-$pkgname-system-s390x:system_s390x
-$pkgname-system-sh4:system_sh4
-$pkgname-system-sh4eb:system_sh4eb
-$pkgname-system-sparc:system_sparc
-$pkgname-system-sparc64:system_sparc64
-$pkgname-system-tricore:system_tricore
-$pkgname-system-unicore32:system_unicore32
-$pkgname-system-x86_64:system_x86_64
-$pkgname-system-xtensa:system_xtensa
-$pkgname-system-xtensaeb:system_xtensaeb
-$pkgname-unicore32:unicore32
-$pkgname-x86_64:x86_64
+subpackages="$pkgname-guest-agent:guest"
 
-$pkgname-guest-agent:guest
-"
+_subsystems="
+	aarch64
+	alpha
+	arm
+	armeb
+	cris
+	i386
+	m68k
+	microblaze
+	microblazeel
+	mips
+	mips64
+	mips64el
+	mipsel
+	mipsn32
+	mipsn32el
+	or32
+	ppc
+	ppc64
+	ppc64abi32
+	ppc64le
+	s390x
+	sh4
+	sh4eb
+	sparc
+	sparc32plus
+	sparc64
+	system-aarch64
+	system-alpha
+	system-arm
+	system-cris
+	system-i386
+	system-lm32
+	system-m68k
+	system-microblaze
+	system-microblazeel
+	system-mips
+	system-mips64
+	system-mips64el
+	system-mipsel
+	system-moxie
+	system-or32
+	system-ppc
+	system-ppc64
+	system-ppcemb
+	system-s390x
+	system-sh4
+	system-sh4eb
+	system-sparc
+	system-sparc64
+	system-tricore
+	system-unicore32
+	system-x86_64
+	system-xtensa
+	system-xtensaeb
+	unicore32
+	x86_64
+	"
+for _sub in $_subsystems; do
+	subpackages="$subpackages $pkgname-$_sub:${_sub//-/_}"
+	eval "${_sub//-/_}() { _subsys $_sub; }"
+done
 
 case "$CARCH" in
-	x86)
-		_arch=i386
-		subpackages="$subpackages $pkgname-gtk"
-		;;
-	x86_64)
-		_arch=x86_64
-		subpackages="$subpackages $pkgname-gtk"
-		;;
-	*)	_arch=""
-		;;
+	x86) _arch=i386 ;;
+	x86_64) _arch=x86_64 ;;
+	*) _arch="" ;;
 esac
+if [ -n "$_arch" ]; then
+	subpackages="$subpackages $pkgname-gtk"
+	gtk() { _subsys system-$_arch-gtk; }
+fi
 
-subpackages="$subpackages $pkgname-img"
+subpackages="$subpackages $pkgname-img"  # -img must be declared the last
 
 source="http://wiki.qemu-project.org/download/$pkgname-$pkgver.tar.bz2
 	0001-elfload-load-PIE-executables-to-right-address.patch
@@ -123,15 +124,10 @@ source="http://wiki.qemu-project.org/download/$pkgname-$pkgver.tar.bz2
 	80-kvm.rules
 	"
 
-_builddir="$srcdir"/$pkgname-$pkgver
+builddir="$srcdir"/$pkgname-$pkgver
 
 prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
+	default_prepare || return 1  # apply patches
 
 	# prevent docs to get automatically installed
 	sed -i '/$(DESTDIR)$(docdir)/d' Makefile
@@ -175,9 +171,9 @@ _compile() {
 }
 
 build() {
-	mkdir -p "$_builddir"/build \
-		"$_builddir"/build-gtk
-	cd "$_builddir"/build
+	mkdir -p "$builddir"/build \
+		"$builddir"/build-gtk
+	cd "$builddir"/build
 
 	_compile \
 		--enable-vnc \
@@ -194,22 +190,22 @@ build() {
 # http://web.archiveorange.com/archive/v/21oVv8wOfpQGkyy8EK0N
 #	make check || return 1
 
-	[ -z "$_arch" ] && return 0
-
-	cd "$_builddir"/build-gtk
-	_compile \
-		--enable-gtk \
-		--with-gtkabi=3.0 \
-		--disable-linux-user \
-		--disable-vnc \
-		--disable-spice \
-		--disable-guest-agent \
-		--target-list="$_arch-softmmu" \
-		|| return 1
+	if [ -n "$_arch" ]; then
+		cd "$builddir"/build-gtk
+		_compile \
+			--enable-gtk \
+			--with-gtkabi=3.0 \
+			--disable-linux-user \
+			--disable-vnc \
+			--disable-spice \
+			--disable-guest-agent \
+			--target-list="$_arch-softmmu" \
+			|| return 1
+	fi
 }
 
 package() {
-	cd "$_builddir"/build
+	cd "$builddir"/build
 	make DESTDIR="$pkgdir" install || return 1
 	install -Dm644 "$srcdir"/80-kvm.rules \
 		"$pkgdir"/lib/udev/rules.d/80-kvm.rules || return 1
@@ -217,11 +213,11 @@ package() {
 	gzip "$pkgdir"/usr/share/man/man1/*
 	gzip "$pkgdir"/usr/share/man/man8/*
 
-	[ -z "$_arch" ] && return 0
-
-	cd "$_builddir"/build-gtk
-	install $_arch-softmmu/qemu-system-$_arch \
-		"$pkgdir"/usr/bin/qemu-system-$_arch-gtk
+	if [ -n "$_arch" ]; then
+		cd "$builddir"/build-gtk
+		install $_arch-softmmu/qemu-system-$_arch \
+			"$pkgdir"/usr/bin/qemu-system-$_arch-gtk || return 1
+	fi
 }
 
 _subsys() {
@@ -231,67 +227,10 @@ _subsys() {
 	mv "$pkgdir"/usr/bin/qemu-$1 "$subpkgdir"/usr/bin/ || return 1
 }
 
-aarch64() { _subsys aarch64; }
-alpha() { _subsys alpha; }
-arm() { _subsys arm; }
-armeb() { _subsys armeb; }
-cris() { _subsys cris; }
-i386() { _subsys i386; }
-m68k() { _subsys m68k; }
-microblaze() { _subsys microblaze; }
-microblazeel() { _subsys microblazeel; }
-mips() { _subsys mips; }
-mips64() { _subsys mips64; }
-mips64el() { _subsys mips64el; }
-mipsel() { _subsys mipsel; }
-mipsn32() { _subsys mipsn32; }
-mipsn32el() { _subsys mipsn32el; }
-or32() { _subsys or32; }
-ppc() { _subsys ppc; }
-ppc64() { _subsys ppc64; }
-ppc64abi32() { _subsys ppc64abi32; }
-ppc64le() { _subsys ppc64le; }
-s390x() { _subsys s390x; }
-sh4() { _subsys sh4; }
-sh4eb() { _subsys sh4eb; }
-sparc() { _subsys sparc; }
-sparc32plus() { _subsys sparc32plus; }
-sparc64() { _subsys sparc64; }
-system_aarch64() { _subsys system-aarch64; }
-system_alpha() { _subsys system-alpha; }
-system_arm() { _subsys system-arm; }
-system_cris() { _subsys system-cris; }
-system_i386() { _subsys system-i386; }
-system_lm32() { _subsys system-lm32; }
-system_m68k() { _subsys system-m68k; }
-system_microblaze() { _subsys system-microblaze; }
-system_microblazeel() { _subsys system-microblazeel; }
-system_mips() { _subsys system-mips; }
-system_mips64() { _subsys system-mips64; }
-system_mips64el() { _subsys system-mips64el; }
-system_mipsel() { _subsys system-mipsel; }
-system_moxie() { _subsys system-moxie; }
-system_or32() { _subsys system-or32; }
-system_ppc() { _subsys system-ppc; }
-system_ppc64() { _subsys system-ppc64; }
-system_ppcemb() { _subsys system-ppcemb; }
-system_s390x() { _subsys system-s390x; }
-system_sh4() { _subsys system-sh4; }
-system_sh4eb() { _subsys system-sh4eb; }
-system_sparc() { _subsys system-sparc; }
-system_tricore() { _subsys system-tricore; }
-system_sparc64() { _subsys system-sparc64; }
-system_unicore32() { _subsys system-unicore32; }
-system_x86_64() { _subsys system-x86_64; }
-system_xtensa() { _subsys system-xtensa; }
-system_xtensaeb() { _subsys system-xtensaeb; }
-unicore32() { _subsys unicore32; }
-x86_64() { _subsys x86_64; }
-gtk() { _subsys system-$_arch-gtk; }
-
 img() {
 	pkgdesc="QEMU command line tool for manipulating disk images"
 	replaces="qemu"
+
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/qemu-img \
 		"$pkgdir"/usr/bin/qemu-io \
@@ -312,6 +251,7 @@ img() {
 
 guest() {
 	pkgdesc="QEMU guest agent"
+
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/qemu-ga "$subpkgdir"/usr/bin/
 	install -Dm755 "$srcdir"/$pkgname-guest-agent.initd \

--- a/main/qemu/qemu.post-install
+++ b/main/qemu/qemu.post-install
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cat 1>&2 <<EOF
+*
+* If you want to run VM as unprivileged user and let Qemu create tunX devices,
+* then you must add that user to the group "qemu".
+* If you use KVM for hardware-assisted virtualization, then you may also need
+* to add that user to the group "kvm".
+*
+EOF

--- a/main/qemu/qemu.pre-install
+++ b/main/qemu/qemu.pre-install
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 addgroup -S -g 34 kvm 2>/dev/null
+addgroup -S -g 35 qemu 2>/dev/null
 
 exit 0


### PR DESCRIPTION
Changes:
* removed huge code duplication,
* renamed `_builddir` to `builddir`,
* replaced patching for-loop with `default_prepare`,
* ~~moved `qemu-bridge-helper` from `/usr/lib/qemu/` to `/usr/libexec/qemu/` (it’s an executable binary),~~
* changed mode of `qemu-bridge-helper` to 04710 * and group to qemu,
* added info message about the kvm and qemu groups to post-install script.

\* The setuid is essential for `qemu-bridge-helper` to work, the purpose of this binary is to be able to run VM under unprivileged user (see [here](http://wiki.qemu.org/Features-Done/HelperNetworking)). I’ve reduced the security risk by dropping executable bit for _others_ and changing group to _qemu_, so only users explicitly added to the group _qemu_ will be able to use it.