### PR TITLE
update RethinkDB to latest stable version (2.3.4)

### DIFF
--- a/testing/rethinkdb/APKBUILD
+++ b/testing/rethinkdb/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer:
 pkgname=rethinkdb
-pkgver=2.3.1
+pkgver=2.3.4
 pkgrel=0
 pkgdesc="Distributed powerful and scalable NoSQL database"
 url="http://www.rethinkdb.com"
@@ -69,9 +69,9 @@ package() {
 	paxmark -m "$pkgdir"/usr/bin/rethinkdb || return 1
 }
 
-md5sums="dd5a79068b14c076812436d52804f3f7  rethinkdb-2.3.1.tgz
+md5sums="cf81117ed3acdf28cea1d62ef45f3340  rethinkdb-2.3.4.tgz
 bb1cde2ba1d6a71ed79c31161b1bf64b  rethinkdb.initd"
-sha256sums="4a2a84a57a5a03523b66d9ec551e92d5e8bd6b04b7275db1aae890d357387ceb  rethinkdb-2.3.1.tgz
+sha256sums="93a7927d1ed785d084be3b8bac3f9af2d89c86de16e003848acbe21a32a9e1a7  rethinkdb-2.3.4.tgz
 d7294473f30cd2fa7837de6ed4816efd2c8663a15c7396d8c37a0a9f2fc1a787  rethinkdb.initd"
-sha512sums="135aeb32560d0a8721d9426456d81fbd1e07e7c2ceea6365658ca698a610534c4e1d19cceb66c1d27a023ffeab9d0b6634eef0f636799beb3ad9e59ae487ac76  rethinkdb-2.3.1.tgz
+sha512sums="47e62ef57de112129b7409027017882bc31bb2403287845253a0fe0f61d0977f2e37ba487506853ed3421ac57b2558cabde4f8aee4b9723e4c61300b447e1e19  rethinkdb-2.3.4.tgz
 d9997f453623e4a85e19052464d97738be70277fd14b985e9123414792b85cf5e5b30e8ecb94b48cdab43c4fb39898ca35e7fbc8943e13f95db2a992ba2289a1  rethinkdb.initd"


### PR DESCRIPTION
Nothing more than what the title says, really.
