### PR TITLE
Add libtool to gmagick options to keep .la files

### DIFF
--- a/testing/graphicsmagick/APKBUILD
+++ b/testing/graphicsmagick/APKBUILD
@@ -13,6 +13,7 @@ makedepends="$depends_dev libtool libltdl"
 install=""
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://downloads.sourceforge.net/$pkgname/$pkgname/$pkgver/GraphicsMagick-$pkgver.tar.xz"
+options="libtool"
 
 _builddir="$srcdir"/GraphicsMagick-$pkgver
 prepare() {


### PR DESCRIPTION
Related issue: https://bugs.alpinelinux.org/issues/4908.

As of b4a13e731 currently all `.la` files are deleted at build time.

```
$ apk info graphicsmagick
graphicsmagick-1.3.24-r0 description:
Image processing system

graphicsmagick-1.3.24-r0 webpage:
http://www.graphicsmagick.org/

graphicsmagick-1.3.24-r0 installed size:
4268032

$ ls /usr/lib/GraphicsMagick-1.3.24/modules-Q16/coders/*la
ls: /usr/lib/GraphicsMagick-1.3.24/modules-Q16/coders/*la: No such file or directory
```

Without those files gmagick is basically useless as it refuses to identify any file. :smiley: 