### PR TITLE
Xpra update to 1.0.1 / ffmpeg update to 3.2.2

### DIFF
--- a/community/xpra/APKBUILD
+++ b/community/xpra/APKBUILD
@@ -1,19 +1,18 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=xpra
-pkgver=0.17.6
-pkgrel=1
+pkgver=1.0.1
+pkgrel=0
 pkgdesc="Xpra is 'screen for X' & allows you to run X programs, usually on a remote host over SSH or encrypted tcp."
 url="http://xpra.org"
 arch="all"
 license="GPLv2+"
 depends="py-gobject py-gtk py-imaging xf86-video-dummy xvfb setxkbmap xorg-server
 	py-numpy py-pillow py-gtkglext py-lz4 py-rencode py-opencl"
-depends_dev="python2-dev cython-dev libx11-dev libxtst-dev libxcomposite-dev libxdamage-dev
+makedepends="python2-dev cython-dev libx11-dev libxtst-dev libxcomposite-dev libxdamage-dev
 	libxrandr-dev py-gobject-dev py-gtk-dev libxkbfile-dev gtk+2.0-dev x264-dev
-	x265-dev libvpx-dev ffmpeg-dev libwebp-dev"
-makedepends="$depends_dev cython linux-headers"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-tests::noarch"
+	x265-dev libvpx-dev ffmpeg-dev libwebp-dev cython linux-headers"
+subpackages="$pkgname-doc $pkgname-tests::noarch $pkgname-webclient::noarch"
 source="http://xpra.org/src/$pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -38,10 +37,18 @@ package() {
 
 tests() {
 	cd "$builddir"
+	pkgdesc="Xpra test suite"
 	mkdir -p "$subpkgdir"/usr/share/xpra
 	cp -rf tests "$subpkgdir"/usr/share/xpra/
 }
 
-md5sums="8572df8e71f6f5b9ea8ebcdd40c0bedf  xpra-0.17.6.tar.xz"
-sha256sums="f266df26c866699ec71fe7e33e71d38e397563230f0bb12f8b20bc422a2afbfc  xpra-0.17.6.tar.xz"
-sha512sums="9a553e446390792907ec90038b680e5e63a4b91b0dd1e741b65e4dc6e4c899ea550a2e5728057104419686339a3aa557585437d38913f82fa59be013afa2d8f2  xpra-0.17.6.tar.xz"
+webclient() {
+	cd "$pkgdir"
+	pkgdesc="Xpra websockets client"
+	mkdir -p "$subpkgdir"/usr/share/xpra
+	cp -rf usr/share/xpra/www "$subpkgdir"/usr/share/xpra/
+}
+
+md5sums="747e8340b69e41310b513b1ced818c64  xpra-1.0.1.tar.xz"
+sha256sums="415eea94dc7efabb1fd2e4eaa8a7665fefe65ed91be1cf31605394fb6d48ec17  xpra-1.0.1.tar.xz"
+sha512sums="00b512c4a468043846f2f867fdf02d589069634302fda0a3da2df54cd3b49f592902c951edd0f367e32b372ee542f66330c4c254156337e1da0b36841199dcd3  xpra-1.0.1.tar.xz"

--- a/main/ffmpeg/APKBUILD
+++ b/main/ffmpeg/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=ffmpeg
-pkgver=3.1.6
+pkgver=3.2.2
 pkgrel=0
 pkgdesc="Complete and free Internet live audio and video broadcasting solution for Linux/Unix"
 url="http://ffmpeg.org/"
@@ -83,12 +83,12 @@ libs() {
 	mv "$pkgdir"/usr/lib "$subpkgdir"/usr
 }
 
-md5sums="cedb8f7b59b03fda968b5731b2f6de7c  ffmpeg-3.1.6.tar.bz2
+md5sums="82cf25d36df70ee995bbdb3efc079934  ffmpeg-3.2.2.tar.bz2
 627bb0f8b28063cd5d6a090b07bd3754  0001-libavutil-clean-up-unused-FF_SYMVER-macro.patch
 91167b4f601db28836dcc3de9f756ed7  cflags-speed-O2.patch"
-sha256sums="7dcb2974652898d02e3ff6289e3f9c5adae38e8eb20cc518e76e6d9be14f2f31  ffmpeg-3.1.6.tar.bz2
+sha256sums="0b129a56d1b8d06101b1fcbfaa9f4f5eee3182d1ad6e44f511a84c12113a366b  ffmpeg-3.2.2.tar.bz2
 011f8beaf81074c9f4e522b699d27ee0ab74ec43f800286244a5b63b82ec5e8c  0001-libavutil-clean-up-unused-FF_SYMVER-macro.patch
 ed75cdc99acb83b660a9e40b908adec896a9421228a620b016a22e7f647bd92b  cflags-speed-O2.patch"
-sha512sums="6a7e94945a743c65af3fed0f420d49157add6d76dc71c34afa2d1a1b2bb3e3ee9a2858ba9198faad8c00337cb235e3aa27a9c2859d25157c5fcba5ab4510bfeb  ffmpeg-3.1.6.tar.bz2
+sha512sums="7cb61684081bbe905ef324f60d259fd543e8be1ed2593167beb9324bec8bbc012cccff40a73e8be0ccc6bb0a20acd98a3dbac0d1d39403016cb381c1410b45db  ffmpeg-3.2.2.tar.bz2
 32652e18d4eb231a2e32ad1cacffdf33264aac9d459e0e2e6dd91484fced4e1ca5a62886057b1f0b4b1589c014bbe793d17c78adbaffec195f9a75733b5b18cb  0001-libavutil-clean-up-unused-FF_SYMVER-macro.patch
 5ff940abb4265401eebb0f2fd486b51a004d62a480c5a64bc279149731b577b5c95f0b7ff2d73429ec10b1f0b76ecf7fa466b02ba3a0bf79d9b7ac2ae87ee5d5  cflags-speed-O2.patch"


### PR DESCRIPTION
`ffmpeg` update required for the latest `xpra 1.0.1` to build successfully.