### PR TITLE
Update community/R

### DIFF
--- a/community/R/APKBUILD
+++ b/community/R/APKBUILD
@@ -1,9 +1,10 @@
+# Contributor: Artem Klevtsov <a.a.klevtsov@gmail.com>
 # Contributor: Nirosan <pnirosan@gmail.com>
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=R
 pkgver=3.3.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Language and environment for statistical computing"
 url="https://www.r-project.org"
 # openjdk8-jre-base is currently built only for x86*
@@ -11,18 +12,15 @@ arch="x86_64 x86"
 license="GPL-2 GPL-3 LGPL-2.1"
 depends="$pkgname-mathlib"
 depends_dev="gcc gfortran icu-dev libjpeg-turbo libpng-dev make openblas-dev
-	pcre-dev>=8.10 readline-dev xz-dev zlib-dev
+	pcre-dev>=8.10 readline-dev xz-dev zlib-dev bzip2-dev curl-dev>=7.28
 	"
-makedepends="$depends_dev bzip2-dev cairo-dev curl-dev>=7.28 libxmu-dev
-	openjdk8-jre-base pango-dev perl tiff-dev tk-dev
+makedepends="$depends_dev tiff-dev cairo-dev pango-dev libxmu-dev tk-dev
+	openjdk8-jre-base perl
 	"
 install="$pkgname.post-install"
 subpackages="$pkgname-mathlib $pkgname-dev $pkgname-doc"
 source="https://cran.r-project.org/src/base/R-${pkgver%%.*}/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
-
-_rhome="usr/lib/R"
-ldpath="/$_rhome/lib"
 
 build() {
 	cd "$builddir"
@@ -34,33 +32,23 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc/R \
 		--localstatedir=/var \
-		--mandir=/usr/share/man \
 		--libdir=/usr/lib \
 		rdocdir=/usr/share/doc/R \
 		rincludedir=/usr/include/R \
 		rsharedir=/usr/share/R \
 		--disable-nls \
 		--enable-R-shlib \
-		--enable-java \
 		--without-recommended-packages \
-		--with-blas=openblas \
-		--with-cairo \
-		--with-ICU \
-		--with-jpeglib \
+		--with-blas="-lopenblas" \
 		--with-lapack \
-		--with-libpng \
-		--with-libtiff \
-		--with-tcltk \
 		--with-x \
 		|| return 1
 
 	make || return 1
-	make -C src/nmath/standalone
+	make -C src/nmath/standalone || return 1
 }
 
 package() {
-	local destdir="$pkgdir/$_rhome"
-
 	cd "$builddir"
 
 	make DESTDIR="$pkgdir" install || return 1
@@ -71,22 +59,21 @@ package() {
 	cd -
 
 	# Fixup R wrapper script (taken from Arch).
-	rm "$destdir"/bin/R
-	ln -sf /usr/bin/R "$destdir"/bin/R
+	rm "$pkgdir"/usr/lib/R/bin/R
+	ln -sf /usr/bin/R "$pkgdir"/usr/lib/R/bin/R
 
 	# Remove some useless files (COPYING is duplicated, it will be
 	# in -doc, don't worry).
-	rm "$destdir"/COPYING "$destdir"/SVN-REVISION
+	rm "$pkgdir"/usr/lib/R/COPYING "$pkgdir"/usr/lib/R/SVN-REVISION
 
 	mkdir -p "$pkgdir"/etc/R
 
+	# Add Rprofile.site to use further in /etc/R
+	touch "$pkgdir"/usr/lib/R/etc/Rprofile.site
+
 	# R apparently ignores --sysconfdir, so we must manually move configs
 	# to /etc/R and make symlinks.
-	cd "$destdir"/etc || return 1
-	local f; for f in *; do
-		mv "$f" "$pkgdir"/etc/R/ && ln -sf /etc/R/$f $f || return 1
-	done
-	cd -
+	ln -sf "$pkgdir"/usr/lib/R/etc/* "$pkgdir"/etc/R/ || return 1
 }
 
 mathlib() {

--- a/community/R/APKBUILD
+++ b/community/R/APKBUILD
@@ -28,14 +28,15 @@ build() {
 	# CXXFLAGS is propagated to /etc/R/Makeconf that is read when building
 	# additional R modules. -D__MUSL__ is needed for some modules like Rcpp.
 	# htps://github.com/RcppCore/Rcpp/issues/448
-	CXXFLAGS="$CXXFLAGS -D__MUSL__" ./configure \
+	CFLAGS="${CFLAGS} -D_DEFAULT_SOURCE" \
+	CXXFLAGS="${CXXFLAGS} -D__MUSL__" ./configure \
 		--prefix=/usr \
 		--sysconfdir=/etc/R \
 		--localstatedir=/var \
-		--libdir=/usr/lib \
 		rdocdir=/usr/share/doc/R \
 		rincludedir=/usr/include/R \
 		rsharedir=/usr/share/R \
+		--enable-memory-profiling \
 		--disable-nls \
 		--enable-R-shlib \
 		--without-recommended-packages \


### PR DESCRIPTION
Move some deps to depends_dev (required for the several popular packages from CRAN). Remove enabled by default configure opts with the same result. Add `/etc/R/Rprofile.site` and symlink.
Also I think we should use `--without-x` `configure` option.
To significantly reduce the size of package we can build it with the internal BLAS implementation.
