### PR TITLE
community/xpra: update to 1.0.1 / create xpra-webclient subpkg

### DIFF
--- a/community/xpra/APKBUILD
+++ b/community/xpra/APKBUILD
@@ -1,25 +1,23 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=xpra
-pkgver=0.17.6
-pkgrel=1
+pkgver=1.0.1
+pkgrel=0
 pkgdesc="Xpra is 'screen for X' & allows you to run X programs, usually on a remote host over SSH or encrypted tcp."
 url="http://xpra.org"
 arch="all"
 license="GPLv2+"
 depends="py-gobject py-gtk py-imaging xf86-video-dummy xvfb setxkbmap xorg-server
 	py-numpy py-pillow py-gtkglext py-lz4 py-rencode py-opencl"
-depends_dev="python2-dev cython-dev libx11-dev libxtst-dev libxcomposite-dev libxdamage-dev
+makedepends="python2-dev cython-dev libx11-dev libxtst-dev libxcomposite-dev libxdamage-dev
 	libxrandr-dev py-gobject-dev py-gtk-dev libxkbfile-dev gtk+2.0-dev x264-dev
-	x265-dev libvpx-dev ffmpeg-dev libwebp-dev"
-makedepends="$depends_dev cython linux-headers"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-tests::noarch"
+	x265-dev libvpx-dev ffmpeg-dev libwebp-dev cython linux-headers"
+subpackages="$pkgname-doc $pkgname-tests::noarch $pkgname-webclient::noarch"
 source="http://xpra.org/src/$pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
-
 	# https://www.xpra.org/trac/ticket/1080
 	CFLAGS="$CFLAGS -fno-strict-aliasing"
 	python2 setup.py build \
@@ -38,10 +36,19 @@ package() {
 
 tests() {
 	cd "$builddir"
+	pkgdesc="Xpra test suite"
 	mkdir -p "$subpkgdir"/usr/share/xpra
 	cp -rf tests "$subpkgdir"/usr/share/xpra/
 }
 
-md5sums="8572df8e71f6f5b9ea8ebcdd40c0bedf  xpra-0.17.6.tar.xz"
-sha256sums="f266df26c866699ec71fe7e33e71d38e397563230f0bb12f8b20bc422a2afbfc  xpra-0.17.6.tar.xz"
-sha512sums="9a553e446390792907ec90038b680e5e63a4b91b0dd1e741b65e4dc6e4c899ea550a2e5728057104419686339a3aa557585437d38913f82fa59be013afa2d8f2  xpra-0.17.6.tar.xz"
+webclient() {
+	cd "$pkgdir"
+	pkgdesc="Xpra websockets client"
+	mkdir -p "$subpkgdir"/usr/share/xpra
+	cp -rf usr/share/xpra/www "$subpkgdir"/usr/share/xpra/
+}
+
+md5sums="747e8340b69e41310b513b1ced818c64  xpra-1.0.1.tar.xz"
+sha256sums="415eea94dc7efabb1fd2e4eaa8a7665fefe65ed91be1cf31605394fb6d48ec17  xpra-1.0.1.tar.xz"
+sha512sums="00b512c4a468043846f2f867fdf02d589069634302fda0a3da2df54cd3b49f592902c951edd0f367e32b372ee542f66330c4c254156337e1da0b36841199dcd3  xpra-1.0.1.tar.xz"
+


### PR DESCRIPTION
* https://xpra.org/trac/wiki/News

* html5 `websockets` client split into `xpra-webclient` subpkg

if the `xxhash` PR  referenced below can be applied I can update this `xpra` PR to include `xxhash` support.