### PR TITLE
community/php7-apcu: upgrade to 5.1.8

### DIFF
--- a/community/php7-apcu/APKBUILD
+++ b/community/php7-apcu/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=php7-apcu
 _pkgreal=apcu
 # release 5 is php7+
-pkgver=5.1.7
+pkgver=5.1.8
 pkgrel=0
 pkgdesc="PHP extension APC User Cache"
 url="http://pecl.php.net/package/$_pkgreal"
@@ -30,6 +30,6 @@ package() {
 	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/$_pkgreal.ini
 }
 
-md5sums="7803b58fab6ecfe847ef5b9be6825dea  apcu-5.1.7.tgz"
-sha256sums="e71e12985f52d4f4311beedf54540a16b76cf7d2d8b8c1028ec4491d4c0f962c  apcu-5.1.7.tgz"
-sha512sums="104e5b1b5dbf1febf4f147775f621d867a5ca60a1ddfe56af5f42f148f7913aa54a31c96baf35c1fd9b3278355d6f14289ffda1601b4a2579430d585f79753b3  apcu-5.1.7.tgz"
+md5sums="0ef8be2ee8acb4dba5a66b247a254995  apcu-5.1.8.tgz"
+sha256sums="01dfbf0245d8cc0f51ba16467a60b5fad08e30b28df7846e0dd213da1143ecce  apcu-5.1.8.tgz"
+sha512sums="4f377389e713bcae5534c64ea28f72c20ab2176aa758188c4d956c1f2370be49bc33dd2a1db43941fff5344a164aaeebc4e73e6d579f62d17334bcc520171526  apcu-5.1.8.tgz"


### PR DESCRIPTION
Bugfix release for PHP 7

- fix https://github.com/krakjoe/apcu/issues/207 Segmentation fault in apc_sma_api_free()
- fix https://github.com/krakjoe/apcu/issues/221 memory leak
- update to apc dashboard (Tyson Andre)

https://pecl.php.net/package-changelog.php?package=APCu&release=5.1.8