### PR TITLE
testing/gogs: Multiple fixes

### DIFF
--- a/testing/gogs/APKBUILD
+++ b/testing/gogs/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
-# Maintainer:
+# Maintainer: 7heo <7heo@mail.com>
 pkgname=gogs
 pkgver=0.6.1
-pkgrel=4
+pkgrel=5
 pkgdesc="A self-hosted Git service written in Go"
 url="http://gogs.io/"
 arch="all"
@@ -13,32 +13,24 @@ makedepends="$depends_dev go-tools perl"
 install="$pkgname.pre-install"
 subpackages=""
 pkgusers="gogs"
+pkggroups="www-data"
 options="!strip"
 source="http://dev.alpinelinux.org/archive/$pkgname/$pkgname-$pkgver.tar.gz
 	$pkgname.initd
 	$pkgname.confd
-	$pkgname.ini"
+	$pkgname.ini
+	list.tmpl.patch"
 
 _disturl="dev.alpinelinux.org:/archive/$pkgname/"
 _gourl="github.com/gogits/gogs"
 
-_builddir="$srcdir"/src/github.com/gogits
-
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/src/github.com/gogits
 
 snapshot() {
 	abuild clean
 	export GOPATH="$srcdir"
-	mkdir -p $_builddir
-	cd $_builddir
+	mkdir -p $builddir
+	cd $builddir
 	msg "Checking out v${pkgver} tag"
 	git clone -q --branch v${pkgver} https://$_gourl || return 1
 	cd gogs
@@ -51,14 +43,14 @@ snapshot() {
 }
 
 build() {
-	cd "$_builddir"/$pkgname || return 1
+	cd "$builddir"/$pkgname || return 1
 	export GOPATH="$srcdir"
 	go fix || return 1
 	go build -v -tags "sqlite redis memcache cert" || return 1
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	mkdir -p "$pkgdir"/usr/share/webapps/$pkgname \
 		 "$pkgdir"/var/lib/$pkgname/git \
 		 "$pkgdir"/var/lib/$pkgname/db \
@@ -82,14 +74,17 @@ package() {
 }
 
 md5sums="a363596502666e7318a776618f525d80  gogs-0.6.1.tar.gz
-09d4e7596079f3555cbcc85fa83f7cf9  gogs.initd
+91cd8b6b27509beecb53594463315f43  gogs.initd
 6b3f501f9c37b5032cab8b49b5621fc4  gogs.confd
-82edfdabfdf0ac64dc545036ca499465  gogs.ini"
+82edfdabfdf0ac64dc545036ca499465  gogs.ini
+57e21516f0266322097282fcaeafde30  list.tmpl.patch"
 sha256sums="1da9743b4551e7552c84af56a390e55cbab37ca3407ba1b52fc69e546fc4473b  gogs-0.6.1.tar.gz
-a1de13b47b87ee9db5164a808c903efcd534c2bdea19aa5518fea7b4ca8d4b08  gogs.initd
+23a9bfcf7d1fd7cb5b7bf13ab0b0f412c29c1ebdd62fc02c78dd885cbe5d703d  gogs.initd
 a1c584dbc2d44694ffcf87ecafdf6a43ae81370175ca9cc6e6ff7623b8b05254  gogs.confd
-ead0082c56e8e8f9e9ba7f4c206c2a18bb732726137b71e05d83347638562530  gogs.ini"
+ead0082c56e8e8f9e9ba7f4c206c2a18bb732726137b71e05d83347638562530  gogs.ini
+471d404b1766b9267767e46c0207d7a11346e421ee227ced981e37abd79940a4  list.tmpl.patch"
 sha512sums="17e39b637366c5eae9ce29e75a703c8ef7d1b4e42be0299f2c440aa5e0dd5e0caf71e07535675fb7cd5fe19a13db6535e9e88863bbb92c974ee9d21f1dff4a51  gogs-0.6.1.tar.gz
-75eb2b43c8c944c1c95ae03f1c9cae5fd56d7a52c3a76bff6e057bf32407342f0d8f7c7fa7ef73612e5acded8c6553d58516641d40e4a7cda041e0bfe45a9910  gogs.initd
+be5a9ef2cae1ee2e8106feb6a997ae06519af91fe57f746d20996e79c332c93bb43fc53f79ff4e8ce13222afc6f3dc7bc5cbb758ef201b03e49d809c87c8c4c7  gogs.initd
 52ce41c05c263b790221a04d13d2eb9bba689e4bd72daf5b6af31416e80a485a46bae19e18581d7bde879307283847e6486686a2fe4140fe38ebb6f315e11a86  gogs.confd
-4c2b398cf93ebb8b743b9e7ec1b075706427081036effb53fa90729e70fbc3eb92f2f853278b887ca79dc35cd55a64e1bff4d18e1ad246beab2a723aa9cd71ba  gogs.ini"
+4c2b398cf93ebb8b743b9e7ec1b075706427081036effb53fa90729e70fbc3eb92f2f853278b887ca79dc35cd55a64e1bff4d18e1ad246beab2a723aa9cd71ba  gogs.ini
+70ce5ebf453f476ec83480715ae48ce801ddfc42f82b3c45081c650073a1f226e4290f20ba161646f3cce6bfee84a247c544edde299cddc779437ffe8d1f34ae  list.tmpl.patch"

--- a/testing/gogs/gogs.initd
+++ b/testing/gogs/gogs.initd
@@ -1,8 +1,9 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 
 name=gogs
+conffile="$GOGS_CUSTOM/conf/app.ini"
 command="/usr/bin/gogs"
-command_args="web"
+command_args="web -c $conffile"
 start_stop_daemon_args="${GOGS_USER:+--user} $GOGS_USER --env GOGS_CUSTOM=$GOGS_CUSTOM"
 pidfile="/var/run/gogs.pid"
 command_background="yes"

--- a/testing/gogs/gogs.pre-install
+++ b/testing/gogs/gogs.pre-install
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+addgroup -S www-data 2>/dev/null
 adduser -S -D -h /var/lib/gogs -s /bin/ash -G www-data -g gogs gogs 2>/dev/null
 passwd -u gogs 2>/dev/null
 

--- a/testing/gogs/list.tmpl.patch
+++ b/testing/gogs/list.tmpl.patch
@@ -1,0 +1,11 @@
+--- a/gogs/templates/repo/issue/list.tmpl
++++ b/gogs/templates/repo/issue/list.tmpl
+@@ -7,7 +7,7 @@
+         <div class="col-md-3 filters">
+             <div class="filter-list">
+                 <ul class="list-unstyled">
+-                    <li><a href="{{.RepoLink}}/issues?state={{.State}}"{{if eq .ViewType "all"}} class="active"{{end}}>All Issues <strong class="pull-right">{{..IssueStats.AllCount}}</strong></a></li>
++                    <li><a href="{{.RepoLink}}/issues?state={{.State}}"{{if eq .ViewType "all"}} class="active"{{end}}>All Issues <strong class="pull-right">{{.IssueStats.AllCount}}</strong></a></li>
+                     <li><a href="{{.RepoLink}}/issues?type=assigned&state={{.State}}"{{if eq .ViewType "assigned"}} class="active"{{end}}>Assigned to you <strong class="pull-right">{{.IssueStats.AssignCount}}</strong></a></li>
+                     <li><a href="{{.RepoLink}}/issues?type=created_by&state={{.State}}"{{if eq .ViewType "created_by"}} class="active"{{end}}>Created by you <strong class="pull-right">{{.IssueStats.CreateCount}}</strong></a></li>
+                     <li><a href="{{.RepoLink}}/issues?type=mentioned&state={{.State}}"{{if eq .ViewType "mentioned"}} class="active"{{end}}>Mentioning you <strong class="pull-right">{{.IssueStats.MentionCount}}</strong></a></li>


### PR DESCRIPTION
List of fixes:
- Do not try (and fail) to add the user 'gogs' to the group 'www-data'
  if the latter group doesn't exist.
- Explicitely pass the path to the .ini file to the gogs binary.
- Use openrc-run instead of runscript.
- Patch the list.tmpl template not to cause a fatal error when gogs starts.