### PR TITLE
Updates py-lxml to 3.6.3, adds py3-lxml

### DIFF
--- a/main/py-lxml/APKBUILD
+++ b/main/py-lxml/APKBUILD
@@ -1,29 +1,53 @@
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=py-lxml
-_pkgname=lxml
-pkgver=3.6.0
+_pkgname="${pkgname#py-}"
+pkgver=3.6.3
 pkgrel=0
 pkgdesc="Python LXML Library"
+_pkgdesc=$pksdesc
 url="http://lxml.de/"
-arch="all"
+arch="noarch"
 license="BSD"
 depends=""
-makedepends="python-dev libxml2-dev libxslt-dev py-setuptools"
-install=""
-source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+makedepends="python-dev python3-dev libxml2-dev libxslt-dev py-setuptools"
+subpackages="py2-$_pkgname:_py2 py3-$_pkgname:_py3"
+source="${url}files/$_pkgname-$pkgver.tgz"
 
-_builddir="$srcdir"/$_pkgname-$pkgver
+_builddir="$srcdir/$_pkgname-$pkgver"
 build() {
 	cd "$_builddir"
 	python setup.py build || return 1
+	python3 setup.py build || return 1
 }
 
 package() {
-	cd "$_builddir"
-	python setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	mkdir -p "$pkgdir"
 }
 
-md5sums="5957cc384bd6e83934be35c057ec03b6  lxml-3.6.0.tar.gz"
-sha256sums="9c74ca28a7f0c30dca8872281b3c47705e21217c8bc63912d95c9e2a7cac6bdf  lxml-3.6.0.tar.gz"
-sha512sums="2dd25a4f51e3e71b78e82e32f3838137d8b21936c23c16f901f4180277c4d4b7f14e1f47d306022cc1d13dc2e0b7f405319632e554aa989f551f424cc423d60d  lxml-3.6.0.tar.gz"
+_py2() {
+	replaces="$pkgname"
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+
+	depends="$python"
+	py_ver="${python#python}"
+	pkgdesc=$(echo $_pkgdesc | sed -n "s/Python /Python $py_ver/p")
+	pkgdesc="${_pkgdesc/Python /Python $py_ver }"
+	arch="all"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$_builddir"
+	$python setup.py install --prefix=/usr --root="$pkgdir" || return 1
+}
+
+md5sums="87826f860fad672eb48c47fbccfe7152  lxml-3.6.3.tgz"
+sha256sums="e2cace41b3a96c5de769a5970753baf8ef3cf3a4d65b021b08ea3562f3cfb5c6  lxml-3.6.3.tgz"
+sha512sums="addb04df1e312d5c66d64c1e5f33d50ed921434ef9eec82572a7ba96484eaf32811f7d2a332ce31ad832c5c55916e3070dd0065993e015dc32a77b623137e6d9  lxml-3.6.3.tgz"


### PR DESCRIPTION
- adds missing python dependency
- more explicit `pkgdesc`
- changes to a simpler source location
- checksums are generated from a gpg-verified download