### PR TITLE
Add http_realip_module to nginx

### DIFF
--- a/main/nginx/APKBUILD
+++ b/main/nginx/APKBUILD
@@ -143,6 +143,7 @@ build() {
 		--with-http_slice_module \
 		--with-http_stub_status_module \
 		--with-http_perl_module=dynamic \
+		--with-http_realip_module \
 		--with-mail=dynamic \
 		--with-mail_ssl_module \
 		--with-stream=dynamic \


### PR DESCRIPTION
As per https://bugs.alpinelinux.org/issues/5712 - needed to properly track original client IP through multiple layers of proxies/load-balancers.