### PR TITLE
testing/php-xdebug: fix build

### DIFF
--- a/testing/php-xdebug/APKBUILD
+++ b/testing/php-xdebug/APKBUILD
@@ -10,7 +10,7 @@ url="http://pecl.php.net/package/$_pkgreal"
 arch="all"
 license="PHP"
 depends=
-pecldepends="php-dev autoconf"
+pecldepends="php5-dev autoconf"
 makedepends="$pecldepends"
 install=""
 subpackages=""
@@ -28,8 +28,8 @@ build() {
 package() {
 	cd "$_builddir"
 	make INSTALL_ROOT="$pkgdir/" install || return 1
-	install -d "$pkgdir"/etc/php/conf.d || return 1
-	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php/conf.d/$_pkgreal.ini
+	install -d "$pkgdir"/etc/php5/conf.d || return 1
+	echo "zend_extension=$_pkgreal.so" > "$pkgdir"/etc/php5/conf.d/$_pkgreal.ini
 }
 
 md5sums="60e6fdf41840104a23debe16db15a2af  xdebug-2.3.3.tgz"


### PR DESCRIPTION
Mostly all php5 extensions now configured to `/etc/php5/conf.d` instead of `/etc/php/conf.d`

So there's no way to install extension except moving to proper location .so file and .ini

Also this extension should use `zend-extension` to include
```
# php -i|grep xdeb
PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php5/modules/xdebug.so' - Error loading shared library /usr/lib/php5/modules/xdebug.so: No such file or directory in Unknown on line 0
# mv /usr/lib/php/modules/xdebug.so /usr/lib/php5/modules
# php -i|grep xde
PHP Warning:  Xdebug MUST be loaded as a Zend extension in Unknown on line 0
```

Probably it makes sense to rename package to `php5-xdebug` as it was done for other php ones