### PR TITLE
testing/blender: new aport

### DIFF
--- a/testing/blender/APKBUILD
+++ b/testing/blender/APKBUILD
@@ -1,0 +1,122 @@
+# Contributor: Mark Riedesel <mark@klowner.com>
+# Maintainer: Mark Riedesel <mark@klowner.com>
+pkgname=blender
+pkgver=2.77a
+pkgrel=0
+pkgdesc="3D Creation/Animation/Publishing System"
+url="http://www.blender.org/"
+arch="all"
+license="GPL2"
+depends="blender-shared=$pkgver-r$pkgrel"
+makedepends="cmake libx11-dev jpeg-dev zlib-dev libpng-dev freetype-dev python3-dev
+	openimageio-dev opencolorio-dev glew-dev openal-soft-dev ffmpeg2.8-dev
+	fftw-dev tiff-dev mesa-dev libxi-dev libsndfile-dev libxmu-dev boost-dev
+	openexr-dev py-numpy-dev opensubdiv-dev"
+install=""
+subpackages="$pkgname-doc $pkgname-shared $pkgname-headless $pkgname-player py3-$pkgname:python"
+source="http://download.blender.org/source/${pkgname}-${pkgver}.tar.gz
+	blender-2.77a-musl.patch"
+
+builddir="$srcdir"/$pkgname-$pkgver
+
+build() {
+	# Headless
+	cd "$builddir"
+	mkdir "$builddir"/build-headless
+	cd "$builddir"/build-headless
+	_build -C../build_files/cmake/config/blender_headless.cmake
+
+	# Full
+	cd "$builddir"
+	mkdir "$builddir"/build-full
+	cd "$builddir"/build-full
+	_build -C../build_files/cmake/config/blender_full.cmake
+
+	# Python module
+	cd "$builddir"
+	mkdir "$builddir"/build-py
+	cd "$builddir"/build-py
+	_build -C../build_files/cmake/config/bpy_module.cmake
+
+}
+
+_build() {
+	local PY_VERSION=$(python3 -c 'import sys; print("%i.%i" % (sys.version_info.major, sys.version_info.minor))')
+
+	cmake .. $@ \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DWITH_PYTHON_INSTALL:BOOL=OFF \
+		-DWITH_INSTALL_PORTABLE:BOOL=OFF \
+		-DWITH_OPENCOLORIO:BOOL=ON \
+		-DPYTHON_VERSION=$PY_VERSION \
+		-DPYTHON_LIBPATH=/usr/lib \
+		-DPYTHON_LIBRARY=python${PY_VERSION}m \
+		-DPYTHON_INCLUDE_DIRS=/usr/include/python${PY_VERSION}m \
+		-DNO_EXECINFO:BOOL=ON \
+		|| return 1
+	make || return 1
+}
+
+
+package() {
+	local PY_VERSION=$(python3 -c 'import sys; print("%i.%i" % (sys.version_info.major, sys.version_info.minor))')
+	local VERSION=$(echo $pkgver | grep -o '[0-9]+\.[0-9]+')
+
+	# Install headless files
+	cd "$builddir"/build-headless
+	make DESTDIR="$pkgdir"/headless install || return 1
+
+	# Rename the headless blender to blender-headless
+	mkdir -p "$pkgdir"/usr/bin
+	mv "$pkgdir"/headless/usr/bin/blender "$pkgdir"/usr/bin/blender-headless || return 1
+	rm -rf "$pkgdir"/headless
+
+	# Install python module
+	cd "$builddir"/build-py
+	make DESTDIR="$pkgdir" install || return 1
+
+	# Install the full package
+	cd "$builddir"/build-full
+	make DESTDIR="$pkgdir" install || return 1
+}
+
+shared() {
+	pkgdesc="Blender shared runtime data and add-on scripts"
+	arch="noarch"
+	mkdir -p "$subpkgdir"/usr/share/
+	mv "$pkgdir"/usr/share/blender "$subpkgdir"/usr/share/
+}
+
+headless() {
+	pkgdesc="$pkgdesc (headless build)"
+	depends="blender-shared=$pkgver-r$pkgrel"
+	mkdir -p "$subpkgdir"/usr/bin
+	mv "$pkgdir"/usr/bin/blender-headless "$subpkgdir"/usr/bin/
+}
+
+player() {
+	pkgdesc="Blender player runtime"
+	mkdir -p "$subpkgdir"/usr/bin
+	mv "$pkgdir"/usr/bin/blenderplayer "$subpkgdir"/usr/bin/
+}
+
+python() {
+	local PY_VERSION=$(python3 -c 'import sys; print("%i.%i" % (sys.version_info.major, sys.version_info.minor))')
+	local VERSION=$(echo $pkgver | grep -o '[0-9]*\.[0-9]*')
+
+	pkgdesc="Blender modules for Python 3"
+	mkdir -p "$subpkgdir"/usr/lib/python${PY_VERSION}/site-packages
+	mv "$pkgdir"/usr/lib/python${PY_VERSION}/site-packages/bpy.so "$subpkgdir"/usr/lib/python${PY_VERSION}/site-packages/
+	rm -rf "$pkgdir"/usr/lib
+
+	# Symlink to the blender-shared files
+	ln -s /usr/share/blender/${VERSION} "$subpkgdir"/usr/lib/python${PY_VERSION}/site-packages/${VERSION}
+}
+
+md5sums="bb192274fe5957ce62bce9f0557ea4b4  blender-2.77a.tar.gz
+93bda85f6a3c0c587ee7790b7d35e4cc  blender-2.77a-musl.patch"
+sha256sums="3770fa00f50a6654eb8b5fe625ca8942ab5672ac4685b7af24597251ace85c67  blender-2.77a.tar.gz
+f536a69354bd1a4b482a6150542d528a92a0107ff639832500f7dc28c64360ec  blender-2.77a-musl.patch"
+sha512sums="4f8223a3786b80fa613ace27bea9349309b5857bcc1fafdb7d769f6192d5cb455ce4faf60920d7a1c2cb82ef8c40a10b25a760748b305c16c550657cf1e4df93  blender-2.77a.tar.gz
+6ecf4a6a9b56f045c9d14093ae13c6cb714ce8dff2212a08830edcf540ec47f143c2670e197a97ca42f380a60825abab4e7b3d7dbc88c44265fae7f83f2cd602  blender-2.77a-musl.patch"

