### PR TITLE
main/ffmpeg: update to 3.2.2

### DIFF
--- a/main/ffmpeg/APKBUILD
+++ b/main/ffmpeg/APKBUILD
@@ -1,7 +1,8 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
+# Contributor: Jakub Skrzypnik <j.skrzypnik@openmailbox.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=ffmpeg
-pkgver=3.1.6
+pkgver=3.2.2
 pkgrel=0
 pkgdesc="Complete and free Internet live audio and video broadcasting solution for Linux/Unix"
 url="http://ffmpeg.org/"
@@ -83,12 +84,12 @@ libs() {
 	mv "$pkgdir"/usr/lib "$subpkgdir"/usr
 }
 
-md5sums="cedb8f7b59b03fda968b5731b2f6de7c  ffmpeg-3.1.6.tar.bz2
+md5sums="82cf25d36df70ee995bbdb3efc079934  ffmpeg-3.2.2.tar.bz2
 627bb0f8b28063cd5d6a090b07bd3754  0001-libavutil-clean-up-unused-FF_SYMVER-macro.patch
 91167b4f601db28836dcc3de9f756ed7  cflags-speed-O2.patch"
-sha256sums="7dcb2974652898d02e3ff6289e3f9c5adae38e8eb20cc518e76e6d9be14f2f31  ffmpeg-3.1.6.tar.bz2
+sha256sums="0b129a56d1b8d06101b1fcbfaa9f4f5eee3182d1ad6e44f511a84c12113a366b  ffmpeg-3.2.2.tar.bz2
 011f8beaf81074c9f4e522b699d27ee0ab74ec43f800286244a5b63b82ec5e8c  0001-libavutil-clean-up-unused-FF_SYMVER-macro.patch
 ed75cdc99acb83b660a9e40b908adec896a9421228a620b016a22e7f647bd92b  cflags-speed-O2.patch"
-sha512sums="6a7e94945a743c65af3fed0f420d49157add6d76dc71c34afa2d1a1b2bb3e3ee9a2858ba9198faad8c00337cb235e3aa27a9c2859d25157c5fcba5ab4510bfeb  ffmpeg-3.1.6.tar.bz2
+sha512sums="7cb61684081bbe905ef324f60d259fd543e8be1ed2593167beb9324bec8bbc012cccff40a73e8be0ccc6bb0a20acd98a3dbac0d1d39403016cb381c1410b45db  ffmpeg-3.2.2.tar.bz2
 32652e18d4eb231a2e32ad1cacffdf33264aac9d459e0e2e6dd91484fced4e1ca5a62886057b1f0b4b1589c014bbe793d17c78adbaffec195f9a75733b5b18cb  0001-libavutil-clean-up-unused-FF_SYMVER-macro.patch
 5ff940abb4265401eebb0f2fd486b51a004d62a480c5a64bc279149731b577b5c95f0b7ff2d73429ec10b1f0b76ecf7fa466b02ba3a0bf79d9b7ac2ae87ee5d5  cflags-speed-O2.patch"


### PR DESCRIPTION
This update is needed by `community/mpv` as it requires always newest ffmpeg version.i