### PR TITLE
testing/librtas: Adding a new package

### DIFF
--- a/testing/librtas/APKBUILD
+++ b/testing/librtas/APKBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Breno Leitao <breno.leitao@gmail.com>
+pkgname=librtas
+pkgver=2.0.1
+pkgrel=0
+pkgdesc="Librtas provides a set of libraries that access Run-Time Abstraction Services (RTAS)"
+url="https://github.com/nfont/librtas"
+arch="ppc64le"
+license="LGPL"
+depends=""
+makedepends="autoconf automake libtool linux-headers"
+install=""
+subpackages="$pkgname-dev $pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/nfont/librtas/archive/v$pkgver.tar.gz"
+
+builddir="$srcdir"/$pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	./autogen.sh || return 1
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		|| return 1
+	make || return 1
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install  || return 1
+}
+md5sums="3a3ee6c9aecef7721b5045bdd14daaa8  librtas-2.0.1.tar.gz"
+sha256sums="a79fd9cdb2f03e7401027fb80a07f14e29b86cc2d363126d527b211fea85d025  librtas-2.0.1.tar.gz"
+sha512sums="922465aa08bc0de49ae259a2655081eb8f91dcc213475b6cac6c4740279433011699a3b50cc23941bb3275f85deec2ffefc2bf1faae51a4baf8baa067b4d6a4d  librtas-2.0.1.tar.gz"


### PR DESCRIPTION
librtas is a library that is required to access RTAS (Run-Time
Abstraction Services).
Most of the ppc64le packages depends on this package for hardware
access.