### PR TITLE
testing/py-furl: upgrade to 0.5.6 and enable py3

### DIFF
--- a/testing/py-furl/APKBUILD
+++ b/testing/py-furl/APKBUILD
@@ -2,40 +2,46 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=py-furl
 _pkgname=furl
-pkgver=0.3.5
+pkgver=0.5.6
 pkgrel=0
 pkgdesc="A Python URL manipulator"
 url="https://github.com/gruns/furl"
 arch="noarch"
 license="Unlicense"
-depends="python2"
-depends_dev=""
-makedepends="python2-dev py-setuptools"
-install=""
-subpackages=""
+makedepends="python2-dev python3-dev py-setuptools"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
-
-_builddir="$srcdir"/$_pkgname-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/$_pkgname-$pkgver
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	python2 setup.py build || return 1
+	python3 setup.py build || return 1
 }
 
 package() {
-	cd "$_builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	mkdir -p "$pkgdir"
 }
 
-md5sums="96bb0b7a9e2572a60f6ba29ab8a123b6  furl-0.3.5.tar.gz"
-sha256sums="a2d817fa6a2007773293c4e18c47abbae3a873de8306ac707b57f0a08685339f  furl-0.3.5.tar.gz"
-sha512sums="1ddf1f6d456fce01f3887040a4067844ebf70b202b300617afa573de3b56633a19da2558da1e7ecb5f6e9167da7a29e2af959a16f77bd82df58a0393c7fd0031  furl-0.3.5.tar.gz"
+_py2() {
+	replaces="$pkgname"
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+md5sums="bcbbb0a90e87534bbc851e54e1afcb42  furl-0.5.6.tar.gz"
+sha256sums="0cdf70cc1a19a5e8f820eba5b211b7f5d1b142b399d590f5f81b1a64ea75f753  furl-0.5.6.tar.gz"
+sha512sums="4b7fcc79ab43a1c3c19df78af1cc374c8209e99931eeadf6e6f77a0fc68cdb6804b2b62d34840af7608ad1759e670de148d315cab491ec0b937c83c14d0dd58d  furl-0.5.6.tar.gz"


### PR DESCRIPTION
Required by #524.