### PR TITLE
community/pdns: upgrade to 4.0.3 and fix module-dir

### DIFF
--- a/community/pdns/APKBUILD
+++ b/community/pdns/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Olivier Mauras <olivier@mauras.ch>
 # Maintainer:  Matt Smith <mcs@darkregion.net>
 pkgname=pdns
-pkgver=4.0.2
+pkgver=4.0.3
 pkgrel=0
 pkgdesc="PowerDNS Authoritative Server"
 url="http://www.powerdns.com/"
@@ -91,12 +91,12 @@ _mv_backend() {
 		"$subpkgdir"/usr/lib/pdns/pdns/ || return 1
 }
 
-md5sums="7629b2393fac3336cc37b49d8e769358  pdns-4.0.2.tar.bz2
+md5sums="bbb1ebed50edc0f2127d6c4331c1429a  pdns-4.0.3.tar.bz2
 db11dfe72474858f706155c817f2ded5  pdns.initd
-351bac7f784a1a40e768466d9e6f1a79  pdns.conf"
-sha256sums="d051e53b63f586c924f00ce8a81662f7bd285b461d125d4991538f92cf7e629d  pdns-4.0.2.tar.bz2
+1d062eec9e7b5b57ad15b92a349e893a  pdns.conf"
+sha256sums="60fa21550b278b41f58701af31c9f2b121badf271fb9d7642f6d35bfbea8e282  pdns-4.0.3.tar.bz2
 081835f812e419b153a9cc716ad55b9cb22c6c185b748e0aafc40430fa5e8b5e  pdns.initd
-5fdf423f829dca0b50bc81bab773d7ec4ee6627e35f861124d8c2ccd79a2f50c  pdns.conf"
-sha512sums="6720289332ee5186f4c58a00a720f3bb58480c0ae7f09915148ca8b40e2dfdc77e2f14123df903692afa464539eeef6b21e8ea3d284278897751ba807e2cdffe  pdns-4.0.2.tar.bz2
+b7418d683f178ceeb51ca4328a560005ae57ea7189a06d4eb97156c3340aca86  pdns.conf"
+sha512sums="58d33ac6cf457a916bae6abd8d2dc17f76fbcd1bd9e649948584dd669f5596b43e3e4d91841700ea1ea2cd1ac102749e503cd9075273540f33a2321e20d8bfc2  pdns-4.0.3.tar.bz2
 71257be925fe57b15ebf29a7810cd70581cb867416ab9562300a1bbc3eb94fcb92ea2eb95f15e3ee3bd409468911077c50f90a2501801b0c8c49ed979f41f3a4  pdns.initd
-9913551bb4d685aaced806134b1037d85ce759e7d9e780e256e67651d9d346aad5e608b4a45a4933f0ba879605b69d06e579c38b7f917f7a9be37c7797c5953b  pdns.conf"
+acde76a5a51232dbd2b1b9fed95328f5bb59e33718338ffaa47618806588a9c3c8691c7e7270944d9e2f40b1fb69fc33e204e2fdfbc9546ab723fc428d2a7955  pdns.conf"

--- a/community/pdns/pdns.conf
+++ b/community/pdns/pdns.conf
@@ -157,7 +157,7 @@ loglevel=3
 #################################
 # module-dir	Default directory for modules
 #
-module-dir=/usr/lib/pdns
+module-dir=/usr/lib/pdns/pdns
 
 #################################
 # negquery-cache-ttl	Seconds to store packets in the PacketCache


### PR DESCRIPTION
I've also updated the .conf file to point to the right "module-dir" since the one that was there by default was broken.

Finally I aligned all the hashes for the source files and the new patched .conf file.