### PR TITLE
main/spamassassin: fix dns resolver

### DIFF
--- a/main/spamassassin/APKBUILD
+++ b/main/spamassassin/APKBUILD
@@ -1,9 +1,10 @@
+# Contributor: Stefan Wagner <stw@bit-strickerei.de>
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer:  Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=spamassassin
 _pkgreal=Mail-SpamAssassin
 pkgver=3.4.1
-pkgrel=4
+pkgrel=5
 pkgdesc="The Powerful #1 Open-Source Spam Filter"
 url="http://search.cpan.org/dist/Mail-SpamAssassin/"
 arch="all"
@@ -18,25 +19,20 @@ source="http://search.cpan.org/CPAN/authors/id/K/KM/KMCGRAIL/${_pkgreal#*-}/$_pk
 	spamd.initd
 	spamd.confd
 	spamd.crond
-	"
+	net-dns-1.01-compat.patch"
 
-_builddir="$srcdir"/$_pkgreal-$pkgver
-
-prepare() {
-	cd "$_builddir"
-	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
-	rm t/dnsbl_subtests.t
-}
+builddir="$srcdir"/$_pkgreal-$pkgver
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test || return 1
+	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor || return 1
+	rm t/dnsbl_subtests.t || return 1
+	make && make test
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	make DESTDIR="$pkgdir" install || return 1
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 	install -Dm755 "$srcdir"/spamd.crond "$pkgdir"/etc/periodic/daily/$pkgname-update
@@ -75,12 +71,15 @@ cpan() {
 md5sums="76eca1f38c11635d319e62c26d5b034b  Mail-SpamAssassin-3.4.1.tar.gz
 a348c160f2a7e90b24a5b995e984248c  spamd.initd
 d72f889cdbcd1289b773db3c00651a9c  spamd.confd
-d11273ff56e329842174cc1f68e91555  spamd.crond"
+d11273ff56e329842174cc1f68e91555  spamd.crond
+f0b128cfd7491a7ea75e74fb4dfc7510  net-dns-1.01-compat.patch"
 sha256sums="9b7a95a594cdca4f265707364478b57813b82a0ec7e520d9bc818bfbcafdd726  Mail-SpamAssassin-3.4.1.tar.gz
 99dd743c53861bab603538638170f7c7adcc8bc1b3363422873674d915f7ca39  spamd.initd
 6533298faf4b0f50f9d7fcf32d60366c02ecc27deeb2725265035fe3267277f5  spamd.confd
-39487360aa9ee536e6f04f8fb86ed755f0536143b792f134667e5cd2a0e0846b  spamd.crond"
+39487360aa9ee536e6f04f8fb86ed755f0536143b792f134667e5cd2a0e0846b  spamd.crond
+4dd3a37fecffed36eae4e0cef29454f8a727b7c1b2cc1947fbf2ac413d76b841  net-dns-1.01-compat.patch"
 sha512sums="6a074f1a4177e1969cef575fe3b1b844d27c813d48fe1e07a46f56ffa728fc780897597d00f11acb269317a6308f284f0dee544d504da874d93b0549d094a6a3  Mail-SpamAssassin-3.4.1.tar.gz
 0a22933290a3abd147689bf3a9de4b6b277628c22966f353c5da932cd98560babf1d0bb9d92c456ea24decfb5af0bbc960192d29a90d9cab437e7986c75c8278  spamd.initd
 274d3aa0d9aab05e83c8d5ad3e93a457649360021a67c8cb19088365bed681ebe26889cfa86f8c46a6044c7ee969231f2a71e3227adf8ad9e38d0286b9caf48d  spamd.confd
-c8c00e4281cefd5e5e15507c8890264a25aa59663c57ccdf7a77905e2550999cfbbfa7271189a9491b0a0e98dff432361f13becdb99e1b583cd9d45d68022a47  spamd.crond"
+c8c00e4281cefd5e5e15507c8890264a25aa59663c57ccdf7a77905e2550999cfbbfa7271189a9491b0a0e98dff432361f13becdb99e1b583cd9d45d68022a47  spamd.crond
+7651b0b6a13322ecc338cd43ef67246c02c846162d419e3d1586e2d53161fc055d1ba80800f5210658cc360ac3ccd3c2176f1463780b0486ec65c0bac3b338fd  net-dns-1.01-compat.patch"

--- a/main/spamassassin/net-dns-1.01-compat.patch
+++ b/main/spamassassin/net-dns-1.01-compat.patch
@@ -1,0 +1,18 @@
+Fix Bug 7223: Net::DNS 1.01 breaks DnsResolver
+
+This bug is already fixed for version 3.4.2 and later.
+
+See: https://bz.apache.org/SpamAssassin/show_bug.cgi?id=7223
+
+--- a/lib/Mail/SpamAssassin/DnsResolver.pm
++++ b/lib/Mail/SpamAssassin/DnsResolver.pm
+@@ -592,6 +592,9 @@
+   };
+ 
+   if ($packet) {
++    # RD flag needs to be set explicitly since Net::DNS 1.01, Bug 7223	
++    $packet->header->rd(1);
++
+   # my $udp_payload_size = $self->{res}->udppacketsize;
+     my $udp_payload_size = $self->{conf}->{dns_options}->{edns};
+     if ($udp_payload_size && $udp_payload_size > 512) {


### PR DESCRIPTION
Without a working dns resolver, SpamAssassin can not perform RBL and SPF
checks. The applied patch fixes this issue.

This bug is already fixed upstream, but not yet released.

See: https://bz.apache.org/SpamAssassin/show_bug.cgi?id=7223