### PR TITLE
testing/hugo: Updated to 0.17

### DIFF
--- a/testing/hugo/APKBUILD
+++ b/testing/hugo/APKBUILD
@@ -1,41 +1,39 @@
 # Contributor: Thomas Boerger <thomas@webhippie.de>
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=hugo
-pkgver=0.16
+pkgver=0.17
 pkgrel=0
 pkgdesc="A Fast and Flexible Static Site Generator built with love in GoLang"
 url="http://gohugo.io/"
 arch="all"
 license="Apache 2.0"
 depends=""
-depends_dev=""
-makedepends="$depends_dev go"
+makedepends="go"
 install=""
 subpackages=""
 source="${pkgname}-${pkgver}.tar.gz::https://github.com/spf13/hugo/archive/v$pkgver.tar.gz"
 
-builddir="${srcdir}/${pkgname}-${pkgver}"
-_godir="${srcdir}/go"
-_gourl="github.com/spf13/hugo"
+builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-	mkdir -p ${_godir}/bin ${_godir}/src/github.com/spf13
-	ln -sf ${builddir} ${_godir}/src/github.com/spf13/hugo
+	goparent="github.com/spf13"
+	gourl="$goparent/$pkgname"
 
-	cd ${_godir}/src/${_gourl}
-	export GOPATH="${_godir}"
+	export GOPATH="$srcdir/go"
 
-	go get -d -v ./...
-	go install -v ${_gourl} || return 1
+	mkdir -p $srcdir/go/bin $srcdir/go/src/$goparent || return 1
+	ln -sf $builddir $srcdir/go/src/$gourl || return 1
+	cd $srcdir/go/src/$gourl || return 1
+
+	go fix || return 1
+	go build -o $srcdir/go/bin/$pkgname -ldflags "-s -w" || return 1
 }
 
 package() {
-	cd "$_godir"/bin
-
-	install -Dm755 hugo \
-		"${pkgdir}/usr/bin/hugo" || return 1
+	install -Dm755 "$srcdir/go/bin/$pkgname" \
+		"$pkgdir/usr/bin/$pkgname" || return 1
 }
 
-md5sums="9f5b952c08436cdff4baec9e73dfd6c5  hugo-0.16.tar.gz"
-sha256sums="a2dbb243535ba69ae8709ffe5ba340951a8834d2c0e86bb76c88d99ad77ef9f5  hugo-0.16.tar.gz"
-sha512sums="4c380d69d0616e43c991a67d499e31ff062b2f3714d944ce87252d1356445a08f59ac5eddebe572071318f1234f0b54cbb625632ba28b583cacffea5d728a230  hugo-0.16.tar.gz"
+md5sums="6e2b1c6b1eeac2cadda53a34caf5d9d6  hugo-0.17.tar.gz"
+sha256sums="c09913e00d8af9d7ffc7a6aa414c147f8edd7417d430fd59478989e544347590  hugo-0.17.tar.gz"
+sha512sums="1c21b029895182be2648fa4f4f3a8040a44f3d7db13fff378992b7eec23cd58ca4354358defbb317e679c1b2f176c1e4f0812b737404abc36f7f739ba3da0844  hugo-0.17.tar.gz"


### PR DESCRIPTION
This currently doesn't work because it's missing the dependencies. The dependencies are defined at https://github.com/spf13/hugo/blob/v0.17/vendor/vendor.json but how do you handle the dependency retrieve now?
