### PR TITLE
Fix readline_* functions on PHP7 (issue 5670)

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -167,7 +167,7 @@ build() {
 		--enable-fpm \
 		--enable-embed \
 		--with-litespeed \
-		--with-readline=shared \
+		--with-readline \
 		|| return 1
 }
 


### PR DESCRIPTION
The bug is documented in the issue tracker[1], basically all `readline_*` functions are broken under PHP7, thus any code that relies on them (like the Boris REPL) cannot work on Alpine. Fortunately they _do_ work in PHP5.

Comparing both APKBUILDs I noticed that in PHP5 the readline library is embedded into the php executable rather than distributed as a separate `php5-readline` package[2].

As of now this patch just removes the `shared` modifier of the `--with-readline` option to do the same in PHP7, and it seems to work. However, there's still a couple of issues with it.
- The apache module also has a `--with-readline=shared` flag. Editing it just like the other one broke my build.
- The `php7-readline` package still exists, even though it is now useless. I tried removing it from the `_exts` list[3], but this change also broke the build.
- Maybe there was a good reason to not embed readline into php in the first place. Maybe the patch should fix the `php7-readline` package instead of making it redundant. At the very least, thin base binaries seem to align more closely with the whole Alpine philosophy.
- I've noticed some discrepancies between the PHP5 and PHP7 build scripts. The former does not embed readline into the fpm daemon nor the apache module, but the latter does.

I'd appreciate some help to turn this patch into a proper fix. Thanks!

[1] https://bugs.alpinelinux.org/issues/5670
[2] https://github.com/alpinelinux/aports/blob/master/main/php5/APKBUILD#L258
[3] https://github.com/alpinelinux/aports/blob/master/community/php7/APKBUILD#L41
