### PR TITLE
main/rxvt-unicode: add rxvt-unicode-terminfo subpackage

### DIFF
--- a/main/rxvt-unicode/APKBUILD
+++ b/main/rxvt-unicode/APKBUILD
@@ -1,5 +1,6 @@
 # Contributor: Moritz Wilhelmy
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
+# Contributor: Jakub Skrzypnik <j.skrzypnik@openmailbox.org>
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=rxvt-unicode
 pkgver=9.22
@@ -8,10 +9,10 @@ pkgdesc="rxvt fork with improved unicode support"
 arch=all
 url="http://software.schmorp.de/pkg/rxvt-unicode.html"
 license="GPL"
-depends=""
+depends="$pkgname-terminfo"
 makedepends="libx11-dev libxft-dev ncurses fontconfig-dev
 	gdk-pixbuf-dev libxrender-dev perl-dev startup-notification-dev"
-subpackages="$pkgname-doc"
+subpackages="$pkgname-doc $pkgname-terminfo::noarch"
 source="http://dist.schmorp.de/rxvt-unicode/$pkgname-$pkgver.tar.bz2
 	gentables.patch
 	rxvt-unicode-kerning.patch"
@@ -57,11 +58,21 @@ build() {
 }
 
 package() {
+	# despite having a separate terminfo subpackage
+	# TERMINFO env var is used by rxvt-unicode makefile
+	# leaving it as is ~skrzyp
 	export TERMINFO="$pkgdir/usr/share/terminfo"
 	install -d "$TERMINFO"
 
 	make DESTDIR="$pkgdir" \
 		-C "$_builddir" install || return 1
+}
+
+terminfo() {
+    pkgdesc="$pkgdesc (terminfo data)"
+    install -d "$subpkgdir"/usr/share/terminfo
+    mv -v "$pkgdir"/usr/share/terminfo/* \
+       "$subpkgdir"/usr/share/terminfo/
 }
 
 md5sums="93782dec27494eb079467dacf6e48185  rxvt-unicode-9.22.tar.bz2


### PR DESCRIPTION
Using urxvt to connect with remote Alpine servers causes them to act
very weird due to missing terminfo data.

This package contains only terminfo data to use with headless instances,
but main rxvt-unicode package adds is as dependency because it cant't
work properly without it.