### PR TITLE
main/php5-phpmailer: upgrade to 5.2.19

### DIFF
--- a/main/php5-phpmailer/APKBUILD
+++ b/main/php5-phpmailer/APKBUILD
@@ -2,11 +2,10 @@
 # Maintainer:  Timo Teräs <timo.teras@iki.fi>
 _php=php5
 pkgname=${_php}-phpmailer
-_pkgname=PHPMailer
-pkgver=5.2.4
+pkgver=5.2.19
 pkgrel=0
 pkgdesc="PHP class for SMTP mailing"
-url="http://code.google.com/a/apache-extras.org/p/phpmailer/"
+url="https://github.com/PHPMailer/PHPMailer"
 arch="noarch"
 license="LGPL"
 depends="$_php"
@@ -14,9 +13,9 @@ depends_dev=
 makedepends="$depends_dev"
 install=""
 subpackages=""
-source="https://storage.googleapis.com/google-code-archive-downloads/v2/apache-extras.org/phpmailer/${_pkgname}_${pkgver}.tgz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/PHPMailer/PHPMailer/archive/v$pkgver.tar.gz"
 
-builddir="$srcdir/${_pkgname}_$pkgver"
+builddir="$srcdir/PHPMailer-$pkgver"
 build() {
 	cd "$builddir"
 }
@@ -27,6 +26,6 @@ package() {
 	install -D -m644 "$builddir"/class.*.php "$pkgdir"/usr/share/pear || return 1
 }
 
-md5sums="c990db0d0859599eafa4338ce90154a7  PHPMailer_5.2.4.tgz"
-sha256sums="805e414daf56a8bda443c0e0c209c5cc29a3fcb0c55b36450e5b4635c0991dd8  PHPMailer_5.2.4.tgz"
-sha512sums="c5bbac3d60db83052a76474b5e7c975fa6aaa0bf157fba21b4c382a645d113bcda5d8214e08a844904d0f6e99cf324dae5796bb8d1de29852591d23471d0436a  PHPMailer_5.2.4.tgz"
+md5sums="e87015596431c395ab16e6533f9cb88a  php5-phpmailer-5.2.19.tar.gz"
+sha256sums="5c167f6d84bd74bff9de6b5594f2c262e748a021ce4686cadfc2ed273e71f82f  php5-phpmailer-5.2.19.tar.gz"
+sha512sums="2eda1b856305c10017fe026f7de0e96796706216d64dce9ee9f3aa1bc8db4be277b8e8d88954d447e138f9d8701a7c7a86b75ba12b93160ff13ec65d1c0131ba  php5-phpmailer-5.2.19.tar.gz"


### PR DESCRIPTION
Security release after CVE-2016-10033
Also package home moved to github