### PR TITLE
main/quagga: upgrade to 1.1.1, one CVE

### DIFF
--- a/main/quagga/APKBUILD
+++ b/main/quagga/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=quagga
-pkgver=1.1.0
+pkgver=1.1.1
 pkgrel=0
 pkgdesc="A free routing daemon replacing Zebra supporting RIP, OSPF and BGP."
 url="http://quagga.net/"
@@ -62,17 +62,17 @@ package() {
 	install -Dm644 "$srcdir/zebra.confd" "$pkgdir"/etc/conf.d/zebra
 	install -o quagga -g quagga -d -m755 "$pkgdir"/etc/quagga
 }
-md5sums="daa303871e07ea5856aae6fd79e89722  quagga-1.1.0.tar.gz
+md5sums="fb7e4f50638886b5701422bc2279a9af  quagga-1.1.1.tar.gz
 1224ba91ea6b6e81f583bad7813aba98  dont-hook-core-signals.patch
 09a77e2e84e71c43f5a449738c026261  bgpd.initd
 916f1dd1a286ee7b862cda4fe56cbf21  zebra.initd
 34e06a1d2bc602ce691abc9ed169dd15  zebra.confd"
-sha256sums="f7a43a9c59bfd3722002210530b2553c8d5cc05bfea5acd56d4f102b9f55dc63  quagga-1.1.0.tar.gz
+sha256sums="b5a94e5bdad3062e04595a5692b8cc435f0a85102f75dfdca0a06d093b4ef63f  quagga-1.1.1.tar.gz
 4b71588e34ac14f8d6e72e6064b5e4ec302f286ebbe43df94c97411cceb66a23  dont-hook-core-signals.patch
 aab037454c6a70cd5cb45e14c47b7dfea358f8d81c7d12418edcf7e58a86c679  bgpd.initd
 c1d7526581927e990e687cbd5d08447eb060f76a439475572785b5b90c60c460  zebra.initd
 f7a52d383f60270a5a8fee5d4ac522c5c0ec2b7c4b5252cff54e260f32d9b323  zebra.confd"
-sha512sums="3b29a90c4f05593714bda3c702fd2c8886ce48fba2fbfb98f55cc04d1025edd5427944e9a9fb7cd630e5e8ccea388b72a8e611ab65c370e760f3f319d03f090f  quagga-1.1.0.tar.gz
+sha512sums="51eb64ada07b42c663705cedf56be5b8b54143a5543b472e3dc7c703a4ab0542f39cfbeed64d1c33ceee6a15ea8d25ef84616fa40b6bf9cc32023f7241c18c58  quagga-1.1.1.tar.gz
 5ef5c5e6d70d991b33b13a062e25b6fbde395dceee36aea29384b0640a48d2957ed5f50d416a1f2f770bf69bae2340133e35b1114be7e1fa722eb6d3d021f37a  dont-hook-core-signals.patch
 13b5b57e10df013bd2d931abc49bf76b8c4dee59dbceab22c9f151ccb988b2c5f7167f2909027d5e0f990b59da8de115667b02484aee9a67d347625700f6cacd  bgpd.initd
 1638a4a64ffd066b1884f7e5a4243edab68739aabd83bd35ea8c9608af7b8623eece1d59fb08feead84e4386b6d1da4220764ccf5fd7f2a9959a8470d5cce86a  zebra.initd


### PR DESCRIPTION
Fixes CVE-2017-5495.