### PR TITLE
testing/rspamd: update to 1.3.5 + config fixes

### DIFF
--- a/testing/rspamd/APKBUILD
+++ b/testing/rspamd/APKBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Contributor: Nathan Angelacos <nangel@alpinelinux.org>
+# Contributor: Andrew Lewis <nerf@judo.za.org>
 pkgname=rspamd
-pkgver=1.3.4
-pkgrel=1
+pkgver=1.3.5
+pkgrel=0
 pkgdesc="Rapid spam filtering system"
 url="https://rspamd.com"
 arch="x86_64 x86 armhf"
@@ -13,7 +14,7 @@ pkggroups="rspamd"
 depends=""
 depends_dev=""
 makedepends="$depends_dev cmake libressl-dev libevent-dev glib-dev gmime-dev
-	lua5.1-dev lua5.1 sqlite-dev hiredis-dev file-dev pcre-dev ragel"
+	lua5.1-dev lua5.1 sqlite-dev perl file-dev pcre-dev ragel"
 install="$pkgname.pre-install"
 subpackages="$pkgname-doc $pkgname-web $pkgname-client"
 source="https://rspamd.com/downloads/$pkgname-$pkgver.tar.xz
@@ -35,6 +36,7 @@ build() {
 		-DRSPAMD_USER=$pkgusers \
 		-DRSPAMD_GROUP=$pkggroups \
 		-DENABLE_HIREDIS=ON \
+		-DENABLE_LUAJIT=OFF \
 		-DINSTALL_EXAMPLES=ON \
 		|| return 1
 	make || return 1
@@ -46,7 +48,6 @@ package() {
 	find "$pkgdir"/usr/bin -type l -delete
 	rm -fr "$pkgdir"/etc/$pkgname/rspamd* "$pkgdir"/etc/$pkgname/worker*
 
-	sed -i -E 's~DBDIR(/rspamd.sock)~RUNDIR\1~' "$pkgdir"/etc/$pkgname/options.inc
 	install -Dm644 "$srcdir"/$pkgname.conf "$pkgdir"/etc/$pkgname/$pkgname.conf
 	install -Dm644 "$srcdir"/$pkgname.worker_normal "$pkgdir"/etc/$pkgname/worker.d/normal.conf
 	mkdir -p "$pkgdir"/etc/$pkgname/local.d "$pkgdir"/etc/$pkgname/override.d
@@ -55,7 +56,7 @@ package() {
 	install -Dm755 "$srcdir"/$pkgname.initd "$pkgdir"/etc/init.d/$pkgname
 	install -Dm644 "$srcdir"/$pkgname.confd "$pkgdir"/etc/conf.d/$pkgname
 
-	install -dm750 -o $pkgusers -g $pkggroups "$pkgdir"/var/lib/$pkgname/rspamd_dynamic
+	install -dm750 -o $pkgusers -g $pkggroups "$pkgdir"/var/lib/$pkgname
 	install -dm750 -g $pkggroups "$pkgdir"/var/log/$pkgname
 
 	mkdir "$pkgdir"/usr/sbin
@@ -84,24 +85,24 @@ client() {
 	mv "$pkgdir"/usr/bin/rspamc-$pkgver "$subpkgdir"/usr/bin/rspamc
 }
 
-md5sums="ab81d063861d68b1e2260d1c599bf29c  rspamd-1.3.4.tar.xz
+md5sums="27746ff806dac22e4b92f38282fe6bd5  rspamd-1.3.5.tar.xz
 c152c6a90f6ae9e5a7a1d137dfbc0305  rspamd.logrotated
 3f32a16e76e1461ffba9231cfb1e3d17  rspamd.initd
 ecfea2a25b95727ae91c04001fbd3e46  rspamd.confd
 0ba1c9aea1820de74d831fd531cce51a  rspamd.conf
-560b2d4746510fe9a7a2fb1c09181c38  rspamd.worker_normal
-15a9f5dde0076eaab4565549b05b991c  rspamd.worker_controller"
-sha256sums="64fcabb3dc6767b5dc22c89f968414d1028f34ab8a21e1b22482aace069d527c  rspamd-1.3.4.tar.xz
+95a48d27f69f957e99ac5f443943f59c  rspamd.worker_normal
+30639cb7040ec45f8a6806a93aef818b  rspamd.worker_controller"
+sha256sums="d4413ccfc238c3023e2b8a9441b101a6437f521f333fc9db2dd924d473fee696  rspamd-1.3.5.tar.xz
 6c5e79e9052d957f3d0d634b2ae7a56bbc0901a5d6946dc991c92f19a72fce97  rspamd.logrotated
 6b531f95724b2a3990524ab09b7304ce4e811b6e082dfdbe633f201a6bc7eee3  rspamd.initd
 82be6a663af2e2333b0dfbbbfd05a9ff3d02e05c7e506235b1b0dbd9d0b72972  rspamd.confd
 8b51fbd06a46adceb8cc4b0dc06e7b98d263336acbff913c34ff8e451173aa23  rspamd.conf
-ccb271cc6b1ff69add9d6e00edcb14e1c1ae664ee6ecf28304647f6cb32240c9  rspamd.worker_normal
-91848312e707032bb159f042da04b4a15efd43f69a17225481962cb07751e90a  rspamd.worker_controller"
-sha512sums="41a3aa9b699ca1e40d229ebc9c3fd41ef07ad99b0badda44481fe4ff3003000069352f58379fa47013f96d98b08430a3c7bea0d97cab4a7e6db17a9084b082d6  rspamd-1.3.4.tar.xz
+308a0bb4e6e442309a6f4e22b6a8a86871b249c1ee834c01b53b3c3647e81c59  rspamd.worker_normal
+7ce08f8e77e6db490c61eca9b4c4ebbd5e635ac8ea53f98c5a8877f11a8fc136  rspamd.worker_controller"
+sha512sums="6d7223c6be6e49296a5228d3d05a5f8dfd4a4002df9d247740bce75f2f652a01d86c30456b8475d08d529d2787aa30191713961ffc82c380c00612cae371b61c  rspamd-1.3.5.tar.xz
 2efe28575c40d1fba84b189bb872860e744400db80dce2f6330be6c6287fb3f46e6511284729b957488bf40bcb9b0952e26df9934f5f138334bd2766075c45cb  rspamd.logrotated
 30b45812ef68f2b82d0d7f370b44bec52691296c7349c96c8273342eb4f9b5708c13ad97b13f63d81bee588b4e459c0da3092a62adff9e5b8938f44546df3dcd  rspamd.initd
 0b73b159cec9a4a1d337fbb429814f78da23b55f72c9fb8a777ab5f06634206a4f9b25e587f8dbfa7c3242ac5501ebcc90b9a0e926adfd37e14a12ac4607fa62  rspamd.confd
 856000ab9b76dd7acff95ab9a55a0eddfc66486a439fcba7fbb36ecdeaa9740f29301cf7248c982e2d5b745b1bad521abb0f4d5e240d442440a36103d3ee634d  rspamd.conf
-e669882c35891eee37c4121ea065e72545c618ac5e16044ccd19db4cdb14bed271fa87dc261e43e587a08ea6149e13952626c8cea8a797a59b649203c2ac4731  rspamd.worker_normal
-e830ccd5d7999e8cf8d0a82baba1ca80c8b8eb3a7f710c8c067af937258fff49f010cead46619adebc1d481d1131c9e0146fa654a4f4c28749437e5b2c49e755  rspamd.worker_controller"
+48f655ae449d1b560a9cf610d770acc568c3220aed2fa5616bc52c8999b39df932019d8930f142753e0bdac2a7f7bbdca2a29e773a6a4e63dbcb4c11cf6647a4  rspamd.worker_normal
+349737be95d0797d6e0091d268a7d5542b4aa64e4f38f73604247ee66eca9180d81ea4478ae54db9573c10bba1580823fc4422596a29cb5435f910dc6a3f2d33  rspamd.worker_controller"

--- a/testing/rspamd/rspamd.worker_controller
+++ b/testing/rspamd/rspamd.worker_controller
@@ -6,6 +6,6 @@ worker {
     secure_ip = "127.0.0.1";
     secure_ip = "::1";
     static_dir = "${WWWDIR}";
-    .include(try=true; priority=1) "$LOCAL_CONFDIR/local.d/worker-controller.inc"
+    .include(try=true; priority=1; duplicate=merge) "$LOCAL_CONFDIR/local.d/worker-controller.inc"
     .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/worker-controller.inc"
 }

--- a/testing/rspamd/rspamd.worker_normal
+++ b/testing/rspamd/rspamd.worker_normal
@@ -3,6 +3,6 @@ worker {
     type = "normal";
     mime = true;
     task_timeout = 8s;
-    .include(try=true; priority=1) "$LOCAL_CONFDIR/local.d/worker-normal.inc"
+    .include(try=true; priority=1; duplicate=merge) "$LOCAL_CONFDIR/local.d/worker-normal.inc"
     .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/worker-normal.inc"
 }


### PR DESCRIPTION
- Update to 1.3.5
- /var/lib/rspamd/rspamd_dynamic is a _file_ that might be created by web interface so do not precreate it as a directory.
- Changing path to control socket breaks rspamadm control commands: don't do it.
- Perl is a build dependency
- Hiredis is _bundled_ so is not a dependency (it's patched)

I've fixed my edits now. ;) Feedback welcome.
