### PR TITLE
testing/py-mystrom: new aport

### DIFF
--- a/testing/py-mystrom/APKBUILD
+++ b/testing/py-mystrom/APKBUILD
@@ -1,0 +1,51 @@
+# Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
+# Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
+pkgname=py-mystrom
+_pkgname=python-mystrom
+pkgver=0.3.6
+pkgrel=0
+pkgdesc="Python API for controlling myStrom switches/plugs"
+url="https://github.com/fabaff/python-mystrom"
+arch="noarch"
+license="MIT"
+depends="py-requests"
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py3-$_pkgname:_py3 py2-$_pkgname:_py2"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+
+build() {
+	cd "$builddir"
+	python2 setup.py build || return 1
+	python3 setup.py build || return 1
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+md5sums="b02039068f4c4b5c2ba29201aadbb941  python-mystrom-0.3.6.tar.gz"
+sha256sums="01b732d222779a0f39e45720d4e757143952979c5a2d71ce00ed3bf72a8ec32d  python-mystrom-0.3.6.tar.gz"
+sha512sums="45f7c85d41a47e0295a7bda1f07b920cd8b89944b2bdfb4ff7da088659e345b8ad5b76eb6ac010aaad55d471b3d8c9d162101dca5be6b3366fdad85077ad06df  python-mystrom-0.3.6.tar.gz"


### PR DESCRIPTION
Python API for controlling myStrom switches
https://github.com/fabaff/python-mystrom

Required by #506.