### PR TITLE
Update Vips to v8.3.3

### DIFF
--- a/testing/vips/APKBUILD
+++ b/testing/vips/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Will Jordan <will.jordan@gmail.com>
 # Maintainer: Will Jordan <will.jordan@gmail.com>
 pkgname=vips
-pkgver=8.3.1
+pkgver=8.3.3
 pkgrel=0
 pkgdesc="A fast image processing library with low memory needs"
 url="http://www.vips.ecs.soton.ac.uk/"
@@ -44,6 +44,6 @@ tools() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-md5sums="1213f9a4286dad44790cf90838c229a5  vips-8.3.1.tar.gz"
-sha256sums="09cb7f8d5640c7693bae07080202de0cead60c668e086f2739248bacd40a1006  vips-8.3.1.tar.gz"
-sha512sums="0ba378015b85688f173be59d76655fc33a6704e8bad4bc91261c3e5d4851a288e1c083718b2a03076fd2d9069c9ee6110780ae64b4d22e49ba68fa3cacece212  vips-8.3.1.tar.gz"
+md5sums="50551b647160f14b2062f863757b812b  vips-8.3.3.tar.gz"
+sha256sums="797f5c7dc179db2cc597da4b929b2c7aebb7390d5da24bc472f41f801d9396c5  vips-8.3.3.tar.gz"
+sha512sums="9d870b12a3d6eb668eba111368e702e51bb314b170ead6ed146d941005c09176cf608e34e707472fd049df6f222d8d9140e99afc73c28dc21df94351996587e6  vips-8.3.3.tar.gz"


### PR DESCRIPTION
Package update needed for lovell/sharp#564 (support latest version of Sharp on alpine linux).