### PR TITLE
Add entry for powerpc platforms

### DIFF
--- a/main/linux-headers/APKBUILD
+++ b/main/linux-headers/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=linux-headers
 pkgver=4.4.6
 _kernver=${pkgver%.*}
-pkgrel=1
+pkgrel=2
 pkgdesc="Linux system headers"
 url="http://kernel.org"
 arch="all"
@@ -39,6 +39,7 @@ package() {
 	aarch64*) _carch="arm64" ;;
 	arm*) _carch="arm" ;;
 	s390*) _carch="s390" ;;
+	ppc64*) _carch="powerpc" ;;
 	esac
 
 	cd "$srcdir"/linux-$_kernver


### PR DESCRIPTION
This patch simply adds an entry to build linux-header for powerpc
platforms.
The main target is ppc64le architecture, which uses Linux ARCH=powerpc
on the Makefiles.