### PR TITLE
testing/php5-xdebug: moved to community

### DIFF
--- a/community/php5-xdebug/APKBUILD
+++ b/community/php5-xdebug/APKBUILD
@@ -1,4 +1,5 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
+# Contributor: Andy Postnikov <apostnikov@gmail.com>
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=php5-xdebug
 _pkgreal=xdebug


### PR DESCRIPTION
We using this package at least half of year and it very useful for development
Suppose better to keep testing clean as @clandmeter said in mailing list