### PR TITLE
community/imapsync: move to community & update to 1.727

### DIFF
--- a/community/imapsync/APKBUILD
+++ b/community/imapsync/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=imapsync
-pkgver=1.678
-pkgrel=1
+pkgver=1.727
+pkgrel=0
 pkgdesc="IMAP synchronisation, sync, copy or migration tool"
 url="http://imapsync.lamiral.info"
 arch="noarch"
@@ -10,13 +10,13 @@ license="custom"
 depends="perl-digest-hmac perl-authen-ntlm perl-io-compress perl-data-dumper \
 	perl-data-uniqid perl-digest-md5 perl-file-copy-recursive perl-io-socket-inet6 \
 	perl-io-socket-ssl perl-io-tee perl-mail-imapclient perl-parse-recdescent \
-	perl-term-readkey perl-test-pod perl-test-tester perl-unicode-string perl-uri"
-depends_dev=""
+	perl-term-readkey perl-test-pod perl-test-tester perl-unicode-string perl-uri \
+	perl-test-mockobject perl-readonly perl-json-webtoken"
 makedepends="$depends_dev perl-module-scandeps perl-par-packer"
 subpackages="$pkgname-doc"
 source="https://github.com/$pkgname/$pkgname/archive/$pkgname-$pkgver.tar.gz"
-
 builddir="$srcdir"/$pkgname-$pkgname-$pkgver
+
 package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install || return 1
@@ -27,6 +27,6 @@ package() {
 	install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE || return 1
 }
 
-md5sums="065961c37544635861a068a0596e4e29  imapsync-1.678.tar.gz"
-sha256sums="77cd7b58bc1872bcf6c531ee8f764dda87e0dec3f6ffed752748ff9ae74534b0  imapsync-1.678.tar.gz"
-sha512sums="88dd59bbd1567f76c70aca74d86540f00baa6df0869e7679505e8402138665e0380b942167b1cfe4fb55c5e01402b7820163bfa9d296de67e05248699592b799  imapsync-1.678.tar.gz"
+md5sums="e753235abed1d8162f2c9adbc916291c  imapsync-1.727.tar.gz"
+sha256sums="5028727d476a581335105ff24ea677311afa5ce6f812f0926cb2377635791468  imapsync-1.727.tar.gz"
+sha512sums="b5ab0f3b4ae12d9d65d5c65e65fa5778ade5ac68432523fcb6839e84af742abf5a3ca0a04d3308936c7b99f16415b9d8076f96ec37d84e82dcdf53413f625e75  imapsync-1.727.tar.gz"

--- a/community/perl-io-socket-inet6/APKBUILD
+++ b/community/perl-io-socket-inet6/APKBUILD
@@ -10,28 +10,27 @@ url="http://search.cpan.org/dist/IO-Socket-INET6/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-socket6"
-cpanmakedepends="   "
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends perl-module-build"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/S/SH/SHLOMIF/$_pkgreal-$pkgver.tar.gz"
-
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare || return 1
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	perl Build.PL installdirs=vendor || return 1
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	./Build ### && ./Build test #no ipv6 in buildozer
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	./Build install destdir="$pkgdir" || return 1
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }

--- a/community/perl-json-webtoken/APKBUILD
+++ b/community/perl-json-webtoken/APKBUILD
@@ -1,0 +1,40 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+pkgname=perl-json-webtoken
+_pkgname=JSON-WebToken
+pkgver=0.10
+pkgrel=0
+pkgdesc="JSON Web Token (JWT) implementation for Perl"
+url="https://github.com/xaicron/p5-JSON-WebToken"
+arch="noarch"
+license="PerlArtistic"
+depends="perl-json perl-module-runtime perl-mime-base64 perl-carp"
+makedepends="perl-dev perl-module-build perl-json perl-module-runtime perl-test-requires \
+		perl-crypt-openssl-rsa perl-crypt-openssl-bignum perl-test-mock-guard \
+		perl-class-load"
+subpackages="$pkgname-doc"
+source="http://search.cpan.org/CPAN/authors/id/X/XA/XAICRON/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+prepare() {
+	cd "$builddir"
+	default_prepare || return 1
+	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
+	perl Build.PL --installdirs=vendor || return 1
+}
+
+build() {
+	cd "$builddir"
+	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
+	./Build && ./Build test
+}
+
+package() {
+	cd "$builddir"
+	./Build install --destdir="$pkgdir" || return 1
+	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
+}
+
+md5sums="a68a0e415493495c5d3c516d854de047  JSON-WebToken-0.10.tar.gz"
+sha256sums="77c182a98528f1714d82afc548d5b3b4dc93e67069128bb9b9413f24cf07248b  JSON-WebToken-0.10.tar.gz"
+sha512sums="ce4acd42814db12fc16c60a8937a4e7d420b0243c3ca26f96a36ee2a2fb4a14f93538340b199fcce9cfbb090d60de5d7e24d5f008a84e1365d7c31f6db9ee312  JSON-WebToken-0.10.tar.gz"

