### PR TITLE
testing/darktable: new aport

### DIFF
--- a/testing/colord-gtk/APKBUILD
+++ b/testing/colord-gtk/APKBUILD
@@ -1,0 +1,42 @@
+# Contributor: Kevin Daudt <ops@ikke.info>
+# Maintainer: Kevin Daudt <ops@ikke.info>
+pkgname=colord-gtk
+pkgver=0.1.26
+pkgrel=0
+pkgdesc="GTK support library for colord"
+url="https://www.freedesktop.org/software/colord/"
+arch="all"
+license="GPL3"
+makedepends="intltool glib-dev gtk+3.0-dev colord-dev"
+subpackages="$pkgname-dev"
+source="https://www.freedesktop.org/software/colord/releases/colord-gtk-$pkgver.tar.xz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--localstatedir=/var \
+		--disable-systemd \
+		--disable-systemd-login \
+		--disable-argyllcms-sensor \
+		--disable-nls \
+		--disable-schemas-compile \
+		|| return 1
+	make || return 1
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install || return 1
+}
+
+md5sums="bb9d6f3c037152ad791003375aa6c16c  colord-gtk-0.1.26.tar.xz"
+sha256sums="28d00b7f157ea3e2ea5315387b2660fde82faba16674861c50465e55d61a3e45  colord-gtk-0.1.26.tar.xz"
+sha512sums="14f59110e2bc100c542323a68566102e9fb5ab44b679da21bf29101960dae38e646e926d884e14f1838a5991e6ebe15af72d5338723265868eadd5f026545c3d  colord-gtk-0.1.26.tar.xz"

--- a/testing/darktable/APKBUILD
+++ b/testing/darktable/APKBUILD
@@ -1,0 +1,39 @@
+# Contributor: Kevin Daudt <ops@ikke.info>
+# Maintainer: Kevin Daudt <ops@ikke.info>
+_tag=release-2.2.0rc0
+pkgname=darktable
+pkgver=2.2.0_rc0
+pkgrel=0
+pkgdesc="an open source photography workflow application and raw developer"
+url="http://www.darktable.org/"
+arch="all"
+license="GPL3"
+depends="libxslt gtk+3.0-dev libgphoto2-dev libwebp-dev
+	 lensfun-dev librsvg-dev sqlite-dev curl-dev jpeg-dev tiff-dev
+	 lcms2-dev json-glib-dev exiv2-dev lua5.2-dev pugixml-dev
+	 colord-dev colord-gtk-dev openexr-dev"
+makedepends="cmake intltool"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+source="https://github.com/darktable-org/darktable/archive/$_tag.tar.gz"
+builddir="$srcdir/$pkgname-$_tag"
+
+prepare() {
+	cd "$builddir"
+	mkdir -p build
+}
+
+build() {
+	cd "$builddir/build"
+	cmake -DCMAKE_INSTALL_PREFIX=/usr .. || exit 1
+	make
+
+}
+
+package() {
+	cd "$builddir/build"
+	make DESTDIR="$pkgdir" install
+}
+
+md5sums="d64520874c0c9606849309b4110a5d73  release-2.2.0rc0.tar.gz"
+sha256sums="67cf6f5a460689b7babb65877c5226ef73155d5134e2e4a2c62ad47156ca394d  release-2.2.0rc0.tar.gz"
+sha512sums="83efe4414420a19239fafdfb5d7ea8bf1bbf3d6cceae97bd8b9e4e65adce4d420dcf0104ed909904eb6fcd4749d6c8bad9f0951de5b63d7cb4d55f0056e260b3  release-2.2.0rc0.tar.gz"

--- a/testing/pugixml/APKBUILD
+++ b/testing/pugixml/APKBUILD
@@ -1,0 +1,27 @@
+# Contributor: Kevin Daudt <ops@ikke.info>
+# Maintainer: Kevin Daudt <ops@ikke.info>
+pkgname=pugixml
+pkgver=1.7
+pkgrel=0
+pkgdesc="Light-weight, simple and fast XML parser for C++ with XPath support"
+url="http://pugixml.org"
+arch="all"
+license="MIT"
+makedepends="cmake"
+source="http://github.com/zeux/pugixml/releases/download/v1.7/pugixml-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=YesPlease scripts/ || exit 1
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+md5sums="17e6a3996de2942629dce65db1a701c5  pugixml-1.7.tar.gz"
+sha256sums="fbe10d46f61d769f7d92a296102e4e2bd3ee16130f11c5b10a1aae590ea1f5ca  pugixml-1.7.tar.gz"
+sha512sums="708d34ba2a210df7e75faaaa8a5f170a1d43b9541b2ffe9ab4bde0101f698810617b8d61d4db2131406d22e33aa90111a0b53e7302a60126cc1ed2141deec360  pugixml-1.7.tar.gz"


### PR DESCRIPTION
Musl support was recently added, so there is no tag to use yet.
