### PR TITLE
community/py3-yarl: new aport

### DIFF
--- a/community/py3-yarl/APKBUILD
+++ b/community/py3-yarl/APKBUILD
@@ -1,0 +1,28 @@
+# Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
+# Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
+pkgname=py3-yarl
+_pkgname=yarl
+pkgver=0.7.0
+pkgrel=0
+pkgdesc="An URL library"
+url="http://yarl.readthedocs.io/"
+arch="all"
+license="ASL 2.0"
+depends="python3 py3-multidict"
+makedepends="python3-dev"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	python3 setup.py build || return 
+}
+
+package() {
+	cd "$builddir"
+	python3 setup.py install --root="$pkgdir" --optimize=1 || return 1
+}
+
+md5sums="d658c903a4666979913a7487c1d06574  yarl-0.7.0.tar.gz"
+sha256sums="43222e76b17d62e23c2ff62dde7b6d3cd64453be7529876b4967ec5c3e0fa3fd  yarl-0.7.0.tar.gz"
+sha512sums="a63e5912eef2899773b05188bf4673ce0beb254605da81bff93c5a364e4f8d3864287a1f8165758a1ac86f97613b5d997d77c29f9ed4261c7fe2e9bc861c8470  yarl-0.7.0.tar.gz"


### PR DESCRIPTION
The module provides handy URL class for url parsing and changing.

http://yarl.readthedocs.io/en/latest/