### PR TITLE
community/py-py: new aport

### DIFF
--- a/community/py-py/APKBUILD
+++ b/community/py-py/APKBUILD
@@ -1,0 +1,45 @@
+# Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
+# Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
+pkgname=py-py
+_pkgname=py
+pkgver=1.4.31
+pkgrel=0
+pkgdesc="A python library with cross-python path, ini-parsing, io, code, log facilities"
+url="http://pytest.org"
+arch="noarch"
+license="MIT"
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py3-$_pkgname:_py3 py2-$_pkgname:_py2"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	python2 setup.py build || return 1
+	python3 setup.py build || return 1	
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py() {
+	local python=$1
+	pkgdesc="$pkgdesc - $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python" 	
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+_py2() {
+	_py python2
+	replaces="$pkgname"
+}
+
+_py3() {
+	_py python3
+}
+
+md5sums="5d2c63c56dc3f2115ec35c066ecd582b  py-1.4.31.tar.gz"
+sha256sums="a6501963c725fc2554dabfece8ae9a8fb5e149c0ac0a42fd2b02c5c1c57fc114  py-1.4.31.tar.gz"
+sha512sums="fd0f4f509d81beb8e5cdb5a8d5d7d40d8a74737c017c915b0630ce740868c32fbf1af4a01dec2ae998e5a9516578e8404ad2b8d966606919767ae25f27eb0b0d  py-1.4.31.tar.gz"


### PR DESCRIPTION
A python library with cross-python path, ini-parsing, io, code, log facilities
http://pytest.org

Required by community/pytest > 1.4 (#494)
