### PR TITLE
community/php7: bundle php7-readline extension

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=php7
 _pkgreal=php
 pkgver=7.0.14
-pkgrel=2
+pkgrel=3
 pkgdesc="The PHP language runtime engine - 7th branch"
 url="http://www.php.net/"
 arch="all"
@@ -23,7 +23,7 @@ makedepends="autoconf bison re2c apache2-dev libxml2-dev libxslt-dev libzip-dev 
 	libical-dev libressl-dev openldap-dev net-snmp-dev db-dev krb5-dev gdbm-dev sqlite-dev
 	freetds-dev mariadb-dev postgresql-dev unixodbc-dev freetype-dev tidyhtml-dev libxpm-dev
 	libpng-dev libwebp-dev libjpeg-turbo-dev libmcrypt-dev gsoap-dev recode-dev
-	readline-dev paxmark gettext-dev
+	libedit-dev paxmark gettext-dev
 	"
 source="http://php.net/distributions/$_pkgreal-$pkgver.tar.bz2
 	$pkgname-fpm.initd
@@ -39,7 +39,7 @@ builddir="$srcdir/$_pkgreal-$pkgver"
 
 _exts="bcmath bz2 calendar ctype curl dba dom enchant exif ftp gd gettext gmp iconv imap intl json
 	ldap mbstring mcrypt mysqli mysqlnd odbc opcache openssl pcntl pdo pdo_dblib pdo_mysql
-	pdo_odbc pdo_pgsql pdo_sqlite pgsql phar:phar posix pspell readline session shmop snmp soap
+	pdo_odbc pdo_pgsql pdo_sqlite pgsql phar:phar posix pspell session shmop snmp soap
 	sockets sqlite3 sysvmsg sysvsem sysvshm tidy wddx xml xmlreader xmlrpc xsl zip zlib
 	"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-apache2 $pkgname-phpdbg $pkgname-embed
@@ -124,6 +124,8 @@ _build() {
 		--enable-posix=shared \
 		--enable-phar=shared \
 		--with-pspell=shared \
+		--without-readline \
+		--with-libedit \
 		--enable-session=shared \
 		--enable-shmop=shared \
 		--with-snmp=shared \
@@ -153,14 +155,12 @@ build() {
 		--enable-phpdbg-webhelper \
 		--disable-cgi \
 		--disable-cli \
-		--with-readline \
 		|| return 1
 	# apache2 module
 	_build --disable-phpdbg \
 		--disable-cgi \
 		--disable-cli \
 		--with-apxs2 \
-		--with-readline=shared \
 		|| return 1
 	mv libs/libphp7.so sapi/apache2handler/mod_php7.so
 	# cgi,cli,fpm,embed,litespeed
@@ -168,7 +168,6 @@ build() {
 		--enable-fpm \
 		--enable-embed \
 		--with-litespeed \
-		--with-readline=shared \
 		|| return 1
 }
 


### PR DESCRIPTION
There's no way to keep `php7-readline` extension shared

So I suggest to include it into build like Redhat doing https://apps.fedoraproject.org/packages/php/sources/spec/
Also official PHP for Alpine docker image following the same pattern
https://github.com/docker-library/php/blob/master/7.0/alpine/Dockerfile#L114

Follow-up to https://github.com/alpinelinux/aports/pull/384