### PR TITLE
main/rsync: Fix URL of the project

### DIFF
--- a/main/rsync/APKBUILD
+++ b/main/rsync/APKBUILD
@@ -9,7 +9,7 @@ license="GPL3"
 depends=
 makedepends="perl acl-dev popt-dev"
 subpackages="$pkgname-doc"
-source="http://$pkgname.samba.org/ftp/$pkgname/$pkgname-$pkgver.tar.gz
+source="https://download.samba.org/pub/$pkgname/$pkgname-$pkgver.tar.gz
 	rsyncd.initd
 	rsyncd.confd
 	rsyncd.conf


### PR DESCRIPTION
Current rsync download pages gives error 404. I just fixed the URL
to map to the new page.

The pacakge checksum continues to be the same.