### PR TITLE
main/php5: upgrade to 5.6.22

### DIFF
--- a/main/php5/APKBUILD
+++ b/main/php5/APKBUILD
@@ -3,8 +3,8 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
-pkgver=5.6.21
-pkgrel=2
+pkgver=5.6.22
+pkgrel=0
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
 arch="all"
@@ -493,17 +493,17 @@ pdo_dblib()	{ _mv_ext pdo_dblib "$pkgname-pdo freetds"; }
 wddx()		{ _mv_ext wddx; }
 opcache()	{ _mv_ext opcache; }
 
-md5sums="141464ce6b297aa2295b8416c6dbd5e5  php-5.6.21.tar.bz2
+md5sums="2244754a50d0a5f07c20967d0c9e0b8d  php-5.6.22.tar.bz2
 11375b4f0aaedc589eba5e31c19e5a7d  php-fpm.initd
 67719f428f44ec004da18705cbabe2ee  php5-module.conf
 483bc0a85c50a9a9aedbe14a19ed4526  php-install-pear-xml.patch
 162d8d079944387eab2bc80edab347ae  gd-iconv.patch"
-sha256sums="b4ed7ab574b689fd6d6494fde954826c06efc85c505e017b8d776c7c7f479590  php-5.6.21.tar.bz2
+sha256sums="90da8a80cc52fa699cf2bfa4c6fa737c772df7c92b81ef483460aa3b1e9f88c6  php-5.6.22.tar.bz2
 8fc31134677746d5d972d4ed4ab0abe42669e78f46ce45c18bc042b99bc034cd  php-fpm.initd
 ceec4d5b2a128c6a97e49830af604f0bb555bca1a86a9cd0366b828ba392257f  php5-module.conf
 f739ca427a1dd53a388bad0823565299c5d4a5796b1171b892884e4d7d099bab  php-install-pear-xml.patch
 6122bf279cdb7c387dd000761b2426969a73cf63a10a132aa98a79eb1dd259b2  gd-iconv.patch"
-sha512sums="028d62434e7932b4a07fa7d404b8ad938f0ca7968ae2b23386038f77482984d2b6145523e11f37b9e72621c8bf40f08e38a6db1d209493770ac99e13e2fac0d0  php-5.6.21.tar.bz2
+sha512sums="9d21104832a1053a350ff31196e2c41cef713a9dfe207491236219954cf2eea216049b2f40313fb2a8e9ef641aad0af3f69456bbcebdf8fee312b0dd4a7df320  php-5.6.22.tar.bz2
 ded5cdebc74aeb2d0f0899fe448477ba9eaa01e2e9fbfa6f3425398daccdf26fbe440ab184761cd87b0ea271f97ee237c482a621397d6588c6d353513cdbed1e  php-fpm.initd
 895e94c791bd82060ad820fef049d366a09c932097faa6b7b9a2c2e9e00a18cb7c0f9b128679c7659b404379266fd0f95dba5c0333f626194cf60f7bf6044102  php5-module.conf
 f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c939768584f3e4edbe52e8bd6103fb6777462326a9d94e8ab1f505  php-install-pear-xml.patch

--- a/main/php5/gd-iconv.patch
+++ b/main/php5/gd-iconv.patch
@@ -1,5 +1,5 @@
 diff --git a/ext/gd/config.m4 b/ext/gd/config.m4
-index 0e35ece..3593cd7 100644
+index e643e52..fc41ab9 100644
 --- a/ext/gd/config.m4
 +++ b/ext/gd/config.m4
 @@ -6,6 +6,9 @@ dnl
@@ -10,9 +10,9 @@ index 0e35ece..3593cd7 100644
 +[  --with-iconv-dir=DIR      GD/XMLRPC-EPI: iconv dir for GD/XMLRPC-EPI],no,no)
 +
  PHP_ARG_WITH(gd, for GD support,
- [  --with-gd[=DIR]         Include GD support.  DIR is the GD library base
+ [  --with-gd[=DIR]           Include GD support.  DIR is the GD library base
                            install directory [BUNDLED]])
-@@ -374,6 +377,18 @@ dnl enable the support in bundled GD library
+@@ -329,6 +332,18 @@ dnl enable the support in bundled GD library
      GDLIB_CFLAGS="$GDLIB_CFLAGS -DJISX0208"
    fi
  


### PR DESCRIPTION
Security release
http://php.net/archive/2016.php#id2016-05-26-3
http://php.net/ChangeLog-5.php#5.6.22