### PR TITLE
community/openjdk7: fix build with GCC 6

### DIFF
--- a/community/openjdk7/APKBUILD
+++ b/community/openjdk7/APKBUILD
@@ -6,7 +6,7 @@ _icedteaver=2.6.3
 # pkgver is <JDK version>.<JDK update>
 # check icedtea JDK when updating
 pkgver=7.91.$_icedteaver
-pkgrel=2
+pkgrel=3
 pkgdesc="Sun OpenJDK 7 via IcedTea"
 url="http://icedtea.classpath.org/"
 arch="all"
@@ -123,6 +123,14 @@ build() {
 	export JAVA_HOME=$BOOTSTRAP_JAVA_HOME
 	export PATH=$JAVA_HOME/bin:$srcdir/apache-ant-$ANT_VER/bin:$PATH
 	export DISTRIBUTION_PATCHES=""
+
+	# Explicitly set the C++ standard as the default has changed on GCC 6+
+	# and disable optimizations that lead to a broken JVM. These options
+	# has been adopted from the Fedora package.
+	export EXTRA_CPP_FLAGS="$CFLAGS -std=gnu++98 -fno-delete-null-pointer-checks -fno-lifetime-dse"
+	# CXXFLAGS doesn't make it to all calls, so we set the C++ standard
+	# version for C too.
+	export EXTRA_CFLAGS="$CXXFLAGS -std=gnu++98 -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse"
 
 	local patch
 	for patch in $source; do


### PR DESCRIPTION
Travis: The log length has exceeded the limit of 4 MB (this usually means that the test suite is raising the same exception over and over). The job has been terminated