### PR TITLE
Add jansson-dev to make bareos-webui work

### DIFF
--- a/community/bareos/APKBUILD
+++ b/community/bareos/APKBUILD
@@ -11,7 +11,7 @@ depends=""
 depends_dev=""
 makedepends="$depends_dev libtool libintl libpcap-dev lzo-dev \
 	sqlite-dev postgresql-dev openssl-dev mariadb-dev acl-dev \
-	qt-dev python-dev readline-dev ncurses-dev"
+	qt-dev python-dev readline-dev ncurses-dev jansson-dev"
 install="$pkgname.pre-install $pkgname.post-install"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-trayicon"
 pkgusers="bareos"


### PR DESCRIPTION
bareos-webui does not work after login:
"Error: API 2 not available on director. Please upgrade to version 15.2.1 or greater and/or compile with jansson support."

See similar issue:
https://bugs.bareos.org/view.php?id=543