### PR TITLE
community/tor: build against openssl

### DIFF
--- a/community/tor/APKBUILD
+++ b/community/tor/APKBUILD
@@ -9,7 +9,7 @@ arch="all"
 license="BSD"
 pkgusers="tor"
 depends=""
-makedepends="linux-headers bash libevent-dev libressl-dev ca-certificates
+makedepends="linux-headers bash libevent-dev openssl-dev ca-certificates
 	zlib-dev"
 install="$pkgname.post-upgrade $pkgname.pre-install"
 subpackages="$pkgname-doc"


### PR DESCRIPTION
https://www.torproject.org
Anonymous network connectivity

Tor should be compiled against openssl-dev instead of libressl-dev, because libressl seems to lack accelerated support for the NIST P-224 and P-256 groups (openssl "enable-ec_nistp_64_gcc_128" compile flag). Using openssl will prevent this warning on tor start: 
"We were built to run on a 64-bit CPU, with OpenSSL 1.0.1 or later, but with a version of OpenSSL that apparently lacks accelerated support for the NIST P-224 and P-256 groups. Building openssl with such support (using the enable-ec_nistp_64_gcc_128 option when configuring it) would make ECDH much faster."
And, as warning is telling, will improve tor performance, especially if you are running a high-traffic exit-,middle- or bridge-node. 