### PR TITLE
testing/radicale: fix permissions for config files

### DIFF
--- a/testing/radicale/APKBUILD
+++ b/testing/radicale/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=radicale
 pkgver=1.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A simple CalDAV (calendar) and CardDAV (contact) server"
 url="http://radicale.org"
 arch="noarch"
@@ -40,8 +40,8 @@ package() {
 		--root="$pkgdir" || return 1
 
 	install -d "$pkgdir"/etc/radicale
-	install -m640 config "$pkgdir"/etc/radicale/ || return 1
-	install -m640 logging "$pkgdir"/etc/radicale/ || return 1
+	install -m640 -g radicale config "$pkgdir"/etc/radicale/ || return 1
+	install -m640 -g radicale logging "$pkgdir"/etc/radicale/ || return 1
 
 	install -d -o radicale "$pkgdir"/var/lib/radicale \
 		"$pkgdir"/var/log/radicale || return 1


### PR DESCRIPTION
Radicale is started as user radicale, so the config should be readable by this
user. Currently the config files aren't world readable, which makes the
application crash on startup.