### PR TITLE
testing/php7-redis: upgrade to 3.0.0

### DIFF
--- a/testing/php7-redis/APKBUILD
+++ b/testing/php7-redis/APKBUILD
@@ -4,8 +4,8 @@ pkgname=php7-redis
 _pkgreal=redis
 _pkgrepo=phpredis
 _pkgbranch=php7
-pkgver=2.2.8
-pkgrel=1
+pkgver=3.0.0
+pkgrel=0
 pkgdesc="PHP extension for interfacing with Redis (Dev PHP7)"
 url="https://github.com/$_pkgrepo/$_pkgrepo/tree/$_pkgbranch"
 arch="x86_64 armhf"
@@ -33,6 +33,6 @@ package() {
 	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/20_$_pkgreal.ini
 }
 
-md5sums="6c47b6722d2970267e0f6b4f85cff675  phpredis-2.2.8.tar.gz"
-sha256sums="9304805acbe5d7c9b4378279b27297bf1bddb96a66541c5e4b2fe22ffa2297f0  phpredis-2.2.8.tar.gz"
-sha512sums="3c943d21d305dfa8db6c56760031ac2e0de26a6282de0ddbbd61926cb336c76160d3533087fa0198c45b3fb72fb2e9eae5d95189cb2dcace52861ce1a596b10f  phpredis-2.2.8.tar.gz"
+md5sums="4ceb9fcfaf005f12e49c7410a4620f4c  phpredis-3.0.0.tar.gz"
+sha256sums="030997370bb1906793989c89550d9cafd4fa35dccbad7040b2339301aa961dba  phpredis-3.0.0.tar.gz"
+sha512sums="51f9492189443b851ec721cb0285a82426130162ab8ce2cd7ea26b1b7757a8c893d00b91f4dbb8dd1fd6bcef828ca98c4378c24faf59afa8df5b9c92a81798d5  phpredis-3.0.0.tar.gz"


### PR DESCRIPTION
Upgrade is needed because php7 is supported starting from 3.0.0
http://pecl.php.net/package/redis/3.0.0