### PR TITLE
main/dpkg: Current version is not available anymore

### DIFF
--- a/main/dpkg/APKBUILD
+++ b/main/dpkg/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dpkg
-pkgver=1.18.10
+pkgver=1.18.18
 pkgrel=0
 pkgdesc="The Debian Package Manager"
 url="http://packages.debian.org/dpkg"
@@ -71,9 +71,9 @@ dev() {
 	mv "$pkgdir"/usr/share/perl* "$subpkgdir"/usr/share/
 }
 
-md5sums="ccff17730c0964428fc186ded2f2f401  dpkg_1.18.10.tar.xz
+md5sums="f68cee943aa275a326c0d7e263ee4242  dpkg_1.18.18.tar.xz
 360155cfe9e989a9ee12b56a579dfa75  add-muslgnueabihf.patch"
-sha256sums="025524da41ba18b183ff11e388eb8686f7cc58ee835ed7d48bd159c46a8b6dc5  dpkg_1.18.10.tar.xz
+sha256sums="c88b61e3d4660500753142689e8ddbeff1c731f29549f3338e6975f655936ff5  dpkg_1.18.18.tar.xz
 63d331e297e2e5765bf919485cc87f6ce307344f38921015a5564f94b37af6e1  add-muslgnueabihf.patch"
-sha512sums="83188277a703b57fa3b5570765db849f9b20f592237fa9a9f3a7e0b24c292c8cfc5528a049f6ecd85f2598c89521727599b406cd3924b2b8c56f9295b560e279  dpkg_1.18.10.tar.xz
+sha512sums="7682c8ac523ff710acd6742b9a884ed8ec8537e3b38496f871f112fdfd2f874af6d676cfef2d31d2474c5637df043838c814ef4038097b009cf06b3d4e66029c  dpkg_1.18.18.tar.xz
 5f83bce6a1d724f690ba8eded74c87dbd3b4c8a7850a53d5c68ad7cfc9712662a50a8a00a02329b2be64f3246cff1d6d7037950a81d4732aba2498ac1da114ac  add-muslgnueabihf.patch"


### PR DESCRIPTION
Debian upgraded dpkg version to 1.18.18, and version 1.18.10 URL is now
returning 404. This patch simply moves dpkg to version 1.18.18.