### PR TITLE
update camlp4 and ocaml

### DIFF
--- a/community/camlp4/APKBUILD
+++ b/community/camlp4/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jon Ong <jonongjs@rottenmage.com>
 # Maintainer: Anil Madhavapeddy <anil@recoil.org>
 pkgname=camlp4
-pkgver=4.03
+pkgver=4.04
 _versuffix='+1'
 pkgrel=0
 pkgdesc="Caml preprocessor and pretty-printer"
@@ -31,6 +31,6 @@ package() {
 		PKGDIR="$pkgdir/usr/lib/ocaml" \
 		install install-META || return 1
 }
-md5sums="65ece8d2c8f4b1e06d62323e78759a7c  4.03-4.03+1.tar.gz"
-sha256sums="6eefeacced81cca59ddf90c2538505fd5cd6596a3fc1acf4971e9796c2e7f2ae  4.03-4.03+1.tar.gz"
-sha512sums="0a329e18deffebb5245415f822f91e692076fca4dbe38748f18e72f417ce7354faed744fdff25f9976659192cb02d56ceb2cf1be5c64da463413ec4a28a9d3ac  4.03-4.03+1.tar.gz"
+md5sums="305f61ffd98c4c03eb0d9b7749897e59  4.04-4.04+1.tar.gz"
+sha256sums="6044f24a44053684d1260f19387e59359f59b0605cdbf7295e1de42783e48ff1  4.04-4.04+1.tar.gz"
+sha512sums="7db8eebcf3d230f60650ba62d9cb630c069394237e97b678a40b61d3dcaded752a2b7e089a50ff528f1ea0740d0291b722df123a072f2cee489cadc5201c6776  4.04-4.04+1.tar.gz"

--- a/community/ocaml/APKBUILD
+++ b/community/ocaml/APKBUILD
@@ -2,12 +2,13 @@
 # Maintainer: Borys Zhukov <mp5@mp5.im>
 pkgname=ocaml
 pkgver=4.04.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Main implementation of the Caml programming language"
 url="http://caml.inria.fr"
 arch="all !x86 !armhf"
 license="LGPLv2"
 makedepends="ncurses-dev zlib-dev gdbm-dev"
+depends="ncurses"
 install=""
 options="textrels"
 subpackages="$pkgname-doc"


### PR DESCRIPTION
- ocaml: require ncurses due to needing it at runtime (and not detected by apk as a shared dependency)
- camlp4: alpine 3.5 got released with the camlp4 and ocaml versions being out of sync, which wont work.