### PR TITLE
testing/nginx-naxsi: update to 1.11.8 with dynamic modules

### DIFF
--- a/testing/nginx-naxsi/APKBUILD
+++ b/testing/nginx-naxsi/APKBUILD
@@ -5,25 +5,44 @@
 
 pkgname=nginx-naxsi
 _pkgname=nginx
-pkgver=1.11.5
-_ngx_naxsi_ver=0.55.1
-_ngx_cache_purge_ver=2.3
-_ngx_upstream_fair_ver=0.1.0
-_ngx_http_sysguard_ver=2.1.0
-pkgrel=1
+pkgver=1.11.8
+pkgrel=0
 pkgdesc="lightweight HTTP and reverse proxy server with Naxsi WAF support, see also 'nxapi'"
 url="http://www.nginx.org | https://github.com/nbs-system/naxsi"
 arch="all"
 license="custom"
-install="$pkgname.pre-install $pkgname.pre-upgrade"
+
+# Modules
+_ngx_naxsi_name=naxsi
+_ngx_naxsi_ver=0.55.1
+_ngx_naxsi_dir="$srcdir/$_ngx_naxsi_name-$_ngx_naxsi_ver/naxsi_src"
+
+_ngx_cache_purge_name=ngx_cache_purge
+_ngx_cache_purge_ver=2.3.0.1
+_ngx_cache_purge_dir="$srcdir/$_ngx_cache_purge_name-$_ngx_cache_purge_ver"
+
+_ngx_upstream_fair_name=nginx-upstream-fair
+_ngx_upstream_fair_ver=0.1.1
+_ngx_upstream_fair_dir="$srcdir/$_ngx_upstream_fair_name-$_ngx_upstream_fair_ver"
+
+_ngx_http_sysguard_name=tengine-http-sysguard
+_ngx_http_sysguard_ver=2.2.0
+_ngx_http_sysguard_dir="$srcdir/$_ngx_http_sysguard_name-$_ngx_http_sysguard_ver"
+
 depends="!nginx"
-makedepends="pcre-dev libressl-dev zlib-dev paxmark linux-headers"
-subpackages="$pkgname-doc $pkgname-vim:vim"
+makedepends="linux-headers gd-dev geoip-dev libxml2-dev libxslt-dev libressl-dev
+	pcre-dev perl-dev pkgconf zlib-dev"
+pkgusers="nginx"
+_grp_ngx="nginx"
+_grp_www="www-data"
+pkggroups="$_grp_ngx $_grp_www"
+install="$pkgname.pre-install $pkgname.pre-upgrade"
+subpackages="$pkgname-doc"
 source="http://nginx.org/download/$_pkgname-$pkgver.tar.gz
-	naxsi-$_ngx_naxsi_ver.tar.gz::https://github.com/nbs-system/naxsi/archive/$_ngx_naxsi_ver.tar.gz
-	ngx_cache_purge-$_ngx_cache_purge_ver.tar.gz::https://github.com/FRiCKLE/ngx_cache_purge/archive/$_ngx_cache_purge_ver.tar.gz
-	upstream-fair-$_ngx_upstream_fair_ver.tar.gz::https://github.com/hnlq715/nginx-upstream-fair/archive/v$_ngx_upstream_fair_ver.tar.gz
-	sysguard-$_ngx_http_sysguard_ver.tar.gz::https://github.com/itoffshore/nginx-http-sysguard/archive/$_ngx_http_sysguard_ver.tar.gz
+	naxsi-$_ngx_naxsi_ver.tar.gz::https://github.com/nbs-system/$_ngx_naxsi_name/archive/$_ngx_naxsi_ver.tar.gz
+	ngx_cache_purge-$_ngx_cache_purge_ver.tar.gz::https://github.com/itoffshore/$_ngx_cache_purge_name/archive/v$_ngx_cache_purge_ver.tar.gz
+	upstream-fair-$_ngx_upstream_fair_ver.tar.gz::https://github.com/itoffshore/$_ngx_upstream_fair_name/archive/v$_ngx_upstream_fair_ver.tar.gz
+	sysguard-$_ngx_http_sysguard_ver.tar.gz::https://github.com/itoffshore/$_ngx_http_sysguard_name/archive/v$_ngx_http_sysguard_ver.tar.gz
 
 	anonymise.patch
 	ipv6.patch
