### PR TITLE
testing/terraform: upgrade to 0.8.1

### DIFF
--- a/testing/terraform/APKBUILD
+++ b/testing/terraform/APKBUILD
@@ -2,11 +2,11 @@
 # Contributor: Gennady Feldman <gena01@gmail.com>
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=terraform
-pkgver=0.7.12
+pkgver=0.8.1
 pkgrel=0
 pkgdesc="Building, changing, and combining infrastructure safely and efficiently"
 url="https://www.terraform.io/"
-arch="x86_64"
+arch="all"
 license="MPL 2.0"
 depends=""
 makedepends="go"
@@ -15,24 +15,21 @@ source="${pkgname}-${pkgver}.tar.gz::https://github.com/hashicorp/terraform/arch
 builddir="$srcdir/src/github.com/hashicorp/$pkgname"
 
 prepare() {
-	mkdir -p "$srcdir/src/github.com/hashicorp"
+	mkdir -p ${builddir%/*}
 	mv $srcdir/$pkgname-$pkgver "$builddir"/ || return 1
 	default_prepare
 }
 
 build() {
-	cd $builddir
-
-	GOPATH="$srcdir" go build -v -o bin/$pkgname || return 1
+	cd "$builddir"
+	export GOPATH="$srcdir"
+	go build -v -o bin/$pkgname || return 1
 }
 
 package() {
-	cd "$builddir"
-
-	install -Dm755 bin/$pkgname \
-		"${pkgdir}/usr/bin/$pkgname" || return 1
+	install -Dm755 "$builddir"/bin/$pkgname "$pkgdir"/usr/bin/$pkgname || return 1
 }
 
-md5sums="403fd330efb11e18737f1c4e47dc75be  terraform-0.7.12.tar.gz"
-sha256sums="e5bd86492557b17dd12b99ff41eb0b31c0d19ceb54292c399ab56ec209a22200  terraform-0.7.12.tar.gz"
-sha512sums="72c6f5ef997c3d538537a21a7a96a97e8d89a4b7ec18872d962afb72fae2cf4eb62608424dcfde8375c9f6561fbb2d230d84c941ba8e1624327e7b63278fd296  terraform-0.7.12.tar.gz"
+md5sums="b9daa0203e761775d94cb56edc586dc6  terraform-0.8.1.tar.gz"
+sha256sums="927b4909a64b8550376e87c737eab0f34a0895f2700fa8bc81de339f4a7ffe20  terraform-0.8.1.tar.gz"
+sha512sums="3134c42b58262869e6c314210d3b19e5bade85fc80146ece6e5de8e980f186774f18bf8f8b04e118ec5667d2d699bb9149852d70ecbe28f7ada1061cfe251532  terraform-0.8.1.tar.gz"


### PR DESCRIPTION
I have upgraded terraform to the latest stable release, I have applied the same variables and functions like @clandmeter got for hugo at https://github.com/tboerger/aports/blob/a7edb288d896e937ec5290fb51b8317c30e1c522/testing/hugo/APKBUILD to have it in a similar fashion.