### PR TITLE
main/strace: fix pt_regs collision on ppc64le

### DIFF
--- a/main/strace/APKBUILD
+++ b/main/strace/APKBUILD
@@ -9,7 +9,8 @@ license="BSD"
 depends=
 makedepends="linux-headers"
 subpackages="$pkgname-doc"
-source="http://downloads.sourceforge.net/sourceforge/$pkgname/$pkgname-$pkgver.tar.xz"
+source="http://downloads.sourceforge.net/sourceforge/$pkgname/$pkgname-$pkgver.tar.xz
+	fix-ppc-pt-regs-collision.patch"
 
 builddir="$srcdir/$pkgname-$pkgver"
 prepare() {
@@ -41,4 +42,5 @@ package() {
 	make -j1 DESTDIR="$pkgdir" install
 }
 
-sha512sums="d1a7b782cb8196eb95b431b66f9b0eff7886869a7e3a4618d985f73b2eed7590ba73150b9c33e55ee5c65fc8f863588b64c5611dca7b5d7a4183110eaf4451d5  strace-4.16.tar.xz"
+sha512sums="d1a7b782cb8196eb95b431b66f9b0eff7886869a7e3a4618d985f73b2eed7590ba73150b9c33e55ee5c65fc8f863588b64c5611dca7b5d7a4183110eaf4451d5  strace-4.16.tar.xz
+b70cee89dd49a2b5a69dc2a56c3a11169d3306e1a73981155188b574486965c034aa52b4ac1c6edff5ef55c9d52f27750acb242fac095a8a9f69689b51b3fad1  fix-ppc-pt-regs-collision.patch"

--- a/main/strace/fix-ppc-pt-regs-collision.patch
+++ b/main/strace/fix-ppc-pt-regs-collision.patch
@@ -1,0 +1,19 @@
+--- a/ptrace.h
++++ b/ptrace.h
+@@ -48,7 +48,15 @@
+ # define ptrace_peeksiginfo_args XXX_ptrace_peeksiginfo_args
+ #endif
+ 
+-#include <linux/ptrace.h>
++#if defined(__powerpc__) || defined(__powerpc64__)
++# include <linux/types.h>
++# define __ASSEMBLY__
++# include <linux/ptrace.h>
++# undef __ASSEMBLY__
++#else 
++# include <linux/ptrace.h>
++#endif
++
+ 
+ #ifdef HAVE_STRUCT_IA64_FPREG
+ # undef ia64_fpreg


### PR DESCRIPTION
strace build requires <linux/ptrace.h> and it includes <asm/ptrace.h>
that, by its turn, defines the pt_regs struct. However the same struct
is also define in <bits/user.h> from musl-dev, creating therefore a
conflict. A simple solution is to add the __ASSEMBLY__ guard so pt_regs
struct from <asm/ptrace.h> is not include twice, avoiding the collision
in question.