### PR TITLE
main/json-c: replaced chain of autotools commands

### DIFF
--- a/main/json-c/APKBUILD
+++ b/main/json-c/APKBUILD
@@ -23,8 +23,7 @@ prepare() {
 		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
 		esac
 	done
-	libtoolize --force && aclocal && autoconf && autoheader \
-		&& automake --add-missing
+	autoreconf -f -v -i
 }
 
 build() {


### PR DESCRIPTION
This replaces the various autotools commands by autoreconf which
additionally updates config.sub and config.guess, that were kept and
led json-c to fail on ppc64le due to this arch being relatively new.

Signed-off-by: Fernando Seiti Furusato <ferseiti@linux.vnet.ibm.com>