### PR TITLE
testing/xxhash && testing/py-xxhash: new aports

### DIFF
--- a/testing/xxhash/APKBUILD
+++ b/testing/xxhash/APKBUILD
@@ -1,0 +1,67 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+pkgname=xxhash
+_pkgname=xxHash
+pkgver=0.6.2
+_pypkg=python-xxhash
+_pyver=0.6.1
+pkgrel=0
+pkgdesc="Extremely fast non-cryptographic hash algorithm"
+url="http://www.xxhash.com"
+arch="all"
+license="BSD/GPL"
+depends=""
+makedepends="python2-dev python3-dev py-setuptools valgrind"
+subpackages="$pkgname-dev $pkgname-doc py2-$pkgname:_py2 py3-$pkgname:_py3"
+source="$_pkgname-$pkgver.tar.gz::https://github.com/Cyan4973/$_pkgname/archive/v$pkgver.tar.gz
+	$_pypkg-$pkgver.tar.gz::https://github.com/ifduyue/$_pypkg/archive/v$_pyver.tar.gz
+	"
+builddir="$srcdir/"$_pkgname-$pkgver
+pybuilddir="$srcdir/"$_pypkg-$_pyver
+
+build() {
+	cd "$builddir"
+	sed -i 's|--leak-check=yes|-v --leak-check=full --show-leak-kinds=all|' Makefile
+#	make test || return 1
+	make xxhsum || return 1
+
+	cd "$pybuilddir"
+	ln -s "$srcdir"/$_pkgname-$pkgver/xxhash.c ./xxhash/xxhash.c
+	ln -s "$srcdir"/$_pkgname-$pkgver/xxhash.h ./xxhash/xxhash.h
+	python2 setup.py build || return 1
+	python3 setup.py build || return 1
+}
+
+package() {
+	cd "$builddir"
+	mkdir -p "$pkgdir"/usr/bin
+	mkdir -p "$pkgdir"/usr/include/xxhash
+	mkdir -p "$pkgdir"/usr/share/man/man1
+	mkdir -p "$pkgdir"/usr/share/doc/xxhash
+	install -m755 xxhsum "$pkgdir"/usr/bin || return 1
+	install -m644 xxhsum.1 "$pkgdir"/usr/share/man/man1 || return 1
+	install -m644 LICENSE "$pkgdir"/usr/share/doc/xxhash || return 1
+	install -m644 xxhash.h "$pkgdir"/usr/include/xxhash || return 1
+	install -m644 xxhash.c "$pkgdir"/usr/include/xxhash || return 1
+}
+
+_py2() {
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends=xxhash
+	install_if="py-xxhash=$pkgver-r$pkgrel $python"
+
+	cd "$pybuilddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="1e8017f78baf5747f739d6ab0c6c3ce51e4ddf53bd0aced3e2495fceefea23b408e395ff2f38681ad54e8588525fa12c13b08c1ff5fabf1df75044525c15e781  xxHash-0.6.2.tar.gz
+72a99d744ccaac830e9789053acb9728b2da457c7841e2aae96e9748450f09366b9830f6d92b62ac494e938f43c1fea7910c9d5257824ae33c1fe48f199ed9cc  python-xxhash-0.6.2.tar.gz"


### PR DESCRIPTION
both are needed to close:

* https://bugs.alpinelinux.org/issues/6743
* https://bugs.alpinelinux.org/issues/6744

after they are applied I will update `xpra` to `1.0.3` & add `xxhash` support.