### PR TITLE
main/apache2 : add install -d /run/apache2 

### DIFF
--- a/main/apache2/APKBUILD
+++ b/main/apache2/APKBUILD
@@ -136,7 +136,7 @@ package() {
 	install -d "$pkgdir"/var/www || return 1
 	install -d -m 2750 -g wheel "$pkgdir"/var/log/apache2 || return 1
 	ln -fs /var/log/apache2 "$pkgdir"/var/www/logs
-	mkdir -p -m775 /run/apache2 || return 1
+  install -d -m 775 "$pkgdir"/run/apache2 || return 1
 	ln -fs /run/apache2 "$pkgdir"/var/www/run
 	ln -fs /usr/lib/apache2 "$pkgdir"/var/www/modules
 	rm -fr "$pkgdir"/run

--- a/main/apache2/APKBUILD
+++ b/main/apache2/APKBUILD
@@ -136,6 +136,7 @@ package() {
 	install -d "$pkgdir"/var/www || return 1
 	install -d -m 2750 -g wheel "$pkgdir"/var/log/apache2 || return 1
 	ln -fs /var/log/apache2 "$pkgdir"/var/www/logs
+	mkdir -p -m775 /run/apache2 || return 1
 	ln -fs /run/apache2 "$pkgdir"/var/www/run
 	ln -fs /usr/lib/apache2 "$pkgdir"/var/www/modules
 	rm -fr "$pkgdir"/run


### PR DESCRIPTION
Recently, I used  alpine linux and apache2 for docker container base image.
apache runs as foreground process.

However, its failed because /run/apache2/ doesn't exist.

Sure, case of execute apache2 as a daemon, /run/apache2/ was created by rc-service.

This problem caused by directly execute apache2.

```
localhost:~# cat /etc/alpine-release
3.5.0
localhost:~# date;uptime
Fri Jan 20 06:19:49 UTC 2017
 06:19:49 up 3 min,  load average: 0.00, 0.00, 0.00
localhost:~# apk update;apk add apache2
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/APKINDEX.tar.gz
v3.5.0-52-ga3e2bc088b [http://dl-cdn.alpinelinux.org/alpine/v3.5/main]
OK: 5644 distinct packages available
(1/5) Installing apr (1.5.2-r1)
(2/5) Installing expat (2.2.0-r0)
(3/5) Installing apr-util (1.5.4-r2)
(4/5) Installing pcre (8.39-r0)
(5/5) Installing apache2 (2.4.23-r10)
Executing apache2-2.4.23-r10.pre-install
Executing busybox-1.25.1-r0.trigger
OK: 298 MiB in 43 packages
localhost:~# httpd -D FOREGROUND
localhost:~# tail /var/log/apache2/error.log
[Fri Jan 20 06:21:30.450426 2017] [core:error] [pid 3792] (2)No such file or directory: AH00099: could not create /run/apache2/httpd.pid
[Fri Jan 20 06:21:30.450454 2017] [core:error] [pid 3792] AH00100: httpd: could not log pid to file /run/apache2/httpd.pid
localhost:~# mkdir -p /run/apache2
localhost:~# httpd -D FOREGROUND
localhost:~# tail /var/log/apache2/error.log
[Fri Jan 20 06:21:30.450426 2017] [core:error] [pid 3792] (2)No such file or directory: AH00099: could not create /run/apache2/httpd.pid
[Fri Jan 20 06:21:30.450454 2017] [core:error] [pid 3792] AH00100: httpd: could not log pid to file /run/apache2/httpd.pid
[Fri Jan 20 06:22:03.721738 2017] [mpm_prefork:notice] [pid 3795] AH00163: Apache/2.4.23 (Unix) configured -- resuming normal operations
[Fri Jan 20 06:22:03.721790 2017] [core:notice] [pid 3795] AH00094: Command line: 'httpd -D FOREGROUND'
[Fri Jan 20 06:22:05.116120 2017] [mpm_prefork:notice] [pid 3795] AH00169: caught SIGTERM, shutting down
localhost:~# rmdir /run/apache2/
localhost:~# rc-service apache2 start
 * /run/apache2: creating directory
 * Starting apache2 ...
localhost:~# ls -l /run | grep apache2
drwxrwxr-x    2 root     root            60 Jan 20 06:54 apache2
```