### PR TITLE
community/firejail: update to 0.9.44.4

### DIFF
--- a/community/firejail/APKBUILD
+++ b/community/firejail/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=firejail
-pkgver=0.9.44.2
-pkgrel=1
+pkgver=0.9.44.4
+pkgrel=0
 pkgdesc="Linux namespaces and seccomp-bpf sandbox"
 url="https://firejail.wordpress.com/"
 arch="all"
@@ -50,6 +50,6 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-md5sums="52e296946129e430092fb0dce1ecb3a3  firejail-0.9.44.2.tar.gz"
-sha256sums="d06efc94cef17632adf2cb086ccf4622a07e0809bff3a6765bde16be84181ec1  firejail-0.9.44.2.tar.gz"
-sha512sums="44ffcf1a71939b692f31c49742ed28c328d1c53ba287acd0924f45eb723a0e28ed34d8068edbb876faa0c33856e389069d623ce397de267d77330faa240c2302  firejail-0.9.44.2.tar.gz"
+md5sums="a6a6a4970e3e93498c69f328f8a338cd  firejail-0.9.44.4.tar.gz"
+sha256sums="35da9220f220b23bc643de5acc38f3eda3f04edb083f997d8a57301bb296279a  firejail-0.9.44.4.tar.gz"
+sha512sums="3aa9b355fcbc743e20fd5954f03df1ae30adc95e3b18074622833f016bc52175c21b7533a1df251b39a53288c2e0cbdd81185cb1fcf46eccba4e645eca2e3d41  firejail-0.9.44.4.tar.gz"


### PR DESCRIPTION
firejail (0.9.44.4) baseline; urgency=low
  * security: --bandwidth root shell found by Martin Carpenter (CVE-2017-5207)
  * security: disabled --allow-debuggers when running on kernel
    versions prior to 4.8; a kernel bug in ptrace system call
    allows a full bypass of seccomp filter; problem reported by
    Lizzie Dixon (CVE-2017-5206)
  * security: root exploit found by Sebastian Krahmer (CVE-2017-5180)
 -- netblue30   Sat, 7 Jan 2017 10:00:00 -0500