### PR TITLE
main/php5: upgrade to 5.6.28

### DIFF
--- a/main/php5/APKBUILD
+++ b/main/php5/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
-pkgver=5.6.27
+pkgver=5.6.28
 pkgrel=0
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
@@ -501,17 +501,17 @@ pdo_dblib()	{ _mv_ext pdo_dblib "$pkgname-pdo freetds"; }
 wddx()		{ _mv_ext wddx; }
 opcache()	{ _mv_ext opcache; }
 
-md5sums="b5a66d238c27cfdc6cdf5e83062e50d9  php-5.6.27.tar.bz2
+md5sums="56758fdb5ff156a36fb600950b7999aa  php-5.6.28.tar.bz2
 63b16caff0d7aa881a31a1e02f3080c3  php-fpm.initd
 67719f428f44ec004da18705cbabe2ee  php5-module.conf
 483bc0a85c50a9a9aedbe14a19ed4526  php-install-pear-xml.patch
 7200972a23adae799921c4ca20ff0074  gd-iconv.patch"
-sha256sums="3b77d3a067b6e9cc7bb282d4d5b0e6eeb0623a828bb0479241e3b030446f2a3c  php-5.6.27.tar.bz2
+sha256sums="c55ea3f4aad5a0b65631d01c4468930fd981ad208ffcd242acdf731bcb47548f  php-5.6.28.tar.bz2
 be9bfdab10a994fe553119b181be7015325a7618de454a58bdee06bcfb711454  php-fpm.initd
 ceec4d5b2a128c6a97e49830af604f0bb555bca1a86a9cd0366b828ba392257f  php5-module.conf
 f739ca427a1dd53a388bad0823565299c5d4a5796b1171b892884e4d7d099bab  php-install-pear-xml.patch
 98de37c650a36870a543225f6a6b81813ccd447a484f0881511be4eb6e901844  gd-iconv.patch"
-sha512sums="d9118b7937eb111cebf1020296a3105dc4ae5aee9a5e655643b872d6948e68ceb3340e861810b8fcaa4a201c5aec6c1009a7e3cf3ff1678e0ea68aefb632f10b  php-5.6.27.tar.bz2
+sha512sums="57efbbf422b74d74cdbc701ada03e3eb517bbc543169de642bada5843f612e2f1a43f1654b0ab92d015d3d1e777ac15c630d05f98f0ee259f2e3c0ba63b9dbc2  php-5.6.28.tar.bz2
 1f5cb18f85a2e279e24344d993f5c51c7bfbcbecc0e9bfcf075bebd1b0b893e2ffb793d95a632c9333033597d4b4f74840bfd00520a6dc700444d1a054225da1  php-fpm.initd
 895e94c791bd82060ad820fef049d366a09c932097faa6b7b9a2c2e9e00a18cb7c0f9b128679c7659b404379266fd0f95dba5c0333f626194cf60f7bf6044102  php5-module.conf
 f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c939768584f3e4edbe52e8bd6103fb6777462326a9d94e8ab1f505  php-install-pear-xml.patch


### PR DESCRIPTION
security release http://php.net/archive/2016.php#id2016-11-10-3