### PR TITLE
testing/libmilter: set default pthread stack size

### DIFF
--- a/testing/libmilter/APKBUILD
+++ b/testing/libmilter/APKBUILD
@@ -5,7 +5,7 @@ pkgname=libmilter
 _pkgname="sendmail"
 pkgver=1.0.2
 _pkgver=8.15.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Sendmail Mail Filter API"
 url="http://www.sendmail.com/sm/open_source"
 arch="all"
@@ -14,6 +14,7 @@ makedepends="$depends_dev m4 linux-headers bsd-compat-headers"
 subpackages="$pkgname-dev $pkgname-doc"
 source="ftp://ftp.sendmail.org/pub/$_pkgname/$_pkgname.$_pkgver.tar.gz
 	libmilter-sharedlib.patch
+	default-pthread-stacksize.patch
 	site.config.m4"
 builddir="$srcdir"/$_pkgname-$_pkgver
 
@@ -37,10 +38,13 @@ package() {
 
 md5sums="a824fa7dea4d3341efb6462ccd816f00  sendmail.8.15.2.tar.gz
 49558fc2c9e38f433e0dc64d76705c05  libmilter-sharedlib.patch
+ab96f2f07362c988081d986f163dc0c0  default-pthread-stacksize.patch
 e9fc99ec22265e5e561711f64bb9a0fa  site.config.m4"
 sha256sums="24f94b5fd76705f15897a78932a5f2439a32b1a2fdc35769bb1a5f5d9b4db439  sendmail.8.15.2.tar.gz
 3a753b0881fe622814b471ee5f9037905c7cc3ed08ef74908464ab5307e59d5a  libmilter-sharedlib.patch
+14212647a18ccb2d9665d65ffcf90dbebaf35ad100f0079c94f3009fc20279fe  default-pthread-stacksize.patch
 fb8d43d33dda08aac9762983cadb24c54d5e3130b8808dadf4d189ceea564f48  site.config.m4"
 sha512sums="04feb37316c13b66b1518596507a7da7c16cb0bf1abf10367f7fd888a428fadb093a9efa55342fa55b936c3f0cbdc63b9e2505cd99201a69a0c05b8ad65f49f9  sendmail.8.15.2.tar.gz
 31c36b57739946c1b9c7c85307fe5c53c45d7f8cbf427a0f2248db8b74871a6f5a30ef1af524915821aeca54310d28272bcd0a587cb918192214fa5c30e4a8da  libmilter-sharedlib.patch
+7de312f972e935ca1232d77866459427ded06c17a8b21ded118da67479748c305a33c711bb05aad691822fea12d3f9b7fcd26d045aa05116f1059e4c5dc0c4bf  default-pthread-stacksize.patch
 b939c19a82cd56f06102a7ad9f446c788d1eff0870f35c2f7d0a904782a7524f25adbb16c57373e0f592247d9898fdd1ef4212da15239b96ddbd9ff5010c630f  site.config.m4"

--- a/testing/libmilter/default-pthread-stacksize.patch
+++ b/testing/libmilter/default-pthread-stacksize.patch
@@ -1,0 +1,34 @@
+Only in b/devtools/Site: site.config.m4
+diff -ru a/libmilter/libmilter.h b/libmilter/libmilter.h
+--- a/libmilter/libmilter.h	2014-06-12 19:30:47.000000000 +0200
++++ b/libmilter/libmilter.h	2016-11-06 22:58:10.106901590 +0100
+@@ -127,10 +127,10 @@
+ # define MI_SOCK_READ(s, b, l)	read(s, b, l)
+ # define MI_SOCK_READ_FAIL(x)	((x) < 0)
+ # define MI_SOCK_WRITE(s, b, l)	write(s, b, l)
+-
+-# define thread_create(ptid,wr,arg) pthread_create(ptid, NULL, wr, arg)
+ # define sthread_get_id()	pthread_self()
+
++extern int thread_create(pthread_t *ptid, void *(*wr) (void *), void *arg);
++
+ typedef pthread_mutex_t smutex_t;
+ # define smutex_init(mp)	(pthread_mutex_init(mp, NULL) == 0)
+ # define smutex_destroy(mp)	(pthread_mutex_destroy(mp) == 0)
+diff -ru a/libmilter/main.c b/libmilter/main.c
+--- a/libmilter/main.c	2014-06-12 19:30:47.000000000 +0200
++++ b/libmilter/main.c	2016-11-06 22:59:27.266904577 +0100
+@@ -16,6 +16,12 @@
+ #include <fcntl.h>
+ #include <sys/stat.h>
+
++int thread_create(pthread_t *ptid, void *(*wr) (void *), void *arg) {
++	pthread_attr_t attr;
++	pthread_attr_init(&attr);
++	pthread_attr_setstacksize(&attr,8*1024*1024);
++	return pthread_create(ptid, &attr, wr, arg);
++}
+
+ static smfiDesc_ptr smfi = NULL;
+
+Only in b: obj.Linux.4.4.17-2-t430.x86_64


### PR DESCRIPTION
This patch tries to fix various crashes for applications depending on
libmilter by setting the stack size for pthreads to 8MB. The default stack size
for musl libc is set to 80KB whereas glibc has it set to 8MB. This causes
problems when a large amount of memory is allocated on the stack.

For example, opendkim allocates blocks of 64KB multiple times, which causes
libmilter (and therefore opendkim) to crash.
Maybe a stack size of 1MB or 2MB would be sufficient, but as opendkim
depends on the default glibc behavior, 8MB should be safe.

I know this patch is kind of ugly, a better solution may be to file
a request for opendkim to allocate large blocks of memory on the heap.
But as libmilter/opendkim are fairly unusable at the moment, I suggest
to apply this patch as long as these packages are in testing.

* refs: #6360