### PR TITLE
testing/opendkim: fix init script

### DIFF
--- a/testing/opendkim/opendkim.conf
+++ b/testing/opendkim/opendkim.conf
@@ -1,1 +1,1 @@
-EXTRA_OPTS="-x /etc/opendkim/opendkim.conf"
+EXTRA_OPTS="-f -x /etc/opendkim/opendkim.conf"

--- a/testing/opendkim/opendkim.initd
+++ b/testing/opendkim/opendkim.initd
@@ -4,6 +4,7 @@ pidfile=/run/opendkim/opendkim.pid
 
 command=/usr/sbin/opendkim
 command_args="${EXTRA_OPTS}"
+command_background=yes
 
 depend() {
 	need net


### PR DESCRIPTION
OpenDKIM always gets listed as "crashed" in openrc. Running it in foreground fixes the problem.