### PR TITLE
testing/py-netdisco: new aport

### DIFF
--- a/testing/py-netdisco/APKBUILD
+++ b/testing/py-netdisco/APKBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
+pkgname=py-netdisco
+_pkgname=netdisco
+pkgver=0.7.6
+pkgrel=0
+pkgdesc="Python library to scan local network for services and devices"
+url="https://github.com/home-assistant/netdisco/"
+arch="noarch"
+license="MIT"
+depends="py-zeroconf py-requests py-netifaces"
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	python2 setup.py build || return 1
+	python3 setup.py build || return 1
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+md5sums="4ac015686cf79718b4ede9bc9502fa92  netdisco-0.7.6.tar.gz"
+sha256sums="b1a797ff2050a8ad122db4fc79cdd1a1ad25b6c37cf216675cd2cb84f9cf7f8f  netdisco-0.7.6.tar.gz"
+sha512sums="5fbe4d854a7916048d0a97e749595df4f7f5ccd420b66f03418bbec3ba215bfb6154b93077cf20f3dd9115587408eef8b37e172ed2073ae13d87903d349f1c11  netdisco-0.7.6.tar.gz"


### PR DESCRIPTION
Python library to scan local network for services and devices
https://github.com/home-assistant/netdisco/

Depends on #499.
Required by #506.