### PR TITLE
main/libunwind: upgrade to 1.2_rc1

### DIFF
--- a/main/libunwind/10-disable-tests.patch
+++ b/main/libunwind/10-disable-tests.patch
@@ -1,11 +1,14 @@
+These tests are known to fail, so disable them. It's not problem just on
+Alpine, Julia also disabled libunwind tests in their Makefile.
+
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -313,7 +313,7 @@
- 	$(am__append_7) $(am__append_8) $(am__append_9) \
- 	$(am__append_10)
- nodist_include_HEADERS = include/libunwind-common.h
--SUBDIRS = src tests doc
-+SUBDIRS = src doc
- noinst_HEADERS = include/dwarf.h include/dwarf_i.h include/dwarf-eh.h	\
- 	include/compiler.h include/libunwind_i.h include/mempool.h	\
- 	include/remote.h						\
+@@ -218,7 +218,7 @@
+ ETAGS = etags
+ CTAGS = ctags
+ CSCOPE = cscope
+-DIST_SUBDIRS = src tests doc
++DIST_SUBDIRS = src doc
+ DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
+ distdir = $(PACKAGE)-$(VERSION)
+ top_distdir = $(distdir)

--- a/main/libunwind/APKBUILD
+++ b/main/libunwind/APKBUILD
@@ -1,22 +1,21 @@
 # Contributor: Ben Pye <ben@curlybracket.co.uk>
 # Maintainer: Ben Pye <ben@curlybracket.co.uk>
-
 pkgname=libunwind
-pkgver=1.1
-pkgrel=3
+pkgver=1.2_rc1
+_pkgver=${pkgver/_/-}
+pkgrel=0
 pkgdesc="Portable and efficient C programming interface (API) to determine the call-chain of a program"
 url="http://www.nongnu.org/libunwind/"
 arch="x86_64 armhf"
 license="MIT"
 depends=""
-depends_dev=""
-makedepends="$depends_dev linux-headers"
-install=""
+depends_dev="libexecinfo-dev"
+makedepends="$depends_dev autoconf automake libtool linux-headers"
 subpackages="$pkgname-dev $pkgname-doc"
-source="http://download.savannah.gnu.org/releases/libunwind/libunwind-$pkgver.tar.gz
-        10-disable-tests.patch"
-
-builddir="$srcdir/$pkgname-$pkgver"
+source="http://download.savannah.gnu.org/releases/libunwind/libunwind-$_pkgver.tar.gz
+	10-disable-tests.patch
+	force-enable-man.patch"
+builddir="$srcdir/$pkgname-$_pkgver"
 
 prepare() {
 	cd "$builddir"
@@ -26,7 +25,9 @@ prepare() {
 
 build() {
 	cd "$builddir"
-	./configure \
+
+	./autogen.sh || return 1
+	LDFLAGS="-lexecinfo" ./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
@@ -34,7 +35,7 @@ build() {
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
 		|| return 1
-		make || return 1
+	make || return 1
 }
 
 package() {
@@ -42,9 +43,12 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-md5sums="fb4ea2f6fbbe45bf032cd36e586883ce  libunwind-1.1.tar.gz
-1f6a9820ff7839cc44b285d2239fa69b  10-disable-tests.patch"
-sha256sums="9dfe0fcae2a866de9d3942c66995e4b460230446887dbdab302d41a8aee8d09a  libunwind-1.1.tar.gz
-920e037b775a05e762cc47b0bc361e403337db986e3d471b95933375738ee31f  10-disable-tests.patch"
-sha512sums="bfe04f2bfac9f9e47c37f0b23ed2f264d8d3d3d6f1392fe9d794ee13cad216b3740979e922e4276fb65c1ccdc836fce48812cb5459ecdd2a89a621036a35d7c1  libunwind-1.1.tar.gz
-6302a9ef7c785c459f2966af5a0367bf752e4c7ea6e4f6136f51d674a66b253aecb81072ffb65c3df1c2dd4f949413abbf13a6d5c425394e23aa6a09102bc187  10-disable-tests.patch"
+md5sums="9ae4db46a273444b046ca3bd52dbdf1f  libunwind-1.2-rc1.tar.gz
+1d0372df3e69f0356235097137576e46  10-disable-tests.patch
+59d14a816557c7abb3386696e07ba4c5  force-enable-man.patch"
+sha256sums="d222f186b6bc60f49dac5030516ec35a7ed0ccca675551d6cf81008112116abc  libunwind-1.2-rc1.tar.gz
+03f76f7ee23b7b97e33b8d19a0f7b3cb397ab83623c9d495ee8e038907081db6  10-disable-tests.patch
+ae56606aafa1b8954f8a205dc10d5e4c41f0976f0fe70209cf56582283fddd6e  force-enable-man.patch"
+sha512sums="810cdcf9e1e9a33eb286a6527c2d4bfc507313c596df9cdeb46b1c7b7343ac784fec3ed7c6aa135fc25dbf3e2cd8c99d1fa51e265b63614b51fd37bd84000b08  libunwind-1.2-rc1.tar.gz
+b217dff3ccc3d4b6665ee5d888872ac57a8f15499f9532b1c78f9faca725fae8da975dcf9597964637ebbc270d901232b76c78c556d7ebd62cce6b32211d1401  10-disable-tests.patch
+7c2b9f48b74464c8c27367bfb0ede317bfbc5fc392c0d1371a9a82ae518d3799c019f6e258ec2262c4117c6fb936c40b7cb9f2bfebddb3ea4efbbcbcc4268822  force-enable-man.patch"

--- a/main/libunwind/force-enable-man.patch
+++ b/main/libunwind/force-enable-man.patch
@@ -1,0 +1,16 @@
+Man pages are already built in the release tarball, so we don't need latex2man.
+--- a/configure.ac
++++ b/configure.ac
+@@ -385,12 +385,6 @@
+ AC_SUBST(enable_debug_frame)
+ AC_SUBST(DLLIB)
+ 
+-AC_PATH_PROG([LATEX2MAN],[latex2man])
+-if test "x$LATEX2MAN" = "x"; then
+-  AC_MSG_WARN([latex2man not found. Install latex2man. Disabling docs.])
+-  enable_documentation="no";
+-fi
+-
+ AM_CONDITIONAL([CONFIG_DOCS], [test x$enable_documentation = xyes])
+ if test "x$enable_documentation" = "xyes"; then
+   AC_CONFIG_FILES(doc/Makefile doc/common.tex)

--- a/testing/julia/APKBUILD
+++ b/testing/julia/APKBUILD
@@ -6,7 +6,7 @@ pkgver=0.4.6
 _libuv_ver=efb40768b7c7bd9f173a7868f74b92b1c5a61a0e
 # Keep in sync with deps/Versions.make.
 _rmathjulia_ver=0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level, high-performance dynamic language for technical computing"
 url="http://julialang.org"
 # x86: libunwind package is currently not built for x86

--- a/testing/weston/APKBUILD
+++ b/testing/weston/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 pkgname=weston
 pkgver=1.11.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Reference implementation of a Wayland compositor"
 url="http://wayland.freedesktop.org"
 arch="x86_64 armhf"


### PR DESCRIPTION
This is just a release candidate, but the latest stable release (1.1) is already 4 years old and very outdated. For example Julia, that uses libunwind, strongly recommends to use latest version, not 1.1.