### PR TITLE
testing/php5-memcached: rename abuild

### DIFF
--- a/testing/php5-memcached/APKBUILD
+++ b/testing/php5-memcached/APKBUILD
@@ -1,6 +1,6 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
-pkgname=php-memcached
+pkgname=php5-memcached
 _pkgreal=memcached
 pkgver=2.2.0
 _pkgver=${pkgver/_rc/RC}
@@ -10,16 +10,15 @@ url="http://pecl.php.net/package/$_pkgreal"
 arch="all"
 license="PHP"
 depends=
-pecldepends="php-dev autoconf"
+pecldepends="php5-dev autoconf"
 makedepends="$pecldepends libmemcached-dev zlib-dev"
 install=""
 subpackages=""
 source="http://pecl.php.net/get/$_pkgreal-$_pkgver.tgz"
-
-_builddir="$srcdir"/$_pkgreal-$_pkgver
+builddir="$srcdir"/$_pkgreal-$_pkgver
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	phpize || return 1
 	./configure \
 		--prefix=/usr \
@@ -28,10 +27,10 @@ build() {
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	make INSTALL_ROOT="$pkgdir/" install || return 1
-	install -d "$pkgdir"/etc/php/conf.d || return 1
-	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php/conf.d/$_pkgreal.ini
+	install -d "$pkgdir"/etc/php5/conf.d || return 1
+	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php5/conf.d/$_pkgreal.ini
 }
 
 md5sums="28937c6144f734e000c6300242f44ce6  memcached-2.2.0.tgz"


### PR DESCRIPTION
Package is broken because .ini and .so files should be in php5
Renamed to be inline with other php5 extensions