--- a/community/perl-readonly/APKBUILD
+++ b/community/perl-readonly/APKBUILD
@@ -1,0 +1,37 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+pkgname=perl-readonly
+_pkgname=Readonly
+pkgver=2.05
+pkgrel=0
+pkgdesc="Readonly - Facility for creating read-only scalars, arrays, hashes"
+url="https://github.com/sanko/readonly"
+arch="noarch"
+license="PerlArtistic"
+makedepends="perl-dev perl-module-build-tiny"
+subpackages="$pkgname-doc"
+source="https://cpan.metacpan.org/authors/id/S/SA/SANKO/Readonly-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+prepare() {
+	cd "$builddir"
+	default_prepare || return 1
+	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
+	perl Build.PL --installdirs=vendor || return 1
+}
+
+build() {
+	cd "$builddir"
+	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
+	./Build && ./Build test
+}
+
+package() {
+	cd "$builddir"
+	./Build install --destdir="$pkgdir" || return 1
+	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
+}
+
+md5sums="acae851d7d55c509f5f00a8849597e54  Readonly-2.05.tar.gz"
+sha256sums="4b23542491af010d44a5c7c861244738acc74ababae6b8838d354dfb19462b5e  Readonly-2.05.tar.gz"
+sha512sums="d42406c1985248a352860f80c3b0b1a41476e5a7b4bff71e83122d7c5eb609296a1eb00aa71cf9f899317e31c706d75ff07950815eff84afb6bec40de6de2ace  Readonly-2.05.tar.gz"

--- a/community/perl-test-mock-guard/APKBUILD
+++ b/community/perl-test-mock-guard/APKBUILD
@@ -1,0 +1,37 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+pkgname=perl-test-mock-guard
+_pkgname=Test-Mock-Guard
+pkgver=0.10
+pkgrel=0
+pkgdesc="Simple mock test library using RAII"
+url="https://github.com/zigorou/p5-test-mock-guard"
+arch="noarch"
+license="PerlArtistic"
+makedepends="perl-dev perl-module-build perl-class-load"
+subpackages="$pkgname-doc"
+source="http://search.cpan.org/CPAN/authors/id/X/XA/XAICRON/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+prepare() {
+	cd "$builddir"
+	default_prepare || return 1
+	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
+	perl Build.PL --installdirs=vendor || return 1
+}
+
+build() {
+	cd "$builddir"
+	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
+	./Build && ./Build test
+}
+
+package() {
+	cd "$builddir"
+	./Build install --destdir="$pkgdir" || return 1
+	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
+}
+
+md5sums="b2866485cc29c787f85793279e2f2360  Test-Mock-Guard-0.10.tar.gz"
+sha256sums="7f228a63f8d6ceb92aa784080a13e85073121b2835eca06d794f9709950dbd3d  Test-Mock-Guard-0.10.tar.gz"
+sha512sums="17a8cbfea9e33a625ad5a33b40b5a799715d59b57eb4030a9d694fdd1e7361667f326888577291f0807852b86c04b97384ab8a48d95eb92158d35e14131068cc  Test-Mock-Guard-0.10.tar.gz"


### PR DESCRIPTION
the `imapsync` install script runs `perl -m$MODULE::NAME` on the dependent modules so I am adding the new perl modules straight into community as their dependencies are already checked:

```
sh INSTALL.d/prerequisites_imapsync
$SHELL says  /bin/ash
$0 gives  INSTALL.d/prerequisites_imapsync
ps -ef gives 116661root       0:00 sh INSTALL.d/prerequisites_imapsync
Linux musl64 4.4.20-1-MANJARO #1 SMP PREEMPT Wed Sep 7 19:11:34 UTC 2016 x86_64 Linux
Ok: Found Perl 5.24.0
Ok: Found Perl module Authen::NTLM
Ok: Found Perl module Compress::Zlib
Ok: Found Perl module Data::Dumper
Ok: Found Perl module Data::Uniqid
Ok: Found Perl module Digest::HMAC_MD5
Ok: Found Perl module Digest::HMAC
Ok: Found Perl module Digest::MD5
Ok: Found Perl module File::Copy::Recursive
Ok: Found Perl module IO::Socket::INET
Ok: Found Perl module IO::Socket::INET6
Ok: Found Perl module IO::Socket::SSL
Ok: Found Perl module IO::Tee
Ok: Found Perl module JSON::WebToken
Ok: Found Perl module Mail::IMAPClient
Ok: Found Perl module Parse::RecDescent
Ok: Found Perl module Readonly
Ok: Found Perl module Term::ReadKey
Ok: Found Perl module Test::MockObject
Ok: Found Perl module Test::More
Ok: Found Perl module Test::Pod
Ok: Found Perl module Unicode::String
Ok: Found Perl module URI::Escape
All needed modules are already installed
imapsync syntax OK
```
