### PR TITLE
testing/php7: Change php7-module.conf to use SetHandler

### DIFF
--- a/testing/php7/php7-module.conf
+++ b/testing/php7/php7-module.conf
@@ -1,5 +1,28 @@
 LoadModule php7_module modules/mod_php7.so
 
 DirectoryIndex index.php index.html
-AddHandler application/x-httpd-php .php
-AddHandler application/x-httpd-php-source .phps
+
+<FilesMatch ".+\.ph(p[3457]?|t|tml)$">
+    SetHandler application/x-httpd-php
+</FilesMatch>
+
+# Deny access to raw php sources by default
+<FilesMatch ".+\.phps$">
+    # SetHandler application/x-httpd-php-source
+    Require all denied
+</FilesMatch>
+
+# Deny access to files without filename (e.g. '.php3')
+<FilesMatch "^\.ph(p[3457]?|t|tml|ps)$">
+    Require all denied
+</FilesMatch>
+
+# Disable running PHP scripts in user directories
+# To re-enable PHP in user directories comment the following lines
+# (from <IfModule ...> to </IfModule>.) Do NOT set it to On as it
+# prevents .htaccess files from disabling it.
+<IfModule mod_userdir.c>
+    <Directory /home/*/public_html>
+        php_admin_flag engine Off
+    </Directory>
+</IfModule>


### PR DESCRIPTION
Avoids serving non php files by php handler.
Deny access to *.phps files.
Deny access to files without filename e.g. .php3
Disable running PHP scripts in user directories by default.
