### PR TITLE
testing/kakoune: new aport

### DIFF
--- a/testing/kakoune/APKBUILD
+++ b/testing/kakoune/APKBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Jakub Skrzypnik <j.skrzypnik@openmailbox.org>
+_commit="7fabda2e45d095757d59efc125086e2e8c079735"
+pkgname=kakoune
+pkgver=0_git20170501
+pkgrel=0
+pkgdesc="Code editor heavily inspired by Vim, but with less keystrokes"
+url="http://kakoune.org"
+arch="all"
+license="Unlicense"
+makedepends="ncurses-dev boost-dev asciidoc"
+subpackages="$pkgname-doc"
+source="https://github.com/mawww/kakoune/archive/${_commit}.zip"
+
+builddir="$srcdir/$pkgname-${_commit}/src"
+build() {
+	cd "$builddir"
+	make debug=no || return 1
+}
+
+package() {
+	cd "$builddir"
+	make PREFIX="/usr" DESTDIR="$pkgdir/" debug=no install || return 1
+}
+
+md5sums="0a9aa94f2db1425f82e2294c5a76099a  7fabda2e45d095757d59efc125086e2e8c079735.zip"
+sha256sums="52180fb02c8a4fe9fb9a6f942daa98d0d54e59900f5e41c73e818ad34b6430d8  7fabda2e45d095757d59efc125086e2e8c079735.zip"
+sha512sums="f155653496c2e2b8e213819e595f0593f255fe8902c9e0beb8bd519c4395e7735ddde8df49721c64ea6c7322f40e35d7c24abe440d9b8f0ffd86b7e012ea0c7e  7fabda2e45d095757d59efc125086e2e8c079735.zip"


### PR DESCRIPTION
**[kakoune](http://kakoune.org)** is a vim-linke text editor with selection-oriented approach.
Very nice and useful fo me, really lighweight (uses shell as scripting backend), re-uses tmux/screen/i3/xterm for buffer management.

Despite being "git-only", the project is pretty mature, stable, pushing only minor fixes for now. Author has not decided yet what kind of software versioning model to use, but he said it'll be introduced for sure in next weeks.