### PR TITLE
testing/py-pexpect: upgrade to 4.1.0, fix missing dependency

### DIFF
--- a/testing/py-pexpect/APKBUILD
+++ b/testing/py-pexpect/APKBUILD
@@ -1,41 +1,30 @@
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=py-pexpect
-_pkgname=pexpect
-pkgver=4.0.1
+_pkgname=${pkgname#py-}
+pkgver=4.1.0
 pkgrel=0
 pkgdesc="Make Python a better tool for controlling and automating other programs"
 url="http://pexpect.readthedocs.org/en/stable"
 arch="noarch"
 license="MIT"
-depends="python"
-depends_dev=""
-makedepends="$depends_dev python-dev"
-install=""
+depends="python py-ptyprocess"
+makedepends="python-dev"
 subpackages="$pkgname-doc"
-source="http://pypi.python.org/packages/source/p/$_pkgname/$_pkgname-$pkgver.tar.gz"
-
-_builddir="$srcdir"/$_pkgname-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+source="$pkgname-$pkgver.tar.gz::https://github.com/pexpect/$_pkgname/archive/$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	python setup.py build || return 1
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	python setup.py install --prefix=/usr --root="$pkgdir" || return 1
 	install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }
-md5sums="056df81e6ca7081f1015b4b147b977b7  pexpect-4.0.1.tar.gz"
-sha256sums="232795ebcaaf2e120396dbbaa3a129eda51757eeaae1911558f4ef8ee414fc6c  pexpect-4.0.1.tar.gz"
-sha512sums="c2476f977964379faa3ecef1bc4800f3a87bd6cdd9e2d52e4e4f33a4060a97bb54f0770dfb5804d5a863eaf6ddef6b11be1d24f1617cc4837015202868ca7e87  pexpect-4.0.1.tar.gz"
+
+md5sums="049f3c98f4b0b7426e6b5d8a01566786  py-pexpect-4.1.0.tar.gz"
+sha256sums="be665e01713acc296014a9883bc1ab12232424053ae884a317864b0e8ece6f93  py-pexpect-4.1.0.tar.gz"
+sha512sums="eecd0a4d621e9c14249922bfc36efb8e89c527625d2e2f4fdc0053911f3666e5de7608ce08e023a4020a6baefadbd4643fe32b9e8c34d961296c6b388a2cc2d5  py-pexpect-4.1.0.tar.gz"

--- a/testing/py-ptyprocess/APKBUILD
+++ b/testing/py-ptyprocess/APKBUILD
@@ -1,0 +1,28 @@
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
+# Maintainer: Francesco Colista <fcolista@alpinelinux.org>
+pkgname=py-ptyprocess
+_pkgname=${pkgname#py-}
+pkgver=0.5.1
+pkgrel=0
+pkgdesc="Run a subprocess in a pseudo terminal"
+url="https://github.com/pexpect/ptyprocess"
+arch="noarch"
+license="ISC"
+depends="python"
+makedepends="python-dev"
+source="http://pypi.python.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	python setup.py build
+}
+
+package() {
+	cd "$builddir"
+	python setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+md5sums="94e537122914cc9ec9c1eadcd36e73a1  ptyprocess-0.5.1.tar.gz"
+sha256sums="0530ce63a9295bfae7bd06edc02b6aa935619f486f0f1dc0972f516265ee81a6  ptyprocess-0.5.1.tar.gz"
+sha512sums="9e7481e8e3facde73086ef0728a57516a15b6bc2a5fb6bf6d6f892c396c9376d9d6334ee37737f3469929c4086d5678a2c5deaf44d70589d41644a98f2239dad  ptyprocess-0.5.1.tar.gz"


### PR DESCRIPTION
Thanks @yuyichao for reporting the missing dependency in https://github.com/alpinelinux/aports/pull/112#issuecomment-224458565.

@fcolista, can I specify you as a maintainer of the new package py-ptyprocess, that is a dependency of your package py-pexpect?