### PR TITLE
main/py-sphinx: fix missing dependency on py-imagesize, upgrade to 1.4.3 and add new abuild main/py-imagesize

### DIFF
--- a/main/py-imagesize/APKBUILD
+++ b/main/py-imagesize/APKBUILD
@@ -1,0 +1,28 @@
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
+# Maintainer: Jakub Jirutka <jakub@jirutka.cz>
+pkgname=py-imagesize
+_pkgname=imagesize_py
+pkgver=0.7.1
+pkgrel=0
+pkgdesc="Getting image size from png/jpeg/jpeg2000/gif file"
+url="https://github.com/shibukawa/imagesize_py"
+arch="noarch"
+license="MIT"
+depends="python"
+makedepends="py-setuptools"
+source="$pkgname-$pkgver.tar.gz::https://github.com/shibukawa/$_pkgname/archive/$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	python setup.py build
+}
+
+package() {
+	cd "$builddir"
+	python setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+md5sums="1ddd41c09cf289a8897fda3cfe8f72e2  py-imagesize-0.7.1.tar.gz"
+sha256sums="781367e05a2aba5b66c76e46394cf627bfdd85dba94e066c49df7d57897c67c3  py-imagesize-0.7.1.tar.gz"
+sha512sums="05f6db46d871eef6771a8b1e797bb6c9c33af3bab1efd86d2abf365e91575823cfad905162656606f552a0fab7d59a3596a2210d4246e0148ea605ffc01eb733  py-imagesize-0.7.1.tar.gz"

--- a/main/py-sphinx/APKBUILD
+++ b/main/py-sphinx/APKBUILD
@@ -2,13 +2,14 @@
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=py-sphinx
 pkgver=1.4.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Python Documentation Generator"
 url="http://sphinx.pocoo.org/"
 arch="noarch"
 license="BSD"
-depends="python py-docutils py-jinja2 py-pygments py-setuptools make py-six
-	py-sphinx_rtd_theme py-alabaster py-babel py-snowballstemmer"
+depends="python make py-docutils py-jinja2 py-pygments py-setuptools py-six
+	py-sphinx_rtd_theme py-alabaster py-babel py-snowballstemmer
+	py-imagesize"
 depends_dev=""
 makedepends="$depends_dev"
 install=""

--- a/main/py-sphinx/APKBUILD
+++ b/main/py-sphinx/APKBUILD
@@ -1,8 +1,9 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=py-sphinx
-pkgver=1.4.1
-pkgrel=1
+_pkgname=${pkgname#py-}
+pkgver=1.4.3
+pkgrel=0
 pkgdesc="Python Documentation Generator"
 url="http://sphinx.pocoo.org/"
 arch="noarch"
@@ -10,33 +11,20 @@ license="BSD"
 depends="python make py-docutils py-jinja2 py-pygments py-setuptools py-six
 	py-sphinx_rtd_theme py-alabaster py-babel py-snowballstemmer
 	py-imagesize"
-depends_dev=""
 makedepends="$depends_dev"
-install=""
-subpackages=""
-source="sphinx-$pkgver.tar.gz::https://github.com/sphinx-doc/sphinx/archive/$pkgver.tar.gz"
-
-_builddir="$srcdir"/sphinx-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+source="$_pkgname-$pkgver.tar.gz::https://github.com/sphinx-doc/sphinx/archive/$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
-        cd "$_builddir"
-        python setup.py build || return 1
+	cd "$builddir"
+	python setup.py build || return 1
 }
 
 package() {
-        cd "$_builddir"
-        python setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	cd "$builddir"
+	python setup.py install --prefix=/usr --root="$pkgdir" || return 1
 }
 
-md5sums="fdfe0e3f02d6761ee49e0369475814f1  sphinx-1.4.1.tar.gz"
-sha256sums="ebc119385f986d1f099be799ffac456dbaef6d46d239632c446e8d6e27f2af56  sphinx-1.4.1.tar.gz"
-sha512sums="ef1583d1378056556c36e639916c54cd83a71328a6e0a6c74ee7b6d032a06e32b8f1bbc2e490f0ea85591336fb8051d1cf86664cbe7ac2dec7e96f955bea6295  sphinx-1.4.1.tar.gz"
+md5sums="b86c840a2b5ca06d18b0242360663c04  sphinx-1.4.3.tar.gz"
+sha256sums="d70f7da9f68b5d460a118881eee371046f43b1c0bd3308d283a4f5aeda3b252c  sphinx-1.4.3.tar.gz"
+sha512sums="25ba8f577424d9a59f03cad49807b47d3f2a17d80a1148da44dc0fb4c4cce2976b190056bacc6266f22046b7f100131f931738b4c5046a8d529654f46ef0b1ae  sphinx-1.4.3.tar.gz"


### PR DESCRIPTION
🔙 Backport requested in http://bugs.alpinelinux.org/issues/5688.