### PR TITLE
testing/llvm3.7: rewrite abuild and fix many issues to make it usable

### DIFF
--- a/testing/llvm3.7/APKBUILD
+++ b/testing/llvm3.7/APKBUILD
@@ -1,123 +1,135 @@
-# Contributor Travis Tilley <ttilley@gmail.com>
-# Contributor Mitch Tishmack <mitch.tishmack@gmail.com>
+# Contributor: Travis Tilley <ttilley@gmail.com>
+# Contributor: Mitch Tishmack <mitch.tishmack@gmail.com>
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Travis Tilley <ttilley@gmail.com>
 pkgname=llvm3.7
 _pkgname=llvm
-pkgver=3.7.1
-pkgrel=0
-pkgdesc="low level virtual machine compiler system"
+_majorver=3.7
+pkgver=$_majorver.1
+pkgrel=1
+pkgdesc="Low Level Virtual Machine compiler system (version $_majorver)"
 arch="all"
 url="http://llvm.org/"
 license="UOI-NCSA"
 depends=""
-makedepends="$depends_dev
+makedepends="
 	binutils-dev
 	bison
 	chrpath
 	cmake
+	file
 	flex
 	groff
 	isl-dev
 	libffi-dev
 	make
-	file
 	paxmark
 	py-sphinx
 	python
 	python-dev
 	zlib-dev
 	"
-install=
 subpackages="$pkgname-static $pkgname-libs $pkgname-dev"
-source="
+source="http://llvm.org/releases/$pkgver/llvm-$pkgver.src.tar.xz
 	llvm-0001-Add-Musl-MuslEABI-and-Musl-EABIHF-triples.patch
 	llvm-0002-Fix-build-with-musl-libc.patch
 	llvm-0003-Fix-DynamicLibrary-to-build-with-musl-libc.patch
 	llvm-nm-workaround.patch
-
-	http://llvm.org/releases/$pkgver/llvm-$pkgver.src.tar.xz
+	config.guess.patch
 	"
+builddir="$srcdir/$_pkgname-$pkgver.src"
 
-builddir="$srcdir"/"$_pkgname-$pkgver.src"
+# NOTE: It seems that there's no (sane) way how to change includedir, sharedir
+# etc. separately, just the CMAKE_INSTALL_PREFIX. Standard CMake variables and
+# even  LLVM-specific variables, that are related to these paths, actually
+# don't work (in llvm 3.7).
+#
+# When building a software that depends on LLVM, utility llvm-config should be
+# used to discover where is LLVM installed. It provides options to print
+# path of bindir, includedir, and libdir separately, but in its source, all
+# these paths are actually hard-coded against INSTALL_PREFIX. We can patch it
+# and move paths manually, but I'm really not sure what it may break...
+#
+# Also note that we should *not* add version suffix to files in llvm bindir!
+# It breaks build system of some software that depends on LLVM, because they
+# don't expect these files to have a sufix.
+#
+# So, we install all the LLVM files into /usr/lib/llvm-$_majorver.
+# BTW, Debian do the same thing.
+#
+_prefix="usr/lib/llvm-$_majorver"
+ldpath="/$_prefix/lib"
 
 prepare() {
 	cd "$builddir"
 	mkdir -p "$builddir"/build
 
 	update_config_sub || return 1
-	sed -i -e '/case "\${UNAME_MACHINE}:\${UNAME_SYSTEM}:\${UNAME_RELEASE}:\${UNAME_VERSION}" in/i \' \
-		-e 'if [ x != "x$CBUILD" ]; then echo "$CBUILD"; exit; fi' \
-		./autoconf/config.guess || return 1
 
-	local i
-	for i in $source; do
+	# Apply patches while ignoring whitespace changes.
+	local i; for i in $source; do
 		case $i in
-		llvm-*.patch)
+		*.patch)
 			msg "Applying $i..."
 			patch --ignore-whitespace -s -p1 -N -i "$srcdir"/$i || return 1
 			;;
 		esac
 	done
 
-	# remove some tests that fails
+	# Remove some tests that fails.
 	rm test/tools/llvm-objdump/macho-compact-unwind-x86_64.test \
 		test/tools/llvm-objdump/macho-compact-unwind-i386.test \
