### PR TITLE
main/libpciaccess: include limits.h for ppc64le

### DIFF
--- a/main/libpciaccess/APKBUILD
+++ b/main/libpciaccess/APKBUILD
@@ -11,6 +11,7 @@ depends=
 makedepends=
 source="http://xorg.freedesktop.org/releases/individual/lib/$pkgname-$pkgver.tar.bz2
 	fix-arm.patch
+	ppc64le-limits.patch
 	"
 
 _builddir="$srcdir/$pkgname-$pkgver"
@@ -40,8 +41,11 @@ package() {
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 md5sums="ace78aec799b1cf6dfaea55d3879ed9f  libpciaccess-0.13.4.tar.bz2
-0381322b67ad34689013af74bdfe77c0  fix-arm.patch"
+0381322b67ad34689013af74bdfe77c0  fix-arm.patch
+f20c340d92ee4a8c9e3660860fd7459b  ppc64le-limits.patch"
 sha256sums="07f864654561e4ac8629a0ef9c8f07fbc1f8592d1b6c418431593e9ba2cf2fcf  libpciaccess-0.13.4.tar.bz2
-3ed71a117c3c89ffcdd1635bf66a95b906fdd79f96102d73b466bfa4f8c2bd8d  fix-arm.patch"
+3ed71a117c3c89ffcdd1635bf66a95b906fdd79f96102d73b466bfa4f8c2bd8d  fix-arm.patch
+aba228ec15b6a61573e542e9fc03bd6cc3f19955df5b08c773de9e2b3df13322  ppc64le-limits.patch"
 sha512sums="d5b32c525dd36dc85c9a09f45696808730eabbbd3cce892a6dbfb02a566598baad27be58567eb7ced15b3d99fb9afa1d1c24ec19754bcf7a1857a0c8cea34d92  libpciaccess-0.13.4.tar.bz2
-a6c95f42c926ffcd62014cf619c6aacf8db3b1862fa87c8eae9c3e64f31fcaddb682d34c767756bede5d2949a7285a415ca1d14249713bc12514c8e40f9d989f  fix-arm.patch"
+a6c95f42c926ffcd62014cf619c6aacf8db3b1862fa87c8eae9c3e64f31fcaddb682d34c767756bede5d2949a7285a415ca1d14249713bc12514c8e40f9d989f  fix-arm.patch
+acdacd2fdf2c2cddb927e3952f267455228b1bb73dce0505e5a75368d70b562386475c4e76f7c701e75eed98e52c10b58343d9e0f8a5c8fbf3b19ef865928769  ppc64le-limits.patch"

--- a/main/libpciaccess/ppc64le-limits.patch
+++ b/main/libpciaccess/ppc64le-limits.patch
@@ -1,0 +1,13 @@
+--- a/src/linux_sysfs.c
++++ b/src/linux_sysfs.c
+@@ -66,6 +66,10 @@
+ #include <sys/ioctl.h>
+ #endif
+ 
++#ifdef __PPC64__
++#include <limits.h>
++#endif
++
+ #include "pciaccess.h"
+ #include "pciaccess_private.h"
+ #include "linux_devmem.h"


### PR DESCRIPTION
When limits.h is not included for ppc64le, the macro PATH_MAX is undefined 
which causes libpciaccess to fail to build.

Signed-off-by: Fernando Seiti Furusato <ferseiti@linux.vnet.ibm.com>