### PR TITLE
main/apache2: fix missing /run directory

### DIFF
--- a/main/apache2/APKBUILD
+++ b/main/apache2/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=apache2
 _pkgreal=httpd
 pkgver=2.4.23
-pkgrel=2
+pkgrel=3
 pkgdesc="A high performance Unix-based HTTP server"
 url="http://httpd.apache.org/"
 arch="all"

--- a/main/apache2/apache2.pre-install
+++ b/main/apache2/apache2.pre-install
@@ -4,5 +4,6 @@ addgroup -S -g 82 www-data 2>/dev/null
 addgroup -S apache 2>/dev/null
 adduser -S -D -H -h /var/www -s /sbin/nologin -G apache -g apache apache 2>/dev/null
 addgroup apache www-data 2>/dev/null
+mkdir -p /run/apache2
 
 exit 0


### PR DESCRIPTION
When setting up apache2 on a minimal environement (say, a docker image),
/run/apache2 doesn't exist and won't be created. So httpd will silently
fail. In such a case the error will only be visible in the logs (i.e.
nothing in stderr).