### PR TITLE
community/firejail: enable support for busybox

### DIFF
--- a/community/firejail/APKBUILD
+++ b/community/firejail/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=firejail
 pkgver=0.9.44.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux namespaces and seccomp-bpf sandbox"
 url="https://firejail.wordpress.com/"
 arch="all"
@@ -31,6 +31,7 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
+		--enable-busybox-workaround \
 		|| return 1
 	make || return 1
 }


### PR DESCRIPTION
The default configuration doesn't allow execution of /bin/sh linked to /bin/busybox.

For example, trying to start firefox with the default profile results in:

`/bin/bash: /usr/bin/firefox: /bin/sh: bad interpreter: Permission denied`