### PR TITLE
community/py3-aiohttp: upgrade to 1.1.1

### DIFF
--- a/community/py3-aiohttp/APKBUILD
+++ b/community/py3-aiohttp/APKBUILD
@@ -2,17 +2,14 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=py3-aiohttp
 _pkgname=aiohttp
-pkgver=0.22.5
+pkgver=1.1.1
 pkgrel=0
 pkgdesc="HTTP client/server for asyncio"
 url="http://pypi.python.org/pypi/aiohttp"
 arch="all"
 license="ASL 2.0"
-depends="python3 py3-chardet py3-multidict"
-depends_dev=""
+depends="python3 py3-chardet py3-multidict py3-yarl py3-async-timeout"
 makedepends="$depends_dev py-setuptools python3-dev"
-install=""
-subpackages="$pkgname-dev"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 
 builddir="$srcdir"/$_pkgname-$pkgver
@@ -26,6 +23,6 @@ package() {
 	python3 setup.py install --root="$pkgdir" --optimize=1 || return 1
 }
 
-md5sums="8541b6085fee8f8b51e0144df6470186  aiohttp-0.22.5.tar.gz"
-sha256sums="9c51af030c866f91e18a219614e39d345db4483ed9860389d0536d74d04b0d3b  aiohttp-0.22.5.tar.gz"
-sha512sums="919818445590b386b40edd05e8a58fac0b1b2993fe82faf95e10b53b5c0b3b464e92ea2484bc1929cb737351f3629b77a4ff67788248e19d69eb638bbf44a5e3  aiohttp-0.22.5.tar.gz"
+md5sums="0c67c7e13eef5d707ac51fbc0043824c  aiohttp-1.1.1.tar.gz"
+sha256sums="15d440616c6211099d7c3d08fea20fe2c775a75261c218a4051041e104019ee5  aiohttp-1.1.1.tar.gz"
+sha512sums="8aadcc62129c40aa155dca5719a25849900320e7b92a31d9962b50855d3a2b7fb2b12fddbb2084e52cd941d0d19197bfaab4146efa86450c7348e5d0c4a840c9  aiohttp-1.1.1.tar.gz"


### PR DESCRIPTION
Depends on #454 and #453.

Required by #506.