### PR TITLE
main/nodejs: Add depends 'ca-certificates'

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -2,16 +2,18 @@
 # Contributor: Jose-Luis Rivas <ghostbar@riseup.net>
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Contributor: Dave Esaias <dave@containership.io>
+# Contributor: Tadahisa Kamijo <kamijin@live.jp>
 # Maintainer: Eivind Uggedal <eivind@uggedal.com>
 pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
 pkgver=6.9.4
-pkgrel=0
+pkgrel=1
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="http://nodejs.org/"
 arch="all"
 license="MIT"
+depends="ca-certificates"
 depends_dev="libuv"
 # gold is needed for mksnapshot
 makedepends="$depends_dev python2 openssl-dev zlib-dev libuv-dev linux-headers


### PR DESCRIPTION
npm command dependy to 'ca-certificates'.

Logs in environments where CA is not installed

```bash
# try insatll del package...
bash-4.3# npm i del
npm ERR! Linux 4.2.0-36-generic
npm ERR! argv "/usr/bin/node" "/usr/bin/npm" "i" "del"
npm ERR! node v6.9.2
npm ERR! npm  v3.10.9
npm ERR! code UNABLE_TO_GET_ISSUER_CERT_LOCALLY

npm ERR! unable to get local issuer certificate
npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /src/npm-debug.log
```

```bash
# install ca-certificates package...
bash-4.3# apk add ca-certificates
(1/1) Installing ca-certificates (20161130-r0)
Executing busybox-1.25.1-r0.trigger
Executing ca-certificates-20161130-r0.trigger
OK: 90 MiB in 27 packages
```

```bash
# retry insatll del package...
bash-4.3# npm i del
foo@0.0.1 /src
`-- del@2.2.2
  +-- globby@5.0.0
  | +-- array-union@1.0.2
  | | `-- array-uniq@1.0.3
  | +-- arrify@1.0.1
  | `-- glob@7.1.1
  |   +-- fs.realpath@1.0.0
  |   +-- inflight@1.0.6
  |   | `-- wrappy@1.0.2
  |   +-- inherits@2.0.3
  |   +-- minimatch@3.0.3
  |   | `-- brace-expansion@1.1.6
  |   |   +-- balanced-match@0.4.2
  |   |   `-- concat-map@0.0.1
  |   +-- once@1.4.0
  |   `-- path-is-absolute@1.0.1
  +-- is-path-cwd@1.0.0
  +-- is-path-in-cwd@1.0.0
  | `-- is-path-inside@1.0.0
  |   `-- path-is-inside@1.0.2
  +-- object-assign@4.1.0
  +-- pify@2.3.0
  +-- pinkie-promise@2.0.1
  | `-- pinkie@2.0.4
  `-- rimraf@2.5.4
                                                     
```
