### PR TITLE
main/apache2: upgrade to 2.4.25

### DIFF
--- a/main/apache2/APKBUILD
+++ b/main/apache2/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 pkgname=apache2
 _pkgreal=httpd
-pkgver=2.4.23
-pkgrel=10
+pkgver=2.4.25
+pkgrel=0
 pkgdesc="A high performance Unix-based HTTP server"
 url="http://httpd.apache.org/"
 arch="all"
@@ -45,7 +45,6 @@ source="http://archive.apache.org/dist/$_pkgreal/$_pkgreal-$pkgver.tar.bz2
 	conf/0012-httpd.conf-MIMEMagicFile.patch
 	conf/0013-httpd-.conf-IfModule.patch
 	conf/0014-httpd-.conf-LoadModule.patch
-	CVE-2016-5387.patch
 	"
 options="suid"
 
@@ -296,7 +295,7 @@ _lua() {
 		"$subpkgdir"/usr/lib/apache2/ || return 1
 	_load_mods
 }
-md5sums="04f19c60e810c028f5240a062668a688  httpd-2.4.23.tar.bz2
+md5sums="2826f49619112ad5813c0be5afcc7ddb  httpd-2.4.25.tar.bz2
 257d2572921dd4506b0464441f88fab4  apache2.confd
 8519af87c57b50441866ad4216e4d663  apache2.logrotate
 11b2718d7a0550498aaddf41e940ad04  apache2.initd
@@ -314,9 +313,8 @@ md5sums="04f19c60e810c028f5240a062668a688  httpd-2.4.23.tar.bz2
 aa73ec65c4c67819f297e48da8d3fb8e  0011-httpd.conf-IncludeOptional.patch
 605536ff208f88ea97331b6b5d03278f  0012-httpd.conf-MIMEMagicFile.patch
 78f648c86a895107a9381374d5497f51  0013-httpd-.conf-IfModule.patch
-3c873b99a197a7fa1792bc7fa5b05233  0014-httpd-.conf-LoadModule.patch
-61489c5f174756e63bae95c5d85d0e46  CVE-2016-5387.patch"
-sha256sums="0c1694b2aad7765896faf92843452ee2555b9591ae10d4f19b245f2adfe85e58  httpd-2.4.23.tar.bz2
+3c873b99a197a7fa1792bc7fa5b05233  0014-httpd-.conf-LoadModule.patch"
+sha256sums="f87ec2df1c9fee3e6bfde3c8b855a3ddb7ca1ab20ca877bd0e2b6bf3f05c80b2  httpd-2.4.25.tar.bz2
 6ca904ad65c1a4122d8ea4a3303ea8184429a4a4d7fb81defc30f3e184258c0a  apache2.confd
 8e2a8870d51796cf04cc7d8985c43e36afe9ae79e2d6765050a0e72c0de8dce7  apache2.logrotate
 8761faa68c2db7114b3f463f3b8ef1aec8f8373da9908d943cc765765914ab36  apache2.initd
@@ -334,9 +332,8 @@ f22abd948065649d9972be320a1feb855b5807ca9f45af3ad354b9560cb257d1  0010-httpd-ssl
 9ecd79e4a084d876c56000ccc2fa88463fb57617b575fe4f8104c099715c691b  0011-httpd.conf-IncludeOptional.patch
 5bad32417abc9fdf3e430aabd1ac8d13d90304911d6bd76515896df0aaa3e8d7  0012-httpd.conf-MIMEMagicFile.patch
 9603bf79c7eab05e635ee7c9b2ecc67c49146f955b59852a88f2c618bd489a78  0013-httpd-.conf-IfModule.patch
-34d0202635660c961ee5186a4950e2af714b27bbd4aef23901c1f05a5e6c6fcd  0014-httpd-.conf-LoadModule.patch
-c38bf5061a7c8d2da010db57ecf36a8c29739d34a04f55c66405a2e9fc319cd8  CVE-2016-5387.patch"
-sha512sums="c520de5be748c0a785ef0dc77102749eb4f47e224968b8d4bed2ae644faa0964623a0e960b64486a0888446790d050b52a6ae34fe61717fab95b37384b4825b1  httpd-2.4.23.tar.bz2
+34d0202635660c961ee5186a4950e2af714b27bbd4aef23901c1f05a5e6c6fcd  0014-httpd-.conf-LoadModule.patch"
+sha512sums="6ba4ce1dcef71416cf1c0de2468c002767b5637a75744daf5beb0edd045749a751b3826c4132f594c48e4b33ca8e1b25ebfb63ac4c8b759ca066a89d3261fb22  httpd-2.4.25.tar.bz2
 8e62b101f90c67babe864bcb74f711656180b011df3fd4b541dc766b980b72aa409e86debf3559a55be359471c1cad81b8779ef3a55add8d368229fc7e9544fc  apache2.confd
 18e8859c7d99c4483792a5fd20127873aad8fa396cafbdb6f2c4253451ffe7a1093a3859ce719375e0769739c93704c88897bd087c63e1ef585e26dcc1f5dd9b  apache2.logrotate
 81a2d2a297d8049ba1b021b879ec863767149e056d9bdb2ac8acf63572b254935ec96c2e1580eba86639ea56433eec5c41341e4f1501f9072745dccdb3602701  apache2.initd
@@ -354,5 +351,4 @@ e151a8ebb23b1a3a92ea9a8b83b6bf64c950ec8ded8d514df8f16f074c5f712de7c44cb42190ca15
 fc3352b50bee11e7560594398948a1af0279d339e891915e38766c9c0f930cc01f207e438afe9a43329b6d23fe438939666309e8ad77938dbe8dc784aaae4113  0011-httpd.conf-IncludeOptional.patch
 da3a99ccf54c8d4adc633cceb3e520e48b47e868e8f1be33c81027ce3173401c8b9b79af4f75c73c94f77a50452219a4d23774b03a74f6271a677ec271396ada  0012-httpd.conf-MIMEMagicFile.patch
 564866cadebd957eb9b23624286deb8cadb0ebeda0e3e80ec2cd8912731c8273f5ef5fa9f2d8295accb304da40c850772a854eb0c76c3aa08bb93b059c730882  0013-httpd-.conf-IfModule.patch
-3742b8ed06cfd081a02c171b5ddf42652d2848fd520e0ff1a4799fce90300e70ab8edbbecc7111a1083133077a57703a631879143777565e6918099a873d4aa0  0014-httpd-.conf-LoadModule.patch
-ebfcac5e4bc12a64d4d7e723d362cfc4912a6369ddd265a06dee95af1d5dbf8dd4bfe87ce227661afb386e19dc738e475e11aebd0ddcb5f827c14fe7c66d998c  CVE-2016-5387.patch"
+3742b8ed06cfd081a02c171b5ddf42652d2848fd520e0ff1a4799fce90300e70ab8edbbecc7111a1083133077a57703a631879143777565e6918099a873d4aa0  0014-httpd-.conf-LoadModule.patch"


### PR DESCRIPTION
Security release http://www.apache.org/dist/httpd/CHANGES_2.4.25
Also it includes previous patch for httpoxy