### PR TITLE
main/gsl: don't disable deprecated symbols

### DIFF
--- a/main/gsl/APKBUILD
+++ b/main/gsl/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gsl
 pkgver=2.2.1
-pkgrel=0
+pkgrel=1
 pkgdesc="The GNU Scientific Library (GSL) is a modern numerical library for C and C++ programmers"
 url="http://www.gnu.org/software/gsl/gsl.html"
 arch="all"
@@ -10,13 +10,11 @@ depends=
 makedepends=
 install=
 subpackages="$pkgname-dev $pkgname-doc"
-source="http://ftp.gnu.org/gnu/gsl/gsl-$pkgver.tar.gz"
+source="http://ftp.gnu.org/gnu/gsl/gsl-$pkgver.tar.gz
+	dont-disable-deprecated.patch"
 
 _builddir="$srcdir"/$pkgname-$pkgver
 
-prepare() {
-	cd "$_builddir"
-}
 build() {
 	cd "$_builddir"
 	./configure \
@@ -31,6 +29,9 @@ package() {
 	cd "$_builddir"
 	make DESTDIR="$pkgdir" install || return 1
 }
-md5sums="3d90650b7cfe0a6f4b29c2d7b0f86458  gsl-2.2.1.tar.gz"
-sha256sums="13d23dc7b0824e1405f3f7e7d0776deee9b8f62c62860bf66e7852d402b8b024  gsl-2.2.1.tar.gz"
-sha512sums="834210d91db6bc4be1df0c0be8e66af16bdf607bfc9d9d33bc240c428e3452e60bdab92240b88dcb15f24171be541e1fafa18368c7a257a44241e568c1c11942  gsl-2.2.1.tar.gz"
+md5sums="3d90650b7cfe0a6f4b29c2d7b0f86458  gsl-2.2.1.tar.gz
+293cf2947f41453e3b46bd5392a58b4a  dont-disable-deprecated.patch"
+sha256sums="13d23dc7b0824e1405f3f7e7d0776deee9b8f62c62860bf66e7852d402b8b024  gsl-2.2.1.tar.gz
+a7b4689dfb36546723df50c7ced5117c42eb86bfbee1693818b7d96632680529  dont-disable-deprecated.patch"
+sha512sums="834210d91db6bc4be1df0c0be8e66af16bdf607bfc9d9d33bc240c428e3452e60bdab92240b88dcb15f24171be541e1fafa18368c7a257a44241e568c1c11942  gsl-2.2.1.tar.gz
+88d40e599a9e619d8968f9848a91c54492d99032734371ee23072c8dae9d9920da445c1f8a880baa613479facec4afca3d3dec1070c240e5dfd5a662a41c92e8  dont-disable-deprecated.patch"

--- a/main/gsl/dont-disable-deprecated.patch
+++ b/main/gsl/dont-disable-deprecated.patch
@@ -1,0 +1,24 @@
+diff -urp gsl-2.2.1/configure.ac patched/configure.ac
+--- gsl-2.2.1/configure.ac	2016-08-31 15:54:07.000000000 +0100
++++ patched/configure.ac	2017-01-31 14:52:10.000000000 +0000
+@@ -575,10 +575,6 @@ AH_BOTTOM([#if defined(GSL_RANGE_CHECK_O
+ AH_BOTTOM([#define RETURN_IF_NULL(x) if (!x) { return ; }
+ ])
+ 
+-AH_VERBATIM([GSL_DISABLE_DEPRECATED],
+-[/* Disable deprecated functions and enums while building */
+-#define GSL_DISABLE_DEPRECATED 1])
+-
+ dnl
+ AC_CONFIG_FILES([            \
+ Makefile                     \
+--- gsl-2.2.1/config.h.in       2016-08-31 15:54:51.000000000 +0100
++++ patched/config.h.in 2017-01-31 16:01:17.000000000 +0000
+@@ -1,8 +1,5 @@
+ /* config.h.in.  Generated from configure.ac by autoheader.  */
+
+-/* Disable deprecated functions and enums while building */
+-#define GSL_DISABLE_DEPRECATED 1
+-
+ /* Define if you have inline with C99 behavior */
+ #undef HAVE_C99_INLINE


### PR DESCRIPTION
gsl disables "deprecated" symbols by default.

This for example breaks compatibility with the ruby bindings for gsl https://github.com/SciRuby/rb-gsl/issues/40

In debian they solved this issue with a similar approach https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=841611