### PR TITLE
community/runit: improve initd

### DIFF
--- a/community/runit/APKBUILD
+++ b/community/runit/APKBUILD
@@ -7,37 +7,21 @@ pkgdesc="UNIX init scheme with service supervision"
 url="http://smarden.org/runit/"
 arch="all"
 license="BSD"
-depends=""
-depends_dev=""
-makedepends="$depends_dev"
-install=""
 subpackages="$pkgname-doc"
 source="http://smarden.org/runit/runit-$pkgver.tar.gz
 	run-service-dir.patch
 	README.alpine
 	$pkgname.initd
 	"
-
-_builddir="$srcdir"/admin/runit-$pkgver/src
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-	echo "$CC $CFLAGS" > conf-cc
-	echo "$CC $LDFLAGS" > conf-ld
-}
+builddir="$srcdir"/admin/runit-$pkgver/src
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	make
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	install -d "$pkgdir"/sbin
 	for i in chpst runit runit-init runsv runsvchdir runsvdir sv svlogd utmpset; do
 		install -m755 "$i" "$pkgdir"/sbin/$i || return 1
@@ -55,12 +39,12 @@ package() {
 md5sums="6c985fbfe3a34608eb3c53dc719172c4  runit-2.1.2.tar.gz
 13b3d1e097d58c7fe78c8c2ae9c829ff  run-service-dir.patch
 735265c11ac8653fe61615e5756af272  README.alpine
-df31f105e66ee755fd990ba7184884ed  runit.initd"
+78cbc567c4c0da26d07a1600fc375ca7  runit.initd"
 sha256sums="6fd0160cb0cf1207de4e66754b6d39750cff14bb0aa66ab49490992c0c47ba18  runit-2.1.2.tar.gz
 b051476a9cea0673cdd3f849c33555e364540f49436ab7d05f5aeee553d84ab7  run-service-dir.patch
 6a49cdf4c9fd8326d9e3fed3df8ff6fae47f60fd586b56d561e0b2d629ea949a  README.alpine
-aed913227ba4035fe0a84423610817f551ea890d5c5d5a64399b504b2d6f7cc1  runit.initd"
+c0e39b97fddc5a19e7f596975118491d7fd6291bf5bff9868f5cc0971f1d3961  runit.initd"
 sha512sums="a18773ebf1aa22305dd89ed67363165b9fcf86c192b2be4e268d08005dd82d51265160c637abe072f2f2e378c4b315a75bd3d3e602c3e75bdd451a3b0190f8cf  runit-2.1.2.tar.gz
 7107da162f7c13e1483f17bf04a844c23a8d1b81ef982c3d956a4c0e23b2a20e415850f0b95999b1eb1e04638284884948937377756ca080037bd6455e3301e8  run-service-dir.patch
 88d1efcf366add7803ed026ec8e693b271c842d4e3d5a52587b7ead96266ee27b4ceb1b2696551243f0d9efa93199a07231d2b37186ce1535e9a6b9d90192909  README.alpine
-32487bec20e1313eae2e9f315b5b82c67c93c11f15b737f00469006f5fd7f2944ac91887e6ceefa2934fc02f83d4184af9db74acad381a4d9caf952f76621a60  runit.initd"
+a3e82785650dbb0a96454ae29635012022bd3a705318bdb56a4430a2f487f4aa17661fb1a87fce56ca535b6a526a618a7673ad66848d5fffb47f5795cdcbf18b  runit.initd"

--- a/community/runit/runit.initd
+++ b/community/runit/runit.initd
@@ -8,7 +8,10 @@ description="starts and monitors a collection of runsv(8) processes"
 retry="SIGHUP/5"
 
 depend() {
-    need localmount
-    after firewall
+	need localmount
+	after firewall
+	if [ -x /sbin/socklog ]; then
+		provide logger
+	fi
 }
 


### PR DESCRIPTION
if `socklog` is detected this prevents busybox `syslog` starting even
when disabled (due to `crond` needing `logger`).