### PR TITLE
main/llvm: fix segfault when unpacking aggregates structs

### DIFF
--- a/main/llvm/APKBUILD
+++ b/main/llvm/APKBUILD
@@ -32,6 +32,7 @@ source="
 	llvm-0002-Fix-build-with-musl-libc.patch
 	llvm-0003-Fix-DynamicLibrary-to-build-with-musl-libc.patch
 	llvm-nm-workaround.patch
+	llvm-3.8.0-fix-unpack-load.patch
 
 	http://llvm.org/releases/$pkgver/llvm-$pkgver.src.tar.xz
 	"
@@ -157,14 +158,17 @@ md5sums="10904f363abd86c5c4729e5630ea319c  llvm-0001-Add-Musl-MuslEABI-and-Musl-
 b0cd098117223159b76e96c3f884536b  llvm-0002-Fix-build-with-musl-libc.patch
 9cc5050619f764ca9dc842a5ab122290  llvm-0003-Fix-DynamicLibrary-to-build-with-musl-libc.patch
 785147afd8ab80fa95955a5637b6582f  llvm-nm-workaround.patch
+56253040e1f68c57af202d0b08f38b4d  llvm-3.8.0-fix-unpack-load.patch
 07a7a74f3c6bd65de4702bf941b511a0  llvm-3.8.0.src.tar.xz"
 sha256sums="708db2b21570e48e2c2e155a0c7b7969acecbb82393e306b5b69b0353ac108dd  llvm-0001-Add-Musl-MuslEABI-and-Musl-EABIHF-triples.patch
 e1b0fd5f6918d8c8404f3ec4b8d3ab8fbe8dadc2d6011792349b56e5e8ee51e2  llvm-0002-Fix-build-with-musl-libc.patch
 fc28356bf0d5fcfe9b99e28f4abbc2f49f50d263b44e428e30f33bf5472747b4  llvm-0003-Fix-DynamicLibrary-to-build-with-musl-libc.patch
 1870f910a6f5f2ba6144bd079ec55ed879fe8fd8b1b1b384935f36da43e5f114  llvm-nm-workaround.patch
+122c19c4dc0237d9e58010568e075269d1b2c3d5516da1db035a0f873284d7b1  llvm-3.8.0-fix-unpack-load.patch
 555b028e9ee0f6445ff8f949ea10e9cd8be0d084840e21fbbe1d31d51fc06e46  llvm-3.8.0.src.tar.xz"
 sha512sums="a97ad7a71ec4878f1a8a335dbc0c161323d957aeb95917b0c4837405c69b53b5f9718094e0e9fd7814c74f44aaa8cff3a9379202964b537c8162a53214621bc5  llvm-0001-Add-Musl-MuslEABI-and-Musl-EABIHF-triples.patch
 4cb3fabbb627b596ce398ed717c66ad20bbea7092ba30751520cc5a63d38e1ac53d23e98a6ad82121ddcf2434383ba5cadbc2990f99a4528e99c6e2160c2f725  llvm-0002-Fix-build-with-musl-libc.patch
 19bfb9282455d39d07dbb2b1293b03a45c57d522fbb9c5e58dac034200669628b97e7a90cd4ff5d52d9bb79acfccbef653d8a1140a7f0589ecd6f9b7c4ba0eb6  llvm-0003-Fix-DynamicLibrary-to-build-with-musl-libc.patch
 11db6f3c5d697bc536c7d053530f7a5572756185e16399c32c31306861b58046ca9bc14b8d8097758c00a8c1a7026cbfb75636c0e697e59c53dda5848f93b006  llvm-nm-workaround.patch
+7a83a9709c55eeaf805ba48ee711df866c493acd3ccc36dd34337e4399be9092fb2b4a76aaf2864c8b07ce815c317a685e43d8af505d17a48bfb04d99ead3b9a  llvm-3.8.0-fix-unpack-load.patch
 2c76e79d803768ed20af6ca1801cf2518071bf9835c54580ea3eb6219a66cdcf8b4c575f192c15082cc18d2468b7611dacb57950b605813a2317125c2d33c138  llvm-3.8.0.src.tar.xz"

