### PR TITLE
main/mkinitfs: add support for resume

### DIFF
--- a/main/mkinitfs/0001-resume-support.patch
+++ b/main/mkinitfs/0001-resume-support.patch
@@ -1,0 +1,42 @@
+Common subdirectories: a/features.d and b/features.d
+diff -u a/initramfs-init.in b/initramfs-init.in
+--- a/initramfs-init.in	2016-06-15 12:57:27.000000000 +0200
++++ b/initramfs-init.in	2016-08-16 00:30:42.936992624 +0200
+@@ -248,7 +248,7 @@
+ myopts="alpine_dev autodetect autoraid chart cryptroot cryptdm debug_init
+	dma init_args keep_apk_new modules ovl_dev pkgs quiet root_size root
+	usbdelay ip alpine_repo apkovl alpine_start splash blacklist
+-	overlaytmpfs rootfstype rootflags"
++	overlaytmpfs rootfstype rootflags resume"
+
+ for opt; do
+	case "$opt" in
+@@ -351,16 +351,25 @@
+	fi
+
+	ebegin "Mounting root"
++	nlplug-findfs $cryptopts -p /sbin/mdev $KOPT_root
++
++	if [ -n "$KOPT_resume" ]; then
++		echo "Resume from disk"
++		if [ -e /sys/power/resume ]; then
++			printf "%d:%d" $(stat -Lc "0x%t 0x%T" "$KOPT_resume") >/sys/power/resume
++		else
++			echo "resume: no hibernation support found"
++		fi
++	fi
++
+	if [ "$KOPT_overlaytmpfs" = "yes" ]; then
+		mkdir -p /media/root-ro /media/root-rw $sysroot/media/root-ro \
+			$sysroot/media/root-rw
+-		nlplug-findfs $cryptopts -p /sbin/mdev $KOPT_root \
+-			&& mount -o ro $KOPT_root /media/root-ro
++		mount -o ro $KOPT_root /media/root-ro
+		mount -t tmpfs root-tmpfs /media/root-rw
+		mkdir -p /media/root-rw/work /media/root-rw/root
+		mount -t overlay -o lowerdir=/media/root-ro,upperdir=/media/root-rw/root,workdir=/media/root-rw/work overlayfs $sysroot
+	else
+-		nlplug-findfs $cryptopts -p /sbin/mdev $KOPT_root
+		mount ${KOPT_rootfstype:+-t} ${KOPT_rootfstype} \
+			-o ${KOPT_rootflags:-ro} \
+			$KOPT_root $sysroot

--- a/main/mkinitfs/APKBUILD
+++ b/main/mkinitfs/APKBUILD
@@ -16,6 +16,7 @@ source="http://dev.alpinelinux.org/archive/$pkgname/$pkgname-$_ver.tar.xz
 	0001-init-dont-use-local-in-global-scope.patch
 	0001-group-sync-with-alpine-baselayout.patch
 	0001-mkinitfs-add-K-flag-to-copy-host-keys-to-new-initram.patch
+	0001-resume-support.patch
 	"
 arch="all"
 license="GPL2"
@@ -35,14 +36,17 @@ md5sums="de3f95912a542dfabbf0573620549a29  mkinitfs-3.0.5.tar.xz
 a4227598291fa7338ad1128bfef3720c  0001-init-add-support-for-ttyMFD-and-ttyUSB-serial-consol.patch
 a74631b5f40001dd259a2a6ebcaec544  0001-init-dont-use-local-in-global-scope.patch
 db888a1a502fe281bbe0b1add81bf62f  0001-group-sync-with-alpine-baselayout.patch
