### PR TITLE
testing/vault: bumping to 0.6.2

### DIFF
--- a/testing/vault/APKBUILD
+++ b/testing/vault/APKBUILD
@@ -1,15 +1,15 @@
 # Contributor: Christian Kampka <christian@kampka.net>
 # Maintainer:
 pkgname=vault
-pkgver=0.6.1
-pkgrel=1
+pkgver=0.6.2
+pkgrel=0
 pkgdesc="Vault is a tool for securely accessing secrets."
 url="https://www.vaultproject.io/"
 arch="all"
 license="MPL-2.0"
 depends=""
 makedepends="go"
-install="$pkgname.pre-install"
+install="$pkgname.pre-install $pkgname.pre-deinstall"
 pkgusers="vault"
 pkggroups="vault"
 options="!strip"
@@ -39,21 +39,25 @@ package() {
 	install -m750 -o root -g vault -D bin/$pkgname \
 		"$pkgdir/usr/sbin/$pkgname" || return 1
 
+	# allow vault to use mlock as "vault" user
+	setcap cap_ipc_lock=+ep \
+		"$pkgdir/usr/sbin/$pkgname" || return 1
+
 	install -m750 -o root -g vault -D "$srcdir/$pkgname.hcl" \
 		"$pkgdir/etc/$pkgname.hcl" || return 1
 
 	install -m750 -o vault -g vault -d "$pkgdir/var/lib/$pkgname" || return 1
 }
 
-md5sums="246bf47e3a90eb5b7c855b83befd5841  vault-0.6.1.tar.gz
+md5sums="06b1253f0aa1f3ac39e6e23d929c6ea5  vault-0.6.2.tar.gz
 2148a788620484be07e1e24feb1cbd34  vault.confd
 1f7802f479024809856e3be2e44a1b19  vault.hcl
 ca400b34773b25367acc85a950c3c887  vault.initd"
-sha256sums="5f90f22ba8c2be8b8324cf3794b3f1d2599238eb46cb23cd20a40eefb9b7e0ec  vault-0.6.1.tar.gz
+sha256sums="295197e8ec7d03d4e141733579250ed653b13862a2d83dfd0d11a6e82f28b436  vault-0.6.2.tar.gz
 f197536bc5bf4531072c0a5cb17627bf01abd188b0cc2005e0ff1768e6143d32  vault.confd
 cacbd75cbaccf1034cd21d3015797cf0c1c1ce9c7e7ef7c1e4db4b54b92fe696  vault.hcl
 8274a9c735906980a734a8a720232d8816bfbeb8294d4c96baac2e9885abf6a2  vault.initd"
-sha512sums="e1bfa5fbcc68b82a407de5ba40c44084d15c3f42bc4027783b25f97d0ef044d5d88a3650b412f2044b73cc525d115f1441a657861ad977644ca7f7a0259a18c7  vault-0.6.1.tar.gz
+sha512sums="5d444c32ee1dc464f9210331ed26ab56b9aaeb5fbdcb5c2fcc4d9363c6d1e60780d7c2f5020ebc3345fb8c3f32b3b8f8acc58533d5a036202685252b2affbe3e  vault-0.6.2.tar.gz
 6f3f30e5c9d9dd5117f18fce0e669f0cd752a6be4910405d6b394f15273372731ee887a5ba4c700293e5b8bc2bf40fd69d4337156f77b03549d2dc2c0a666bec  vault.confd
 8c064aa5dcca84822c1fa85e9d0ff520df46f794b2e9c689a9b4f81f74279387b3aebc08b3ca26cf786c2fcf1a330e765bf5a511074c24f87e5346672346ba1c  vault.hcl
 34993256eb1700ef0738e24227af7732ea81f9e096b34b5f6a282fce364e9c92319c2fc219083eec0185927dde89d565dfcc0d0507bcdbebd3e003027760d447  vault.initd"

--- a/testing/vault/vault.pre-deinstall
+++ b/testing/vault/vault.pre-deinstall
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Stop vault service
+rc-service vault stop 2>/dev/null
+exit 0
+


### PR DESCRIPTION
* Build latest 0.6.2 release
* Fix "mlock" permission in init.d script so vault can start
  as "vault" user.
* Adding cleanup script to stop the vault service on package
  removal
* Ading cleanup script to remove vault user and group on package
  removal