### PR TITLE
testing/i3wm-gaps: new aport

### DIFF
--- a/testing/i3wm-gaps/APKBUILD
+++ b/testing/i3wm-gaps/APKBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Jakub Skrzypnik <j.skrzypnik@openmailbox.org>
+pkgname=i3wm-gaps
+pkgver=4.13
+pkgrel=0
+pkgdesc="A tiling window manager with gaps and other additional features"
+url="https://github.com/Airblader/i3"
+arch="all"
+license="BSD"
+replaces="i3wm"
+makedepends="bison flex libxcb-dev xcb-util-cursor-dev
+             xcb-util-keysyms-dev xcb-util-wm-dev libev-dev pango-dev cairo-dev
+             yajl-dev startup-notification-dev pcre-dev libxkbcommon-dev
+             xcb-util-xrm-dev asciidoc perl xmlto autoconf automake libtool"
+subpackages="$pkgname-doc"
+source="i3wm-$pkgver.tar.gz::https://github.com/Airblader/i3/archive/$pkgver.tar.gz
+        musl.patch"
+
+builddir="$srcdir/i3-$pkgver"
+
+build() {
+  cd "$srcdir/i3-$pkgver"
+  autoreconf -fi || return 1
+  mkdir -p "$builddir"/build && cd "$builddir"/build
+  ../configure --prefix="/usr"
+  make || return 1
+}
+
+package() {
+  cd "$builddir"/build
+  make DESTDIR="$pkgdir/" install || return 1
+
+  install -d "$pkgdir/usr/share/man/man1"
+  install -m644 man/*.1 "$pkgdir"/usr/share/man/man1/ || return 1
+}
+
+md5sums="a591216c8a84d27431b057e4d01b151e  i3wm-4.13.tar.gz
+aa998beb0b9a83d2910508768ac7faae  musl.patch"
+sha256sums="e80c07e525a07f2d3d2f02d282774d3264b6d1f165713c9903c06626ba4d2571  i3wm-4.13.tar.gz
+b7d084c53addc71fda13ccb8b3dcca2a32d9ca1590a28bf3be1a0c61870d3817  musl.patch"
+sha512sums="9b0c888c1c412622282f5e56ba6763eba3af88682d1652d1a1e6ce4e7fcdbec30e4fd6731b7e4d306bd33871a2581e0979714b47c9614210302c491ce9366ba8  i3wm-4.13.tar.gz
+8ce7d00371c43b93dabbe0dadf9caf7c58a68f4a0079f5a9b9552c15c55bfa0df16d7e87a281595af2ac5254632ba28ccf82a467cea16159b41490f6f2910299  musl.patch"

--- a/testing/i3wm-gaps/musl.patch
+++ b/testing/i3wm-gaps/musl.patch
@@ -1,0 +1,73 @@
+diff -urp i3-4.11/i3bar/src/main.c i3-4.11.new/i3bar/src/main.c
+--- i3-4.11/i3bar/src/main.c	2015-09-30 07:55:10.000000000 +0100
++++ i3-4.11.new/i3bar/src/main.c	2016-02-08 20:03:41.777392482 +0000
+@@ -45,14 +45,20 @@ void debuglog(char *fmt, ...) {
+  *
+  */
+ char *expand_path(char *path) {
+-    static glob_t globbuf;
+-    if (glob(path, GLOB_NOCHECK | GLOB_TILDE, NULL, &globbuf) < 0) {
+-        ELOG("glob() failed\n");
+-        exit(EXIT_FAILURE);
++    char *home, *expanded;
++
++    if (strncmp(path, "~/", 2) == 0) {
++        home = getenv("HOME");
++        if (home != NULL) {
++            /* new length: sum - 1 (omit '~') + 1 (for '\0') */
++            expanded = scalloc(strlen(home)+strlen(path), 1);
++            strcpy(expanded, home);
++            strcat(expanded, path+1);
++            return expanded;
++        }
+     }
+-    char *result = sstrdup(globbuf.gl_pathc > 0 ? globbuf.gl_pathv[0] : path);
+-    globfree(&globbuf);
+-    return result;
++
++    return sstrdup(path);
+ }
+ 
+ void print_usage(char *elf_name) {
+diff -urp i3-4.11/libi3/resolve_tilde.c i3-4.11.new/libi3/resolve_tilde.c
+--- i3-4.11/libi3/resolve_tilde.c	2015-09-30 07:55:10.000000000 +0100
++++ i3-4.11.new/libi3/resolve_tilde.c	2016-02-08 20:03:47.849230953 +0000
+@@ -19,27 +19,18 @@
+  *
+  */
+ char *resolve_tilde(const char *path) {
+-    static glob_t globbuf;
+-    char *head, *tail, *result;
++    char *home, *expanded;
+ 
+-    tail = strchr(path, '/');
+-    head = sstrndup(path, tail ? (size_t)(tail - path) : strlen(path));
+-
+-    int res = glob(head, GLOB_TILDE, NULL, &globbuf);
+-    free(head);
+-    /* no match, or many wildcard matches are bad */
+-    if (res == GLOB_NOMATCH || globbuf.gl_pathc != 1)
+-        result = sstrdup(path);
+-    else if (res != 0) {
+-        err(EXIT_FAILURE, "glob() failed");
+-    } else {
+-        head = globbuf.gl_pathv[0];
+-        result = scalloc(strlen(head) + (tail ? strlen(tail) : 0) + 1, 1);
+-        strncpy(result, head, strlen(head));
+-        if (tail)
+-            strncat(result, tail, strlen(tail));
++    if (strncmp(path, "~/", 2) == 0) {
++        home = getenv("HOME");
++        if (home != NULL) {
++            /* new length: sum - 1 (omit '~') + 1 (for '\0') */
++            expanded = scalloc(strlen(home)+strlen(path), 1);
++            strcpy(expanded, home);
++            strcat(expanded, path+1);
++            return expanded;
++        }
+     }
+-    globfree(&globbuf);
+ 
+-    return result;
++    return sstrdup(path);
+ }

--- a/testing/xcb-util-xrm/APKBUILD
+++ b/testing/xcb-util-xrm/APKBUILD
@@ -1,0 +1,28 @@
+# Maintainer: Jakub Skrzypnik <j.skrzypnik@openmailbox.org>
+pkgname=xcb-util-xrm
+pkgver=1.2
+pkgrel=0
+pkgdesc="Utility functions for the X resource manager"
+url="https://github.com/Airblader/xcb-util-xrm/"
+arch="all"
+license="MIT"
+makedepends="libx11-dev libxcb-dev xcb-util-dev util-macros bsd-compat-headers autoconf automake libtool"
+source="https://github.com/Airblader/xcb-util-xrm/releases/download/v1.2/xcb-util-xrm-$pkgver.tar.gz"
+subpackages="$pkgname-dev"
+
+builddir="$srcdir/$pkgname-$pkgver"
+build() {
+	cd "$builddir"
+	autoreconf -fi || return 1
+	./configure --prefix="/usr"
+	make || return 1
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir/" install || return 1
+}
+
+md5sums="c9c63ac728d19eefbf2319f0dad4c127  xcb-util-xrm-1.2.tar.gz"
+sha256sums="c4a1d64d4a6973c649e3b6e3c418242f11e39c65d4d227d555d48f6df0558567  xcb-util-xrm-1.2.tar.gz"
+sha512sums="7f992eaca739b9518ffe8f39b921617e092f4a8534cab95f072071ea952e86269971bfc422945ae5f63eda661f61424c1315ece862e2689d1048e5c2b49ff673  xcb-util-xrm-1.2.tar.gz"


### PR DESCRIPTION
This PR adds a fork of `i3wm` with Airblader patches too large to fit into upstream.
While it's a very popular fork, I thought it would be nice to have it in Alpine too.

Works very well, `musl.patch` from regular `i3wm` is still needed and applies well.
I've also added `xcb-util-xrm` which is a required library for `i3wm-gaps` now.