### PR TITLE
testing/wireguard: new aport

### DIFF
--- a/testing/wireguard-grsec/APKBUILD
+++ b/testing/wireguard-grsec/APKBUILD
@@ -1,0 +1,103 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+
+_flavor=${FLAVOR:-grsec}
+_kpkg=linux-$_flavor
+_kver=4.9.13
+_kpkgrel=0
+
+# when changing _ver we *must* bump _mypkgrel
+_ver=0.0.20170223
+_mypkgrel=0
+_name=wireguard
+
+# verify the kernel version before entering chroot
+_kapkbuild=../../linux-${_flavor}/APKBUILD
+if [ -f $_kapkbuild ]; then
+	. $_kapkbuild
+	pkgname=$_name-$_flavor
+	[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
+	[ "$_kpkgrel" != "$pkgrel" ] && die "please update _kpkgrel to $pkgrel"
+fi
+
+_kpkgver="$_kver-r$_kpkgrel"
+_abi_release=${_kver}-${_kpkgrel}-${_flavor}
+
+pkgname=${_name}-${_flavor}
+pkgver=$_kver
+pkgrel=$(($_kpkgrel + $_mypkgrel))
+pkgdesc="Next generation secure network tunnel: kernel modules for $_flavor"
+arch='all'
+url='https://www.wireguard.io'
+license="GPLv2"
+makedepends="linux-grsec-dev=$_kpkgver libmnl-dev sparse"
+subpackages="$_name-doc $_name-tools:tools $_name-bash-completion:bashcomp:noarch \
+	 $_name-tests:tests:noarch"
+source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$_ver.tar.xz"
+builddir="$srcdir"/WireGuard-$_ver
+
+build() {
+	cd "$builddir"
+	make -C src/ \
+		KERNELDIR=/lib/modules/${_abi_release}/build \
+		|| return 1
+}
+
+package() {
+	cd "$builddir/src"
+
+	install_if="linux-${_flavor}=${_kver} $pkgname"
+
+	mkdir -p ../../../pkg/$_name-doc
+	mkdir -p ../../../pkg/$_name-tools/usr
+	mkdir -p "$pkgdir"/usr/share/doc/$_name
+
+	local module=
+	for module in *.ko; do
+		install -v -D -m644 ${module} \
+			"$pkgdir/lib/modules/$_abi_release/extra/${module}"
+	done
+
+	make -C tools \
+		DESTDIR="$pkgdir" \
+		WITH_BASHCOMPLETION=yes \
+		WITH_WGQUICK=yes \
+		WITH_SYSTEMDUNITS=no \
+		install || return 1
+
+	find "$builddir"/contrib/examples -name '.gitignore' -delete
+	cp -rf "$builddir"/contrib/examples "$pkgdir"/usr/share/doc/$_name/
+}
+
+tools() {
+	pkgdesc="Wireguard tools"
+	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
+}
+
+bashcomp() {
+	depends="bash"
+	pkgdesc="Wireguard BASH completions"
+
+	mkdir -p "$subpkgdir"/usr
+	mv "$pkgdir"/usr/share "$subpkgdir"/usr
+}
+
+tests() {
+	pkgdesc="Wireguard test suites"
+
+	mkdir -p "$subpkgdir"/usr/share/wireguard
+	mv "$builddir"/src/tests "$subpkgdir"/usr/share/wireguard
+	cp -rf "$builddir"/contrib/external-tests "$subpkgdir"/usr/share/wireguard
+}
+
+check() {
+	return 0
+	# currently failing: attribute 'nocapture': unknown attribute
+	# not part of musl libc ?
+	make -C src/ \
+		KERNELDIR=/lib/modules/${_abi_release}/build \
+		check \
+		|| return 1
+}
+
+sha512sums="273ef6463d447cb04b608a0379cce5c0ed4065f988b3f449995593592b42f2fc269fc249a8e3c22c28bfa682430ee20b5b7a46a96803c9c67d1b6fed7b800455  WireGuard-0.0.20170223.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -1,0 +1,65 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+
+pkgname=wireguard-tools
+pkgver=0.0.20170223
+pkgrel=0
+pkgdesc="Next generation secure network tunnel: userspace tools"
+arch='all'
+url='https://www.wireguard.io'
+license="GPLv2"
+makedepends="libmnl-dev sparse"
+subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch \
+		$pkgname-tests:tests:noarch"
+source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$pkgver.tar.xz"
+builddir="$srcdir"/WireGuard-$pkgver
+
+build() {
+	cd "$builddir"
+	make -C src/tools || return 1
+}
+
+package() {
+	cd "$builddir"
+
+	install_if="linux-${_flavor}=${_kver} $pkgname"
+	mkdir -p "$pkgdir"/usr/share/doc/$_name
+
+	make -C src/tools \
+		DESTDIR="$pkgdir" \
+		WITH_BASHCOMPLETION=yes \
+		WITH_WGQUICK=yes \
+		WITH_SYSTEMDUNITS=no \
+		install || return 1
+
+	find "$builddir"/contrib/examples -name '.gitignore' -delete
+	cp -rf "$builddir"/contrib/examples "$pkgdir"/usr/share/doc/$_name/
+}
+
+bashcomp() {
+	depends="bash"
+	pkgdesc="Wireguard BASH completions"
+
+	mkdir -p "$subpkgdir"/usr
+	mv "$pkgdir"/usr/share "$subpkgdir"/usr
+}
+
+tests() {
+	pkgdesc="Wireguard test suites"
+
+	mkdir -p "$subpkgdir"/usr/share/wireguard
+	mv "$builddir"/src/tests "$subpkgdir"/usr/share/wireguard
+	cp -rf "$builddir"/contrib/external-tests "$subpkgdir"/usr/share/wireguard
+}
+
+check() {
+	return 0
+	# currently failing: attribute 'nocapture': unknown attribute
+	# not part of musl libc ?
+	make -C src/ \
+		KERNELDIR=/lib/modules/${_abi_release}/build \
+		check \
+		|| return 1
+}
+
+sha512sums="273ef6463d447cb04b608a0379cce5c0ed4065f988b3f449995593592b42f2fc269fc249a8e3c22c28bfa682430ee20b5b7a46a96803c9c67d1b6fed7b800455  WireGuard-0.0.20170223.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
-_flavor=${FLAVOR:-grsec}
+_flavor=${FLAVOR:-vanilla}
 _kpkg=linux-$_flavor
-_kver=4.9.13
+_kver=4.4.47
 _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
@@ -21,7 +21,7 @@ if [ -f $_kapkbuild ]; then
 fi
 
 _kpkgver="$_kver-r$_kpkgrel"
-_abi_release=${_kver}-${_kpkgrel}-${_flavor}
+_abi_release=${_kver}
 
 pkgname=${_name}-${_flavor}
 pkgver=$_kver
@@ -30,7 +30,7 @@ pkgdesc="Next generation secure network tunnel: kernel modules for $_flavor"
 arch='all'
 url='https://www.wireguard.io'
 license="GPLv2"
-makedepends="linux-grsec-dev=$_kpkgver libmnl-dev sparse"
+makedepends="linux-vanilla-dev=$_kpkgver libmnl-dev sparse"
 source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$_ver.tar.xz"
 builddir="$srcdir"/WireGuard-$_ver
 


### PR DESCRIPTION
WireGuard is a novel VPN that runs inside the Linux Kernel and utilizes
**state-of-the-art cryptography**.

It aims to be faster, simpler, leaner, and more useful than IPSec, while
avoiding the massive headache. It intends to be considerably more performant
than OpenVPN.

WireGuard is designed as a general purpose VPN for running on embedded
interfaces and super computers alike, fit for many different circumstances.
It runs over UDP.

https://www.wireguard.io