### PR TITLE
community/openjdk7: fix cacerts

### DIFF
--- a/community/openjdk7/APKBUILD
+++ b/community/openjdk7/APKBUILD
@@ -6,12 +6,12 @@ _icedteaver=2.6.7
 # pkgver is <JDK version>.<JDK update>
 # check icedtea JDK when updating
 pkgver=7.111.$_icedteaver
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenJDK 7 via IcedTea"
 url="http://icedtea.classpath.org/"
 arch="all"
 license="GPL2 with Classpath"
-depends="$pkgname-jre"
+depends="$pkgname-jre java-cacerts"
 options="sover-namecheck"
 makedepends="bash findutils tar zip file paxmark gawk util-linux libxslt
 	autoconf automake linux-headers coreutils
@@ -184,6 +184,11 @@ package() {
 
 	# pax mark again (due to fakeroot xattr handling bug)
 	"$builddir"/pax-mark-vm "$pkgdir"/$INSTALL_BASE
+
+        # symlink to shared java cacerts store
+        rm -f "$pkgdir"/$INSTALL_BASE/jre/lib/security/cacerts
+        ln -sf /etc/ssl/certs/java/cacerts \
+          "$pkgdir"/$INSTALL_BASE/jre/lib/security/cacerts
 }
 
 jrelib() {
@@ -203,7 +208,7 @@ jrelib() {
 
 jrebase() {
 	pkgdesc="OpenJDK 7 Java Runtime (no GUI support)"
-	depends="$pkgname-jre-lib java-common"
+	depends="$pkgname-jre-lib java-common java-cacerts"
 
 	mkdir -p "$subpkgdir"/$INSTALL_BASE/bin
 
@@ -217,6 +222,7 @@ jrebase() {
 
 	# pax mark again (due to fakeroot xattr handling bug)
 	"$builddir"/pax-mark-vm "$subpkgdir"/$INSTALL_BASE
+
 }
 
 jre() {


### PR DESCRIPTION
This is just a backport of 94969c8a556eedeeafb78a33752ab6b6e6f7f892
from openjdk8.