### PR TITLE
testing/libtorrent-rasterbar: downgrade to 1.0.9

### DIFF
--- a/testing/deluge/APKBUILD
+++ b/testing/deluge/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=deluge
 pkgver=1.3.12
-pkgrel=0
+pkgrel=1
 pkgdesc="A lightweight, Free Software, cross-platform BitTorrent client"
 url="http://deluge-torrent.org"
 arch="noarch"
 license="GPL3"
-depends="libtorrent-rasterbar librsvg py-cffi py-chardet py-cryptography
+depends="libtorrent-rasterbar<1.1.0 librsvg py-cffi py-chardet py-cryptography
 	py-enum34 py-gtk py-mako py-openssl py-setuptools py-six py-twisted
 	py-xdg xdg-utils"
 depends_dev=""

--- a/testing/libtorrent-rasterbar/APKBUILD
+++ b/testing/libtorrent-rasterbar/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: August Klein <amatcoder@gmail.com>
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=libtorrent-rasterbar
-pkgver=1.1.0
+pkgver=1.0.9
 _pkgver=${pkgver%.0}
 _pkgver=${_pkgver//./_}
 pkgrel=0
@@ -34,6 +34,6 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-md5sums="3a291044b5b33fec3e30b22a94fda31f  libtorrent-rasterbar-1.1.0.tar.gz"
-sha256sums="2713df7da4aec5263ac11b6626ea966f368a5a8081103fd8f2f2ed97b5cd731d  libtorrent-rasterbar-1.1.0.tar.gz"
-sha512sums="5770e3b243605aabe94951f0d3774a1a928b87690c0ba9f8a093ecf90852cf1c76d29a477ab0efc4a352802ca9b405d5c00a5dcdc8d03c6c1644aabe6ad020df  libtorrent-rasterbar-1.1.0.tar.gz"
+md5sums="361c3d91a7c7447bb271b1775553a03b  libtorrent-rasterbar-1.0.9.tar.gz"
+sha256sums="11a93125ed49f796fca83da925ab7dc29e91d88b915f078caaddaaf559d63db6  libtorrent-rasterbar-1.0.9.tar.gz"
+sha512sums="68558d440c8220711a410e54a28316b7b98f6dd4d0dae2d56cee3a3f0bd031f8b0623a8eb3fde312c4d1b61b4be8fc21396cb3e9fd7f6d86e3a9a693ee036b66  libtorrent-rasterbar-1.0.9.tar.gz"


### PR DESCRIPTION
1) Fix arm build
2) Version 1.1.0 is not supported by deluge: http://forum.deluge-torrent.org/viewtopic.php?f=7&t=53939