### PR TITLE
testing/vault: fixing vault version

### DIFF
--- a/testing/vault/APKBUILD
+++ b/testing/vault/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 pkgname=vault
 pkgver=0.6.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Vault is a tool for securely accessing secrets."
 url="https://www.vaultproject.io/"
 arch="all"
@@ -20,10 +20,10 @@ source="${pkgname}-${pkgver}.tar.gz::https://github.com/hashicorp/${pkgname}/arc
   vault.hcl
   vault.initd"
 
-_builddir="${srcdir}/${pkgname}-${pkgver}"
+builddir="${srcdir}/${pkgname}-${pkgver}"
 
 prepare() {
-  cd "${_builddir}"
+  cd "${builddir}"
   local i
   for i in $source; do
     case $i in
@@ -33,20 +33,20 @@ prepare() {
 }
 
 build() {
-  cd "$_builddir" || return 1
-  mkdir -p "${_builddir}/src/github.com/hashicorp"
-  ln -s "${_builddir}" "${_builddir}/src/github.com/hashicorp/vault"
-  GOPATH="${_builddir}" go build -x -v -o bin/${pkgname} || return 1
+  cd "$builddir" || return 1
+  mkdir -p "${builddir}/src/github.com/hashicorp"
+  ln -s "${builddir}" "${builddir}/src/github.com/hashicorp/vault"
+  GOPATH="${builddir}" go build -v -o bin/${pkgname} --tags vault || return 1
 }
 
 package() {
-  cd "$_builddir"
+  cd "$builddir"
   install -m755 -D "${srcdir}/${pkgname}.initd" \
   "${pkgdir}/etc/init.d/${pkgname}" || return 1
   install -m644 -D "${srcdir}/${pkgname}.confd" \
   "${pkgdir}/etc/conf.d/$pkgname" || return 1
   install -m750 -o root -g vault \
-  -D "${_builddir}/bin/${pkgname}" \
+  -D "${builddir}/bin/${pkgname}" \
   "${pkgdir}/usr/sbin/${pkgname}" || return 1
   install -m750 -o vault -g vault -d "$pkgdir/var/lib/${pkgname}" || return 1
   install -m750 -o root -g vault -D "$srcdir/${pkgname}.hcl" \


### PR DESCRIPTION
* Adding --tags vault to "go build" line. Fixes version.
* Replacing _builddir with builddir.