--- a/testing/blender/blender-2.77a-musl.patch
+++ b/testing/blender/blender-2.77a-musl.patch
@@ -1,0 +1,72 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1efaa14..20a75a1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1220,6 +1220,19 @@ if(UNIX AND NOT APPLE)
+ 		set(PLATFORM_LINKFLAGS "${PLATFORM_LINKFLAGS} -static-intel")
+ 	endif()
+ 
++	# musl-libc related checks (missing execinfo.h, and feenableexcept())
++	include(CheckIncludeFiles)
++	check_include_files(execinfo.h HAVE_EXECINFO_H)
++	if (HAVE_EXECINFO_H)
++		add_definitions(-DHAVE_EXECINFO_H)
++	endif()
++
++	include(CheckLibraryExists)
++	check_library_exists(m feenableexcept "fenv.h" HAVE_FEENABLEEXCEPT)
++	if (HAVE_FEENABLEEXCEPT)
++		add_definitions(-DHAVE_FEENABLEEXCEPT)
++	endif()
++
+ elseif(WIN32)
+ 
+ 	add_definitions(-DWIN32)
+diff --git a/intern/guardedalloc/intern/mallocn_intern.h b/intern/guardedalloc/intern/mallocn_intern.h
+index 3f7e462..4fb49f3 100644
+--- a/intern/guardedalloc/intern/mallocn_intern.h
++++ b/intern/guardedalloc/intern/mallocn_intern.h
+@@ -52,7 +52,7 @@
+ #undef HAVE_MALLOC_STATS
+ #define USE_MALLOC_USABLE_SIZE  /* internal, when we have malloc_usable_size() */
+ 
+-#if defined(__linux__) || (defined(__FreeBSD_kernel__) && !defined(__FreeBSD__)) || defined(__GLIBC__)
++#if (defined(__linux__) && defined(HAVE_EXECINFO_H)) || (defined(__FreeBSD_kernel__) && !defined(__FreeBSD__)) || defined(__GLIBC__)
+ #  include <malloc.h>
+ #  define HAVE_MALLOC_STATS
+ #elif defined(__FreeBSD__)
+diff --git a/source/blender/blenlib/intern/system.c b/source/blender/blenlib/intern/system.c
+index 5d1bdd6..b1c004f 100644
+--- a/source/blender/blenlib/intern/system.c
++++ b/source/blender/blenlib/intern/system.c
+@@ -30,7 +30,7 @@
+ #include "MEM_guardedalloc.h"
+ 
+ /* for backtrace */
+-#if defined(__linux__) || defined(__APPLE__)
++#if (defined(__linux__) && defined(HAVE_EXECINFO_H)) || defined(__APPLE__)
+ #  include <execinfo.h>
+ #elif defined(WIN32)
+ #  include <windows.h>
+@@ -76,7 +76,7 @@ void BLI_system_backtrace(FILE *fp)
+ {
+ 	/* ------------- */
+ 	/* Linux / Apple */
+-#if defined(__linux__) || defined(__APPLE__)
++#if (defined(__linux__) && defined(HAVE_EXECINFO_H)) || defined(__APPLE__)
+ 
+ #define SIZE 100
+ 	void *buffer[SIZE];
+diff --git a/source/creator/creator.c b/source/creator/creator.c
+index bf8347d..1dabe60 100644
+--- a/source/creator/creator.c
++++ b/source/creator/creator.c
+@@ -618,7 +618,7 @@ static int set_fpe(int UNUSED(argc), const char **UNUSED(argv), void *UNUSED(dat
+ 	 * set breakpoints on fpe_handler */
+ 	signal(SIGFPE, fpe_handler);
+ 
+-# if defined(__linux__) && defined(__GNUC__)
++# if defined(__linux__) && defined(__GNUC__) && defined(HAVE_FEENABLEEXCEPT)
+ 	feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW);
+ # endif /* defined(__linux__) && defined(__GNUC__) */
+ # if defined(OSX_SSE_FPE)

--- a/testing/opensubdiv/APKBUILD
+++ b/testing/opensubdiv/APKBUILD
@@ -1,0 +1,51 @@
+# Contributor: Mark Riedesel <mark@klowner.com>
+# Maintainer: Mark Riedesel <mark@klowner.com>
+pkgname=opensubdiv
+pkgver=3.0.5
+pkgrel=0
+pkgdesc="An Open-Source subdivision surface library"
+url="http://graphics.pixar.com/opensubdiv"
+arch="all"
+license="apache"
+makedepends="cmake glew-dev glfw-dev doxygen py-docutils libxcursor-dev"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-tutorials $pkgname-tools"
+source="$pkgname-$pkgver.tar.gz::https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v${pkgver//./_}.tar.gz"
+builddir="$srcdir/"OpenSubdiv-${pkgver//./_}
+
+build() {
+	cd "$builddir"
+	mkdir -p build
+	cd build
+	cmake .. \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DNO_TBB=TRUE \
+		-DNO_PTEX=TRUE \
+		-DNO_MAYA=TRUE \
+		-DNO_CUDA=TRUE \
+		-DNO_OPENCL=TRUE \
+		|| return 1
+	make || return 1
+}
+
+package() {
+	cd "$builddir"/build
+	make DESTDIR="$pkgdir" install
+}
+
+tutorials() {
+	mkdir -p "$subpkgdir"/usr/bin/
+	for tut in "$pkgdir"/usr/bin/tutorials/*; do
+		mv $tut "$subpkgdir"/usr/bin/opensubdiv_${tut##*/}
+	done
+	rmdir "$pkgdir"/usr/bin/tutorials
+}
+
+tools() {
+	mkdir -p "$subpkgdir"/usr
+	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
+}
+
+md5sums="f16fa309b3fa3d400e6dcbf59d316dfe  opensubdiv-3.0.5.tar.gz"
+sha256sums="60bb7d709adfd949ff865864b68ff3b7e97a682a1841ccc70cd60a6c5a28ff30  opensubdiv-3.0.5.tar.gz"
+sha512sums="cee4c13fd0ef0a8dac6f880bdda8b6eed1ac3c17f7eadbd5f00bb8fe0140ca12a244b7e51edc98186af0551a26ac88e402651837f3f49195d3a9697437b86bf8  opensubdiv-3.0.5.tar.gz"


### PR DESCRIPTION
Lots of subpackages in this one. I'm not sure what the preferred way for handling alternate binaries is; for the headless build I renamed the binary to `blender-headless`, although I'm not sure why someone would want headless and regular builds installed at the same time. Is this maybe a use-case for `provides`?

Thanks!

(depends on openimageio)
