### PR TITLE
testing/powerpc-utils: Userspace packages for powerpc

### DIFF
--- a/testing/powerpc-utils/APKBUILD
+++ b/testing/powerpc-utils/APKBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Breno Leitao <breno.leitao@gmail.com>
+pkgname=powerpc-utils
+pkgver=1.3.3
+pkgrel=0
+pkgdesc="Utilities which are intended for maintenance of powerpc platforms"
+url="https://github.com/nfont/powerpc-utils"
+arch="ppc64le"
+license="GPL"
+depends=""
+makedepends="autoconf automake zlib-dev"
+install=
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/nfont/powerpc-utils/archive/v$pkgver.tar.gz"
+
+builddir="$srcdir"/$pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	./autogen.sh
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--mandir=/usr/share/man \
+		--without-librtas \
+		|| return 1
+	make || return 1
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install || return 1
+}
+md5sums="26c80f0d0ec886efa1530233f178463e  powerpc-utils-1.3.3.tar.gz"
+sha256sums="2a3f4e7ef219d4de642c7da100d7d6511e93556778c0814b2ebc1170256fc844  powerpc-utils-1.3.3.tar.gz"
+sha512sums="cdd7c355b5fd7aa11f717282bad8a03e553249ca104018519faf72a36753e1ac2f6347af3d65acaadbffd0906fd5835d8b6a49dbd545d0a2519b26cbaf9d96ae  powerpc-utils-1.3.3.tar.gz"


### PR DESCRIPTION
This package contains utilities which are intended for maintenance of PowerPC platforms that follow the POWER Architecture Platform Reference (PAPR).

This build was tested on ppc64le and amd64 arches.