### PR TITLE
main/libpciaccess: include limits.h

### DIFF
--- a/main/libpciaccess/APKBUILD
+++ b/main/libpciaccess/APKBUILD
@@ -11,6 +11,7 @@ depends=
 makedepends=
 source="http://xorg.freedesktop.org/releases/individual/lib/$pkgname-$pkgver.tar.bz2
 	fix-arm.patch
+	limits_h.patch
 	"
 
 _builddir="$srcdir/$pkgname-$pkgver"
@@ -40,8 +41,11 @@ package() {
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 md5sums="ace78aec799b1cf6dfaea55d3879ed9f  libpciaccess-0.13.4.tar.bz2
-0381322b67ad34689013af74bdfe77c0  fix-arm.patch"
+0381322b67ad34689013af74bdfe77c0  fix-arm.patch
+32100cb5679d9b9082ffd1de8b0c8c7b  limits_h.patch"
 sha256sums="07f864654561e4ac8629a0ef9c8f07fbc1f8592d1b6c418431593e9ba2cf2fcf  libpciaccess-0.13.4.tar.bz2
-3ed71a117c3c89ffcdd1635bf66a95b906fdd79f96102d73b466bfa4f8c2bd8d  fix-arm.patch"
+3ed71a117c3c89ffcdd1635bf66a95b906fdd79f96102d73b466bfa4f8c2bd8d  fix-arm.patch
+4b9d9652038a019d3d8169c152f8326b67c080b6611ac53e6d1fc1a48210f554  limits_h.patch"
 sha512sums="d5b32c525dd36dc85c9a09f45696808730eabbbd3cce892a6dbfb02a566598baad27be58567eb7ced15b3d99fb9afa1d1c24ec19754bcf7a1857a0c8cea34d92  libpciaccess-0.13.4.tar.bz2
-a6c95f42c926ffcd62014cf619c6aacf8db3b1862fa87c8eae9c3e64f31fcaddb682d34c767756bede5d2949a7285a415ca1d14249713bc12514c8e40f9d989f  fix-arm.patch"
+a6c95f42c926ffcd62014cf619c6aacf8db3b1862fa87c8eae9c3e64f31fcaddb682d34c767756bede5d2949a7285a415ca1d14249713bc12514c8e40f9d989f  fix-arm.patch
+331a498059d8b2bfd0a7da0ced3616266ebc129b785090ef1dc19cd645b013428c60d5678fc080bd15ecaf7598ec8b1084509d6bea5d563101169a449b6fe75b  limits_h.patch"

--- a/main/libpciaccess/limits_h.patch
+++ b/main/libpciaccess/limits_h.patch
@@ -1,0 +1,10 @@
+--- a/src/linux_sysfs.c
++++ b/src/linux_sysfs.c
+@@ -48,6 +48,7 @@
+ #include <sys/mman.h>
+ #include <dirent.h>
+ #include <errno.h>
++#include <limits.h>
+ 
+ #if defined(__i386__) || defined(__x86_64__) || defined(__arm__)
+ #include <sys/io.h>


### PR DESCRIPTION
The package libpciaccess uses the macro PATH_MAX, which is defined
in limits.h and needs to be explicitly included in some archs.

Signed-off-by: Fernando Seiti Furusato <ferseiti@linux.vnet.ibm.com>

I have recreated this, due to review by @fabled on #795 (sorry I did not follow guidelines correctly!)
I've tested this on x86_64 as well as ppc64le.