### PR TITLE
testing/logcheck-busybox: new aport

### DIFF
--- a/testing/logcheck-busybox/00-busybox-compat.patch
+++ b/testing/logcheck-busybox/00-busybox-compat.patch
@@ -1,0 +1,100 @@
+--- logcheck-1.3.17/src/logcheck
++++ logcheck-1.3.17/src/logcheck.new
+@@ -73,7 +73,7 @@
+ CONFFILE="/etc/logcheck/logcheck.conf"
+ STATEDIR="/var/lib/logcheck"
+ LOGFILES_LIST="/etc/logcheck/logcheck.logfiles"
+-LOGFILE_FALLBACK="/var/log/syslog"
++LOGFILE_FALLBACK="/var/log/messages"
+ LOGTAIL="/usr/sbin/logtail2"
+ CAT="/bin/cat"
+ SYSLOG_SUMMARY="/usr/bin/syslog-summary"
+@@ -89,8 +89,8 @@
+ SORTUNIQ=0
+ SUPPORT_CRACKING_IGNORE=0
+ SYSLOGSUMMARY=0
+-LOCKDIR=/run/lock/logcheck
+-LOCKFILE="$LOCKDIR/logcheck"
++LOCKDIR=/var/lib/logcheck
++LOCKFILE="$LOCKDIR/logcheck"
+ 
+ # Carry out the clean up tasks
+ cleanup() {
+@@ -215,13 +215,13 @@
+ 	    mkdir "$cleaned" \
+ 	        || error "Could not make dir $cleaned for cleaned rulefiles."
+ 	fi
+-	for rulefile in $(run-parts --list "$dir"); do
++	for rulefile in $(ls $dir/*); do
+ 	    rulefile="$(basename "$rulefile")"
+ 	    if [ -f "${dir}/${rulefile}" ]; then
+ 		debug "cleanrules: ${dir}/${rulefile}"
+ 		if [ -r "${dir}/${rulefile}" ]; then
+ 			# pipe to cat on greps to get usable exit status
+-			egrep --text -v '^[[:space:]]*$|^#' "$dir/$rulefile" | cat \
++			egrep -v '^[[:space:]]*$|^#' "$dir/$rulefile" | cat \
+ 				>> "$cleaned/$rulefile" \
+ 			|| error "Couldn't append to $cleaned/$rulefile."
+ 		else
+@@ -326,7 +326,7 @@
+ 	debug "greplogoutput: $grepfile"
+ 
+ 	# Raise entries that match
+-	egrep --text -f "$raise/$grepfile" "$TMPDIR/logoutput-sorted" | cat \
++	egrep -f "$raise/$grepfile" "$TMPDIR/logoutput-sorted" | cat \
+ 	    > "$TMPDIR/checked" \
+ 	    || error "Could not output to $TMPDIR/checked."
+ 
+@@ -403,7 +403,7 @@
+ 
+     if [ -f "$clean" ]; then
+ 	debug "cleanchecked - file: $clean"
+-        egrep --text -v -f "$clean" "$TMPDIR/checked" | cat >> "$TMPDIR/checked.1"  \
++        egrep -v -f "$clean" "$TMPDIR/checked" | cat >> "$TMPDIR/checked.1"  \
+ 	    || error "Could not output to $TMPDIR/checked.1."
+ 	mv "$TMPDIR/checked.1" "$TMPDIR/checked" \
+ 	    || error "Could not move $TMPDIR/checked.1 to $TMPDIR/checked"
+@@ -411,7 +411,7 @@
+ 	debug "cleanchecked - dir - $clean"
+ 	for file in $(ls -1 "$clean/"); do
+ 	debug "cleanchecked - dir - $clean/$file"
+-	    egrep --text -v -f "$clean/$file" "$TMPDIR/checked" | cat \
++	    egrep -v -f "$clean/$file" "$TMPDIR/checked" | cat \
+ 		>> "$TMPDIR/checked.1" \
+ 		    || error "Could not output to TMPDIR/checked.1."
+ 	    mv "$TMPDIR/checked.1" "$TMPDIR/checked" \
+@@ -663,7 +663,7 @@
+     || error "Could not mkdir for log files"
+ if [ ! "$LOGFILE" ] && [ -r "$LOGFILES_LIST" ]; then
+     SAVEIFS=$IFS; IFS=$(echo -en "\n\b");
+-    for file in $(egrep --text -v "(^#|^[[:space:]]*$)" "$LOGFILES_LIST"); do
++    for file in $(egrep -v "(^#|^[[:space:]]*$)" "$LOGFILES_LIST"); do
+ 	logoutput "$file"
+     done
+     IFS=$SAVEIFS
+@@ -785,3 +785,4 @@
+ elif [ "$SYSTEM" -eq 1 ]; then
+     sendreport "$EVENTSSUBJECT"
+ fi
++
+
+--- logcheck-1.3.17/src/logcheck-test
++++ logcheck-1.3.17/src/logcheck-test.new
+@@ -176,9 +176,9 @@
+     exit 3
+ else
+     if [ -n "$RULEFILE" ] ; then
+-        CLEANRULE="$(mktemp --tmpdir logcheck-test.XXXXXXXXXX)"
++        CLEANRULE="$(mktemp -t logcheck-test.XXXXXXXXXX)"
+         cleanup() { rm -rf $CLEANRULE; }
+-        egrep --text -v '^[[:space:]]*$|^#' "$RULEFILE" >> $CLEANRULE
++        egrep -v '^[[:space:]]*$|^#' "$RULEFILE" >> $CLEANRULE
+         sed -e 's/[[:space:]]*$//' $FILE | egrep $INVERT -f "$CLEANRULE"
+         GREP="$?"
+         cleanup
+@@ -203,3 +203,4 @@
+     fi
+     exit $EXIT
+ fi
++
+

--- a/testing/logcheck-busybox/01-kernel_regex.patch
+++ b/testing/logcheck-busybox/01-kernel_regex.patch
@@ -1,0 +1,6 @@
+--- logcheck-1.3.17/rulefiles/linux/violations.d/kernel
++++ logcheck-1.3.17/rulefiles/linux/violations.d/kernel.new
+@@ -1,2 +1,2 @@
+-^\w{3} [ :0-9]{11} [._[:alnum:]-]+ kernel:( \[ *[[:digit:]]+\.[[:digit:]]+\])? [[:alnum:]]+: media error \(bad sector\): status=0x[[:xdigit:]]+ { DriveReady SeekComplete Error }$
++^\w{3} [ :0-9]{11} [._[:alnum:]-]+ kernel:( \[ *[[:digit:]]+\.[[:digit:]]+\])? [[:alnum:]]+: media error \(bad sector\): status=0x[[:xdigit:]]+ \{ DriveReady SeekComplete Error \}$
+ ^\w{3} [ :0-9]{11} [._[:alnum:]-]+ kernel:( \[ *[[:digit:]]+\.[[:digit:]]+\])? end_request: I/O error, dev [[:alnum:]]+, sector [[:digit:]]+

--- a/testing/logcheck-busybox/02-sh-not-bash.patch
+++ b/testing/logcheck-busybox/02-sh-not-bash.patch
@@ -1,0 +1,21 @@
+--- logcheck-1.3.17/src/logcheck
++++ logcheck-1.3.17/src/logcheck.new
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env bash
++#!/bin/sh
+ #
+ # Copyright (C) 2004-2012,2014 Debian Logcheck Team
+ #                              <logcheck-devel@alioth.lists.debian.org>
+@@ -24,10 +24,10 @@
+ 
+ if [ `id -u` = 0 ]; then
+     echo "logcheck should not be run as root. Use su to invoke logcheck:"
+-    echo "su -s /bin/bash -c \"/usr/sbin/logcheck${@:+ $@}\" logcheck"
++    echo "su -s /bin/sh -c \"/usr/sbin/logcheck${@:+ $@}\" logcheck"
+     echo "Or use sudo: sudo -u logcheck logcheck${@:+ $@}."
+     # you may want to uncomment that hack to let logcheck invoke itself.
+-    # su -s /bin/bash -c "$0 $*" logcheck
++    # su -s /bin/sh -c "$0 $*" logcheck
+     exit 1
+ fi
+ 

--- a/testing/logcheck-busybox/APKBUILD
+++ b/testing/logcheck-busybox/APKBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+pkgname=logcheck-busybox
+_pkgname=${pkgname/-busybox/}
+pkgver=1.3.17
+pkgrel=0
+pkgdesc="Monitor log files for anomalies [patched to work with busybox builtin tools]"
+url="http://packages.debian.org/source/sid/logcheck"
+arch="noarch"
+license="GPL"
+depends="lockfile-progs perl-mime-construct"
+install="$pkgname.pre-install"
+subpackages="$pkgname-doc"
+pkgusers="logcheck"
+options="!check"
+source="http://ftp.debian.org/debian/pool/main/l/logcheck/${_pkgname}_$pkgver.tar.xz
+	logcheck.cron.d
+	logcheck.cron.sample.d
+	logcheck.initd
+	00-busybox-compat.patch
+	01-kernel_regex.patch
+	02-sh-not-bash.patch
+	"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+	mkdir -p "$pkgdir"/var/lib/logcheck
+	mkdir -p "$pkgdir"/var/lock/logcheck
+	mkdir -p "$pkgdir"/usr/share/man/man8
+	mkdir -p "$pkgdir"/usr/share/man/man1
+	mkdir -p "$pkgdir"/usr/share/doc/logcheck
+
+	install -D -m 755 "$srcdir"/logcheck.cron.d "$pkgdir"/etc/periodic/hourly/logcheck
+	install -D -m 755 "$srcdir"/logcheck.initd "$pkgdir"/etc/init.d/logcheck
+	install -D -m 644 "$srcdir"/logcheck.cron.sample.d "$pkgdir"/etc/logcheck/logcheck.cron.sample
+	mv "$builddir"/docs/*.8 "$pkgdir"/usr/share/man/man8/
+	mv "$builddir"/docs/*.1 "$pkgdir"/usr/share/man/man1/
+	mv "$builddir"/docs/* "$pkgdir"/usr/share/doc/logcheck/
+
+	rm -rf "$pkgdir"/var/lock # lockfile kept in /var/lib/logcheck => run as logcheck user
+	chown -R $pkgusers "$pkgdir"/etc/logcheck "$pkgdir"/var/lib/logcheck
+	chmod 750 "$pkgdir"/etc/logcheck
+}
+
+sha512sums="e4a30b6ccd7a9f0f51354b1a6e577f6a3837e3db078f61b3d3ceaf630a1f1eeae03324e6ec58307f8f723dbd017e1543c15f7dc34e50c0eeb9ee0b160b2c879d  logcheck_1.3.17.tar.xz
+9f1ab5c161e816ed8e327197216737bf9c37784b2c4874b19aff1a45c5b2c1d3032b3f5053535b22de7e807ba5bb8232a5bff8a7e5abef6cba71e5b0ca1946fc  logcheck.cron.d
+6eb2b86b110b18c6cc5f27637897f8d7a0021722b7f2662a04047c0e8e5a2058173ebb0d2794efe52b7d3b5bd82e971899a21a033d6ac93a19f78b57bdcbbf83  logcheck.cron.sample.d
+f36b30255652bb944fc62c4f4ea7e3b3228d2220b37d910de5489b12b2a54d00dccc92eed94ca9d63314416c94903c8ba7366a943ab505150f55361f0ca0967f  logcheck.initd
+b93465c6c1583c94a88d3fe808a8ef37ccdf12610a378872c05b614cc988c6184f7b233d8230b63881bc294a27aae2807df8429fbbdbe330532f363973aa9b15  00-busybox-compat.patch
+f1269ea4692284095404aa84f1a5ba5c67c6233e5b6054618ae1ddb941dc6605f2df4bcfc875028634178ee3c7c15638a951e4de951ad5481d7cfab612636344  01-kernel_regex.patch
+c2947555cfee113d09164b14ed6c975d28a16fcbad98feeceedad29963d02b5bc66f04ce23355459bb434996fa6d1353e3dfac52d79573c2ca7f1eee943c1816  02-sh-not-bash.patch"

--- a/testing/logcheck-busybox/logcheck-busybox.pre-install
+++ b/testing/logcheck-busybox/logcheck-busybox.pre-install
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+addgroup -S logcheck 2>/dev/null
+adduser -S -D -H -h /var/lib/logcheck -s /sbin/nologin -G logcheck -g logcheck logcheck 2>/dev/null
+printf "adding logcheck user to group => mail\n"
+addgroup logcheck mail
+
+exit 0

--- a/testing/logcheck-busybox/logcheck.cron.d
+++ b/testing/logcheck-busybox/logcheck.cron.d
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# fix permissions
+# busybox syslog => add logcheck to group wheel
+# ---------------------------------------------------------------
+if [ -d /var/log/socklog ]; then
+        find /var/log/socklog -type d -exec chown :logcheck {} \;
+        chown :logcheck /var/log/socklog/*/current
+fi
+
+chown -R logcheck /etc/logcheck
+# ---------------------------------------------------------------
+
+if [ "$1" = "reboot" ]; then
+        REBOOT="-R"
+fi
+
+if [ -x /usr/sbin/logcheck ]; then
+        if [ ! -d /etc/pam.d ]; then
+                # libpam does not work with a subshell
+                su -s /bin/sh -c "nice -n10 /usr/sbin/logcheck ${REBOOT} &" logcheck
+        else
+                # sudo works without modification
+                if [ -x /usr/bin/sudo ]; then
+                        sudo -u logcheck nice -n10 /usr/sbin/logcheck ${REBOOT} &
+                else
+                        logger "install sudo to use logcheck with linux-pam"
+                fi
+        fi
+fi
+

--- a/testing/logcheck-busybox/logcheck.cron.sample.d
+++ b/testing/logcheck-busybox/logcheck.cron.sample.d
@@ -1,0 +1,34 @@
+## non busybox cron:
+## /etc/cron.d/logcheck: crontab entries for the logcheck package
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+MAILTO=root
+
+@reboot         logcheck    if [ -x /usr/sbin/logcheck ]; then nice -n10 /usr/sbin/logcheck -R; fi
+2 * * * *       logcheck    if [ -x /usr/sbin/logcheck ]; then nice -n10 /usr/sbin/logcheck; fi
+
+# EOF
+
+## busybox cron:
+
+see included:
+
+/etc/init.d/logcheck (for @reboot functionality)
+/etc/periodic/hourly/logcheck
+
+
+## sSMTP configuration
+
+addgroup logcheck mail
+chown :mail /etc/ssmtp/ssmtp.conf
+chmod 640 /etc/ssmtp/ssmtp.conf
+
+
+## socklog configuration [ /etc/sv/socklog-unix/log/run ]
+
+#!/bin/sh
+exec chpst -ulog:logcheck svlogd \
+  main/main main/auth main/cron main/daemon main/debug main/ftp \
+  main/kern main/local main/mail main/news main/syslog main/user
+
+#EOF

--- a/testing/logcheck-busybox/logcheck.initd
+++ b/testing/logcheck-busybox/logcheck.initd
@@ -1,0 +1,19 @@
+#!/sbin/openrc-run
+
+name="$RC_SVCNAME"
+description="Provide @reboot functionality for logcheck in Busybox"
+command="/etc/periodic/hourly/logcheck reboot"
+
+depend() {
+	need localmount
+}
+
+start() {
+        einfo "Logcheck: cleaning all dead.letter"
+        rm -f /var/lib/logcheck/dead.letter
+        rm -f /srv/lxc/*/rootfs/var/lib/logcheck/dead.letter
+}
+
+stop() {
+        return 0
+}


### PR DESCRIPTION
The version of `logcheck` in main requires `bash` GNU `grep` / Debian `run-parts` to work. It also cannot be called from an init script as `openrc` will cause busybox `grep` & `run-parts` to be used by `logcheck`. 

`logcheck-busybox` is patched to use the busybox builtin tools so it works out of the box.

includes:

* `/etc/init.d/logcheck` to provide `@reboot` functionality to `logcheck` with busybox `crond`

* `/etc/periodic/hourly/logcheck`