### PR TITLE
testing/nginx-naxsi: update to 1.11.5 / naxsi 0.55.1

### DIFF
--- a/testing/nginx-naxsi/APKBUILD
+++ b/testing/nginx-naxsi/APKBUILD
@@ -5,8 +5,8 @@
 
 pkgname=nginx-naxsi
 _pkgname=nginx
-pkgver=1.11.3
-_ngx_naxsi_ver=0.54
+pkgver=1.11.5
+_ngx_naxsi_ver=0.55.1
 _ngx_cache_purge_ver=2.3
 _ngx_upstream_fair_ver=0.1.0
 _ngx_http_sysguard_ver=2.1.0
@@ -17,7 +17,7 @@ arch="all"
 license="custom"
 install="$pkgname.pre-install $pkgname.pre-upgrade"
 depends="!nginx"
-makedepends="pcre-dev openssl-dev zlib-dev paxmark linux-headers"
+makedepends="pcre-dev libressl-dev zlib-dev paxmark linux-headers"
 subpackages="$pkgname-doc $pkgname-vim:vim"
 source="http://nginx.org/download/$_pkgname-$pkgver.tar.gz
 	naxsi-$_ngx_naxsi_ver.tar.gz::https://github.com/nbs-system/naxsi/archive/$_ngx_naxsi_ver.tar.gz
@@ -80,7 +80,6 @@ build() {
 		--with-mail_ssl_module \
 		--with-file-aio \
 		--with-http_v2_module \
-		--with-ipv6 \
 		--without-http_uwsgi_module \
 		--without-http_scgi_module \
 		--add-module="$srcdir/naxsi-$_ngx_naxsi_ver/naxsi_src" \
@@ -119,8 +118,8 @@ vim() {
         done
 }
 
-md5sums="18275c1daa39c5fac12e56c34907d45b  nginx-1.11.3.tar.gz
-1bc31058991268e4cfdb44e9b6d8b3b3  naxsi-0.54.tar.gz
+md5sums="db43f2b19746f6f47401c3afc3924dc6  nginx-1.11.5.tar.gz
+b894ea5327a3d102a56aeddb79d2e047  naxsi-0.55.1.tar.gz
 dc4c0688ed03ca7f5563097c2a8a76ca  ngx_cache_purge-2.3.tar.gz
 f3562ef6573f616e254d382d6f86b8e1  upstream-fair-0.1.0.tar.gz
 fdb072dc8d67b573a0ea7983530a7d2b  sysguard-2.1.0.tar.gz
@@ -129,8 +128,8 @@ f478d8391dafa32a8b0b3a9f21d7a080  ipv6.patch
 50357b75049d878c0bcce10d0c60f9ed  sysguard.patch
 609ea97ab6c3c30f9e8329968aadc4f3  nginx.initd
 8823274a834332d3db4f62bf7dd1fb7d  nginx.logrotate"
-sha256sums="4a667f40f9f3917069db1dea1f2d5baa612f1fa19378aadf71502e846a424610  nginx-1.11.3.tar.gz
-9cc2c09405bc71f78ef26a8b6d70afcea3fccbe8125df70cb0cfc480133daba5  naxsi-0.54.tar.gz
+sha256sums="223f8a2345a75f891098cf26ccdf208b293350388f51ce69083674c9432db6f6  nginx-1.11.5.tar.gz
+45dd0df7a6b0b6aa9c64eb8c39a8e294d659d87fb18e192cf58f1402f3cdb0a8  naxsi-0.55.1.tar.gz
 cb7d5f22919c613f1f03341a1aeb960965269302e9eb23425ccaabd2f5dcbbec  ngx_cache_purge-2.3.tar.gz
 dd0bfb79d2489f48ea63ac004d91890cd471eb4020500ce9179c3612cb13246c  upstream-fair-0.1.0.tar.gz
 97e0cc9a36fcce375c5b0667b002d2f7acd580e968a2318e3276fbdc1b99f8e4  sysguard-2.1.0.tar.gz
@@ -139,8 +138,8 @@ dd0bfb79d2489f48ea63ac004d91890cd471eb4020500ce9179c3612cb13246c  upstream-fair-
 18090329435c32d91621a5943acc5b8bbe89aaa3c2fa334c3a4cdeb00efb6226  sysguard.patch
 8cbef405295eac299dfc3b9b119c02bda354a9b335923bed6ff6992c1fd8f493  nginx.initd
 cea0c6f8de55a4c3a3eccc57910de1c3116634082c8e5b660630fb927a29f38d  nginx.logrotate"
-sha512sums="b983aca61335facf5778675b80fc28341ec9cfee2190319ed130b9c5d5ceff8133677f4609ecafd5a782daa5962e41bb6cb6a857380bbbe9cee67cd0ab2026d4  nginx-1.11.3.tar.gz
-91934bfd41495715269cc6e549d17f6da66f2bdd0c9a6821fa9096b694dd3927109c4aad2f8b327620ae7c34f76a0839ac16669cd8c65081bc01fa7f829c1d43  naxsi-0.54.tar.gz
+sha512sums="f41b21b5d8c6b7fe7f8713e96fb6b1c40da49bf64ebb790fb5aa38f036a37b36fcf048ff72c2216552b2f75366b30c5fcdef26312bd4e5515b2476a1cd944b8c  nginx-1.11.5.tar.gz
+aebda20e5b78e9111b7bac1e15829258e6b85b80e4ce333e4dba8caead36287b3f0fcb453c51d7c59f07d637fa62f5c6b23aecd3bf6a3c3da4abebf1a6689f14  naxsi-0.55.1.tar.gz
 81929ca57ce5c2e1af6ec43882a54ff1da8dc77786bfb7505ff94fbcf970ae8870b419dc5c0bc7b80794d75a359e0100f360c1cf458a300f802b1d8bd7053811  ngx_cache_purge-2.3.tar.gz
 2ff9894986c5cd483ecee97d8818675ef6d063e5f45bb66e8cf56c78bbd043b9c0c37eb3cf650b7cfb6d40da9f7a4ba0e030fe39de5ef1f715cbcd6560248428  upstream-fair-0.1.0.tar.gz
 f9587b8aa7a2b09be016dc6f7a07fe3fee154d16172194e899bf3c78a3f4e373c78f79932794cd9ac75793514c606ab878f88be9400b70e37528d263f1541b34  sysguard-2.1.0.tar.gz


### PR DESCRIPTION
https://nginx.org/en/CHANGES

- `--with-ipv6` option is [deprecated](https://github.com/nginx/nginx/commit/2c84f7af2c97a55bf138a5fcedeb164733dc9bea) (ipv6 support included by default)
- built with `libressl`