### PR TITLE
main/cjdns: Add musl seccomp patch

### DIFF
--- a/main/cjdns/APKBUILD
+++ b/main/cjdns/APKBUILD
@@ -3,7 +3,7 @@
 
 pkgname=cjdns
 pkgver=18
-pkgrel=0
+pkgrel=1
 pkgdesc="A routing engine designed for security, scalability, speed and ease of use"
 url="https://github.com/cjdelisle/cjdns"
 arch="all !x86"
@@ -12,7 +12,8 @@ depends=
 makedepends="bash nodejs-lts python2 linux-headers libseccomp-dev"
 install="$pkgname.post-install"
 subpackages="$pkgname-doc"
-source="${pkgname}-${pkgver}.tar.gz::https://github.com/cjdelisle/${pkgname}/archive/cjdns-v${pkgver}.tar.gz"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/cjdelisle/${pkgname}/archive/cjdns-v${pkgver}.tar.gz
+        musl-compat.patch"
 
 builddir="$srcdir/$pkgname-$pkgname-v$pkgver"
 
@@ -41,6 +42,9 @@ package() {
 		doc/tunnel.md
 }
 
-md5sums="9f6600d9ed0d87d4e17fbc9155ff0368  cjdns-18.tar.gz"
-sha256sums="57e5fe05b9775daf16f23c16c24035a4e380a3c9461faa2e1bc9de0bc6b147ab  cjdns-18.tar.gz"
-sha512sums="3b7ed50c81ed51f8deea3999aa0b820f78de53da3d3937c13f572e35bb7c2a6f963d3779c2f0b7b4afc64e6a45ae98c4a6958a0c31d43d4309a47ae3ccbb709b  cjdns-18.tar.gz"
+md5sums="9f6600d9ed0d87d4e17fbc9155ff0368  cjdns-18.tar.gz
+1c0890e06965f6de50cea48e5f7d2462  musl-compat.patch"
+sha256sums="57e5fe05b9775daf16f23c16c24035a4e380a3c9461faa2e1bc9de0bc6b147ab  cjdns-18.tar.gz
+257058401034f818f8968dc2ccc863453bc30ab188b5e41f2e935db817ead58b  musl-compat.patch"
+sha512sums="3b7ed50c81ed51f8deea3999aa0b820f78de53da3d3937c13f572e35bb7c2a6f963d3779c2f0b7b4afc64e6a45ae98c4a6958a0c31d43d4309a47ae3ccbb709b  cjdns-18.tar.gz
+18e8a2cc25978f24dfa527d81d71fa416628a91d6947174ba74089cd8b257e9f0b8b13399c97bcb0516a77310e62bd788bfb78076ac357f410dd89c22464735d  musl-compat.patch"

--- a/main/cjdns/musl-compat.patch
+++ b/main/cjdns/musl-compat.patch
@@ -1,0 +1,17 @@
+diff --git a/util/Seccomp.c b/util/Seccomp.c
+index e8a0ed7..7e724c4 100644
+--- a/util/Seccomp.c
++++ b/util/Seccomp.c
+@@ -337,6 +337,12 @@ static struct sock_fprog* mkFilter(struct Allocator* alloc, struct Except* eh)
+         #ifdef __NR_getsockname
+         IFEQ(__NR_getsockname, success),
+         #endif
++
++        // musl free() calls madvise()
++        #ifdef __NR_madvise
++        IFEQ(__NR_madvise, success),
++        #endif
++
+         RET(SECCOMP_RET_TRAP),
+
+         LABEL(socket),


### PR DESCRIPTION
Musl free() uses madvise syscall which is not allowed in the seccomp.
This makes cjdns crash whenever it tries to use it. This patch
is a workaround until it gets fixed on cjdns' side.
Originally proposed by cjd on #cjdns on EFnet.