### PR TITLE
main/mariadb: move dialog.so and mysql_clear_password.so to -common

### DIFF
--- a/main/mariadb/APKBUILD
+++ b/main/mariadb/APKBUILD
@@ -125,11 +125,16 @@ _client_libs() {
 }
 
 common() {
-	pkgdesc="MariaDB common files for boh server and client"
+	pkgdesc="MariaDB common files for both server and client"
 	replaces="mysql-common"
 	depends=
-	mkdir -p "$subpkgdir"/usr/share/mysql "$subpkgdir"/etc
+	mkdir -p "$subpkgdir"/usr/share/mysql \
+		"$subpkgdir"/etc \
+		"$subpkgdir"/usr/lib/mysql/plugin
 	mv "$pkgdir"/etc/mysql "$subpkgdir"/etc/ || return 1
+	mv "$pkgdir"/usr/lib/mysql/plugin/dialog.so \
+		"$pkgdir"/usr/lib/mysql/plugin/mysql_clear_password.so \
+		"$subpkgdir"/usr/lib/mysql/plugin/ || return 1
 	local lang="charsets danish english french greek italian korean norwegian-ny
 		portuguese russian slovak swedish czech dutch estonian german
 		hungarian japanese norwegian polish romanian serbian spanish


### PR DESCRIPTION
This patch fixes a typo and makes the `mariadb-common` package more consistent with MariaDB packaging for CentOS. 

``` bash
$ rpm -qlp http://yum.mariadb.org/10.1/centos/7.1/x86_64/rpms/MariaDB-10.1.16-centos7-x86_64-common.rpm | grep plugin
/usr/lib64/mysql/plugin
/usr/lib64/mysql/plugin/dialog.so
/usr/lib64/mysql/plugin/mysql_clear_password.so
```

This is logical for the client use-case that wishes to use `dialog.so`, for connection to a PAM authenticating server, but not include `mariadb`.
