### PR TITLE
main/mutt: enable sidebar feature

### DIFF
--- a/main/mutt/APKBUILD
+++ b/main/mutt/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mutt
 pkgver=1.7.1
-pkgrel=0
+pkgrel=1
 pkgdesc="a small but very powerful text-mode email client"
 url="http://www.mutt.org"
 arch="all"
@@ -33,6 +33,7 @@ build() {
 		--enable-smtp \
 		--enable-hcache \
 		--enable-gpgme \
+		--enable-sidebar \
 		--with-curses \
 		--with-mailpath=/var/spool/mail \
 		--with-docdir=/usr/share/doc/$pkgname \


### PR DESCRIPTION
Starting with version 1.7.0, mutt upstream has merged the popular sidebar patch.
This commit suggests to enable this feature.

* refs: #5387