### PR TITLE
Switch to apparently more available SourceForge 1st-party mirror for xz

### DIFF
--- a/main/xz/APKBUILD
+++ b/main/xz/APKBUILD
@@ -10,7 +10,7 @@ license="custom"
 depends=""
 makedepends=""
 subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
-source="http://tukaani.org/xz/xz-$pkgver.tar.gz"
+source="http://downloads.sourceforge.net/project/lzmautils/xz-$pkgver.tar.gz"
 
 _builddir="$srcdir"/$pkgname-$pkgver
 build () {


### PR DESCRIPTION
Hi!

Over the past few days I've been battling this particular mirror (tukaani) as it's very very flaky. Perhaps it could be considered to use the sourceforge mirror that seems to be a first-party one? 😄 