### PR TITLE
community/php7: disabled debug output in phpdbg

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -150,7 +150,6 @@ build() {
 	_build --enable-phpdbg \
 		--enable-phpdbg \
 		--enable-phpdbg-webhelper \
-		--enable-phpdbg-debug \
 		--disable-cgi \
 		--disable-cli \
 		--with-readline \


### PR DESCRIPTION
The purpose of this flag was to make phpdbg more verbose (see https://github.com/krakjoe/phpdbg/blob/master/config.m4#L12)
Which add a lot of noise in stderr.

This PR removes this debug flag