### PR TITLE
testing/rabbitmq-c: update to version 0.8.0

### DIFF
--- a/testing/rabbitmq-c/APKBUILD
+++ b/testing/rabbitmq-c/APKBUILD
@@ -1,27 +1,46 @@
 # Contributor: Fabio Ribeiro <fabiorphp@gmail.com>
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
 pkgname=rabbitmq-c
-pkgver=0.7.1
+pkgver=0.8.0
 pkgrel=0
 pkgdesc="RabbitMQ C client"
 url="https://github.com/alanxz/rabbitmq-c"
+subpackages="$pkgname-bin $pkgname-doc $pkgname-dev"
+depends_dev="openssl-dev popt-dev"
+makedepends="$depends_dev cmake xmlto doxygen"
 arch="all"
 license="MIT"
-source="https://github.com/alanxz/$pkgname/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/alanxz/$pkgname/archive/v$pkgver.tar.gz"
 
 builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
 	cd "$builddir"
-	./configure --prefix=/usr || return 1
+	mkdir build && cd build || return 1
+	cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr/lib .. || return 1
 	make || return 1
 }
 
 package() {
-	cd "$builddir"
+	cd "$builddir"/build
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-md5sums="6216c8876299a5efc4ff5ff84dc636d8  rabbitmq-c-0.7.1.tar.gz"
-sha256sums="23df349a7d157543e756acc67e47b217843ecbdafaefe3e4974073bb99d8a26d  rabbitmq-c-0.7.1.tar.gz"
-sha512sums="197b8476373e3a9056d5f24e0d932a37a556a946d2b6471c95e8b0e693b611de51882be4911bd099f2c2e76153225d83cac1bec8106c031058315f062a8a4ab4  rabbitmq-c-0.7.1.tar.gz"
+bin() {
+	pkgdesc="command line utilities for rabbitmq"
+	depends="$pkgname"
+	mkdir -p "$subpkgdir"/usr/bin
+	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
+}
+
+doc() {
+	pkgdesc="rabbitmq-c documentation and examples"
+	arch="noarch"
+	mkdir -p "$subpkgdir"/usr/share/"$pkgname"
+	cp -a "$builddir"/build/docs "$subpkgdir"/usr/share/"$pkgname"/
+	cp -a "$builddir"/examples "$subpkgdir"/usr/share/"$pkgname"/
+}
+
+md5sums="51d5827651328236ecb7c60517c701c2  rabbitmq-c-0.8.0.tar.gz"
+sha256sums="d8ed9dcb49903d83d79d7b227da35ef68c60e5e0b08d0fc1fb4e4dc577b8802b  rabbitmq-c-0.8.0.tar.gz"
+sha512sums="54e1c98a6b0eb7de848c9fac13dcde6455a6f71acee9e62a96c171f0e3e1cf860a70837f07b633d1a55b1ffd3d33ed7186b52495fa4c6e755b69a7e728eb9f1a  rabbitmq-c-0.8.0.tar.gz"


### PR DESCRIPTION
Also splitting package into -dev, -doc and -bin packages.