### PR TITLE
main/snort: Bump to version 2.9.9.0

### DIFF
--- a/main/snort/APKBUILD
+++ b/main/snort/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Leonardo Arena <rnalrd@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=snort
-pkgver=2.9.8.3
+pkgver=2.9.9.0
 pkgrel=0
 pkgdesc="An open source network intrusion prevention and detection system"
 url="http://www.snort.org/"
@@ -75,12 +75,12 @@ package() {
 	touch "$pkgdir"/var/lib/snort/rules/black_list.rules
 }
 
-md5sums="dd6084f8d20f651b276fa35c991dc482  snort-2.9.8.3.tar.gz
+md5sums="fd3012bf36710481d66b40ad046b231d  snort-2.9.9.0.tar.gz
 f163599315be80d682a51f8d22849ab5  snort.initd
 446f8d2b3435b8a6be738da978670605  snort.confd"
-sha256sums="856d02ccec49fa30c920a1e416c47c0d62dd224340a614959ba5c03239100e6a  snort-2.9.8.3.tar.gz
+sha256sums="71b147125e96390a12f3d55796ed5073df77206bd3563d84d3e5a1f19e7d7a56  snort-2.9.9.0.tar.gz
 d447f1481a49543878030d361c8c31a6538c41b2c57e1c0cffd858cc5f83f70b  snort.initd
 d504cb31ffcce9acc8fc7b68123a31a53b491444c52730339ea9a4e986521f71  snort.confd"
-sha512sums="2f3dfe46e14a5106a02ca60b2d334549f4924ff916de0804b2b7792cdd31e104fbb454b4b932855b5f25a861698db0f8988844782b12b0e5fa132d88d4a7a687  snort-2.9.8.3.tar.gz
+sha512sums="2c17539c80484c90198a2e5d5efd1e70f26afb79ce7c28e745ded356b6f1a1f97763ff21fde986652af1768fa3bcdafbbcc3c82ee8ad6d2ef0471f360cfcab83  snort-2.9.9.0.tar.gz
 c71d11f4cde4aba432641d3915faec8070e9fea5b33c71f6b2872b2208871180b3c7dbbadd2ddaebe5f3280adf7c5c9daf1585afd331fe552486a675ff676e52  snort.initd
 abc0846ea6e08029c772f24e213f211a39219701e6e2c8b3aa112632318479db7b21014c5f2c4987cb2981cafce0ea744549c3ce754e9145cba9ec5604ae66f3  snort.confd"


### PR DESCRIPTION
Snort is not able to build because the URL for version 2.9.8.3 is returning
404.  Upgrading it to 2.9.90.