-		test/Transforms/GlobalOpt/alias-used.ll \
-		|| return 1
+		test/Transforms/GlobalOpt/alias-used.ll || return 1
 }
 
 build() {
 	cd "$builddir"/build
 
-	# auto-detect it by guessing either.
-	local _ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
+	# Auto-detect it by guessing either.
+	local ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
 
 	cmake -G "Unix Makefiles" -Wno-dev \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_PREFIX=/$_prefix \
 		-DCMAKE_VERBOSE_MAKEFILE=NO \
 		\
-		-DFFI_INCLUDE_DIR="$_ffi_include_dir" \
-		-DLLVM_BINUTILS_INCDIR=/usr/include/llvm-3.7 \
-		-DLLVM_BUILD_DOCS=YES \
-		-DLLVM_BUILD_EXAMPLES=NO \
+		-DFFI_INCLUDE_DIR="$ffi_include_dir" \
+		-DLLVM_BINUTILS_INCDIR=/usr/include \
+		-DLLVM_BUILD_DOCS=ON \
+		-DLLVM_BUILD_EXAMPLES=OFF \
 		-DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON \
 		-DLLVM_BUILD_LLVM_DYLIB=ON \
-		-DLLVM_BUILD_TESTS=YES \
-		-DLLVM_DEFAULT_TARGET_TRIPLE=$CBUILD \
+		-DLLVM_BUILD_TESTS=ON \
+		-DLLVM_DEFAULT_TARGET_TRIPLE="$CBUILD" \
 		-DLLVM_DYLIB_EXPORT_ALL=ON \
-		-DLLVM_ENABLE_ASSERTIONS=NO \
-		-DLLVM_ENABLE_CXX1Y=YES \
-		-DLLVM_ENABLE_FFI=YES \
-		-DLLVM_ENABLE_LIBCXX=NO \
-		-DLLVM_ENABLE_PIC=YES \
-		-DLLVM_ENABLE_RTTI=YES \
-		-DLLVM_ENABLE_SPHINX=NO \
-		-DLLVM_ENABLE_TERMINFO=YES \
-		-DLLVM_ENABLE_ZLIB=YES \
-		-DLLVM_HOST_TRIPLE=$CHOST \
-		-DLLVM_INCLUDE_EXAMPLES=NO \
-		-DLLVM_LINK_LLVM_DYLIB=ON \
+		-DLLVM_ENABLE_ASSERTIONS=OFF \
+		-DLLVM_ENABLE_CXX1Y=ON \
+		-DLLVM_ENABLE_FFI=ON \
+		-DLLVM_ENABLE_LIBCXX=OFF \
+		-DLLVM_ENABLE_PIC=ON \
+		-DLLVM_ENABLE_RTTI=ON \
+		-DLLVM_ENABLE_SPHINX=OFF \
+		-DLLVM_ENABLE_TERMINFO=ON \
+		-DLLVM_ENABLE_ZLIB=ON \
+		-DLLVM_HOST_TRIPLE="$CHOST" \
+		-DLLVM_INCLUDE_EXAMPLES=OFF \
 		-DLLVM_TARGETS_TO_BUILD=all \
 		\
-		-DSPHINX_WARNINGS_AS_ERRORS=NO \
-		"${builddir}" || return 1
+		"$builddir" || return 1
 
 	make llvm-tblgen || return 1
 	make || return 1
 
-	paxmark m bin/llvm-rtdyld || return 1
-	paxmark m bin/lli || return 1
-	paxmark m bin/lli-child-target || return 1
-
-	paxmark m unittests/ExecutionEngine/MCJIT/MCJITTests || return 1
-	paxmark m unittests/Support/SupportTests || return 1
-
+	paxmark m bin/llvm-rtdyld \
+		bin/lli \
+		bin/lli-child-target \
+		unittests/ExecutionEngine/MCJIT/MCJITTests \
+		unittests/Support/SupportTests || return 1
 
 	case "$CARCH" in
 	arm*)
 		# ARM has few failures in test suite
-		# that we don't care about currently
+		# that we don't care about currently.
 		;;
 	*)
 		make check-llvm || return 1
