### PR TITLE
testing/criu: new aport

### DIFF
--- a/testing/criu/APKBUILD
+++ b/testing/criu/APKBUILD
@@ -1,0 +1,49 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+pkgname=criu
+pkgver=2.6
+pkgrel=0
+pkgdesc="A Checkpoint/Restore utility for Linux in Userspace"
+url="http://criu.org"
+arch="all"
+license="GPL2"
+makedepends="xmlto asciidoc python protobuf-c-dev protobuf-dev libaio-dev libnl3-dev \
+		py-protobuf libcap-dev"
+subpackages="$pkgname-dev $pkgname-doc py-$pkgname:_py"
+source="$pkgname-$pkgver.tar.gz::https://github.com/xemul/$pkgname/archive/v$pkgver.tar.gz
+	unknown-type__uid_t.patch
+	fix-wait.h.patch
+	"
+builddir="$srcdir/"$pkgname-$pkgver
+
+build() {
+	cd "$builddir" # https://wiki.gentoo.org/wiki/Project:Quality_Assurance/As-needed
+	export LDFLAGS=$(echo $LDFLAGS |sed 's|-Wl,--as-needed||')
+	make || return 1
+#	make test || return 1
+}
+
+package() {
+	cd "$builddir"
+	make PREFIX=/usr DESTDIR="$pkgdir" install || return 1
+	rm "$pkgdir"/usr/libexec/criu/scripts/systemd-autofs-restart.sh || return 1
+	for dir in $(find "$pkgdir"/usr/libexec -type d | sort -r); do rmdir $dir || return 1; done
+}
+
+_py() {
+	pkgdesc="Python bindings for Criu"
+	depends="python"
+	arch="noarch"
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/python* "$subpkgdir"/usr/lib/ || return 1
+}
+
+md5sums="f31216c3769536b0daa04bd71df7e351  criu-2.6.tar.gz
+94e0c93b6c82d4e9e26a64da6ed4e6d9  unknown-type__uid_t.patch
+50a7fa53171d082bdbc2558d5c0cec9e  fix-wait.h.patch"
+sha256sums="e4e0ba905593a5b8b1112b789dd2a04e9d183dfc0f0ac36a59e74381c2c0ec54  criu-2.6.tar.gz
+703ce29be3324b92b2118482da17656bd691d844f787e50ec9a3c379827d81ad  unknown-type__uid_t.patch
+75f2d549250d4eddb17db92c8c2c63cbe125d27058b51665184c5536bf3a783e  fix-wait.h.patch"
+sha512sums="5fca78f6a14e338ae58a6f565dfef34f97267e9dbea12fe32237e75cd00603809ae9f03eac24a1dec3166ea99bb20742055a6d0dc2643a8276fbdfdeda19eeb5  criu-2.6.tar.gz
+a9abac887a453b5265f18ebd75432eecfd1a1be18b43078651163789ebea76f2d155ff4574bc43d9d025d6bd3360a053aee0a73bf5dcc319294e8138ee514019  unknown-type__uid_t.patch
+c35ae61b7bd20b2205949213d5a54a5a31e7aab6eaed5f9afa00dad6ab0fa8007cae25f4cda89957b5535f3073487a854169b09eda3ee48ab6d9af8ce055d991  fix-wait.h.patch"

--- a/testing/criu/fix-wait.h.patch
+++ b/testing/criu/fix-wait.h.patch
@@ -1,0 +1,55 @@
+--- criu-2.6/test/zdtm/static/socket6_udp.c
++++ criu-2.6/test/zdtm.new/static/socket6_udp.c
+@@ -13,7 +13,7 @@
+ #include <stdlib.h>
+ #include <sys/socket.h>
+ #include <arpa/inet.h>  /* for sockaddr_in and inet_ntoa() */
+-#include <wait.h>
++#include <sys/wait.h>
+ 
+ static int port = 8880;
+ static char buf[64];
+--- criu-2.6/test/zdtm/static/socket_aio.c
++++ criu-2.6/test/zdtm.new/static/socket_aio.c
+@@ -16,7 +16,7 @@
+ #include <errno.h>
+ #include <stdlib.h>
+ #include <aio.h>
+-#include <wait.h>
++#include <sys/wait.h>
+ #include <netinet/tcp.h>
+ 
+ static int port = 8880;
+--- criu-2.6/test/zdtm/static/socket_listen.c
++++ criu-2.6/test/zdtm.new/static/socket_listen.c
+@@ -19,7 +19,7 @@
+ #include <unistd.h>
+ #include <errno.h>
+ #include <stdlib.h>
+-#include <wait.h>
++#include <sys/wait.h>
+ #include <netinet/tcp.h>
+ 
+ static int port = 8880;
+--- criu-2.6/test/zdtm/static/socket_udp.c
++++ criu-2.6/test/zdtm.new/static/socket_udp.c
+@@ -18,7 +18,7 @@
+ #include <stdlib.h>
+ #include <sys/socket.h>
+ #include <arpa/inet.h>  /* for sockaddr_in and inet_ntoa() */
+-#include <wait.h>
++#include <sys/wait.h>
+ 
+ static int port = 8880;
+ static char buf[8];
+--- criu-2.6/test/zdtm/static/socket_udplite.c
++++ criu-2.6/test/zdtm.new/static/socket_udplite.c
+@@ -18,7 +18,7 @@
+ #include <stdlib.h>
+ #include <sys/socket.h>
+ #include <arpa/inet.h>  /* for sockaddr_in and inet_ntoa() */
+-#include <wait.h>
++#include <sys/wait.h>
+ 
+ static int port = 8890;
+ static char buf[8];

--- a/testing/criu/unknown-type__uid_t.patch
+++ b/testing/criu/unknown-type__uid_t.patch
@@ -1,0 +1,10 @@
+--- criu-2.6/test/zdtm/static/pid00.c
++++ criu-2.6/test/zdtm/static/pid00.c.new
+@@ -1,4 +1,7 @@
+ #define _GNU_SOURCE
++#ifndef __GLIBC__
++        typedef unsigned int __uid_t;
++#endif
+ #include <errno.h>
+ #include <unistd.h>
+ #include <sys/types.h>


### PR DESCRIPTION
A utility for the live checkpoint / restore of `lxc` containers.

Requires the following additional kernel modules to be enabled:

```
CONFIG_CHECKPOINT_RESTORE=y
CONFIG_FHANDLE=y
```

Optional (incremental dumps):

`CONFIG_MEM_SOFT_DIRTY=y`
