### PR TITLE
testing/iprutils: Adding a new package

### DIFF
--- a/testing/iprutils/APKBUILD
+++ b/testing/iprutils/APKBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Breno Leitao <breno.leitao@gmail.com>
+pkgname=iprutils
+pkgver=2.4.14
+pkgrel=0
+pkgdesc="user space tools required by the ipr device driver."
+url="https://github.com/bjking1/iprutils"
+arch="ppc64le"
+license="CPL"
+depends="zlib ncurses"
+makedepends="autoconf automake libtool linux-headers m4 ncurses-dev zlib-dev"
+install=""
+subpackages="$pkgname-doc"
+_pkgver=${pkgver//./-}
+source="$pkgname-$pkgver.tar.gz::https://github.com/bjking1/$pkgname/archive/rel-$_pkgver.tar.gz"
+
+builddir="$srcdir"/iprutils-rel-$_pkgver
+
+build() {
+	cd "$builddir"
+	./bootstrap.sh
+
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--localstatedir=/var \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		|| return 1
+	make || return 1
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install || return 1
+}
+md5sums="267200f22684688f49c2b0da8d4b18d4  iprutils-2.4.14.tar.gz"
+sha256sums="124c45c7873107b825c93b4a7683f5aafc6b047b87ec9483df9f9dfc3e85719a  iprutils-2.4.14.tar.gz"
+sha512sums="311026de8fd9f98a9d9882c8a88af3ef4c350318b8f569e46ec7598e516759f3476e6fba7cee068a7582792690e43f601c2deffd6e0871bf19f2bc9707f27139  iprutils-2.4.14.tar.gz"


### PR DESCRIPTION
Iprutils is an userspace package required to handle most of
the storage controllers on ppc64le arch.

Build tested on ppc64le and amd64.