### PR TITLE
main/hunspell: build with ncurses and readline

### DIFF
--- a/main/hunspell/APKBUILD
+++ b/main/hunspell/APKBUILD
@@ -7,8 +7,8 @@ url="http://hunspell.github.io/"
 arch="all"
 license="GPL2+ LGPL2+ MPL 1.1"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
-depends="ncurses readline"
-makedepends="gettext-dev"
+depends=""
+makedepends="gettext-dev ncurses-dev readline-dev"
 source="$pkgname-$pkgver.tar.gz::https://github.com/hunspell/hunspell/archive/v$pkgver.tar.gz
 	"
 

--- a/main/hunspell/APKBUILD
+++ b/main/hunspell/APKBUILD
@@ -1,13 +1,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=hunspell
 pkgver=1.3.4
-pkgrel=0
+pkgrel=1
 pkgdesc="Spell checker and morphological analyzer library and program"
 url="http://hunspell.github.io/"
 arch="all"
 license="GPL2+ LGPL2+ MPL 1.1"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
-depends=""
+depends="ncurses readline"
 makedepends="gettext-dev"
 source="$pkgname-$pkgver.tar.gz::https://github.com/hunspell/hunspell/archive/v$pkgver.tar.gz
 	"
@@ -28,6 +28,8 @@ build() {
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
+		--with-ui \
+		--with-readline \
 		--disable-static \
 		--without-included-gettext \
 		|| return 1


### PR DESCRIPTION
So that it can be used as a stand-alone command line spell checker