### PR TITLE
main/lua-yaml: upgrade to 1.1.2

### DIFF
--- a/main/lua-lub/APKBUILD
+++ b/main/lua-lub/APKBUILD
@@ -1,0 +1,39 @@
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
+# Maintainer: Jakub Jirutka <jakub@jirutka.cz>
+pkgname=lua-lub
+_pkgname=lub
+pkgver=1.1.0
+pkgrel=0
+pkgdesc="Lubyk base module for Lua"
+url="http://doc.lubyk.org/lub.html"
+arch="noarch"
+license="MIT"
+depends=""
+makedepends=""
+subpackages=""
+source="$pkgname-$pkgver.tar.gz::https://github.com/lubyk/$_pkgname/archive/REL-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-REL-$pkgver"
+
+_luaversions="5.1 5.2 5.3"
+for _v in $_luaversions; do
+	makedepends="$makedepends lua$_v-dev"
+	subpackages="$subpackages lua$_v-$_pkgname:_subpackage"
+done
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_subpackage() {
+	local lver="${subpkgname:3:3}"
+	pkgdesc="$pkgdesc $lver"
+	depends="$depends lua$lver lua$lver-filesystem"
+	install_if="$pkgname=$pkgver-r$pkgrel lua$lver"
+
+	mkdir -p "$subpkgdir"/usr/share/lua/$lver
+	cp -r "$builddir"/lub "$subpkgdir"/usr/share/lua/$lver/
+}
+
+md5sums="093cbf163ef2fea60031aea2619ae4b9  lua-lub-1.1.0.tar.gz"
+sha256sums="355f427f28155c4cf3a9673aa24c3754ea782c1c5f2081cbc4c28c00ed69a0b7  lua-lub-1.1.0.tar.gz"
+sha512sums="46f18cfc12d919694ddba7ab875e579381cd964c18b91dfb46d4f8091b90fd7daef96eaf0e16bd4fb3e01962adb74eeed47259aac014ebf24f85955d99a873f3  lua-lub-1.1.0.tar.gz"

--- a/main/lua-yaml/APKBUILD
+++ b/main/lua-yaml/APKBUILD
@@ -1,38 +1,65 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=lua-yaml
-pkgver=0.2
+_pkgname=yaml
+pkgver=1.1.2
 pkgrel=0
 pkgdesc="LibYaml binding for Lua"
 url="http://yaml.luaforge.net"
-arch="all"
+arch="noarch"
 license="MIT"
 depends=""
-makedepends="yaml-dev lua-dev"
-install=""
+makedepends="cmake yaml-dev"
 subpackages=""
-source="http://luaforge.net/frs/download.php/4284/yaml-$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/lubyk/$_pkgname/archive/REL-$pkgver.tar.gz
+	cmake.patch"
+builddir="$srcdir/$_pkgname-REL-$pkgver"
 
-_builddir="$srcdir"/yaml-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
+_luaversions="5.1 5.2 5.3"
+for _v in $_luaversions; do
+	makedepends="$makedepends lua$_v-dev"
+	subpackages="$subpackages lua$_v-$_pkgname:_subpackage"
+done
+
+build() {
+	local lver; for lver in $_luaversions; do
+		msg "Building for Lua $lver..."
+
+		mkdir -p "$builddir"/build/$lver
+		cd "$builddir"/build/$lver
+
+		cmake \
+			-DCMAKE_C_FLAGS="$CFLAGS -Wall -DNDEBUG $(pkg-config --cflags lua$lver)" \
+			-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+			-DCMAKE_SKIP_RPATH=TRUE \
+			-DCMAKE_VERBOSE_MAKEFILE=TRUE \
+			-DLUA_INSTALL_DIR=/usr/share/lua/$lver \
+			-DLUA_INSTALL_BINDIR=/usr/lib/lua/$lver \
+			"$builddir" || return 1
+		make || return 1
 	done
 }
 
-build() {
-	cd "$_builddir"
-	make || return 1
-}
-
 package() {
-	cd "$_builddir"
-	install -d "$pkgdir"/usr/lib/lua/5.1
-	make PREFIX="$pkgdir"/usr install || return 1
+	mkdir -p "$pkgdir"
 }
 
-md5sums="18c25a2a6609b2862e3485952cf73634  yaml-0.2.tar.gz"
+_subpackage() {
+	local lver="${subpkgname:3:3}"
+	pkgdesc="$pkgdesc $lver"
+	arch="all"
+	depends="$depends lua$lver lua$lver-lub"
+	install_if="$pkgname=$pkgver-r$pkgrel lua$lver"
+	[ "$lver" = 5.1 ] && replaces="$pkgname"
+
+	cd "$builddir"/build/$lver
+	make DESTDIR="$subpkgdir" install
+}
+
+md5sums="6665b0c82da0edae184b8a32be7518b5  lua-yaml-1.1.2.tar.gz
+44294987c54623c6a5b013ba7ebb5c58  cmake.patch"
+sha256sums="b4391d182677ab644403bf1ac028c7421c2605db124f9792193013c582a273ec  lua-yaml-1.1.2.tar.gz
+b898249d2dbeff2152b84ba46c94571c058a3b9339db1683de69cb6161575715  cmake.patch"
+sha512sums="9d2ff4ddc243922f11c2ebea1d45bb3fa02e96a30752c04e65aec236e76780780511fe605a7a0bdbe9764189764a3951aadff8bb028c402571fd052cd70e35ac  lua-yaml-1.1.2.tar.gz
+db024b2acfa88441a4a72ec9c2a42d0980465cd759815474f02e3912ca458d913317aacdecf911e4048d43bab7878f472ce044f57dac3df66d20752e1255a8a8  cmake.patch"

--- a/main/lua-yaml/cmake.patch
+++ b/main/lua-yaml/cmake.patch
@@ -1,0 +1,15 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -53,12 +53,6 @@
+   endif(WIN32)
+ endif(UNIX)
+ 
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -fPIC -O2")
+-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -fPIC -O2")
+-if (RELEASE)
+-  add_definitions(-O2 -DNDEBUG)
+-endif(RELEASE)
+-
+ # --------------------------------------------------------------
+ #  yaml.core
+ # --------------------------------------------------------------


### PR DESCRIPTION
@ncopa Latest version of lua-yaml requires new dependency – lua-[lub](http://doc.lubyk.org/lub.html). What to do in this case? Add new aport lua-lub to the main, or move lua-yaml to testing or community?