### PR TITLE
main/ipset: improve initd / add conf.d

### DIFF
--- a/main/ipset/APKBUILD
+++ b/main/ipset/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Kaarle Ritvanen <kaarle.ritvanen@datakunkku.fi>
 pkgname=ipset
 pkgver=6.29
-pkgrel=0
+pkgrel=1
 pkgdesc="Manage Linux IP sets"
 url=http://ipset.netfilter.org/
 arch="all"
@@ -11,21 +11,13 @@ depends_dev="libmnl-dev"
 makedepends="$depends_dev automake autoconf libtool linux-headers"
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://ipset.netfilter.org/ipset-$pkgver.tar.bz2
-		ipset.initd"
-
-_builddir=$srcdir/ipset-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+		ipset.initd
+		ipset.confd
+		"
+builddir=$srcdir/ipset-$pkgver
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -36,17 +28,21 @@ build() {
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	make install DESTDIR=$pkgdir || return
 
-	mkdir -p "$pkgdir/etc/init.d" \
-		"$pkgdir/etc/ipset.d"
-	install -m 755 "$startdir/ipset.initd" "$pkgdir/etc/init.d/ipset"
+	mkdir -p "$pkgdir/etc/ipset.d" \
+		"$pkgdir/var/lib/ipset"
+	install -m 755 -D "$startdir/ipset.initd" "$pkgdir/etc/init.d/ipset"
+	install -m 644 -D "$startdir/ipset.confd" "$pkgdir/etc/conf.d/ipset"
 }
 
 md5sums="fd8ea35997115c5c630eee22f0beecec  ipset-6.29.tar.bz2
-5879eb9ff65f102003376634f60c578f  ipset.initd"
+c1008b16846e160b047824ec413c1641  ipset.initd
+42dba16016476fff1e96e87f203bf9ce  ipset.confd"
 sha256sums="6af58b21c8b475b1058e02529ea9f15b4b727dbc13dc9cbddf89941b0103880e  ipset-6.29.tar.bz2
-90822d788ef4b1d04bcf5130ac5b97bbfd044a62be35360289ec1252c590a3c1  ipset.initd"
+e41feffe703b8485cc3501b8ec8c7e2cf186ac60236126053698b2bdbc9b955b  ipset.initd
+da86b6a8b9089c58faad3042bc13f0f374c9672d8d396bda91da366b991da6cb  ipset.confd"
 sha512sums="ce62c72c4cea1b52f069602a90fbffe9bcb12bf70f5b42d93cacb48e4b5d1192a13b18be45391c66a65421f41968e73416e16af25ae6ef19ba92bdbb2cd45ff3  ipset-6.29.tar.bz2
-73993eb882371f5ef605762c96ad33625b99680aa38c823ed908dfc43b1fa86eb7714fe3b6e4cd5547b7b0a9b1f4209d2541d60341548fcbbfa95244471cfc93  ipset.initd"
+8f1f7cf84e843201b199b77ef72c6ab32e53c19e005747cf2a901481465735f8ad4942adbe97e16fa88ca7675ee3ed5102a663260265f26bdeb47b2ae1612a3c  ipset.initd
+822fbabee6ed009e386913a296f8c6cf66b513626aa23eaa33fe0f8ec5ac97d88dd66e5e94f8d0129265015b450c6520c196dc4b0187390c09e87876d0eb2f4d  ipset.confd"

--- a/main/ipset/ipset.confd
+++ b/main/ipset/ipset.confd
@@ -1,0 +1,24 @@
+# /etc/conf.d/ipset
+
+# Location in which ipset initscript will save set rules on 
+# service shutdown
+IPSET_SAVE="/var/lib/ipset/rules-save"
+
+# Save state on stopping ipset
+SAVE_ON_STOP="yes"
+
+# If you need to log iptables messages as soon as iptables starts,
+# AND your logger does NOT depend on the network, then you may wish
+# to uncomment the next line.
+# If your logger depends on the network, and you uncomment this line
+# you will create an unresolvable circular dependency during startup.
+# After commenting or uncommenting this line, you must run 'rc-update -u'.
+#rc_use="logger"
+
+# Auto manage iptables rules
+#IPT_MANAGE="yes"
+
+# enable iptables logging (will also trigger PSAD)
+IPT_LOGS="no"
+IPTABLES_LOG_PREFIX="IPSET BLOCKED"
+

--- a/main/ipset/ipset.initd
+++ b/main/ipset/ipset.initd
@@ -1,13 +1,17 @@
 #!/sbin/openrc-run
 # Init script for ipset
-# Copyright (C) 2012 Kaarle Ritvanen
+# Copyright (C) 2016  Stuart Cardall
 # Licensed under the terms of the GPL2
 
 description="Manage IP sets in the Linux kernel"
+description_info="List active IP sets / raw iptables rules"
 description_save="Save firewall IP sets"
