### PR TITLE
testing/mitmproxy: upgrade to 0.18.2 and improve abuild

### DIFF
--- a/testing/mitmproxy/APKBUILD
+++ b/testing/mitmproxy/APKBUILD
@@ -1,47 +1,33 @@
 # Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=mitmproxy
-pkgver=0.17.1
+pkgver=0.18.2
 pkgrel=0
 pkgdesc="An interactive SSL-capable intercepting HTTP proxy"
 url="http://www.mitmproxy.org/"
 arch="noarch"
 license="MIT"
 depends="python2 py-netlib py-flask py-urwid py-$pkgname py-itsdangerous"
-depends_dev=""
-makedepends="python2-dev py-setuptools "
-install=""
+makedepends="python2-dev py-setuptools"
 subpackages="py-$pkgname:py"
 source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$pkgver.tar.gz"
-
-_builddir="$srcdir"/$pkgname-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	python2 setup.py build || return 1
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
 }
 
 py() {
-	cd "$_builddir"
+	cd "$builddir"
 	pkgdesc="$pkgname python bindings"
 	install -d "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/lib/python* "$subpkgdir"/usr/lib/
 }
 
-md5sums="fe85b8232f0f26e575c70daceb94de46  mitmproxy-0.17.1.tar.gz"
-sha256sums="5f9605f0703f03eca21173067161332eeb0e70a22a67aa3b329dc4a203f4dadc  mitmproxy-0.17.1.tar.gz"
-sha512sums="5e53cfb46e4710674a0a0df5ee0a39ab2766cfab7aace677a6abfa3f8dbd91509759f25bc58773d76323985c37707dcf9d915d33275bd4e76e0374c601fe7ad2  mitmproxy-0.17.1.tar.gz"
+sha512sums="39836063a041d7fd14bb82ccf2fb53262b8ec14b629197776e27ebfb2fc97103ee5b4af979ffe6db35103e833679e2e5a640295831d55a2cd0f20a602b559064  mitmproxy-0.18.2.tar.gz"


### PR DESCRIPTION
https://github.com/mitmproxy/mitmproxy/releases

0.18 will be the last release that supports both Python 2 and 3.5+. The next release will support Python 3.5+ only.
