### PR TITLE
community/postsrsd: new aport

### DIFF
--- a/community/postsrsd/10-fix-defaults.patch
+++ b/community/postsrsd/10-fix-defaults.patch
@@ -1,0 +1,22 @@
+diff --git a/init/postsrsd.default.in b/init/postsrsd.default.in
+index 7cf2b941db..5f7ad5b916 100644
+--- a/init/postsrsd.default.in
++++ b/init/postsrsd.default.in
+@@ -21,7 +21,7 @@ SRS_SEPARATOR==
+ # When postsrsd is installed for the first time, a random secret is generated
+ # and stored in /etc/postsrsd.secret. For most installations, that's just fine.
+ #
+-SRS_SECRET=@SYSCONF_DIR@/@PROJECT_NAME@.secret
++SRS_SECRET=@SYSCONF_DIR@/@PROJECT_NAME@/@PROJECT_NAME@.secret
+ 
+ # Local ports for TCP list.
+ # These ports are used to bind the TCP list for postfix. If you change
+@@ -35,7 +35,7 @@ SRS_REVERSE_PORT=10002
+ # Drop root privileges and run as another user after initialization.
+ # This is highly recommended as postsrsd handles untrusted input.
+ #
+-RUN_AS=nobody
++RUN_AS=@PROJECT_NAME@
+ 
+ # Jail daemon in chroot environment
+ CHROOT=@CHROOT_DIR@

--- a/community/postsrsd/APKBUILD
+++ b/community/postsrsd/APKBUILD
@@ -1,0 +1,52 @@
+# Contributor: Kevin Daudt <ops@ikke.info>
+# Maintainer: Kevin Daudt <ops@ikke.info>
+pkgname=postsrsd
+pkgver=1.4
+pkgrel=0
+pkgdesc="Postfix Sender Rewriting Scheme daemon"
+url="https://github.com/roehling/postsrsd"
+arch="all"
+license="GPL2"
+depends=""
+makedepends="cmake help2man"
+pkgusers="postsrsd"
+install="$pkgname.pre-install"
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/roehling/postsrsd/archive/$pkgver.tar.gz
+	10-fix-defaults.patch
+	postsrsd.initd"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+
+	mkdir build
+	cd build
+
+	cmake .. -DCMAKE_INSTALL_PREFIX=/usr/ \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DGENERATE_SRS_SECRET=OFF \
+		-DCONFIG_DIR=/etc/postsrsd || return 1
+	make all
+}
+
+package() {
+	cd "$builddir"
+
+
+	make DESTDIR="$pkgdir/" install
+
+	install -d "$pkgdir/etc/postsrsd/"
+	install -Dm0644 build/postsrsd.default "$pkgdir/etc/conf.d/postsrsd"
+	install -Dm0755 "$srcdir/postsrsd.initd" "$pkgdir/etc/init.d/postsrsd"
+}
+
+md5sums="cb6e13a06d6bbd7d383efb9bbf0867ce  postsrsd-1.4.tar.gz
+a4104dbe7c6bc88de6a1fa29ee82e531  10-fix-defaults.patch
+575d5c5563def2aabdd752abc54b5e45  postsrsd.initd"
+sha256sums="f3230d57c36ba4688cc3beb90fbb0f199a06381e4df2edbc4ef541a9e8a574ff  postsrsd-1.4.tar.gz
+4e8093e8a90f499402f17ea9be253c499f47218bc7918d58825f6a1e2daa2543  10-fix-defaults.patch
+e59e9193998041023f6ef2740fd8ddaa2903d2a88f39e14f638c5ca2ce023b3b  postsrsd.initd"
+sha512sums="e5b9d2091d562030dd8d35117a3c5fb7d99c0613120fc90f74be57af5e88a3fe0ce73a5ce702708047ae37f70c6aedb4a0df018dccbe480048ccb6ed4debbcef  postsrsd-1.4.tar.gz
+bdafd3921fac6af21cf099ac63fd06692dca37366e197b23aaedd3cf748652bcc5b54cf545b24c7e6cb48d266233a29e9184481af99aa8d58a80e512d326c788  10-fix-defaults.patch
+bec690156e60a10286f92470420e2caccd0cd8fd5707fefddeb768b36a4697b9651acd707c7de08a99832a8b27a0328560501fb1376fe39bc27f5fbe4dca7797  postsrsd.initd"

--- a/community/postsrsd/postsrsd.initd
+++ b/community/postsrsd/postsrsd.initd
@@ -1,0 +1,35 @@
+#!/sbin/openrc-run
+
+description="Postfix SRS Daemon"
+pidfile="/run/postsrsd.pid"
+command="/usr/sbin/postsrsd"
+command_args="-D
+              -d \"${SRS_DOMAIN}\"
+              -s ${SRS_SECRET-/etc/postsrsd/postsrsd.secret}
+              -f ${SRS_FORWARD_PORT-10001}
+              -r ${SRS_REVERSE_PORT-10002}
+              -p \"${pidfile}\"
+              -u \"${RUN_AS-postsrsd}\"
+              -c \"${CHROOT-/usr/lib/postsrsd}\"
+              -a \"${SRS_SEPARATOR-=}\""
+
+stopsig="SIGTERM"
+
+start_pre() {
+        if [ -z "${SRS_DOMAIN}" ]
+        then
+                eerror "SRS_DOMAIN is not set"
+                return 1
+        fi
+
+        if [ ! -s /etc/postsrsd/postsrsd.secret ]
+        then
+                ebegin "Generating secret"
+                dd if=/dev/urandom bs=18 count=1 status=none \
+                    | base64 >${SRS_SECRET}
+
+                chmod 0600 ${SRS_SECRET}
+                chown postsrsd ${SRS_SECRET}
+                eend $?
+        fi
+}

--- a/community/postsrsd/postsrsd.pre-install
+++ b/community/postsrsd/postsrsd.pre-install
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+addgroup -S postsrsd 2>/dev/null
+adduser -S -D -H -s /bin/false -G postsrsd -g postsrsd postsrsd 2>/dev/null
+
+exit 0


### PR DESCRIPTION
Daemon to apply SRS for postfix, which is necessary when relaying messages and still want SPF to pass.