### PR TITLE
testing/envconsul: new aport

### DIFF
--- a/testing/envconsul/APKBUILD
+++ b/testing/envconsul/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Gennady Feldman <gena01@gmail.com>
+# Maintainer:
+pkgname=envconsul
+pkgver=0.6.1
+pkgrel=0
+pkgdesc="Read and set environmental variables for processes from Consul."
+url="https://www.consul.io/"
+arch="all"
+license="MPL-2.0"
+depends=""
+makedepends="go"
+options="!strip"
+source="$pkgname-$pkgver.tar.gz::https://github.com/hashicorp/$pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+
+	mkdir -p "$builddir/src/github.com/hashicorp"
+	ln -s "$builddir" "$builddir/src/github.com/hashicorp/$pkgname"
+	cd "$builddir/src/github.com/hashicorp/$pkgname" || return 1
+
+	GOPATH="$builddir" go build -v -o bin/$pkgname
+}
+
+package() {
+	cd "$builddir"
+
+	# Main binary
+	install -m755 -D bin/$pkgname "$pkgdir"/usr/bin/$pkgname
+}
+
+md5sums="f23dcd8e51910122ebe70a6d7612e129  envconsul-0.6.1.tar.gz"
+sha256sums="b676a12594464408e8fb64fb35f6586c5a43d7a6efc724c0e8e25dc848e3ea5f  envconsul-0.6.1.tar.gz"
+sha512sums="82d0636c4437d5e620d14d86fd8f147782ec15bbbb364e398799dd021dc44da1e24926af2495ea90256e9db9482da3a6b9f8eb866debaa0af9ade0e2d7072025  envconsul-0.6.1.tar.gz"


### PR DESCRIPTION
This is a HashiCorp utility to read and set environmental variables for processes from Consul/Vault.