### PR TITLE
community/modemmanager: update to 1.6.2

### DIFF
--- a/community/modemmanager/APKBUILD
+++ b/community/modemmanager/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=modemmanager
-pkgver=1.6.0
+pkgver=1.6.2
 pkgrel=0
 pkgdesc="ModemManager library"
 url="http://www.freedesktop.org/wiki/Software/ModemManager"
@@ -30,8 +30,6 @@ build() {
 		--with-newest-qmi-commands \
 		--with-dbus-sys-dir=/etc/dbus-1 \
 		--enable-vala=yes \
-		--without-mbim \
-		--without-qmi \
 		|| return 1
 	# https://bugzilla.gnome.org/show_bug.cgi?id=655517
 	sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
@@ -73,9 +71,9 @@ To control your modem without the root password: add your user account to the 'p
 EOF
 }
 
-md5sums="d9d93d2961ee35b4cd8a75a6a8631cb4  ModemManager-1.6.0.tar.xz
+md5sums="ef56967efecdf0573affe1189a48d858  ModemManager-1.6.2.tar.xz
 735e155a785554349906c09dd36d3866  modemmanager.rules"
-sha256sums="a94f4657a8fa6835e2734fcc6edf20aa8c8d452f62299d7748541021c3eb2445  ModemManager-1.6.0.tar.xz
+sha256sums="e4544398d9c166f8e13fe7c97149f262ad1fb48af980e0d4f9c34013920c6393  ModemManager-1.6.2.tar.xz
 577807e59b1e95757a4d94922c66f7f36487922c5092a6c148e7db6a4dc6afe8  modemmanager.rules"
-sha512sums="66f1ff1c872e360a56b5b6c6d4071544b6c6e0423f3c825d3ea8383898e80a177eb9efdf82538ca6fa02ae8db464d3aa8bbe226f195e7065f074b75c115a5182  ModemManager-1.6.0.tar.xz
+sha512sums="265a3bfe3472adb31237745833e8f08422fcef4f722feb4b95df1fdde6ca53868d8c7cede7c5f965193976f899da27cd7c92cb3e22d7f1411c952748c9ab65a9  ModemManager-1.6.2.tar.xz
 3c76ee577334e25c836857f8e7fef6a249cdd9fcd8f889cb64d9c1667bc6a95c087267a153bddd1a13256c59f8cd578ccb448e6b9cb54b73bb74acb8a0ca1e3f  modemmanager.rules"


### PR DESCRIPTION
also re-enables libmbim / libqmi support