### PR TITLE
testing/php7-ssh2: new aport

### DIFF
--- a/testing/php7-ssh2/APKBUILD
+++ b/testing/php7-ssh2/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Andy Postnikov <apostnikov@gmail.com>
+# Maintainer: Andy Postnikov <apostnikov@gmail.com>
+pkgname=php7-ssh2
+_pkgreal=ssh2
+pkgver=1.0
+pkgrel=0
+pkgdesc="PHP extension provide bindings for the libssh2 library"
+url="http://pecl.php.net/package/ssh2"
+arch="all"
+license="PHP"
+depends=""
+pecldepends="php7-dev autoconf"
+makedepends="$pecldepends libssh2-dev"
+source="$pkgname-$pkgver.tgz::http://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
+builddir="$srcdir/$_pkgreal-$pkgver"
+
+build() {
+	cd "$builddir"
+	phpize7 || return 1
+	./configure --prefix=/usr --with-php-config=php-config7 || return 1
+	make || return 1
+}
+
+package() {
+	cd "$builddir"
+	make INSTALL_ROOT="$pkgdir/" install || return 1
+	install -d "$pkgdir"/etc/php7/conf.d || return 1
+	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/$_pkgreal.ini
+}
+
+md5sums="1f84d2d0621933dce06eedeffe54ebd0  php7-ssh2-1.0.tgz"
+sha256sums="6a93891878b23904a773eb814fec7aea4ea00b4a412ee779c8535ed9c5e46ced  php7-ssh2-1.0.tgz"
+sha512sums="9e21b4d5d640f595ff812c341387cd51917aed2df00bb8c94ff7e494953a3599dc1cbfa6f04248f3145fc1b097fcf6c066710c8f2a41e565a3f57cad999877f9  php7-ssh2-1.0.tgz"


### PR DESCRIPTION
https://pecl.php.net/package/ssh2
PHP extension provide bindings for the libssh2 library
Initial PHP7 support