### PR TITLE
Fix segfaults when using irb

### DIFF
--- a/main/ruby/APKBUILD
+++ b/main/ruby/APKBUILD
@@ -13,7 +13,7 @@ arch="all"
 license="Ruby"
 depends=""
 depends_dev="gmp-dev"
-makedepends="$depends_dev zlib-dev libressl-dev gdbm-dev db-dev libedit-dev
+makedepends="$depends_dev zlib-dev libressl-dev gdbm-dev db-dev readline-dev
 	libffi-dev coreutils yaml-dev linux-headers autoconf"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-irb::noarch
 	$pkgname-rdoc::noarch $pkgname-rake::noarch $pkgname-bigdecimal::noarch


### PR DESCRIPTION
Switching from libedit back to readline fiesx segfaults with irb. Bug report: http://bugs.alpinelinux.org/issues/4986.