@@ -32,119 +51,153 @@ source="http://nginx.org/download/$_pkgname-$pkgver.tar.gz
 	nginx.initd
 	nginx.logrotate
 	"
+builddir="$srcdir"/$_pkgname-$pkgver
 
-_builddir="$srcdir"/$_pkgname-$pkgver
+_modules_dir="usr/lib/nginx/modules"
+_modules="
+	http-geoip
+	http-image-filter
+	http-perl
+	http-xslt-filter
+	mail
+	stream
+	http-naxsi
+	http-cache-purge
+	http-upstream-fair
+	http-sysguard
+	"
 
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+for _m in $_modules; do
+	subpackages="$subpackages $pkgname-mod-$_m:_module"
+done
+
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
-		--prefix=/usr \
-		--conf-path=/etc/$_pkgname/$_pkgname.conf \
-		--pid-path=/var/run/$_pkgname.pid \
-		--lock-path=/var/run/$_pkgname.lock \
+                --prefix=/var/lib/$_pkgname \
+                --sbin-path=/usr/sbin/$_pkgname \
+                --modules-path=/$_modules_dir \
+                --conf-path=/etc/$_pkgname/$_pkgname.conf \
+                --pid-path=/run/$_pkgname/$_pkgname.pid \
+                --lock-path=/run/$_pkgname/$_pkgname.lock \
 		--error-log-path=/var/log/$_pkgname/error.log \
 		--http-log-path=/var/log/$_pkgname/access.log \
-		--http-client-body-temp-path=/tmp/$_pkgname/client-body \
-		--http-proxy-temp-path=/tmp/$_pkgname/proxy \
-		--http-fastcgi-temp-path=/tmp/$_pkgname/fastcgi \
-		--user=nginx \
-		--group=nginx \
-		--with-http_ssl_module \
-		--with-http_realip_module \
-		--with-http_addition_module \
-		--with-http_sub_module \
-		--with-http_dav_module \
-		--with-http_flv_module \
-		--with-http_mp4_module \
-		--with-http_gunzip_module \
-		--with-http_gzip_static_module \
-		--with-http_random_index_module \
-		--with-http_secure_link_module \
-		--with-http_stub_status_module \
-		--with-http_auth_request_module \
-		--with-threads \
-		--with-stream \
-		--with-stream_ssl_module \
-		--with-http_slice_module \
-		--with-mail \
-		--with-mail_ssl_module \
-		--with-file-aio \
-		--with-http_v2_module \
-		--without-http_uwsgi_module \
-		--without-http_scgi_module \
-		--add-module="$srcdir/naxsi-$_ngx_naxsi_ver/naxsi_src" \
-		--add-module="$srcdir/ngx_cache_purge-$_ngx_cache_purge_ver" \
-		--add-module="$srcdir/nginx-upstream-fair-$_ngx_upstream_fair_ver" \
-		--add-module="$srcdir/nginx-http-sysguard-$_ngx_http_sysguard_ver" \
+                --http-client-body-temp-path=/var/lib/$_pkgname/tmp/client_body \
+                --http-proxy-temp-path=/var/lib/$_pkgname/tmp/proxy \
+                --http-fastcgi-temp-path=/var/lib/$_pkgname/tmp/fastcgi \
+                --with-perl_modules_path=/usr/lib/perl5/vendor_perl \
+                \
+                --user=$pkgusers \
+                --group=$_grp_ngx \
+                --with-threads \
+                --with-file-aio \
+                --without-http_uwsgi_module \
+                --without-http_scgi_module \
+                \
+                --with-http_ssl_module \
+                --with-http_v2_module \
+                --with-http_realip_module \
+                --with-http_addition_module \
+                --with-http_sub_module \
+                --with-http_dav_module \
+                --with-http_flv_module \
+                --with-http_mp4_module \
+                --with-http_gunzip_module \
+                --with-http_gzip_static_module \
+                --with-http_auth_request_module \
+                --with-http_random_index_module \
+                --with-http_secure_link_module \
+                --with-http_slice_module \
+                --with-http_stub_status_module \
+                --with-http_realip_module \
+                --with-http_xslt_module=dynamic \
+                --with-http_image_filter_module=dynamic \
+                --with-http_geoip_module=dynamic \
+                --with-http_perl_module=dynamic \
+                --with-mail=dynamic \
+                --with-mail_ssl_module \
+                --with-stream=dynamic \
+                --with-stream_ssl_module \
+                \
+                --add-dynamic-module="$_ngx_naxsi_dir" \
+                --add-dynamic-module="$_ngx_cache_purge_dir" \
+                --add-dynamic-module="$_ngx_upstream_fair_dir" \
+                --add-dynamic-module="$_ngx_http_sysguard_dir" \
 		|| return 1
 	make || return 1
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 
-	local paxflags="-m"
-	[ "$CARCH" = "x86" ] && paxflags="-msp"
-	paxmark "$paxflags" "$pkgdir"/usr/sbin/nginx || return 1
+	install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+	install -Dm644 README "$pkgdir"/usr/share/doc/$pkgname/README
 
