### PR TITLE
main/clang: add missing libclang.a

### DIFF
--- a/main/clang/APKBUILD
+++ b/main/clang/APKBUILD
@@ -67,6 +67,7 @@ build() {
 		-DCLANG_INCLUDE_DOCS:BOOL=ON \
 		-DCLANG_INCLUDE_TESTS:BOOL=ON \
 		-DCLANG_BUILD_EXAMPLES:BOOL=OFF \
+		-DLIBCLANG_BUILD_STATIC:BOOL=ON \
 		"${_srcdir}" || return 1
 #		-DLLVM_LINK_LLVM_DYLIB:BOOL=ON \
 
@@ -87,7 +88,8 @@ build() {
 
 package() {
 	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || reeturn 1
+	make DESTDIR="$pkgdir" install || return 1
+	cp lib/libclang.a $pkgdir/usr/lib || return 1
 }
 
 static() {


### PR DESCRIPTION
The clang-dev package is missing libclang.a, which is quite important for applications which want to link against libclang statically. This change adds libclang.a to the package. A manual copy is needed because of an upstream bug where libclang-static is missing a CMake install target.