### PR TITLE
testing/py-colorlog: new aport

### DIFF
--- a/testing/py-colorlog/APKBUILD
+++ b/testing/py-colorlog/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=py-colorlog
 _pkgname=colorlog
-pkgver=2.7.0
+pkgver=2.9.0
 pkgrel=0
 pkgdesc="A formatter for use with Python's logging module"
 url="https://github.com/borntyping/python-colorlog"
@@ -35,13 +35,12 @@ _py3() {
 _py() {
 	local python="$1"
 	pkgdesc="$pkgdesc (for $python)"
-	depends="$depends $python"
 	install_if="$pkgname=$pkgver-r$pkgrel $python"
 
 	cd "$builddir"
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-md5sums="54709d93ee29bf61a2163e3019f4460e  colorlog-2.7.0.tar.gz"
-sha256sums="8e197dae35398049965293021dd69a9db068efe97133597f128e5ef69392f33e  colorlog-2.7.0.tar.gz"
-sha512sums="765923004a2e2b0c0e34f7cbf2d79ac7232a13e9aba68166c8ba295303cd7187317d9a34a405a78cc5f7ca0281fc3b653848e419c0b3a0dd473ad0b859216703  colorlog-2.7.0.tar.gz"
+md5sums="965dc63a658d52bd16d9adc5e4d39560  colorlog-2.9.0.tar.gz"
+sha256sums="f76a0d203a2a01b1a5eb0ede5bea95a4f4f0d39c52e01f6e3b0d32878c2e159f  colorlog-2.9.0.tar.gz"
+sha512sums="596c4df0bbc6fc91db1f34c8c3db9def2612fb9f4606f0c8bda543934e776e14ecef9251592bef60e6a3d8187ac9bbd32b429a2c3e5038bc97ce41df4d08b600  colorlog-2.9.0.tar.gz"

--- a/testing/py-colorlog/APKBUILD
+++ b/testing/py-colorlog/APKBUILD
@@ -1,0 +1,47 @@
+# Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
+# Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
+pkgname=py-colorlog
+_pkgname=colorlog
+pkgver=2.7.0
+pkgrel=0
+pkgdesc="A formatter for use with Python's logging module"
+url="https://github.com/borntyping/python-colorlog"
+arch="noarch"
+license="MIT"
+makedepends="python2-dev python3-dev py-setuptools"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	python2 setup.py build || return 1
+	python3 setup.py build || return 1
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname"
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+md5sums="54709d93ee29bf61a2163e3019f4460e  colorlog-2.7.0.tar.gz"
+sha256sums="8e197dae35398049965293021dd69a9db068efe97133597f128e5ef69392f33e  colorlog-2.7.0.tar.gz"
+sha512sums="765923004a2e2b0c0e34f7cbf2d79ac7232a13e9aba68166c8ba295303cd7187317d9a34a405a78cc5f7ca0281fc3b653848e419c0b3a0dd473ad0b859216703  colorlog-2.7.0.tar.gz"


### PR DESCRIPTION
A formatter for use with Python's logging module
https://github.com/borntyping/python-colorlog

Required by #506.