### PR TITLE
testing/php5-xdebug: rename abuild and upgrade to 2.4.0

### DIFF
--- a/testing/php5-xdebug/APKBUILD
+++ b/testing/php5-xdebug/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
-pkgname=php-xdebug
+pkgname=php5-xdebug
 _pkgreal=xdebug
-pkgver=2.3.3
+pkgver=2.4.0
 _pkgver=${pkgver/_rc/RC}
 pkgrel=0
 pkgdesc="PHP extension provides functions for function traces and profiling"
@@ -10,28 +10,28 @@ url="http://pecl.php.net/package/$_pkgreal"
 arch="all"
 license="PHP"
 depends=
-pecldepends="php-dev autoconf"
+pecldepends="php5-dev autoconf"
 makedepends="$pecldepends"
 install=""
 subpackages=""
 source="http://pecl.php.net/get/$_pkgreal-$_pkgver.tgz"
 
-_builddir="$srcdir"/$_pkgreal-$_pkgver
+builddir="$srcdir"/$_pkgreal-$_pkgver
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	phpize || return 1
 	./configure --prefix=/usr || return 1
 	make || return 1
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	make INSTALL_ROOT="$pkgdir/" install || return 1
-	install -d "$pkgdir"/etc/php/conf.d || return 1
-	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php/conf.d/$_pkgreal.ini
+	install -d "$pkgdir"/etc/php5/conf.d || return 1
+	echo "zend_extension=$_pkgreal.so" > "$pkgdir"/etc/php5/conf.d/$_pkgreal.ini
 }
 
-md5sums="60e6fdf41840104a23debe16db15a2af  xdebug-2.3.3.tgz"
-sha256sums="b27bd09b23136d242dbc94f4503c98f012a521d5597002c9d463a63c6b0cdfe3  xdebug-2.3.3.tgz"
-sha512sums="212604e87caa67b3734befa0f57580532b0edd346ed871bbaba72ba8319ba60eb8d66649cb5716df250f28ef1cd2384ccc6f651b90ab4936dbcb45ef6c5f7438  xdebug-2.3.3.tgz"
+md5sums="f49fc01332468f8b753fb37115505fb5  xdebug-2.4.0.tgz"
+sha256sums="3c4dcb2709d1653534e7cfaa546307041afd298ac48a3670183a12cfdb5eee05  xdebug-2.4.0.tgz"
+sha512sums="3cc4b5d0cec8048543a9b34a61479303b15fe765d24507a2d24ac42f2f18c625cccc3c44b2e4dacb923f05dd429df8ca3a8909a9def9920d3f44514a31f7cf29  xdebug-2.4.0.tgz"


### PR DESCRIPTION
This package is broken so let's upgrade it and rename inline with other php ones

PS Related fix https://github.com/alpinelinux/aports/pull/130