@@ -129,50 +141,57 @@ package() {
 	cd "$builddir"/build
 	make DESTDIR="$pkgdir" install || return 1
 
-	file "$pkgdir"/usr/lib/*.so |\
-		awk -F: '$2~/ELF/{print $1}'|\
-		xargs -r chrpath -d || return 1
+	cd "$pkgdir"/$_prefix
 
-	file "$pkgdir"/usr/bin/* |\
-		awk -F: '$2~/ELF/{print $1}' |\
-		xargs -r chrpath -d || return 1
+	# Remove RPATHs.
+	file lib/*.so bin/* \
+		| awk -F: '$2~/ELF/{print $1}' \
+		| xargs -r chrpath -d || return 1
 
-	for f in $(ls -d "$pkgdir"/usr/bin/*); do
-		mv ${f} ${f}-3.7 || return 1
+	# Symlink files in bindir to /usr/bin with version suffix.
+	mkdir -p "$pkgdir"/usr/bin
+	local path; for path in bin/*; do
+		ln -s ../lib/llvm-$_majorver/$path \
+			"$pkgdir"/usr/$path-$_majorver || return 1
 	done
-
-	mv "$pkgdir"/usr/lib/LLVMgold.so "$pkgdir"/usr/lib/LLVMgold.so.3.7 || return 1
-	mv "$pkgdir"/usr/lib/libLTO.so "$pkgdir"/usr/lib/libLTO.so.3.7 || return 1
-	mv "$pkgdir"/usr/lib/BugpointPasses.so \
-		"$pkgdir"/usr/lib/BugpointPasses.so.3.7 || return 1
-	rm -f "$pkgdir"/usr/lib/libLLVM.so
 }
 
 static() {
-	pkgdesc="LLVM 3.7 static libraries"
-	mkdir -p "$subpkgdir"/usr/lib
-	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib/
+	pkgdesc="LLVM $_majorver static libraries"
+
+	mkdir -p "$subpkgdir"/$_prefix/lib/
+	mv "$pkgdir"/$_prefix/lib/*.a "$subpkgdir"/$_prefix/lib/
 }
 
 libs() {
-	pkgdesc="LLVM 3.7 runtime libraries"
-	mkdir -p "$subpkgdir"/usr/lib
-	mv "$pkgdir"/usr/lib/libLLVM.so.[0-9]* "$subpkgdir"/usr/lib/
+	pkgdesc="LLVM $_majorver runtime libraries"
+
+	mkdir -p "$subpkgdir"/$_prefix/lib/
+	mv "$pkgdir"/$_prefix/lib/libLLVM.so.[0-9]* "$subpkgdir"/$_prefix/lib/
 }
 
+dev() {
+	default_dev || return 1
 
-md5sums="b370ea6589931c560a92699b890dd888  llvm-0001-Add-Musl-MuslEABI-and-Musl-EABIHF-triples.patch
+	mv "$pkgdir"/$_prefix/share "$pkgdir"/$_prefix/lib \
+		"$subpkgdir"/$_prefix/
+}
+
+md5sums="bf8b3a2c79e61212c5409041dfdbd319  llvm-3.7.1.src.tar.xz
+b370ea6589931c560a92699b890dd888  llvm-0001-Add-Musl-MuslEABI-and-Musl-EABIHF-triples.patch
 b0cd098117223159b76e96c3f884536b  llvm-0002-Fix-build-with-musl-libc.patch
 9cc5050619f764ca9dc842a5ab122290  llvm-0003-Fix-DynamicLibrary-to-build-with-musl-libc.patch
 785147afd8ab80fa95955a5637b6582f  llvm-nm-workaround.patch
-bf8b3a2c79e61212c5409041dfdbd319  llvm-3.7.1.src.tar.xz"
-sha256sums="6018671b549f3043ab4d7100956f0e05092d83de72b88edea199c91d5755d819  llvm-0001-Add-Musl-MuslEABI-and-Musl-EABIHF-triples.patch
+57d95aabd731eca1c1411ceb1894120c  config.guess.patch"
+sha256sums="be7794ed0cec42d6c682ca8e3517535b54555a3defabec83554dbc74db545ad5  llvm-3.7.1.src.tar.xz
+6018671b549f3043ab4d7100956f0e05092d83de72b88edea199c91d5755d819  llvm-0001-Add-Musl-MuslEABI-and-Musl-EABIHF-triples.patch
 e1b0fd5f6918d8c8404f3ec4b8d3ab8fbe8dadc2d6011792349b56e5e8ee51e2  llvm-0002-Fix-build-with-musl-libc.patch
 fc28356bf0d5fcfe9b99e28f4abbc2f49f50d263b44e428e30f33bf5472747b4  llvm-0003-Fix-DynamicLibrary-to-build-with-musl-libc.patch
 1870f910a6f5f2ba6144bd079ec55ed879fe8fd8b1b1b384935f36da43e5f114  llvm-nm-workaround.patch
-be7794ed0cec42d6c682ca8e3517535b54555a3defabec83554dbc74db545ad5  llvm-3.7.1.src.tar.xz"
-sha512sums="64388ca3100fd36dfcfa7ba8ec8eb8dd40a7388d4363952ec9b4012e5b82494bd445a1b46506b479283121ec2f74fe3dc07b154f5c76db27b6f5b1af50c265aa  llvm-0001-Add-Musl-MuslEABI-and-Musl-EABIHF-triples.patch
+10a719450c48433756c9f7a51593f415758ac587911349b22f7d440415a0c6d5  config.guess.patch"
+sha512sums="ac521debc02f6deba96ef975d6a546b0c5c77299c1dbf5e1b87a7974ff5e7fd715bd7e384b92d9adf572ce47130bdbf6d3c648eb0d7f72f16f976292e4909e90  llvm-3.7.1.src.tar.xz
+64388ca3100fd36dfcfa7ba8ec8eb8dd40a7388d4363952ec9b4012e5b82494bd445a1b46506b479283121ec2f74fe3dc07b154f5c76db27b6f5b1af50c265aa  llvm-0001-Add-Musl-MuslEABI-and-Musl-EABIHF-triples.patch
 4cb3fabbb627b596ce398ed717c66ad20bbea7092ba30751520cc5a63d38e1ac53d23e98a6ad82121ddcf2434383ba5cadbc2990f99a4528e99c6e2160c2f725  llvm-0002-Fix-build-with-musl-libc.patch
 19bfb9282455d39d07dbb2b1293b03a45c57d522fbb9c5e58dac034200669628b97e7a90cd4ff5d52d9bb79acfccbef653d8a1140a7f0589ecd6f9b7c4ba0eb6  llvm-0003-Fix-DynamicLibrary-to-build-with-musl-libc.patch
 11db6f3c5d697bc536c7d053530f7a5572756185e16399c32c31306861b58046ca9bc14b8d8097758c00a8c1a7026cbfb75636c0e697e59c53dda5848f93b006  llvm-nm-workaround.patch
-ac521debc02f6deba96ef975d6a546b0c5c77299c1dbf5e1b87a7974ff5e7fd715bd7e384b92d9adf572ce47130bdbf6d3c648eb0d7f72f16f976292e4909e90  llvm-3.7.1.src.tar.xz"
+caf1c9466e8163f8844bd40095d1c3ce26c9e96dcb639f64833baca65a81708d39496e8c8ea65c7f11476d752265080998f1873b79cbc92b23349258e4dfa3ab  config.guess.patch"

--- a/testing/llvm3.7/config.guess.patch
+++ b/testing/llvm3.7/config.guess.patch
@@ -1,0 +1,13 @@
+--- a/autoconf/config.guess	2016-08-04 01:13:53.941899947 +0200
++++ b/autoconf/config.guess	2016-08-04 01:16:30.084553757 +0200
+@@ -142,6 +142,10 @@
+ 
+ # Note: order is significant - the case branches are not exclusive.
+ 
++if [ -n "$CBUILD" ]; then
++	echo "$CBUILD"; exit
++fi
++
+ case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}" in
+     *:NetBSD:*:*)
+ 	# NetBSD (nbsd) targets should (where applicable) match one or


### PR DESCRIPTION
The previous version was not actually usable as a dependency for other software (see comments in the abuild). It also generated invalid symlinks, conflicting files, broken configuration etc.