### PR TITLE
community/php-xdebug: fix ini-file comment

### DIFF
--- a/community/php-xdebug/APKBUILD
+++ b/community/php-xdebug/APKBUILD
@@ -5,7 +5,7 @@
 pkgname=php-xdebug
 _pkgname=xdebug
 pkgver=2.5.0
-pkgrel=0
+pkgrel=1
 pkgdesc="PHP extension provides functions for function traces and profiling"
 url="http://pecl.php.net/package/$_pkgname"
 arch="all"
@@ -56,8 +56,8 @@ _subpackage() {
 
 	install -d "$subpkgdir"/etc/php$ver/conf.d || return 1
 	cat > "$subpkgdir"/etc/php$ver/conf.d/$_pkgname.ini <<-EOF
-		# Uncomment to enable this extension.
-		#zend_extension=$_pkgname.so
+		; Uncomment to enable this extension.
+		;zend_extension=$_pkgname.so
 	EOF
 }
 


### PR DESCRIPTION
This package builds for php5 and php7 now but php5 throws notices about `#` comment in ini-file

```
PHP Deprecated:  Comments starting with '#' are deprecated in /etc/php5/conf.d/xdebug.ini on line 1 in Unknown on line 0
PHP Deprecated:  Comments starting with '#' are deprecated in /etc/php5/conf.d/xdebug.ini on line 2 in Unknown on line 0
PHP Deprecated:  Comments starting with '#' are deprecated in /etc/php5/conf.d/xdebug.ini on line 1 in Unknown on line 0
PHP Deprecated:  Comments starting with '#' are deprecated in /etc/php5/conf.d/xdebug.ini on line 2 in Unknown on line 0
```
Suggestion is to replace `#` with `:`