### PR TITLE
testing/py-nmap: new aport

### DIFF
--- a/testing/py-nmap/APKBUILD
+++ b/testing/py-nmap/APKBUILD
@@ -1,0 +1,47 @@
+# Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
+# Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
+pkgname=py-nmap
+_pkgname=nmap
+pkgver=0.6.1
+pkgrel=0
+pkgdesc="A Python class to use nmap and access scan results"
+url="http://xael.org/norman/python/python-nmap/"
+arch="noarch"
+license="GPL3+"
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="http://xael.org/pages/python-$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/python-$_pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	python2 setup.py build || return 1
+	python3 setup.py build || return 1
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname"
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+md5sums="2795bfcbc05cbbbccfcf4df59facaab1  python-nmap-0.6.1.tar.gz"
+sha256sums="80ba0eb10a52283a54a633f40b5baa9c2ff08675d6621dd089ead942852f5bd3  python-nmap-0.6.1.tar.gz"
+sha512sums="8de9ba6d0a4cecce09e82765b8a9ac77fb4368298d5a5f9ce07b7737a90def795f1ad00885fc73ec720bea2a592230e86aaca8cacd884c9299f64ad934bcee18  python-nmap-0.6.1.tar.gz"


### PR DESCRIPTION
A Python class to use nmap and access scan results
http://xael.org/norman/python/python-nmap/

Required by #506.