### PR TITLE
testing/darktable: upgrade to 2.2.0

### DIFF
--- a/testing/darktable/APKBUILD
+++ b/testing/darktable/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Kevin Daudt <ops@ikke.info>
 # Maintainer: Kevin Daudt <ops@ikke.info>
 pkgname=darktable
-pkgver=2.2.0_rc3
+pkgver=2.2.0
 pkgrel=0
 pkgdesc="an open source photography workflow application and raw developer"
 url="https://www.darktable.org/"
@@ -63,6 +63,6 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-md5sums="cff116f7f6acf691f9cbfb28e415300a  darktable-2.2.0.rc3.tar.xz"
-sha256sums="f7b9e8f5f56b2a52a4fa51e085b8aefe016ab08daf7b4a6ebf3af3464b1d2c29  darktable-2.2.0.rc3.tar.xz"
-sha512sums="8565c142e8d44dd7627c94b556a6a491269ae26f3a239e4c24372e3d8e149a9ad95099fb5ac1f7bfd331102094db6ea0f5db8a96463ccf8a2749d502dfdfc6fb  darktable-2.2.0.rc3.tar.xz"
+md5sums="3297a30d69a0adea87ccf0b9c47d5c9f  darktable-2.2.0.tar.xz"
+sha256sums="3eca193831faae58200bb1cb6ef29e658bce43a81706b54420953a7c33d79377  darktable-2.2.0.tar.xz"
+sha512sums="b1acdaacc397d8752d32c5d8a8329222da7d87f159c21b467c950cd9ad61ec331d6dfc3f9e034c44484e8bf082d4df4e9dc01394e018f97c2adc6d09641a9085  darktable-2.2.0.tar.xz"


### PR DESCRIPTION
No longer rc, but a full release.