### PR TITLE
testing/py-distro: new aport

### DIFF
--- a/testing/py-distro/APKBUILD
+++ b/testing/py-distro/APKBUILD
@@ -1,0 +1,45 @@
+# Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
+# Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
+pkgname=py-distro
+_pkgname=distro
+pkgver=1.0.1
+pkgrel=0
+pkgdesc="A Linux OS platform information API"
+url="https://github.com/nir0s/distro"
+arch="noarch"
+license="MIT"
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py3-$_pkgname:_py3 py2-$_pkgname:_py2"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	python2 setup.py build || return 1
+	python3 setup.py build || return 1	
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py() {
+	local python=$1
+	pkgdesc="$pkgdesc - $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python" 	
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+_py2() {
+	_py python2
+	replaces="$pkgname"
+}
+
+_py3() {
+	_py python3
+}
+
+md5sums="d1726863ed44003b4e52884f888918c4  distro-1.0.1.tar.gz"
+sha256sums="b940995858ec63a29a272ddf7916818bb5cccb9297928fb8230fd37a146b1f26  distro-1.0.1.tar.gz"
+sha512sums="adac287d3b36034f92c1c5d7f66216dbffe923d04fd2556b79531dd8ca6dcab73d4771d3e14f5b2516d9692e2a734f614487ffee88738daa13592222d6892860  distro-1.0.1.tar.gz"


### PR DESCRIPTION
A much more elaborate, renewed alternative implementation for Python's platform.linux_distribution()
https://github.com/nir0s/distro

Required by #506.