--- a/main/llvm/llvm-3.8.0-fix-unpack-load.patch
+++ b/main/llvm/llvm-3.8.0-fix-unpack-load.patch
@@ -1,0 +1,150 @@
+From 92c0b571a3a7420bdc3dfad72b4c75dde725d9a9 Mon Sep 17 00:00:00 2001
+From: Amaury Sechet <deadalnix@gmail.com>
+Date: Wed, 17 Feb 2016 19:21:28 +0000
+Subject: [PATCH] Fix load alignement when unpacking aggregates structs
+
+Summary: Store and loads unpacked by instcombine do not always have the right alignement. This explicitely compute the alignement and set it.
+
+Reviewers: dblaikie, majnemer, reames, hfinkel, joker.eph
+
+Subscribers: llvm-commits
+
+Differential Revision: http://reviews.llvm.org/D17326
+
+git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@261139 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ .../InstCombine/InstCombineLoadStoreAlloca.cpp     | 38 +++++++++++++++-------
+ test/Transforms/InstCombine/unpack-fca.ll          | 27 +++++++++++++++
+ 2 files changed, 53 insertions(+), 12 deletions(-)
+
+diff --git a/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp b/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+index dd2889d..4d42658 100644
+--- a/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
++++ b/lib/Transforms/InstCombine/InstCombineLoadStoreAlloca.cpp
+@@ -523,16 +523,17 @@ static Instruction *unpackLoadToAggregate(InstCombiner &IC, LoadInst &LI) {
+   if (!T->isAggregateType())
+     return nullptr;
+ 
++  auto Name = LI.getName();
+   assert(LI.getAlignment() && "Alignment must be set at this point");
+ 
+   if (auto *ST = dyn_cast<StructType>(T)) {
+     // If the struct only have one element, we unpack.
+-    unsigned Count = ST->getNumElements();
+-    if (Count == 1) {
++    auto NumElements = ST->getNumElements();
++    if (NumElements == 1) {
+       LoadInst *NewLoad = combineLoadToNewType(IC, LI, ST->getTypeAtIndex(0U),
+                                                ".unpack");
+       return IC.ReplaceInstUsesWith(LI, IC.Builder->CreateInsertValue(
+-        UndefValue::get(T), NewLoad, 0, LI.getName()));
++        UndefValue::get(T), NewLoad, 0, Name));
+     }
+ 
+     // We don't want to break loads with padding here as we'd loose
+@@ -542,23 +543,29 @@ static Instruction *unpackLoadToAggregate(InstCombiner &IC, LoadInst &LI) {
+     if (SL->hasPadding())
+       return nullptr;
+ 
+-    auto Name = LI.getName();
++    auto Align = LI.getAlignment();
++    if (!Align)
++      Align = DL.getABITypeAlignment(ST);
++
+     SmallString<16> LoadName = Name;
+     LoadName += ".unpack";
+     SmallString<16> EltName = Name;
+     EltName += ".elt";
++
+     auto *Addr = LI.getPointerOperand();
+-    Value *V = UndefValue::get(T);
+-    auto *IdxType = Type::getInt32Ty(ST->getContext());
++    auto *IdxType = Type::getInt32Ty(T->getContext());
+     auto *Zero = ConstantInt::get(IdxType, 0);
+-    for (unsigned i = 0; i < Count; i++) {
++
++    Value *V = UndefValue::get(T);
++    for (unsigned i = 0; i < NumElements; i++) {
+       Value *Indices[2] = {
+         Zero,
+         ConstantInt::get(IdxType, i),
+       };
+-      auto *Ptr = IC.Builder->CreateInBoundsGEP(ST, Addr, makeArrayRef(Indices), EltName);
+-      auto *L = IC.Builder->CreateAlignedLoad(Ptr, LI.getAlignment(),
+-                                              LoadName);
++      auto *Ptr = IC.Builder->CreateInBoundsGEP(ST, Addr,
++                                            makeArrayRef(Indices), EltName);
++      auto EltAlign = MinAlign(Align, SL->getElementOffset(i));
++      auto *L = IC.Builder->CreateAlignedLoad(Ptr, EltAlign, LoadName);
+       V = IC.Builder->CreateInsertValue(V, L, i);
+     }
+ 
+@@ -950,11 +957,16 @@ static bool unpackStoreToAggregate(InstCombiner &IC, StoreInst &SI) {
+     if (SL->hasPadding())
+       return false;
+ 
++    auto Align = SI.getAlignment();
++    if (!Align)
++      Align = DL.getABITypeAlignment(ST);
++
+     SmallString<16> EltName = V->getName();
+     EltName += ".elt";
+     auto *Addr = SI.getPointerOperand();
+     SmallString<16> AddrName = Addr->getName();
+     AddrName += ".repack";
++
+     auto *IdxType = Type::getInt32Ty(ST->getContext());
+     auto *Zero = ConstantInt::get(IdxType, 0);
+     for (unsigned i = 0; i < Count; i++) {
+@@ -962,9 +974,11 @@ static bool unpackStoreToAggregate(InstCombiner &IC, StoreInst &SI) {
+         Zero,
+         ConstantInt::get(IdxType, i),
+       };
+-      auto *Ptr = IC.Builder->CreateInBoundsGEP(ST, Addr, makeArrayRef(Indices), AddrName);
++      auto *Ptr = IC.Builder->CreateInBoundsGEP(ST, Addr,
++                                            makeArrayRef(Indices), AddrName);
+       auto *Val = IC.Builder->CreateExtractValue(V, i, EltName);
+-      IC.Builder->CreateStore(Val, Ptr);
++      auto EltAlign = MinAlign(Align, SL->getElementOffset(i));
++      IC.Builder->CreateAlignedStore(Val, Ptr, EltAlign);
+     }
+ 
+     return true;
+diff --git a/test/Transforms/InstCombine/unpack-fca.ll b/test/Transforms/InstCombine/unpack-fca.ll
+index 4359839..bed3b61 100644
+--- a/test/Transforms/InstCombine/unpack-fca.ll
++++ b/test/Transforms/InstCombine/unpack-fca.ll
+@@ -151,3 +151,30 @@ define i32 @packed_alignment(%struct.S* dereferenceable(9) %s) {
+   %v = extractvalue %struct.T %tv, 1
+   ret i32 %v
+ }
++
++%struct.U = type {i8, i8, i8, i8, i8, i8, i8, i8, i64}
++
++define void @check_alignment(%struct.U* %u, %struct.U* %v) {
++; CHECK-LABEL: check_alignment
++; CHECK: load i8, i8* {{.*}}, align 8
++; CHECK: load i8, i8* {{.*}}, align 1
++; CHECK: load i8, i8* {{.*}}, align 2
++; CHECK: load i8, i8* {{.*}}, align 1
++; CHECK: load i8, i8* {{.*}}, align 4
++; CHECK: load i8, i8* {{.*}}, align 1
++; CHECK: load i8, i8* {{.*}}, align 2
++; CHECK: load i8, i8* {{.*}}, align 1
++; CHECK: load i64, i64* {{.*}}, align 8
++; CHECK: store i8 {{.*}}, i8* {{.*}}, align 8
++; CHECK: store i8 {{.*}}, i8* {{.*}}, align 1
++; CHECK: store i8 {{.*}}, i8* {{.*}}, align 2
++; CHECK: store i8 {{.*}}, i8* {{.*}}, align 1
++; CHECK: store i8 {{.*}}, i8* {{.*}}, align 4
++; CHECK: store i8 {{.*}}, i8* {{.*}}, align 1
++; CHECK: store i8 {{.*}}, i8* {{.*}}, align 2
++; CHECK: store i8 {{.*}}, i8* {{.*}}, align 1
++; CHECK: store i64 {{.*}}, i64* {{.*}}, align 8
++  %1 = load %struct.U, %struct.U* %u
++  store %struct.U %1, %struct.U* %v
++  ret void
++}
+-- 
+2.8.2
+


### PR DESCRIPTION
This patch is backported from upstream, see https://github.com/JuliaLang/julia/pull/16503 for more information.

🔙  Backport requested in https://bugs.alpinelinux.org/issues/5690.

⚠️ The build fails due to a missing dependency in py-sphinx, see #117.