### PR TITLE
testing/exim: add exim-gencert from Debian to exim-utils

### DIFF
--- a/testing/exim/APKBUILD
+++ b/testing/exim/APKBUILD
@@ -5,7 +5,7 @@
 # Maintainer: Jesse Young <jlyo@jlyo.org>
 pkgname=exim
 pkgver=4.88
-pkgrel=1
+pkgrel=2
 pkgdesc="A Message Transfer Agent"
 url="http://www.exim.org/"
 arch="all"
@@ -23,7 +23,8 @@ source="ftp://ftp.exim.org/pub/exim/exim4/$pkgname-$pkgver.tar.bz2
 	exim.Makefile
 	exim.confd
 	exim.initd
-	exim.logrotate"
+	exim.logrotate
+	exim.gencert"
 builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
@@ -81,6 +82,7 @@ utils() {
 	make	DESTDIR="$subpkgdir" \
 		INSTALL_ARG="exim_dbmbuild exim_dumpdb exim_tidydb exim_fixdb exim_lock" \
 		install || return 1
+	install -m755 "$srcdir"/exim.gencert "$subpkgdir"/usr/sbin/exim_gencert || return 1
 	rm -fr "$subpkgdir"/etc
 }
 
@@ -97,18 +99,9 @@ cdb() { _mv_ext cdb; }
 dbmdb() { _mv_ext dbmdb; }
 dnsdb() { _mv_ext dnsdb; }
 
-md5sums="4cc10c910fd18bb9e299e98bc0a32ed2  exim-4.88.tar.bz2
-26f5370c7f7d326da62da5d87ec5f96c  exim.Makefile
-186f4491800be8c56ce39320f24d7264  exim.confd
-dee893356b9fee4276acb018df1c5adf  exim.initd
-2eff3af519bdf8acf0292fffe89871a5  exim.logrotate"
-sha256sums="119d5fd7e31fc224e84dfa458fe182f200856bae7adf852a8287c242161f8a2d  exim-4.88.tar.bz2
-9d0880ba97ca05712521c3cd76ce45695b3dcfd3df7b09131f54ddd1ec884aed  exim.Makefile
-db711754c48dfb7e3810009a1c6ffa331625c9d74d00dc8fa8256d9fa2c353f0  exim.confd
-c7c994777204ec45e0efe791ff818970a819b08ca67ffb252f87323346e6d1b1  exim.initd
-b5a6d449cb1998beb44d4144ef97e66a98b46d164445989a6d624c80549f24bc  exim.logrotate"
 sha512sums="ea094bf703628c201de119fc5f09539475e52158e935f8f2a9e4138c4a1bfe885017145c3cc5e22aa9087b195091955c69385ebf1ea0baec64ed5c1b8e3b1caf  exim-4.88.tar.bz2
 c0733014f52d78e3380c018109cf5628b498cea29e901344598ff128d9f3a190766ce9a5858f4fff6fc4b1c6f921dd1a3589f566eebc1f0ec709d2a8da2bbd82  exim.Makefile
 bb6f5ead067af19ace661cc92bcd428da97570aedd1f9dc5b61a34e7e3fb3e028be6c96d51df73353bdfcaf69a3ee053fb03d245f868d63ebf518aa96ec82d66  exim.confd
 3769e74a54566362bcdf57c45fbf7d130d7a7529fbc40befce431eef0387df117c71a5b57779c507e30d5b125913b5f26c9d16b17995521a1d94997be6dc3e02  exim.initd
-28e748693a6a72d9943fa9c342ff041fe650fa6977f468dee127e845e6c2a91872ce33fb6f5698838906bde3ed92de7a91cdb0349cedc40b806261867e8c06cb  exim.logrotate"
+28e748693a6a72d9943fa9c342ff041fe650fa6977f468dee127e845e6c2a91872ce33fb6f5698838906bde3ed92de7a91cdb0349cedc40b806261867e8c06cb  exim.logrotate
+aa04a3f3909abf4e86a6ae8899ebed94738599855003291b9c3a0f922ce609bbe11c12d42dbe97a38f99f7095ab5cbee22150121ae9a5008000b1a85aae7b3b6  exim.gencert"

--- a/testing/exim/exim.gencert
+++ b/testing/exim/exim.gencert
@@ -1,0 +1,74 @@
+#!/bin/sh -e
+
+if [ -n "$EX4DEBUG" ]; then
+  echo "now debugging $0 $@"
+  set -x
+fi
+
+DIR=/etc/exim
+CERT=$DIR/exim.crt
+KEY=$DIR/exim.key
+
+if ! which openssl > /dev/null ;then
+	echo "$0: openssl is not installed, exiting" 1>&2
+	exit 1
+fi
+
+if [ "$1" != "--force" ] && [ -f $CERT ] && [ -f $KEY ]; then
+  echo "[*] $CERT and $KEY exists!"
+  printf "\n    Use \"$0 --force\" to force generation!\n"
+  exit 0
+fi
+
+case "$1" in
+	--force) shift;;
+	--help) echo "Usage: $0 -or- $0 days keysize"
+		exit 0
+		;;
+esac
+
+DAYS=${1:-1095}
+KEYSIZE=${2:-4096}
+SSLEAY="$(mktemp)" && chmod 600 $SSLEAY
+
+cat > $SSLEAY <<EOM
+RANDFILE = $HOME/.rnd
+[ req ]
+default_bits = $KEYSIZE
+default_keyfile = exim.key
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+countryName = Country Code (2 letters)
+countryName_default = US
+countryName_min = 2
+countryName_max = 2
+stateOrProvinceName = State or Province Name (full name)
+localityName = Locality Name (eg, city)
+organizationName = Organization Name (eg, company; recommended)
+organizationName_max = 64
+organizationalUnitName = Organizational Unit Name (eg, section)
+organizationalUnitName_max = 64
+commonName = Server name (eg. ssl.domain.tld; required!!!)
+commonName_max = 64
+emailAddress = Email Address
+emailAddress_max = 40
+EOM
+
+printf "\n[*] Generating a self signed SSL certificate for Exim:\n\n"
+printf "    Key Size  = $KEYSIZE  Validity = $DAYS days\n"
+printf "    Key File  = $KEY\n"
+printf "    Cert File = $CERT\n\n"
+read -p "Continue [ Y/n ] ? : " ans
+
+case "$ans" in
+	n*|N*) exit 0;;
+	    *)	printf "\n    Please enter the hostname of your MTA at the Common Name (CN) prompt:\n"
+		openssl req -config $SSLEAY -x509 -newkey rsa:$KEYSIZE -keyout $KEY -out $CERT -days $DAYS -nodes
+		rm -f $SSLEAY
+
+		chown root:exim $KEY $CERT $DH
+		chmod 640 $KEY $CERT $DH
+
+		printf "\n[*] Done generating self signed certificates for exim!"
+		;;
+esac


### PR DESCRIPTION
adds `exim-gencert` from [Debian](https://packages.debian.org/sid/amd64/exim4-base/filelist) altered to use custom expiry date
& key size (3 years / `4096` bit by default)