### PR TITLE
testing/zerotier-one: set more specific initd depends

### DIFF
--- a/testing/zerotier-one/APKBUILD
+++ b/testing/zerotier-one/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Kyle Parisi <kyleparisi@gmail.com>
 pkgname=zerotier-one
 pkgver=1.1.14
-pkgrel=0
+pkgrel=1
 pkgdesc="ZeroTier One allows systems to join and participate in ZeroTier virtual networks."
 url="https://www.zerotier.com/"
 arch="all"
@@ -31,8 +31,8 @@ package() {
 }
 
 md5sums="5e381f0864797886b3b3bf20beb49bba  zerotier-one-1.1.14.tar.gz
-45175f743636373dd54597c8adef0dc8  zerotier-one.initd"
+c6bc90e905d8a66c6dbffdd1d72290bf  zerotier-one.initd"
 sha256sums="d206069ad21c665159cdececb0a20a21758849ad73d91234d709962b26f634af  zerotier-one-1.1.14.tar.gz
-de95f8f8011ff6b4b4c53c5267eb8047f755a29f99a15e46ab5f437e22e04320  zerotier-one.initd"
+680d01fbac0aff5ecf7238ddc8ce9dcb91c0d19ca14fd83ec5f0949983d256dd  zerotier-one.initd"
 sha512sums="96806a5eab8204d01585c88dba426fb7d47337562074488f87eb81b7ece6643216e2f60adcf1677f9a61fa5ab5187b7569fc1b9565d7055ba106139b6363e7a5  zerotier-one-1.1.14.tar.gz
-5b5badc9ea9619d3d3cd9b05813704097bfd8c6a03ece93ea8cee5b52b15cadf0ff1350011b8e056155174321724cf947a31e6e17a633923e9543a23da9c1d5b  zerotier-one.initd"
+a63f8e649d63a3de58a556b3adca440cd0c0d4b36239ea547d555b97852d89d0a1446f348d35e98f77faabe1fe4ffb76868b8290ad9f2b4cd8b6c599945a176c  zerotier-one.initd"

--- a/testing/zerotier-one/zerotier-one.initd
+++ b/testing/zerotier-one/zerotier-one.initd
@@ -1,7 +1,9 @@
 #!/sbin/openrc-run
 
 depend() {
-    need net
+    provide net
+    use network
+    before firewall netmount
 }
 
 command="/usr/sbin/zerotier-one"


### PR DESCRIPTION
The reason for this is that zerotier-one can be started without
functioning network and will create it's net-devices as soon as it can.
So, it provides net devices which might be used in e.g. /etc/fstab