-	install -m755 -D "$srcdir"/$_pkgname.initd "$pkgdir"/etc/init.d/$_pkgname
-	install -m644 -D "$srcdir"/$_pkgname.logrotate "$pkgdir"/etc/logrotate.d/$_pkgname
+	cd "$pkgdir"
 
-	install -m644 -D LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
-	install -m644 -D "$srcdir"/naxsi-$_ngx_naxsi_ver/naxsi_config/naxsi_core.rules "$pkgdir"/etc/nginx/naxsi_core.rules
+	install -Dm644 "$srcdir"/nginx.conf ./etc/$_pkgname/nginx.conf
+	install -Dm644 "$srcdir"/default.conf ./etc/$_pkgname/conf.d/default.conf
+	install -m755 -D "$srcdir"/$_pkgname.initd ./etc/init.d/$_pkgname
+	install -m644 -D "$srcdir"/$_pkgname.logrotate ./etc/logrotate.d/$_pkgname
+	install -m644 -D "$srcdir"/naxsi-$_ngx_naxsi_ver/naxsi_config/naxsi_core.rules ./etc/nginx/naxsi_core.rules
+
+	install -dm755 ./etc/$_pkgname/modules
+	install -dm750 -o $pkgusers -g $_grp_ngx ./var/lib/$_pkgname
+	install -dm700 -o $pkgusers -g $_grp_ngx ./var/lib/$_pkgname/tmp
+
+	ln -sf /$_modules_dir ./var/lib/$_pkgname/modules
+	ln -sf /var/log/$_pkgname ./var/lib/$_pkgname/logs
+	ln -sf /run/$_pkgname ./var/lib/$_pkgname/run
+
+	rm -rf ./run ./etc/$_pkgname/*.default
 }
 
-vim() {
-        local t
+_module() {
+	local name="${subpkgname#$pkgname-mod-}"
+	name="${name//-/_}"
+	soname="ngx_${name}_module.so"
 
-        depends=""
-        pkgdesc="Vim syntax for Nginx"
-        arch="noarch"
+	pkgdesc="$pkgdesc (module $name)"
+	depends="!nginx-mod-$name"
+	provides="$name"
 
-        for t in ftdetect syntax indent; do
-                install -Dm644 "$_builddir"/contrib/vim/$t/$_pkgname.vim \
-                        "$subpkgdir"/usr/share/vim/vimfiles/$t/$_pkgname.vim
-        done
+	mkdir -p "$subpkgdir"/$_modules_dir
+	cd "$subpkgdir"
+
+	mv "$pkgdir"/$_modules_dir/$soname ./$_modules_dir/$soname || return 1
+	mkdir -p "$subpkgdir"/etc/nginx/modules
+	echo "load_module \"modules/$soname\";" > ./etc/nginx/modules/$name.conf
 }
 
-md5sums="db43f2b19746f6f47401c3afc3924dc6  nginx-1.11.5.tar.gz
+md5sums="8f68f49b6db510e567bba9e0c271a3ac  nginx-1.11.8.tar.gz
 b894ea5327a3d102a56aeddb79d2e047  naxsi-0.55.1.tar.gz
-dc4c0688ed03ca7f5563097c2a8a76ca  ngx_cache_purge-2.3.tar.gz
-f3562ef6573f616e254d382d6f86b8e1  upstream-fair-0.1.0.tar.gz
-fdb072dc8d67b573a0ea7983530a7d2b  sysguard-2.1.0.tar.gz
+dedef1e47a26500993a88c96112d5d0f  ngx_cache_purge-2.3.0.1.tar.gz
+233861df4dc0872f727fc4c7e5c72dca  upstream-fair-0.1.1.tar.gz
+3a72f075bb114f1a97976c088a81c7f7  sysguard-2.2.0.tar.gz
 31d29937da95b31714faa399aeb07407  anonymise.patch
 f478d8391dafa32a8b0b3a9f21d7a080  ipv6.patch
 50357b75049d878c0bcce10d0c60f9ed  sysguard.patch
-609ea97ab6c3c30f9e8329968aadc4f3  nginx.initd
+2e56b3f21f19aecc5500c9efc9222782  nginx.initd
 8823274a834332d3db4f62bf7dd1fb7d  nginx.logrotate"
-sha256sums="223f8a2345a75f891098cf26ccdf208b293350388f51ce69083674c9432db6f6  nginx-1.11.5.tar.gz
+sha256sums="53aef3715d79015314c2dcb18f2b185a0c64368cc01b30bdf0737a215f666b34  nginx-1.11.8.tar.gz
 45dd0df7a6b0b6aa9c64eb8c39a8e294d659d87fb18e192cf58f1402f3cdb0a8  naxsi-0.55.1.tar.gz
-cb7d5f22919c613f1f03341a1aeb960965269302e9eb23425ccaabd2f5dcbbec  ngx_cache_purge-2.3.tar.gz
-dd0bfb79d2489f48ea63ac004d91890cd471eb4020500ce9179c3612cb13246c  upstream-fair-0.1.0.tar.gz
-97e0cc9a36fcce375c5b0667b002d2f7acd580e968a2318e3276fbdc1b99f8e4  sysguard-2.1.0.tar.gz
+5da9360cd805a432ea7a08832ec3dd3a5d9f1574f71b3acdd53210610aee94e5  ngx_cache_purge-2.3.0.1.tar.gz
+e8aec578f03259c6f457575360f70d57aea385a1864562b0ba6e57d6a75d52c7  upstream-fair-0.1.1.tar.gz
+6051eb52361d602011b4c7e88b63384bcc8ebc4b004bd4b12eec3e5dce953f1d  sysguard-2.2.0.tar.gz
 28adf3605875197d5822fa382f5fd3c9c80f7d3a561e904fee223fa051f98810  anonymise.patch
 4a1a24a92657432012f08c52e8099c7abae390c9c4cb76483cacd012e26a57ac  ipv6.patch
 18090329435c32d91621a5943acc5b8bbe89aaa3c2fa334c3a4cdeb00efb6226  sysguard.patch
-8cbef405295eac299dfc3b9b119c02bda354a9b335923bed6ff6992c1fd8f493  nginx.initd
+decb084e29b584fb54b57a199f5a480dd77a4c1b3ef3da515c2eb76bd32172c5  nginx.initd
 cea0c6f8de55a4c3a3eccc57910de1c3116634082c8e5b660630fb927a29f38d  nginx.logrotate"
-sha512sums="f41b21b5d8c6b7fe7f8713e96fb6b1c40da49bf64ebb790fb5aa38f036a37b36fcf048ff72c2216552b2f75366b30c5fcdef26312bd4e5515b2476a1cd944b8c  nginx-1.11.5.tar.gz
+sha512sums="4bbecf17579022cc925af8808554983c57e4f438edc8f987751413f0a023267a4766edc8321cbbe8a8b675f7e86d8a2cba76bd52236c8d9509b2b301ab349ffa  nginx-1.11.8.tar.gz
 aebda20e5b78e9111b7bac1e15829258e6b85b80e4ce333e4dba8caead36287b3f0fcb453c51d7c59f07d637fa62f5c6b23aecd3bf6a3c3da4abebf1a6689f14  naxsi-0.55.1.tar.gz
-81929ca57ce5c2e1af6ec43882a54ff1da8dc77786bfb7505ff94fbcf970ae8870b419dc5c0bc7b80794d75a359e0100f360c1cf458a300f802b1d8bd7053811  ngx_cache_purge-2.3.tar.gz
-2ff9894986c5cd483ecee97d8818675ef6d063e5f45bb66e8cf56c78bbd043b9c0c37eb3cf650b7cfb6d40da9f7a4ba0e030fe39de5ef1f715cbcd6560248428  upstream-fair-0.1.0.tar.gz
-f9587b8aa7a2b09be016dc6f7a07fe3fee154d16172194e899bf3c78a3f4e373c78f79932794cd9ac75793514c606ab878f88be9400b70e37528d263f1541b34  sysguard-2.1.0.tar.gz
+c49c81dbdb8bd507fccf31295e603cea8f0a964867c27eff0436dcea3b4a547c8ae2f11ecf49c4d82c693cf8138c17ebbed395738539d0d61254951e5f0db7e3  ngx_cache_purge-2.3.0.1.tar.gz
+fd305b859c868ef55171b05f64071a2836c12073bcd89d6197af4946a3d1177f77c6708d4d589d460c84967273dee87ca9de97ab0f0d47e6d65f86b465d70316  upstream-fair-0.1.1.tar.gz
+2743d9aea60bd4984b650213e571cf27e6ff5b3db708242ccb53b8fc669d1cc82ee224ba79aee2f6969b6e13821cfdd3df7b412541e1fdbb867ecc95326e07e1  sysguard-2.2.0.tar.gz
 f8e46dafcf553edd35699dc2a47a54756e0a4c690fc13f81436ad9db1026739ba331ad99d3d05d8a7c089a5c067bf45f4aca3a98fdd9483b7b0123a837e695be  anonymise.patch
 cae9f842c3d1188730d4355440476ad2338b19c027c4b329efe88d4487e90d96bf60dea6feb4be6a6f96d4b356fc154345e32c2bb643d70f68e428df26330a49  ipv6.patch
 2dca2ac74fb92e330fde7b6b6120b2fd2565c377a629c9536cf77beebe41aa4b092d4229d5b487b0fb02be4f2cc5b897c429c87bbbbc7b0d31e1cbb94231ddce  sysguard.patch
-6e9a37176c0ca5a463a2745401bc5a6f9c002a236244b615a2803ec04404cc768678a1fa27ee047f81f4ccf002f7bea4b803522049f4ef839c61bb83577b9d65  nginx.initd
+6c27d605536a31159b65776098926ede0b5045210b190e803681a10c06a10556283d873e772fd635642b18846549ec3a18989ca9fe6466f120ce9e1327dcacd5  nginx.initd
 01b77cff16f6e8bfd7fa1d4d20f625bbcddd08f0509173452d060c342c93dc315a7b0560f4734323a5d29ea294de0491f2e3f32e5337574e1a28ebc005eceea8  nginx.logrotate"

--- a/testing/nginx-naxsi/default.conf
+++ b/testing/nginx-naxsi/default.conf
@@ -1,0 +1,18 @@
+# This is a default site configuration which will simply return 404, preventing
+# chance access to any other virtualhost.
+
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	# Everything is a 404
+	location / {
+		return 404;
+	}
+
+	# You may need this to prevent return 404 recursion.
+	location = /404.html {
+		internal;
+	}
+}
+

--- a/testing/nginx-naxsi/nginx.conf
+++ b/testing/nginx-naxsi/nginx.conf
@@ -1,0 +1,92 @@
+# /etc/nginx/nginx.conf
+
+user nginx;
+
+# Set number of worker processes automatically based on number of CPU cores.
+worker_processes auto;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+# Configures default error logger.
+error_log /var/log/nginx/error.log warn;
+
+# Includes files with directives to load dynamic modules.
+include /etc/nginx/modules/*.conf;
+
+
+events {
+	# The maximum number of simultaneous connections that can be opened by
+	# a worker process.
+	worker_connections 1024;
+}
+
+http {
+	# Includes mapping of file name extensions to MIME types of responses
+	# and defines the default type.
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	# Name servers used to resolve names of upstream servers into addresses.
+	# It's also needed when using tcpsocket and udpsocket in Lua modules.
+	#resolver 208.67.222.222 208.67.220.220;
+
+	# Don't tell nginx version to clients.
+	server_tokens off;
+
+	# Specifies the maximum accepted body size of a client request, as
+	# indicated by the request header Content-Length. If the stated content
+	# length is greater than this size, then the client receives the HTTP
+	# error code 413. Set to 0 to disable.
+	client_max_body_size 1m;
+
+	# Timeout for keep-alive connections. Server will close connections after
+	# this time.
+	keepalive_timeout 65;
+
+	# Sendfile copies data between one FD and other from within the kernel,
+	# which is more efficient than read() + write().
+	sendfile on;
+
+	# Don't buffer data-sends (disable Nagle algorithm).
+	# Good for sending frequent small bursts of data in real time.
+	tcp_nodelay on;
+
+	# Causes nginx to attempt to send its HTTP response head in one packet,
+	# instead of using partial frames.
+	#tcp_nopush on;
+
+
+	# Path of the file with Diffie-Hellman parameters for EDH ciphers.
+	#ssl_dhparam /etc/ssl/nginx/dh2048.pem;
+
+	# Specifies that our cipher suits should be preferred over client ciphers.
+	ssl_prefer_server_ciphers on;
+
+	# Enables a shared SSL cache with size that can hold around 8000 sessions.
+	ssl_session_cache shared:SSL:2m;
+
+
+	# Enable gzipping of responses.
+	#gzip on;
+
+	# Set the Vary HTTP header as defined in the RFC 2616.
+	gzip_vary on;
+
+	# Enable checking the existence of precompressed files.
+	#gzip_static on;
+
+
+	# Specifies the main log format.
+	log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+			'$status $body_bytes_sent "$http_referer" '
+			'"$http_user_agent" "$http_x_forwarded_for"';
+
+	# Sets the path, format, and configuration for a buffered log write.
+	access_log /var/log/nginx/access.log main;
+
+
+	# Includes virtual hosts configs.
+	include /etc/nginx/conf.d/*.conf;
+}
+

--- a/testing/nginx-naxsi/nginx.initd
+++ b/testing/nginx-naxsi/nginx.initd
@@ -1,42 +1,67 @@
 #!/sbin/openrc-run
 
-extra_started_commands="reload"
-extra_commands="configtest"
+description="Nginx http and reverse proxy server"
+extra_started_commands="reload reopen upgrade"
+
+cfgfile=${cfgfile:-/etc/nginx/nginx.conf}
+pidfile=/run/nginx/nginx.pid
+command=/usr/sbin/nginx
+command_args="-c $cfgfile"
+required_files="$cfgfile"
 
 depend() {
 	need net
 	use dns logger netmount
 }
 
-CONFFILE=${CONFFILE:-/etc/nginx/${SVCNAME}.conf}
-PIDFILE=${PIDFILE:-/var/run/${SVCNAME}.pid}
-
-configtest() {
-	ebegin "Checking ${SVCNAME} configuration"
-	mkdir -p /tmp/nginx
-	/usr/sbin/nginx -c ${CONFFILE} -t
-	eend $? "failed, please correct errors above"
-}
-
-start() {
-	configtest || return 1
-	ebegin "Starting ${SVCNAME}"
-	start-stop-daemon --start --pidfile "${PIDFILE}" \
-		--exec /usr/sbin/nginx -- -c ${CONFFILE} -g "pid ${PIDFILE};"
-	eend $? "Failed to start ${SVCNAME}"
-}
-
-stop() {
-	configtest || return 1
-	ebegin "Stopping ${SVCNAME}"
-	start-stop-daemon --stop --pidfile "${PIDFILE}"
-	eend $? "Failed to stop ${SVCNAME}"
-	rm -f "${PIDFILE}"
+start_pre() {
+	ebegin
+	checkpath --directory --owner nginx:nginx ${pidfile%/*}
+	$command $command_args -t -q
+	eend $?
 }
 
 reload() {
-	configtest || return 1
-	ebegin "Refreshing ${SVCNAME} configuration"
-	kill -HUP $(cat "${PIDFILE}") &>/dev/null
-	eend $? "Failed to reload nginx"
+	ebegin "Reloading ${SVCNAME} configuration"
+	start_pre && start-stop-daemon --signal HUP --pidfile $pidfile
+	eend $?
 }
+
+reopen() {
+	ebegin "Reopening ${SVCNAME} log files"
+	start-stop-daemon --signal USR1 --pidfile $pidfile
+	eend $?
+}
+
+upgrade() {
+	start_pre || return 1
+
+	ebegin "Upgrading ${SVCNAME} binary"
+
+	einfo "Sending USR2 to old binary"
+	start-stop-daemon --signal USR2 --pidfile $pidfile
+
+	einfo "Sleeping 3 seconds before pid-files checking"
+	sleep 3
+
+	if [ ! -f $pidfile.oldbin ]; then
+		eerror "File with old pid ($pidfile.oldbin) not found"
+		return 1
+	fi
+
+	if [ ! -f $pidfile ]; then
+		eerror "New binary failed to start"
+		return 1
+	fi
+
+	einfo "Sleeping 3 seconds before WINCH"
+	sleep 3 ; start-stop-daemon --signal 28 --pidfile $pidfile.oldbin
+
+	einfo "Sending QUIT to old binary"
+	start-stop-daemon --signal QUIT --pidfile $pidfile.oldbin
+
+	einfo "Upgrade completed"
+
+	eend $? "Upgrade failed"
+}
+


### PR DESCRIPTION
dynamic module support added

`/usr/lib/nginx/modules`:

3RD PARTY
================================

```
ngx_http_naxsi_module.so
ngx_http_cache_purge_module.so
ngx_http_upstream_fair_module.so
ngx_http_sysguard_module.so
```

* http-sysguard backported from [tengine](http://tengine.taobao.org/document/http_sysguard.html).



CORE
================================
```
ngx_http_geoip_module.so
ngx_http_image_filter_module.so
ngx_http_perl_module.so
ngx_http_xslt_filter_module.so
ngx_mail_module.so
ngx_stream_module.so
```

