### PR TITLE
community/dnscrypt-proxy: update to 1.9.3

### DIFF
--- a/community/dnscrypt-proxy/APKBUILD
+++ b/community/dnscrypt-proxy/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=dnscrypt-proxy
-pkgver=1.9.1
+pkgver=1.9.3
 pkgrel=0
 pkgdesc="A tool for securing communications between a client and a DNS resolver"
 url="http://dnscrypt.org/"
@@ -54,15 +54,15 @@ setup() {
 	install -m755 -D "$srcdir"/$pkgname.setup "$subpkgdir"/sbin/setup-dnscrypt
 }
 
-md5sums="307a363f81ff506150e240f2b5181f47  dnscrypt-proxy-1.9.1.tar.bz2
+md5sums="9b5fb8a39f11ff8fd4c8d7f909a729b7  dnscrypt-proxy-1.9.3.tar.bz2
 6ca1f01a62ca9e937851986560709a61  dnscrypt-proxy.initd
 77b800da6d8cdf6316afacbff740b09a  dnscrypt-proxy.confd
 5f29e17b4345d8ac9bdba26a69e3ba9a  dnscrypt-proxy.setup"
-sha256sums="4f593faeba9facb4718caa011d76497b3e813b110f3a2a44a25c9c950ac74129  dnscrypt-proxy-1.9.1.tar.bz2
+sha256sums="cb02a8d0e08f6fa29666a47c8fb5b7b6ec89afed3a83d0771aca65dc87be05ee  dnscrypt-proxy-1.9.3.tar.bz2
 aa2b83b1944ba5f47ee5b7f2cf3cf63fbef4735753a2daf83fea3bf0ea51a7a3  dnscrypt-proxy.initd
 36bd49d3fdada3ed8fc6abae7a8dd40a1f7a0aabf0eb1311698030b7ec710699  dnscrypt-proxy.confd
 887c0c2d3b3d1a5326e3229ff8180351bc813f7853997e6772123beafc8bd62a  dnscrypt-proxy.setup"
-sha512sums="4f52591980bcc1e7ceacaad667ba006dff110dd67684fdf54da2666836b4799145951c05bc3f0d7d715f4e427c0cdc9182e06355ff5ddc1f12ea3674862c72ae  dnscrypt-proxy-1.9.1.tar.bz2
+sha512sums="a82655fd79a4f57a90b4f28d1e007689885b3e86bb8211d2d37e7e6ab536e21f37ecbb35afd18a850b767637c57de35629364fc2792404d2c1a810d9b26b5670  dnscrypt-proxy-1.9.3.tar.bz2
 5ad36161fc44d9c8c86a13e20d4d5fa0be81b317097bf1c092aab1e1e307021a8b6f1a92dbf2bec5fb7c534b59cf926235ea507fa6b4ccd2974ac2e3b7baa257  dnscrypt-proxy.initd
 8cd2d40c1f465a3b26aa934fe2103650beba9504676faca3ccc9ee2b5bad940e561b3dd201d84c380bfdada72cacbe4862fc1315a4bd44fd7c56ef4f19a884f9  dnscrypt-proxy.confd
 904965588e8e1119600413445627dc85a5efc0e32f7f3ad029921f59f214dd5c999bcd98a6622b572e528da4c5265083221fea189ed96407612842033ffcffe1  dnscrypt-proxy.setup"


### PR DESCRIPTION
* This version can be compiled on Linux distributions using the **musl C** library.

* Version `1.9.3` also restores compatibility with ancient Linux kernels that didn't support
`SO_REUSEPORT`, without having to explicitly compile the package with `NO_REUSEPORT`.

* On Linux, the service now prints when the system doesn't have enough entropy
to initialize the `PRNG`.

https://github.com/jedisct1/dnscrypt-proxy/blob/master/ChangeLog