### PR TITLE
main/php5: Upgrade to 5.6.27

### DIFF
--- a/main/php5/APKBUILD
+++ b/main/php5/APKBUILD
@@ -3,8 +3,8 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
-pkgver=5.6.26
-pkgrel=1
+pkgver=5.6.27
+pkgrel=0
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
 arch="all"
@@ -503,17 +503,17 @@ pdo_dblib()	{ _mv_ext pdo_dblib "$pkgname-pdo freetds"; }
 wddx()		{ _mv_ext wddx; }
 opcache()	{ _mv_ext opcache; }
 
-md5sums="cb424b705cfb715fc04f499f8a8cf52e  php-5.6.26.tar.bz2
+md5sums="b5a66d238c27cfdc6cdf5e83062e50d9  php-5.6.27.tar.bz2
 63b16caff0d7aa881a31a1e02f3080c3  php-fpm.initd
 67719f428f44ec004da18705cbabe2ee  php5-module.conf
 483bc0a85c50a9a9aedbe14a19ed4526  php-install-pear-xml.patch
 7200972a23adae799921c4ca20ff0074  gd-iconv.patch"
-sha256sums="d47aab8083a4284b905777e1b45dd7735adc53be827b29f896684750ac8b6236  php-5.6.26.tar.bz2
+sha256sums="3b77d3a067b6e9cc7bb282d4d5b0e6eeb0623a828bb0479241e3b030446f2a3c  php-5.6.27.tar.bz2
 be9bfdab10a994fe553119b181be7015325a7618de454a58bdee06bcfb711454  php-fpm.initd
 ceec4d5b2a128c6a97e49830af604f0bb555bca1a86a9cd0366b828ba392257f  php5-module.conf
 f739ca427a1dd53a388bad0823565299c5d4a5796b1171b892884e4d7d099bab  php-install-pear-xml.patch
 98de37c650a36870a543225f6a6b81813ccd447a484f0881511be4eb6e901844  gd-iconv.patch"
-sha512sums="fcac6ff1db2d3a897ce7253735216b3784568167d7e1c3738409c45f72bdce6708d42c6935c13c28f16da15218213b202e959fb68355b5c692fdc54a7393b553  php-5.6.26.tar.bz2
+sha512sums="d9118b7937eb111cebf1020296a3105dc4ae5aee9a5e655643b872d6948e68ceb3340e861810b8fcaa4a201c5aec6c1009a7e3cf3ff1678e0ea68aefb632f10b  php-5.6.27.tar.bz2
 1f5cb18f85a2e279e24344d993f5c51c7bfbcbecc0e9bfcf075bebd1b0b893e2ffb793d95a632c9333033597d4b4f74840bfd00520a6dc700444d1a054225da1  php-fpm.initd
 895e94c791bd82060ad820fef049d366a09c932097faa6b7b9a2c2e9e00a18cb7c0f9b128679c7659b404379266fd0f95dba5c0333f626194cf60f7bf6044102  php5-module.conf
 f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c939768584f3e4edbe52e8bd6103fb6777462326a9d94e8ab1f505  php-install-pear-xml.patch


### PR DESCRIPTION
Security release http://ua2.php.net/archive/2016.php#id2016-10-14-1