### PR TITLE
testing/py-cpuinfo: new aport

### DIFF
--- a/testing/py-cpuinfo/APKBUILD
+++ b/testing/py-cpuinfo/APKBUILD
@@ -1,0 +1,45 @@
+# Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
+# Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
+pkgname=py-cpuinfo
+_pkgname=cpuinfo
+pkgver=0.2.3
+pkgrel=0
+pkgdesc="A module for getting CPU info"
+url="https://github.com/workhorsy/py-cpuinfo"
+arch="noarch"
+license="MIT"
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py3-$_pkgname:_py3 py2-$_pkgname:_py2"
+source="https://files.pythonhosted.org/packages/source/${pkgname:0:1}/$pkgname/$pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	python2 setup.py build || return 1
+	python3 setup.py build || return 1	
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py() {
+	local python=$1
+	pkgdesc="$pkgdesc - $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python" 	
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+_py2() {
+	_py python2
+	replaces="$pkgname"
+}
+
+_py3() {
+	_py python3
+}
+
+md5sums="780ff46a0e122af09cb2c40b2706c6dc  py-cpuinfo-0.2.3.tar.gz"
+sha256sums="f6a016fdbc4e7fadf2d519090fcb4fa9d0831bad4e85245d938e5c2fe7623ca6  py-cpuinfo-0.2.3.tar.gz"
+sha512sums="92616d0eaddd47e3fbdad49774aa023a73eb4f9e9b88848c5e2f93540ef8b1b1b8a5011b4148be2f9817eee4d34d5f158b7e37b0f27aab09c86cd4704dd53d7b  py-cpuinfo-0.2.3.tar.gz"


### PR DESCRIPTION
A module for getting CPU info with Python 2 & 3
https://github.com/workhorsy/py-cpuinfo

Required by #506.