### PR TITLE
python: protobuf new aports

### DIFF
--- a/testing/py-protobuf/APKBUILD
+++ b/testing/py-protobuf/APKBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Corentin Henry <corentinhenry@gmail.com>
+# Contributor: Corentin Henry <corentinhenry@gmail.com>
+pkgname=py-protobuf
+_pkgname=protobuf
+pkgver=2.6.1
+pkgrel=0
+pkgdesc="Protocol Buffers are Google's data interchange format."
+url="https://github.com/google/protobuf"
+arch="noarch"
+license="BSD"
+depends="python py-six>=1.9"
+makedepends="python-dev py-setuptools py-google-apputils"
+source="http://pypi.python.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+
+builddir="$srcdir"/$_pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	python setup.py build || return 1
+}
+
+package() {
+	cd "$builddir"
+	python setup.py install --prefix=/usr --root="$pkgdir" || return 1
+}
+
+md5sums="6bf843912193f70073db7f22e2ea55e2  protobuf-2.6.1.tar.gz"
+sha256sums="8faca1fb462ee1be58d00f5efb4ca4f64bde92187fe61fde32615bbee7b3e745  protobuf-2.6.1.tar.gz"
+sha512sums="c345b5b2822e7142e27cd6ff4ca4e8cc307acd3673043428073ed260a899c48ac6afa32e290b2d2f0ee54316d1a0f0ec72287604fb372992715a2191fe5623d4  protobuf-2.6.1.tar.gz"


### PR DESCRIPTION
py-protobuf needs py-google-apputils to build so CI may fail. I also builds without the `makedepends`, since `setuptools` pulls the package anyway but I thought it would be better to make this explicit.