### PR TITLE
main/sntpc: add cron / fix initd

### DIFF
--- a/main/sntpc/APKBUILD
+++ b/main/sntpc/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=sntpc
 pkgver=0.9
-pkgrel=6
+pkgrel=7
 pkgdesc="Simple NTP client"
 url="http://git.alpinelinux.org/cgit/hosted/sntpc/"
 arch="all"
@@ -11,6 +11,7 @@ depends=""
 source="http://dev.alpinelinux.org/archive/$pkgname/$pkgname-$pkgver.tar.xz
 	sntpc.initd
 	sntpc.confd
+	sntpc.cron
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -24,14 +25,18 @@ package() {
 	install -m755 -D sntpc "$pkgdir"/usr/sbin/sntpc || return 1
 	install -m755 -D "$srcdir"/sntpc.initd "$pkgdir"/etc/init.d/sntpc
 	install -m644 -D "$srcdir"/sntpc.confd "$pkgdir"/etc/conf.d/sntpc
+	install -m755 -D "$srcdir"/sntpc.cron "$pkgdir"/etc/periodic/daily/sntpc
 }
 
 md5sums="27037e912a7fc906607702a60106f419  sntpc-0.9.tar.xz
-65cade4d0ffe76ef8744a49a4a7c2078  sntpc.initd
-4ea1ceee01f94080be86188bde8f9adc  sntpc.confd"
+7bbda5e5a8a225791ffbef852ee8f2ee  sntpc.initd
+4ea1ceee01f94080be86188bde8f9adc  sntpc.confd
+76e7fd9dbc5471079913aee5e19b0378  sntpc.cron"
 sha256sums="08048e1a4461ce9a9f08fbcb602acbd6c1e623d172dfca366c381624377b9924  sntpc-0.9.tar.xz
-a09ab9f1dc4f6e222cf2585cead4ce168089002164bc0bf1e67cbdb544fa1f8d  sntpc.initd
-edb737bb2c4980ee2f6c10485c5e7f04e8930beb41d6f04da80179ebbd2f3fd6  sntpc.confd"
+93933c9aca507ca051da1de1d4720d7b19ec367068705e282570b58c4d938dd0  sntpc.initd
+edb737bb2c4980ee2f6c10485c5e7f04e8930beb41d6f04da80179ebbd2f3fd6  sntpc.confd
+1401b648add549d550b410112dc42dff5fa3cf0e355e03fd6c5f77612014333b  sntpc.cron"
 sha512sums="c18bb0da4b7804bcbb81da65dd4ab6de4288d2475c441a7b1246631d2500b474d4e95e60cc7752762fb092b49bb6c9fd5e5290c69e247293b3e094e45d18f76d  sntpc-0.9.tar.xz
-72a803a7393424c996b176d0e4df078b2af26b84650793cf3b7b187416878f467aca3a0c96a9cadead065d169ac80a29ae0ceb46ec4b3b26d6d552e30f3562e3  sntpc.initd
-2fcb7d45f4c6588fd5281c02161a4aebb7e0a9d259a2ac3aa6c3187617dc7029f05fbebbb227feace61cc706e37ca0acb18b0019a67c674c444498fd289a9975  sntpc.confd"
+2ea5d433a3fc6534adf0aeb689f838812e4469585dc1ab80e5a8d01483ff608754f7965bb6fa8809b70658b71b4863edc6b2e4b9c4961a3607945f5d28e282f4  sntpc.initd
+2fcb7d45f4c6588fd5281c02161a4aebb7e0a9d259a2ac3aa6c3187617dc7029f05fbebbb227feace61cc706e37ca0acb18b0019a67c674c444498fd289a9975  sntpc.confd
+d450427e63b33660eaeb956d3716ffb6464b162726156553a4265095d287aab592fe3d57837f6d73c0a8129636a9f49fdfae6ecc6a44f50984300d1bf8eae53b  sntpc.cron"

--- a/main/sntpc/sntpc.cron
+++ b/main/sntpc/sntpc.cron
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# cron job for automatic ntp updates
+sleep $(expr $RANDOM % 7200)
+exec /etc/init.d/sntpc restart
+

--- a/main/sntpc/sntpc.initd
+++ b/main/sntpc/sntpc.initd
@@ -25,7 +25,7 @@ start() {
 
 stop() {
 	ebegin "Stopping ${NAME}"
-		start-stop-daemon --stop --quiet \
+		start-stop-daemon --stop --quiet --quiet \
 			--exec ${DAEMON} 
 	eend $?
 }


### PR DESCRIPTION
`sntpc` exits after setting the time so a 2nd `--quiet` in the initd
suppresses warnings from `openrc` that the daemon is already stopped.