### PR TITLE
testing/suricata: enable support for nfqueue

### DIFF
--- a/testing/suricata/APKBUILD
+++ b/testing/suricata/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Steve McMaster <code@mcmaster.io>
 pkgname=suricata
 pkgver=3.2
-pkgrel=0
+pkgrel=1
 pkgdesc="High performance Network IDS, IPS and Network Security Monitoring engine"
 url="https://suricata-ids.org/"
 arch="all"
@@ -10,7 +10,8 @@ license="GPL-2"
 depends=""
 makedepends="automake autoconf libtool libhtp-dev>=0.5.23 libcap-ng-dev
 	file-dev luajit-dev geoip-dev pcre-dev yaml-dev libpcap-dev hiredis-dev
-	libnet-dev libnetfilter_queue-dev jansson-dev python nss-dev nspr-dev"
+	libnet-dev libnetfilter_queue-dev libnfnetlink-dev jansson-dev python
+	nss-dev nspr-dev"
 install=""
 subpackages="$pkgname-doc"
 source="${pkgname}-${pkgver}.tar.gz::http://www.openinfosecfoundation.org/download/${pkgname}-${pkgver}.tar.gz


### PR DESCRIPTION
nfqueue support was already enabled, but package libnfnetlink-dev was
missing.