### PR TITLE
main/librsync: upgrade to 2.0.0

### DIFF
--- a/main/librsync/APKBUILD
+++ b/main/librsync/APKBUILD
@@ -1,44 +1,28 @@
 # Contributor: Jeremy Thomerson <jeremy@thomersonfamily.com>
 # Maintainer: Jeremy Thomerson <jeremy@thomersonfamily.com>
 pkgname=librsync
-pkgver=1.0.0
+pkgver=2.0.0
 pkgrel=0
 pkgdesc="librsync implements the rolling-checksum algorithm of rsync"
 url="https://github.com/librsync/librsync"
 arch="all"
 license="LGPL 2.1"
-depends=""
-makedepends="autoconf automake libtool popt-dev"
-install=
+makedepends="cmake popt-dev bzip2-dev zlib-dev perl"
 subpackages="$pkgname-dev $pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/librsync/librsync/archive/v$pkgver.tar.gz"
-
-_builddir="$srcdir"/$pkgname-$pkgver
-
-prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
-	./autogen.sh
-}
+builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
-	cd "$_builddir"
-
-	./configure \
-		--build=$CBUILD \
-		--host=$CHOST \
-		--prefix=/usr \
-		--mandir=/usr/share/man \
-		--enable-shared \
-		|| return 1
+	cd "$builddir"
+	cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=release . || return 1
 	make || return 1
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	make DESTDIR="$pkgdir" install || return 1
+	install -D -m644 doc/rdiff.1 "$pkgdir/usr/share/man/man1/rdiff.1" || return 1
+	install -D -m644 doc/librsync.3 "$pkgdir/usr/share/man/man3/librsync.3" || return 1
 }
 
-md5sums="829fad850e470dab9cc38a955746aa72  librsync-1.0.0.tar.gz"
-sha256sums="2195998516960ce84d93f88ee3bfd92f430a16cdba4b5d34560a39fa13fcafd9  librsync-1.0.0.tar.gz"
-sha512sums="8812671ff5d8cb841b188902cb8da117655d2252c2fb8c8b4a445ce535500bda7e43ea82d0a687f30544e922693c268effb08af2856f1b1210d0228daf273bf1  librsync-1.0.0.tar.gz"
+sha512sums="1a88dcc3aa60949e058c57eb0df3e0086823c493de40fed927246f5aada6274db57202074456a0ce5d9aa8b81b41836b0d6221ded6a75d43829572584177e8c0  librsync-2.0.0.tar.gz"


### PR DESCRIPTION
https://github.com/librsync/librsync/releases

Note: despite the major version bump, this release has few changes and should be binary and API compatible with the previous version.
