### PR TITLE
testing/ejabberd: fixes for libressl

### DIFF
--- a/testing/ejabberd/APKBUILD
+++ b/testing/ejabberd/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: John Regan <john@jrjrtech.com>
 pkgname=ejabberd
 pkgver=16.09
-pkgrel=1
+pkgrel=2
 pkgdesc="An erlang jabber server"
 url="http://www.ejabberd.im"
 arch="all"
@@ -20,24 +20,34 @@ pkggroups="ejabberd"
 install="$pkgname.pre-install"
 subpackages="$pkgname-dev $pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/processone/$pkgname/archive/$pkgver.tar.gz
-	ejabberd-16.01-ejabberdctl.patch
-	makefile.patch
+	https://github.com/processone/fast_tls/archive/1.0.7.tar.gz
 	ejabberd.initd
 	ejabberd.logrotate
 	ejabberd.confd
+	ejabberd-16.01-ejabberdctl.patch
+	makefile.patch
+	libressl.patch
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver
 
+prepare() {
+	cd "$builddir"
+	mkdir deps
+	mv "$srcdir"/fast_tls-1.0.7 \
+		"$builddir"/deps/fast_tls || return 1
+	default_prepare
+}
+
 build() {
 	cd "$builddir"
-	./autogen.sh
+	./autogen.sh | return 1
 	./configure --prefix=/usr \
 		--sysconfdir=/etc \
 		--localstatedir=/var \
 		--mandir=/usr/share/man \
-		--infodir=/usr/share/info
-	make || return 1
+		--infodir=/usr/share/info || return 1
+	make
 }
 
 package() {
@@ -58,20 +68,26 @@ package() {
 }
 
 md5sums="6541f96b6943320dcde7176edac931d9  ejabberd-16.09.tar.gz
-583d01f6b6ac7f3cd1118462eaba1c39  ejabberd-16.01-ejabberdctl.patch
-4fb22399211c3a8f259de57fdbfefa0f  makefile.patch
+20d7727afc4fda08b04bc3f81cfe7907  1.0.7.tar.gz
 62242441aaed1025587dcc3b40d08e68  ejabberd.initd
 f97c8a96160f30e0aecc9526c12e6606  ejabberd.logrotate
-fa61d30731cb4d818187d2e5e2fd766a  ejabberd.confd"
+fa61d30731cb4d818187d2e5e2fd766a  ejabberd.confd
+583d01f6b6ac7f3cd1118462eaba1c39  ejabberd-16.01-ejabberdctl.patch
+4fb22399211c3a8f259de57fdbfefa0f  makefile.patch
+6b540035f94b22b25af481a07eb3d49f  libressl.patch"
 sha256sums="ab82222dab13601f12a51d0eadac37f0bbf72dbf876d84d8dd3cf60f1c88fdd9  ejabberd-16.09.tar.gz
-fc971f9eba50c82013f20c78d3ba7f48bb4f70945e41951808b53ef9dbf0b898  ejabberd-16.01-ejabberdctl.patch
-4c939a05bc353a90a585143a5d981069aa7767563979595cef8637f7ab782fa7  makefile.patch
+35da558d86aec4abe571740f5f229cd03dbb3abffaf16991fe88304a3a5f72e2  1.0.7.tar.gz
 aed527edf2008becaa950eddffecdb1d9cb8a9a50e38cee9e51853c1189887cb  ejabberd.initd
 31780cac78736d285e46f445f8c8463a70f2aeb2683280c259129db11832ddd2  ejabberd.logrotate
-e1f690788cd1b5ecb334582af8e019602d297ef8b914a030de69bce2cc20fffd  ejabberd.confd"
+e1f690788cd1b5ecb334582af8e019602d297ef8b914a030de69bce2cc20fffd  ejabberd.confd
+fc971f9eba50c82013f20c78d3ba7f48bb4f70945e41951808b53ef9dbf0b898  ejabberd-16.01-ejabberdctl.patch
+4c939a05bc353a90a585143a5d981069aa7767563979595cef8637f7ab782fa7  makefile.patch
+cb9e030f5df4c989f0e569f0569245b509139dff7c8fc2bb023beb4b9938e209  libressl.patch"
 sha512sums="3ccada115f0ed8a63853c467a0ef52357d0a027ae2f8499ea26d7c1dbb241897c23b969a0a063cdf5ae2ad97071c3b16262fe7890eed73d2246a47a2c6845ad5  ejabberd-16.09.tar.gz
-aeb1f4fc299691751fd687a07bf35dc77f43cb1d14f9ba59e7de050e6953a0051f1827bbd0e21fc84dd4cb745b5603b915ffdf6de2151d6e34b4a4720a0a77ab  ejabberd-16.01-ejabberdctl.patch
-36eacec7780ed95ffc310db30e34f9d5ba8ead65f8fc44fb06c7d825f7252effad83e07c4a010e65b80a63f4a1d985290e8a489906a8c225c306f5b5b642ce36  makefile.patch
+46a3ebab09ec5e18b086c8c3e2a87a5d6a35e406e8988c48979d94c3e303d5f9a8bcdb1e8ce74266ba8c59fbb4a4310e445f5ad65f072d28a7b44a0bdec50b62  1.0.7.tar.gz
 e2310e1b5b471e5c27ce2ec5d5fc6549656f9f49ba1d65a515ebc3af6d3237a461894c6c4c55c8c6eb1b9be0b01573057591ead51eb9014f5cf1258d387c9fc8  ejabberd.initd
 47fd2cfd9177c4e978a9799a153ba74392a9891822221af8194686a40f6bf01f38644833e1e1f5416c6357e0bfb7ca3dae96f55a4fcd7cd629ec798d85a72807  ejabberd.logrotate
-96a571c0ab2be366e931bda423a61ef920cbaba2107e61ddbc501472ce3efe2804418cc6579c99310b902a9a99aaecb9284cf2420c071dbca2f670efb4034135  ejabberd.confd"
+96a571c0ab2be366e931bda423a61ef920cbaba2107e61ddbc501472ce3efe2804418cc6579c99310b902a9a99aaecb9284cf2420c071dbca2f670efb4034135  ejabberd.confd
+aeb1f4fc299691751fd687a07bf35dc77f43cb1d14f9ba59e7de050e6953a0051f1827bbd0e21fc84dd4cb745b5603b915ffdf6de2151d6e34b4a4720a0a77ab  ejabberd-16.01-ejabberdctl.patch
+36eacec7780ed95ffc310db30e34f9d5ba8ead65f8fc44fb06c7d825f7252effad83e07c4a010e65b80a63f4a1d985290e8a489906a8c225c306f5b5b642ce36  makefile.patch
+2579f21ab6428a8450399bea4d0c6f0967606d4cba73432942b34cf5445d037bed436f418e3c5aadec9a3525191824af1195f9e342ec7cbe20f99147445e4e6d  libressl.patch"

--- a/testing/ejabberd/libressl.patch
+++ b/testing/ejabberd/libressl.patch
@@ -1,0 +1,30 @@
+diff -ur a/deps/fast_tls/c_src/fast_tls_drv.c b/deps/fast_tls/c_src/fast_tls_drv.c
+--- a/deps/fast_tls/c_src/fast_tls_drv.c
++++ b/deps/fast_tls/c_src/fast_tls_drv.c
+@@ -26,7 +26,7 @@
+ #include <stdint.h>
+ #include "options.h"
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ #define DH_set0_pqg(dh, dh_p, NULL, dh_g) (dh)->p = dh_p; (dh)->g = dh_g
+ #endif
+ 
+@@ -346,7 +346,7 @@
+    }
+ 
+    driver_free(ht.buckets);
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+     OPENSSL_cleanup();
+ #endif
+ }
+@@ -934,7 +934,7 @@
+   NULL,                 /* process_exit */
+   NULL                  /* stop_select */
+ };
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ #define our_alloc driver_alloc
+ #define our_realloc driver_realloc
+ #define our_free driver_free


### PR DESCRIPTION
This fixes problems with libressl for ejabberd.

I know this patch is kind of ugly, but make deps needs to run before any
dependencies can be patched (dependencies are pulled from git by the Makefile).

* refs #6483