-a46eb97de6742400ca04777a0a8478b2  0001-mkinitfs-add-K-flag-to-copy-host-keys-to-new-initram.patch"
+a46eb97de6742400ca04777a0a8478b2  0001-mkinitfs-add-K-flag-to-copy-host-keys-to-new-initram.patch
+e42f5a75683e252605c8af39e7087433  0001-resume-support.patch"
 sha256sums="3f13619f161c506796b91f2db17644eba25c2ffc923aa0c8fff0213d1f660aa4  mkinitfs-3.0.5.tar.xz
 17547dbc77bd19d940550ea6243b44212d21a6797aee4202e4e22c31143bf9e6  0001-init-add-support-for-ttyMFD-and-ttyUSB-serial-consol.patch
 7253cd8ebc1487e4bfb98d81edd68b24a4364e9fa8e48c73fc6903f2077b056e  0001-init-dont-use-local-in-global-scope.patch
 17b8a04db505eea9e176da00f9389ca80f65ed88c0288f6785f9ab108164361a  0001-group-sync-with-alpine-baselayout.patch
-8daccc844576f0b06fc9c15a30d750bfecda019b476a0be4cf9bcd7139e219cf  0001-mkinitfs-add-K-flag-to-copy-host-keys-to-new-initram.patch"
+8daccc844576f0b06fc9c15a30d750bfecda019b476a0be4cf9bcd7139e219cf  0001-mkinitfs-add-K-flag-to-copy-host-keys-to-new-initram.patch
+4b9cbe297539f9cbba8ffae52301dd91b46f0e487b9c4b229e29371366a9f139  0001-resume-support.patch"
 sha512sums="246f25ce3fb65ea19dbe611ad44a106930c28b2c7111908462d4a252433011280715b2cf87ee81cc6f0860679fd1d0a109d03040647498137e42b22ccc711662  mkinitfs-3.0.5.tar.xz
 35b4cf3f74e394d87b321d335ec4dff6973bfd9a38cdc81609e21e025ee3fb9af7d2744cf9941531603df829af1f7fba433074915ba88a688d375cfe40dad07a  0001-init-add-support-for-ttyMFD-and-ttyUSB-serial-consol.patch
 ca1bd66bc6d366dc74da389397f3e0d81b3afa21a534269230ab33f415e633b19ce54327b78713847461b67d6d23a85019c79e1fbbf1a964ee0bd26013ddf33f  0001-init-dont-use-local-in-global-scope.patch
 2736650e0c06d47f2cd0dcc4a9c3d575b2b5284ee8d1aa0cccd45b5855ff6704171f5b7761b8c88536c8dca84943810e9332db9f2e03681f6355c5068a3a3092  0001-group-sync-with-alpine-baselayout.patch
-712038089d3b58a3937549f25412803291690c992bd8e3002f02a46fc9c24903c94086704b5def3aecb422d46d7c501beeaa665000bc7da6ec20965e52eca5a1  0001-mkinitfs-add-K-flag-to-copy-host-keys-to-new-initram.patch"
+712038089d3b58a3937549f25412803291690c992bd8e3002f02a46fc9c24903c94086704b5def3aecb422d46d7c501beeaa665000bc7da6ec20965e52eca5a1  0001-mkinitfs-add-K-flag-to-copy-host-keys-to-new-initram.patch
+39d0fe3907fdb34b95268e25c63279343361c7ed2785265c3fc27a5fb7061488f7933f2d086b03df01b63214e527c1afd64a13f0ec2e566397c94395e8bf6c6b  0001-resume-support.patch"


### PR DESCRIPTION
This patch tries to add resume from hibernation (aka suspend to disk)
support to mkinitfs. The swap partition can be provided via the resume
option.

I know this feature is mostly needed on destops/notebooks, therefore I'm
not sure if there is any interest for Alpine Linux. The default Alpine Linux
kernel has no hibernation support compiled in, so you need to build
a custom kernel in order to test this.

These links helped me on the topic:
* https://wiki.gentoo.org/wiki/Custom_Initramfs/Hibernation
* https://git.archlinux.org/mkinitcpio.git/tree/hooks/resume

As this might be a dangerous feature I would like to get your opinions.