### PR TITLE
community/php7: fix build for aarch64

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=php7
 _pkgreal=php
 pkgver=7.0.14
-pkgrel=1
+pkgrel=2
 pkgdesc="The PHP language runtime engine - 7th branch"
 url="http://www.php.net/"
 arch="all"
@@ -32,6 +32,7 @@ source="http://php.net/distributions/$_pkgreal-$pkgver.tar.bz2
 	install-pear.patch
 	tidy-buffio.patch
 	includedir.patch
+	fix-asm-constraints-in-aarch64-multiply-macro.patch
 	pid_log.patch
 	"
 builddir="$srcdir/$_pkgreal-$pkgver"
@@ -344,6 +345,7 @@ md5sums="903ff1fd199201d7e69dc0963797072b  php-7.0.14.tar.bz2
 483bc0a85c50a9a9aedbe14a19ed4526  install-pear.patch
 66f0037a029f9eed2b31d2e1d50f1860  tidy-buffio.patch
 d872e633c9b33c3c9f629dd2edd2e5c5  includedir.patch
+fa807a684fa853720b7523eb99869b34  fix-asm-constraints-in-aarch64-multiply-macro.patch
 6ba762ab7a105163b8e5b3913deae109  pid_log.patch"
 sha256sums="fbc4369a0d42b55fd1ce75eb4f3d17b012da754a67567d8e3288fbfbb7490534  php-7.0.14.tar.bz2
 a7e4fc0eeba18aec019f62ed966915afd82b6b5fb1e1af93b59f964b5bd66172  php7-fpm.initd
@@ -352,6 +354,7 @@ a7e4fc0eeba18aec019f62ed966915afd82b6b5fb1e1af93b59f964b5bd66172  php7-fpm.initd
 f739ca427a1dd53a388bad0823565299c5d4a5796b1171b892884e4d7d099bab  install-pear.patch
 5dc8f32e5e2b1cd6317ada5a5adb9b5f0802ed6e0dbe065d7bfcc0f55d47e0d5  tidy-buffio.patch
 ea74966a23b1b54548ee35e9ccc2fc8d2b7c2285c385c44d6b23d9e2f25ea1a7  includedir.patch
+86f4186699f0bc61ce91986fe5efdd7b0da77ff9568c10ba52ca1094da94ed6e  fix-asm-constraints-in-aarch64-multiply-macro.patch
 0cca8729c64682387a8c44ed74f0966da697f2817152d8d05bb25bedc7eaafec  pid_log.patch"
 sha512sums="549b2e03b92df93646e430406cc20791b12de329a1fa83f8c2d42c5894119cd67b88a047b503925a7574077a66d9a0a0ada1921cbe62dba32d51c850b7d589ee  php-7.0.14.tar.bz2
 1c708de82d1086f272f484faf6cf6d087af7c31750cc2550b0b94ed723961b363f28a947b015b2dfc0765caea185a75f5d2c2f2b099c948b65c290924f606e4f  php7-fpm.initd
@@ -360,4 +363,5 @@ fbf9a1572d37370ec0d126502e1d066e045a992484d8fc4f1e2ede330134c1a15f4029f29fa4daeb
 f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c939768584f3e4edbe52e8bd6103fb6777462326a9d94e8ab1f505  install-pear.patch
 6894c9cba7752a3406e774d9efc0e058c37433493c1c20101e9563bf247c112157a67e306b06b9517b0422eca521f543d637a6cbd2cea7639e43f13d773b3d2b  tidy-buffio.patch
 199aecdbd3b4035aabf5379c215f82412d3c98b79a1ee186944e7fe1f0ed6f40789ea30e2355149491de6be34fc66c5e486e2a79a7e41ab2ae18706ef3ffe79b  includedir.patch
+d93d3fc015580cf5f75c6cbca4cd980e054b61e1068495da81a7e61f1af2c9ae14f09964c04928ad338142de78e4844aed885b1ad1865282072999fb045c8ad7  fix-asm-constraints-in-aarch64-multiply-macro.patch
 82231c7b27b4d044272857dc713674884715ed8e36e54be06faa5d2a949ba4bca597628958a9c5683ec51c36e05a00f6be811c7e95112b0314c98528f584a8d6  pid_log.patch"

--- a/community/php7/fix-asm-constraints-in-aarch64-multiply-macro.patch
+++ b/community/php7/fix-asm-constraints-in-aarch64-multiply-macro.patch
@@ -1,0 +1,31 @@
+From 6cbb9f4c247c5361b8c165fbb40b4118d5d7c0e5 Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@linux-m68k.org>
+Date: Mon, 25 Apr 2016 11:59:14 +0200
+Subject: [PATCH] Fix asm constraints in aarch64 multiply macro
+
+All operands must be register operands and the output operands are early
+clobbered.
+
+See https://bugs.php.net/bug.php?id=70015
+---
+ Zend/zend_multiply.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Zend/zend_multiply.h b/Zend/zend_multiply.h
+index dfd21f7..651dd43 100644
+--- a/Zend/zend_multiply.h
++++ b/Zend/zend_multiply.h
+@@ -53,8 +53,8 @@
+ 	__asm__("mul %0, %2, %3\n"										\
+ 		"smulh %1, %2, %3\n"										\
+ 		"sub %1, %1, %0, asr #63\n"									\
+-			: "=X"(__tmpvar), "=X"(usedval)							\
+-			: "X"(a), "X"(b));										\
++			: "=&r"(__tmpvar), "=&r"(usedval)						\
++			: "r"(a), "r"(b));										\
+ 	if (usedval) (dval) = (double) (a) * (double) (b);				\
+ 	else (lval) = __tmpvar;											\
+ } while (0)
+-- 
+2.8.0
+


### PR DESCRIPTION
Follow-up for https://github.com/alpinelinux/aports/pull/587#issuecomment-265750816

Both asm commands works only with registers according docs
* https://developer.arm.com/docs/dui0801/latest/a64-general-instructions/mul
* https://developer.arm.com/docs/dui0801/latest/a64-general-instructions/smulh

So according patch https://bugs.php.net/bug.php?id=70015 and http://stackoverflow.com/questions/36763385/strange-behaviour-of-clang-assembler I added patch to change asm instructions to multiply with registers