### PR TITLE
testing/py-blockdiag: enable py3

### DIFF
--- a/testing/py-blockdiag/APKBUILD
+++ b/testing/py-blockdiag/APKBUILD
@@ -2,23 +2,21 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=py-blockdiag
 _pkgname=blockdiag
-pkgver=1.5.1
-pkgrel=0
+pkgver=1.5.3
+pkgrel=1
 pkgdesc="A python tool to generate block-diagram"
 url="http://blockdiag.com"
 arch="noarch"
 license="ASL 2.0"
-depends="python2 py-pillow py-funcparserlib py-setuptools py-webcolors"
-depends_dev=""
-makedepends="python2-dev py-setuptools"
-install=""
-subpackages=""
+depends="py-pillow py-funcparserlib py-webcolors"
+makedepends="python2-dev python3-dev py-setuptools"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
 
-_builddir="$srcdir"/$_pkgname-$pkgver
 prepare() {
 	local i
-	cd "$_builddir"
+	cd "$builddir"
 	for i in $source; do
 		case $i in
 		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
@@ -27,15 +25,36 @@ prepare() {
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	python2 setup.py build || return 1
+	python3 setup.py build || return 1
 }
 
 package() {
-	cd "$_builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	mkdir -p "$pkgdir"
 }
 
-md5sums="e1bcaf5ae64467f7722ad7883fc06abb  blockdiag-1.5.1.tar.gz"
-sha256sums="893803c5b409130274506034acc990f7915dd026aa90c3b2905495f2df48215c  blockdiag-1.5.1.tar.gz"
-sha512sums="45fa83d7660daf48be29ff971c63aaa43519e0cadcdcaa46f42361123423ea684772b753bcc948231c4ad181b5749d4fc55fb9d196670b7ffe5241487531cccb  blockdiag-1.5.1.tar.gz"
+_py2() {
+	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+md5sums="24c1de40066687a6e0f401a97197f43c  blockdiag-1.5.3.tar.gz"
+sha256sums="5ea3501fca0ca40fbacccc6f4ca177750e4b610009e021faa4868c0f6480ae8b  blockdiag-1.5.3.tar.gz"
+sha512sums="11ff6334d1ae50c103158db6ef9acce76116a17cfb8e0066581c234138f17fabfddd183b154f407fe95dcd414b0054aebdc22682e82a8e7595905f1ee2fd6222  blockdiag-1.5.3.tar.gz"


### PR DESCRIPTION
Depends on #426, #417, and #434.

Required by #437.