### PR TITLE
testing/py-passlib: upgrade to 1.6.5 and py3

### DIFF
--- a/testing/py-passlib/APKBUILD
+++ b/testing/py-passlib/APKBUILD
@@ -1,23 +1,21 @@
 # Contributor: William Pitcock <nenolod@dereferenced.org>
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=py-passlib
-pkgver=1.6.2
+_pkgname=passlib
+pkgver=1.6.5
 pkgrel=0
 pkgdesc="A python hashing library for over 30 schemes"
-url="http://passlib.googlecode.com/"
+url="https://pypi.python.org/pypi/passlib"
 arch="noarch"
 license="BSD"
-depends="python2"
-depends_dev=""
-makedepends="python2-dev"
-install=""
-subpackages=""
-source="https://files.pythonhosted.org/packages/source/p/passlib/passlib-$pkgver.tar.gz"
+makedepends="python2-dev python3-dev py-setuptools"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 
-_builddir="$srcdir"/passlib-$pkgver
+builddir="$srcdir"/passlib-$pkgver
 prepare() {
 	local i
-	cd "$_builddir"
+	cd "$builddir"
 	for i in $source; do
 		case $i in
 		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
@@ -26,15 +24,34 @@ prepare() {
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	python2 setup.py build || return 1
+	python3 setup.py build || return 1
 }
 
 package() {
-	cd "$_builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	mkdir -p "$pkgdir"
 }
 
-md5sums="2f872ae7c72ca338634c618f2cff5863  passlib-1.6.2.tar.gz"
-sha256sums="e987f6000d16272f75314c7147eb015727e8532a3b747b1a8fb58e154c68392d  passlib-1.6.2.tar.gz"
-sha512sums="4c58df875549d9d4a5a9cb5d7b8e853b2614cab1c67a35d0d113fcd6332bbe0f5b6d2521d71eade2e020d0a42cd9ce0a6e866c82bc1a840391f9005ba0baceea  passlib-1.6.2.tar.gz"
+_py2() {
+	replaces="$pkgname"
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+md5sums="d2edd6c42cde136a538b48d90a06ad67  passlib-1.6.5.tar.gz"
+sha256sums="a83d34f53dc9b17aa42c9a35c3fbcc5120f3fcb07f7f8721ec45e6a27be347fc  passlib-1.6.5.tar.gz"
+sha512sums="b5323834a0a7fc7e799882c512a2fcaddb0cbf4dbfb3ec578c9a9ea7a7f08349335cd3124fe2b379eef265ecdf9d823b7562951881710cf4dafff128a65c82d4  passlib-1.6.5.tar.gz"


### PR DESCRIPTION
Required by #510.
Required by #524.