### PR TITLE
main/lua-cqueues: upgrade to 20160808

### DIFF
--- a/main/lua-cqueues/APKBUILD
+++ b/main/lua-cqueues/APKBUILD
@@ -1,73 +1,51 @@
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 _luaversions="5.1 5.2 5.3"
 pkgname=lua-cqueues
-pkgver=20150811
-_commitid=e3af1f6334c3efe4b432f4aa38e29e4c1270bc8b
+_pkgname=cqueues
+pkgver=20160808
 pkgrel=0
 pkgdesc="Lua event loop using coroutines"
 url="http://25thandclement.com/~william/projects/cqueues.html"
-arch="all"
+arch="noarch"
 license="MIT"
 depends=""
-depends_dev=""
+makedepends="openssl-dev m4 bsd-compat-headers"
 subpackages=""
-makedepends="$depends_dev openssl-dev m4 bsd-compat-headers"
-install=""
-source="cqueues-$pkgver.tar.gz::https://github.com/wahern/cqueues/archive/$_commitid.tar.gz
-	"
-
 for _i in $_luaversions; do
 	makedepends="$makedepends lua${_i}-dev"
-	subpackages="$subpackages lua${_i}-cqueues:_split_${_i/./}"
+	subpackages="$subpackages lua${_i}-$_pkgname:_package"
 done
-
-_builddir="$srcdir"/cqueues-$_commitid
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+source="cqueues-$pkgver.tar.gz::https://github.com/wahern/cqueues/archive/rel-$pkgver.tar.gz"
+builddir="$srcdir/cqueues-rel-$pkgver"
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
+
 	# Override the HAVE_* tests that depend on GLIBC. grep for "#define HAVE_" on new releases.
 	export CFLAGS="$CFLAGS -DHAVE_EVENTFD=1 -DHAVE_EPOLL_CREATE1=1 -DHAVE_PIPE2=1"
-	for _i in $_luaversions; do
-		msg "Build for Lua $_i"
-		make all${_i} || return 1
+
+	local lver; for lver in $_luaversions; do
+		msg "Building for Lua $lver"
+		make all$lver || return 1
 	done
 }
 
 package() {
-	cd "$_builddir"
-	for _i in $_luaversions; do
-		msg "Install for Lua $_i"
-		make DESTDIR="$pkgdir" prefix=/usr install${_i} || return 1
-	done
+	mkdir -p "$pkgdir"
 }
 
-_split() {
-	local d= _ver=$1
-	pkgdesc="$pkgdesc - for Lua $_ver"
-	depends=
-	install_if="lua$_ver $pkgname=$pkgver-r$pkgrel"
-	for d in usr/lib/lua usr/share/lua; do
-		if [ -d "$pkgdir"/$d/$_ver ]; then
-			mkdir -p "$subpkgdir"/$d
-			mv "$pkgdir"/$d/$_ver "$subpkgdir"/$d/ || return 1
-		fi
-	done
+_package() {
+	local lver=${subpkgname:3:3}
+	pkgdesc="$pkgdesc - for Lua $lver"
+	arch="all"
+	depends="lua$lver"
+	install_if="lua$lver $pkgname=$pkgver-r$pkgrel"
+
+	cd "$builddir"
+	make DESTDIR="$subpkgdir" prefix=/usr install$lver
 }
 
-for _i in $_luaversions; do
-	eval "_split_${_i/./}() { _split $_i; }"
-done
-
-
-md5sums="532236da61e203fbeafd61e6ba023d2c  cqueues-20150811.tar.gz"
-sha256sums="971760a4ea4795286730a51e614536429cd7992aec155c99b41a4082298d0cb1  cqueues-20150811.tar.gz"
-sha512sums="6655f98a32b6d0ef6c06db9b2f6d2748208d3d0d7f948561f606782acf10c29351639969e6462e5a8fc25b18a015ebeaffadd448a1466067f2110de00a9a1339  cqueues-20150811.tar.gz"
+md5sums="f9b472cb2d534f63a1921dca3f7f889c  cqueues-20160808.tar.gz"
+sha256sums="f4be75b7d07881a5f8e0fb0304bde1af82b36a3913c85fc016cf349d9f28cd26  cqueues-20160808.tar.gz"
+sha512sums="c9b0760a618139e54b49ba3cea9ea575549a650a206d32b5e43ed89e2cae6dd5dffec697a64f8ab79e03095352df107faba484c6057170946c6d696152d2ca0a  cqueues-20160808.tar.gz"


### PR DESCRIPTION
> ```
> # Override the HAVE_* tests that depend on GLIBC. grep for "#define HAVE_" on new releases.
> export CFLAGS="$CFLAGS -DHAVE_EVENTFD=1 -DHAVE_EPOLL_CREATE1=1 -DHAVE_PIPE2=1"
> ```

@ncopa  What exactly should I look for?