### PR TITLE
community/opus-tools: update to 0.1.10

### DIFF
--- a/community/opus-tools/APKBUILD
+++ b/community/opus-tools/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=opus-tools
-pkgver=0.1.9
+pkgver=0.1.10
 pkgrel=0
 pkgdesc="Collection of tools for Opus audio codec"
 url="http://wiki.xiph.org/Opus-tools"
@@ -10,11 +10,10 @@ license="BSD"
 depends=""
 depends_dev=""
 makedepends="$depends_dev libogg-dev opus-dev flac-dev linux-headers"
-install=""
 subpackages="$pkgname-doc"
 source="pkgname-$pkgver.tar.gz::http://downloads.xiph.org/releases/opus/$pkgname-$pkgver.tar.gz"
-
 builddir="$srcdir"/$pkgname-$pkgver
+
 build() {
 	cd "$builddir"
 	./configure \
@@ -32,6 +31,6 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-md5sums="20682e4d8d1ae9ec5af3cf43e808b8cb  pkgname-0.1.9.tar.gz"
-sha256sums="b1873dd78c7fbc98cf65d6e10cfddb5c2c03b3af93f922139a2104baedb4643a  pkgname-0.1.9.tar.gz"
-sha512sums="e2cdc0c9c24297565f9d457893bcc548696b1a9c9b66e4cd48ddbe4dcf865bc50da5ed1b438b2b9ecdcd8be1d7c211d2be199f707cdbcd8a46a75353b0173a4c  pkgname-0.1.9.tar.gz"
+md5sums="6b78535d58b94832710b14e219f65a91  pkgname-0.1.10.tar.gz"
+sha256sums="a2357532d19471b70666e0e0ec17d514246d8b3cb2eb168f68bb0f6fd372b28c  pkgname-0.1.10.tar.gz"
+sha512sums="4ead97b9fe4658968a4b5cbe4bde5e2d8cbfaaea18dd0d817597cc6b6b11f26937b9eee7358ade63568f0213131aa80ecbed169d1b3885980a556871a4a7fe98  pkgname-0.1.10.tar.gz"


### PR DESCRIPTION
This release includes several bug fixes, including security fixes in
opusenc, as well as a few minor enhancements.  Changes include:
* opusenc: Improved handling of malformed input files to avoid crashes
    and other troublesome behavior
* opusenc: Percent progress is shown while encoding
* opusrtp: New --extract option to extract from input pcap file
* New project files for building with Microsoft Visual Studio