### PR TITLE
testing/detenc: Updated source url

### DIFF
--- a/testing/detenc/APKBUILD
+++ b/testing/detenc/APKBUILD
@@ -9,8 +9,8 @@ arch="all"
 license="MIT"
 depends=""
 makedepends="ruby-rake ruby-minitest"
-source="https://github.com/reevoo/$pkgname/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz"
-builddir="$srcdir/$pkgname"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/reevoo/$pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
@@ -22,6 +22,6 @@ package() {
 	make PREFIX="$pkgdir" -C "$builddir" install
 }
 
-md5sums="c2bbd3a16f0cb1e1285f4a8fa31994b8  detenc-2.0.0.tar.gz"
-sha256sums="1c6d27424424e23254b51558729f421290b17f5d330f0c3bf0beed69b7aa40c0  detenc-2.0.0.tar.gz"
-sha512sums="5d653b6768dd3749273403fcde04b16b9c326d0260324ce2829bbb3f517a444991b42102e863a564c324817bc2310f5242b1652e20b2510187b9d124d6e1efcf  detenc-2.0.0.tar.gz"
+md5sums="e880e0b24205fc45e4c6a7e0cf3bfa70  detenc-2.0.0.tar.gz"
+sha256sums="ae50401d0fb25edf781dc8324e0dfc699264c72ef31936729867754586e81f13  detenc-2.0.0.tar.gz"
+sha512sums="b4c0dc71a699b2e30a345d641781bd58146be84a727e89dc9ef39da7ddb752659371ba8fc37b345c514b43f92723ef80c9bbe73c72a562a2729a1626ec3f53db  detenc-2.0.0.tar.gz"


### PR DESCRIPTION
I realised that github provides a stable source tarball, so
switching to that to save a build step upstream.