### PR TITLE
main/dovecot: build pigeonhole extdata plugin

### DIFF
--- a/main/dovecot/APKBUILD
+++ b/main/dovecot/APKBUILD
@@ -7,6 +7,8 @@ pkgver=2.2.26.0
 pkgrel=0
 _majorpkgver=${pkgver%.*.*}
 _pigeonholever=0.4.16
+_majorpigeonholever=${_pigeonholever%.*}
+_pluginextdataver=39
 pkgdesc="IMAP and POP3 server"
 url="http://www.dovecot.org/"
 arch="all"
@@ -15,14 +17,17 @@ depends="libressl"
 pkgusers="dovecot dovenull"
 pkggroups="dovecot dovenull"
 makedepends="libcap-dev zlib-dev libressl-dev bzip2-dev postgresql-dev
-	mariadb-dev sqlite-dev heimdal-dev openldap-dev linux-headers"
+	mariadb-dev sqlite-dev heimdal-dev openldap-dev linux-headers autoconf
+	automake libtool"
 install="dovecot.pre-install dovecot.post-install"
 subpackages="$pkgname-doc $pkgname-dev
 	$pkgname-sql $pkgname-pgsql $pkgname-mysql $pkgname-sqlite
 	$pkgname-gssapi $pkgname-ldap $pkgname-pigeonhole-plugin:_pigeonhole
+	$pkgname-pigeonhole-plugin-extdata:_pluginextdata
 	"
 source="http://www.dovecot.org/releases/$_majorpkgver/$pkgname-$pkgver.tar.gz
 	http://pigeonhole.dovecot.org/releases/$_majorpkgver/$pkgname-$_majorpkgver-pigeonhole-$_pigeonholever.tar.gz
+	http://hg.rename-it.nl/pigeonhole-0.4-sieve-extdata/archive/$_pluginextdataver.tar.gz
 	hide-dl-errors.patch
 	dovecot.logrotate
 	dovecot.initd
@@ -31,6 +36,7 @@ options="libtool"
 
 builddir="$srcdir"/$pkgname-$pkgver
 _builddirpigeonhole="$srcdir"/$pkgname-$_majorpkgver-pigeonhole-$_pigeonholever
+_builddirpluginextdata="$srcdir"/pigeonhole-0-4-sieve-extdata-$_pluginextdataver
 
 prepare() {
 	cd "$builddir"
@@ -77,6 +83,20 @@ build() {
 		--disable-static \
 		|| return 1
 	make || return 1
+
+	# Build the extdata plugin
+	cd "$_builddirpluginextdata"
+	./autogen.sh || return 1
+	./configure \
+		--prefix=/usr \
+		--localstatedir=/var \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--with-dovecot="$builddir" \
+		--with-pigeonhole="$_builddirpigeonhole" \
+		|| return 1
+	make || return 1
 }
 
 package() {
@@ -111,6 +131,10 @@ package() {
 	cd "$_builddirpigeonhole"
 	make install DESTDIR="$pkgdir" || return 1
 
+	# Installing extdata plugin
+	cd "$_builddirpluginextdata"
+	make install DESTDIR="$pkgdir" || return 1
+
 	# Moving config in the correct place
 	mv "$pkgdir"/usr/share/doc/dovecot/example-config/conf.d/* \
 		"$pkgdir"/etc/dovecot/conf.d || return 1
@@ -136,9 +160,16 @@ dev() {
 _pigeonhole() {
 	pkgdesc="Sieve plugin for dovecot"
 	depends="$pkgname"
-	_mv $(cd "$pkgdir" && find usr -name '*sieve*')
+	_mv $(cd "$pkgdir" && find usr -name '*sieve_extprograms*')
+	_mv $(cd "$pkgdir" && find usr -name '*sieve_imapsieve*')
 	_mv $(cd "$pkgdir" && find usr -name '*pigeonhole*')
 	_mv $(cd "$pkgdir" && find etc/dovecot -name '*sieve*')
+}
+
+_pluginextdata() {
+	pkgdesc="Pigeonhole Sieve Extdata Plugin"
+	depends="$pkgname"
+	_mv $(cd "$pkgdir" && find usr -name '*sieve_extdata*')
 }
 
 pgsql() {
@@ -180,16 +211,19 @@ sql() {
 }
 md5sums="85bc42328de41d1eb8d6d3f1db666db8  dovecot-2.2.26.0.tar.gz
 e03eed707b39cffc4b2a82867de45d9c  dovecot-2.2-pigeonhole-0.4.16.tar.gz
+5d26d326856d00ce04c620b549d58f79  39.tar.gz
 49f7a03284cc657857fe2ae22b8c82a0  hide-dl-errors.patch
 df6d43508a82903a97e3a2a5b8436d3d  dovecot.logrotate
 f0c227ab4e2593f6d410440b82103de1  dovecot.initd"
 sha256sums="f692a1f39de36cd15f6681f7fee5fba2ef3e72b529acbee02b23422e16926f05  dovecot-2.2.26.0.tar.gz
 8f0b98f18062d6e241eef74ebe16cc167cd246361cbe6657d94f0ecc5d7d3234  dovecot-2.2-pigeonhole-0.4.16.tar.gz
+da70fb0ce0424e9cad2c03834bd826a3685deb5a986ec5b87ae7c525055256d5  39.tar.gz
 d6accdd6e271647c01ab8fa0a9491ee822486484961e2d5c252bf70e816d2bfa  hide-dl-errors.patch
 d0fef8cd8200549877d7594cf458d6b33f05b31f95f1fd9a8368e8471c082735  dovecot.logrotate
 1a3c845c216bb6f9633d27a8c1c0d01b591942c463bddb5ae835f162bd7fb4bf  dovecot.initd"
 sha512sums="7b4c170efd964eabbd9a0166164e53b7964b90fc245bab1c3328bf199c4880288c89811dcfd9833f899057921eefb4451c561f3b3d725df9ea346df8fde82a3d  dovecot-2.2.26.0.tar.gz
 5f59fb35dbe638f8ddd19c0fd0f3fbd6fec1fa238f3781b94c50a8f7ce72a53ac1381a6f8ad9bcc90df1edfa2b263a6dfba88521578e55ce4b3d840bed022b79  dovecot-2.2-pigeonhole-0.4.16.tar.gz
+832a80264fb9bd3021c4e192eb7594c203100783df547aff35acf4dc4d8de5eddfd676fcc5a07a0691d9bb6eb884c9497a692b72a2af5bf9e9bb7a2d3f38923e  39.tar.gz
 1e9a1f2990019236546c7be581a4d6d0b430110d27a00bc3298f5c154ef9a4aadefa193d02a017912f826d771058fd5c6ef6cb454e14f0d15749fa8f3a68c64a  hide-dl-errors.patch
 9f19698ab45969f1f94dc4bddf6de59317daee93c9421c81f2dbf8a7efe6acf89689f1d30f60f536737bb9526c315215d2bce694db27e7b8d7896036a59c31f0  dovecot.logrotate
 6ec75a8396f4d826390e69aa8177593573eaf0e0ab537b2a4720573e04c92ff615f39e1559b48313b2cd2f03704cd977bb594a568ecc5dd22e38926c12f3c48c  dovecot.initd"


### PR DESCRIPTION
it was discussed that building these external plugins as part of
the Dovecot APKBUILD would prevent ABI version mismatches and
other bugs that arise when Dovecot is updated