-description_reload="Load firewall IP sets"
+description_load="Load inactive ipset.d files"
+description_unload="Unload / remove specific IP set"
+description_reload="Reload all firewall IP sets"
 
-extra_started_commands="save reload"
+extra_commands="info"
+extra_started_commands="save load unload reload"
 
 IPSET=/usr/sbin/ipset
 DIR=/etc/ipset.d
@@ -18,38 +22,73 @@ ipset() {
 }
 
 set_files() {
-	(cd $DIR && ls)
+	find $DIR -maxdepth 1 -type f -exec basename {} \;
 }
 
 set_file() {
-	grep -v ^# $DIR/$1
+	egrep -v '(^//|^/\*|^#|^$|^[[:space:]]+$)' $1
+}
+
+set_comments() {
+	egrep '(^//|^/\*|^#|^$|^[[:space:]]+$)' $1
 }
 
 set_exists() {
 	$IPSET save $1 &> /dev/null
 }
 
-sets() {
+sets_lists() {
 	$IPSET save | sed "s/^create \\([^ ]\\+\\) ${1:+$1 }.*/\\1/;ta;d;:a"
 }
 
+sets() {
+	$IPSET list | grep ^Name: | awk '{print $2}'
+}
 
 depend() {
 	before iptables ip6tables
 }
 
+info() {
+	local len=$(iptables -t raw -L | head -n 1 | wc -m)
+
+	for name in $(sets); do
+		einfo "active: $name"
+	done
+
+	printf "%$(($len -2))s" | sed 's/ /_/g'
+	printf '\n|___ IP4 '
+	printf "%$(($len -11))s" | sed 's/ /_/g' && printf '|\n\n'
+	iptables -t raw -L
+	printf "%$(($len -2))s" | sed 's/ /_/g'
+	printf '\n|___ IP6 '
+	printf "%$(($len -11))s" | sed 's/ /_/g' && printf '|\n\n'
+	ip6tables -t raw -L
+}
+
 start() {
-	reload
+	ebegin "Restoring firewall IP sets from: ${IPSET_SAVE}"
+	$IPSET restore -f ${IPSET_SAVE}
+
+	#add iptables rules
+	add_ip $(sets)
 }
 
 stop() {
+	case "${SAVE_ON_STOP}" in
+		y*|Y*) save || return 1
+	esac
+
 	ebegin "Flushing firewall IP sets"
 
-	for name in $(sets list:set); do
+	for name in $(sets_lists list:set); do
+		del_ip $name
 		ipset destroy $name
 	done
 
 	for name in $(sets); do
+		einfo "destroying ipset: $name"
+		del_ip $name
 		ipset destroy $name
 	done
 
@@ -59,57 +98,141 @@ stop() {
 save() {
 	ebegin "Saving firewall IP sets"
 
-	ipset save | while read cmd; do
-		set -- $cmd
-		local action=$1
-		local file=$DIR/$2
-		shift 2
-		if [ "$action" = create ]; then
-			echo $* > $file
-		elif [ "$action" = add ]; then
-			echo $* >> $file
-		fi
-	done
-
-	for name in $(set_files); do
-		set_exists $name || rm -f $DIR/$name
-	done
+	einfo "--> ${IPSET_SAVE}"
+	$IPSET save > ${IPSET_SAVE}
 
 	eend $STATUS
 }
 
 reload() {
-	ebegin "Loading firewall IP sets"
-
 	local swap=
+	ebegin "Reloading all firewall IP sets"
+
 	for name in $(set_files); do
 		local new=$name
 		if set_exists $name; then
 			new=_init_$name
 			swap="$swap $name"
+			create_setfile $new $DIR/$name
 		fi
-		ipset create $new $(set_file $name | head -n 1)
-	done
-
-	for name in $(set_files); do
-		local new=$name
-		set_exists _init_$name && new=_init_$name
-		set_file $name | tail -n +2 | while read m; do
-			ipset add $new $m
-		done
 	done
 
 	for name in $swap; do
-		ipset swap $name _init_$name
-	done
-
-	for name in $(sets list:set); do
-		[ -f $DIR/$name ] || ipset destroy $name
-	done
-
-	for name in $(sets); do
-		[ -f $DIR/$name ] || ipset destroy $name
+		einfo "swapping _init_$name --> $name"
+		$IPSET swap _init_$name $name
+		ewarn "destroying ipset: _init_$name"
+		$IPSET destroy _init_$name
 	done
 
 	eend $STATUS
+	status
+}
+
+load() {
+	local name= ldsets=$(sets) tmpfile=$(mktemp)
+	ebegin "Loading inactive IP sets in: $DIR"
+
+	for name in $(set_files); do
+		if ! echo $ldsets |grep -q $name; then
+			create_setfile $name $DIR/$name
+			if set_exists $name; then
+				add_ip $name
+			fi
+		fi
+	done
+}
+
+create_setfile() {
+	local tmpfile=$(mktemp) name=$1 file=$2
+	local  set_format=$(head -n 1 $file)
+	einfo "creating ipset: '$name' => type: $set_format"
+
+	# remove any comments
+	set_file $file > $tmpfile
+
+	# loading from a file is much faster
+	# than adding elements individually
+	sed -i "s/^/add $name /" $tmpfile
+	sed -i "1s/.*/create $name $set_format/" $tmpfile
+
+	$IPSET restore -exist -f $tmpfile
+	rm -f $tmpfile
+}
+unload() {
+	local name= ldsets=$(sets) i=0 choice=
+	if [ -n "$ldsets" ]; then
+		for name in $ldsets; do
+			i=$(( $i + 1 ))
+			einfo "($i): $name"
+		done
+		printf "\nSelect ipset to destroy? [1 - $i]: "; read choice
+		case $choice in
+			''|*[!0-9]*) eerror "bad number" ;;
+			*) name=$(echo $ldsets | awk -v VAR=$choice '{print $VAR}')
+				if [ -n "$name" ]; then
+					printf "\n"; del_ip $name
+					ewarn "destroying ipset: $name"
+					ipset destroy $name
+				else
+					eerror "bad number"
+				fi
+				;;
+		esac
+	else
+		eerror "No IP sets loaded"
+	fi
+}
+
+ipt_version() {
+	if head -n 1 $1 |grep -q "family inet6"; then
+		echo ip6tables
+	else
+		echo iptables
+	fi
+}
+
+add_ip() {
+	local name= ipt_cmd=
+	if echo "${IPT_MANAGE}" | egrep -vq '(^y|^Y)'; then
+		return 0
+	fi
+	# block ips in the raw iptable:
+	# http://ipset.netfilter.org/tips.html
+	for name in $@; do
+		ipt_cmd=$(ipt_version $DIR/$name)
+
+		if ! $ipt_cmd -t raw -L | grep -q "match-set $name"; then
+			einfo "adding ipset iptables rule: $name"
+			$ipt_cmd -t raw -I PREROUTING -m set --match-set $name src -j DROP
+			$ipt_cmd -t raw -I OUTPUT -m set --match-set $name dst -j DROP
+
+			case ${IPT_LOGS} in
+			y*|Y*) $ipt_cmd -t raw -I PREROUTING -m set --match-set $name src -j LOG --log-prefix "${IPTABLES_LOG_PREFIX}: $name IN: " \
+				--log-ip-options --log-tcp-options;
+				$ipt_cmd -t raw -I OUTPUT -m set --match-set $name dst -j LOG --log-prefix "${IPTABLES_LOG_PREFIX}: $name OUT: " \
+				--log-ip-options --log-tcp-options;
+				;;
+			esac
+		fi
+	done
+}
+
+del_ip() {
+	local name= ipt_cmd=
+
+	if echo "${IPT_MANAGE}" | egrep -vq '(^y|^Y)'; then
+		return 0
+	fi
+
+	for name in $@; do
+		ipt_cmd=$(ipt_version $DIR/$name)
+
+		ewarn "removing ipset iptables rule: $name"
+		$ipt_cmd -t raw -D PREROUTING -m set --match-set $name src -j DROP 2>/dev/null
+		$ipt_cmd -t raw -D PREROUTING -m set --match-set $name src -j LOG --log-prefix "${IPTABLES_LOG_PREFIX}: $name IN: " \
+			--log-ip-options --log-tcp-options 2>/dev/null
+		$ipt_cmd -t raw -D OUTPUT -m set --match-set $name dst -j DROP 2>/dev/null
+		$ipt_cmd -t raw -D OUTPUT -m set --match-set $name dst -j LOG --log-prefix "${IPTABLES_LOG_PREFIX}: $name OUT: " \
+			--log-ip-options --log-tcp-options 2>/dev/null
+	done
 }


### PR DESCRIPTION
The existing initd loads ip list items individually which delays booting by 1-2 minutes using
the ip lists from iblocklist.com (approximately 140,000 ip addresses)

This patch rewrites `initd` & generates / formats a temporary file for `ipset` to read as a file.
It also saves `ipset` rules to a file for reading in `start()` as done by Gentoo.

* `initd` implements all of http://ipset.netfilter.org/tips.html

* sets are now loaded from `ipset.d` files in a fraction of a second.

* adds optional support to manage `iptables` / `ip6tables` rules [ disabled by default ]

* adds optional support to add `iptables` / `ip6tables` logging [ disabled by default ]

* adds a '`load`' option to load any `ipset.d` file not currently loaded.

* adds an '`info`' option to show loaded sets / `iptables` rules.

To view available options run:

`rc-service ipset describe`
