### PR TITLE
main/busybox-initscripts: udhcpc: act on IPv4 only

### DIFF
--- a/main/busybox-initscripts/default.script
+++ b/main/busybox-initscripts/default.script
@@ -31,7 +31,7 @@ run_scripts() {
 }
 
 deconfig() {
-	ip addr flush dev $interface
+	ip -4 addr flush dev $interface
 }
 
 is_wifi() {
@@ -42,7 +42,7 @@ if_index() {
 	if [ -e  /sys/class/net/$interface/ifindex ]; then
 		cat /sys/class/net/$interface/ifindex
 	else
-		ip link show dev $interface | head -n1 | cut -d: -f1
+		ip -4 link show dev $interface | head -n1 | cut -d: -f1
 	fi
 }
 
@@ -62,12 +62,12 @@ routes() {
 		[ "$i" = "$interface" ] && return
 	done
 	local gw= num=
-	while ip route del default via dev $interface 2>/dev/null; do
+	while ip -4 route del default via dev $interface 2>/dev/null; do
 		:
 	done
 	num=0
 	for gw in $router; do
-		ip route add 0.0.0.0/0 via $gw dev $interface \
+		ip -4 route add 0.0.0.0/0 via $gw dev $interface \
 			metric $(( $num + ${IF_METRIC:-$(calc_metric)} ))
 		num=$(( $num + 1 ))
 	done
@@ -96,21 +96,21 @@ resolvconf() {
 }
 
 bound() {
-	ip addr add $ip/$mask ${broadcast:+broadcast $broadcast} dev $interface
-	ip link set dev $interface up
+	ip -4 addr add $ip/$mask ${broadcast:+broadcast $broadcast} dev $interface
+	ip -4 link set dev $interface up
 	routes
 	resolvconf
 }
 
 renew() {
-	if ! ip addr show dev $interface | grep $ip/$mask; then
-		ip addr flush dev $interface
-		ip addr add $ip/$mask ${broadcast:+broadcast $broadcast} dev $interface
+	if ! ip -4 addr show dev $interface | grep $ip/$mask; then
+		ip -4 addr flush dev $interface
+		ip -4 addr add $ip/$mask ${broadcast:+broadcast $broadcast} dev $interface
 	fi
 
 	local i
 	for i in $router; do
-		if ! ip route show | grep ^default | grep $i; then
+		if ! ip -4 route show | grep ^default | grep $i; then
 			routes
 			break
 		fi


### PR DESCRIPTION
udhcpc works only with IPv4 addresses but the current
/usr/share/udhcpc/default.script script interferes with IPv6.

For example, when getting a new lease from an IPv4 address on a given
interface, all the addresses on this interfaces get flushed, including
IPv6. This issue has been reported to the busybox project:
https://bugs.busybox.net/show_bug.cgi?id=9621

This commit prevents udhcpc to act on IPv6 addresses.