### PR TITLE
Add upx and ucl aports

### DIFF
--- a/testing/ucl/0001-Static-assert.patch
+++ b/testing/ucl/0001-Static-assert.patch
@@ -1,0 +1,34 @@
+From: Robert Luberda <robert@debian.org>
+Date: Sat, 2 Jul 2016 22:23:20 +0200
+Subject: Switch to _Static_assert
+
+Use _Static_assert for compile-time assertion to fix
+build failures with gcc-6 (closes: #811707)
+---
+ acc/acc_defs.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/acc/acc_defs.h b/acc/acc_defs.h
+index 866b7bd..5ee3761 100644
+--- a/acc/acc_defs.h
++++ b/acc/acc_defs.h
+@@ -87,6 +87,9 @@
+ 
+ /* This can be put into a header file but may get ignored by some compilers. */
+ #if !defined(ACC_COMPILE_TIME_ASSERT_HEADER)
++# define ACC_COMPILE_TIME_ASSERT_HEADER(e) _Static_assert(e, #e);
++#endif
++#if !defined(ACC_COMPILE_TIME_ASSERT_HEADER)
+ #  if (ACC_CC_AZTECC || ACC_CC_ZORTECHC)
+ #    define ACC_COMPILE_TIME_ASSERT_HEADER(e)  extern int __acc_cta[1-!(e)];
+ #  elif (ACC_CC_DMC || ACC_CC_SYMANTECC)
+@@ -100,6 +103,9 @@
+ 
+ /* This must appear within a function body. */
+ #if !defined(ACC_COMPILE_TIME_ASSERT)
++# define ACC_COMPILE_TIME_ASSERT(e) _Static_assert(e, #e);
++#endif
++#if !defined(ACC_COMPILE_TIME_ASSERT)
+ #  if (ACC_CC_AZTECC)
+ #    define ACC_COMPILE_TIME_ASSERT(e)  {typedef int __acc_cta_t[1-!(e)];}
+ #  elif (ACC_CC_DMC || ACC_CC_PACIFICC || ACC_CC_SYMANTECC || ACC_CC_ZORTECHC)

--- a/testing/ucl/APKBUILD
+++ b/testing/ucl/APKBUILD
@@ -1,0 +1,31 @@
+#-*-mode: Shell-script; coding: utf-8;-*-
+# Maintainer: Mitch Tishmack <mitch.tishmack@gmail.com>
+pkgname=ucl
+pkgver=1.03
+pkgrel=0
+pkgdesc="Portable lossless data compression library written in ANSI C"
+url="http://www.oberhumer.com/opensource/ucl/"
+arch="all"
+license="gpl"
+makedepends="file"
+source="
+	http://www.oberhumer.com/opensource/$pkgname/download/$pkgname-$pkgver.tar.gz
+	0001-Static-assert.patch
+"
+
+build() {
+	cd "$builddir"
+	./configure --prefix=/usr --enable-shared --enable-static || return 1
+	make || return 1
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install || return 1
+}
+md5sums="852bd691d8abc75b52053465846fba34  ucl-1.03.tar.gz
+e852ab6af348477e6c6b3f1ee41b2200  0001-Static-assert.patch"
+sha256sums="b865299ffd45d73412293369c9754b07637680e5c826915f097577cd27350348  ucl-1.03.tar.gz
+b0269e9f934e23a5992acffe193a27892cd47d91a7e0d65cb6a91e2131896a65  0001-Static-assert.patch"
+sha512sums="7dd1824d01b4bb41ee03bbceddc634a9f7f910d235e5cca163d783680d6743f0f3cc309bbbcc1e094d897d549d3805a555f9093b4d77805443d896dd1862aa34  ucl-1.03.tar.gz
+24a34de871fcfa919985afc29c60496b1f0e730550e8387f212a5229f32ccade4178d1221574d86c36d025c08b3b5ed6d236f2b4d740436afe0451ae9050f890  0001-Static-assert.patch"

--- a/testing/upx/0001-rm-broken-whitespace-check.patch
+++ b/testing/upx/0001-rm-broken-whitespace-check.patch
@@ -1,0 +1,16 @@
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -104,13 +104,6 @@
+ endif
+
+ CHECK_WHITESPACE =
+-ifeq ($(shell uname),Linux)
+-CHECK_WHITESPACE = $(top_srcdir)/src/stub/scripts/check_whitespace.sh $(top_srcdir)
+-ifneq ($(wildcard $(top_srcdir)/.git/.),)
+-CHECK_WHITESPACE = $(top_srcdir)/src/stub/scripts/check_whitespace_git.sh $(top_srcdir)
+-endif
+-check-whitespace : ; $(CHECK_WHITESPACE)
+-endif
+ .PHONY: check-whitespace
+
+ mostlyclean clean distclean maintainer-clean:

--- a/testing/upx/APKBUILD
+++ b/testing/upx/APKBUILD
@@ -1,0 +1,32 @@
+#-*-mode: Shell-script; coding: utf-8;-*-
+# Maintainer: Mitch Tishmack <mitch.tishmack@gmail.com>
+pkgname=upx
+pkgver=3.93
+pkgrel=0
+pkgdesc="UPX - the Ultimate Packer for eXecutables"
+url="https://upx.github.io"
+arch="all"
+license="gpl"
+depends="zlib ucl"
+makedepends="$depends zlib-dev bash"
+source="
+	https://github.com/${pkgname}/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}-src.tar.xz
+	0001-rm-broken-whitespace-check.patch
+"
+builddir="$srcdir/$pkgname-$pkgver-src"
+
+build() {
+	cd "$builddir"
+	make UPX_LZMA_VERSION=0x465 UPX_LZMADIR="${srcdir}" all || return 1
+}
+
+package() {
+	cd "$builddir"
+	install -Dm0755 src/upx.out "${pkgdir}/usr/bin/upx" || return 1	
+}
+md5sums="d8da85311492a5f9e3a1fecc979f879b  upx-3.93-src.tar.xz
+1025aa041780c577d60c3dc8495c66c9  0001-rm-broken-whitespace-check.patch"
+sha256sums="893f1cf1580c8f0048a4d328474cb81d1a9bf9844410d2fd99f518ca41141007  upx-3.93-src.tar.xz
+427e30ecf5cd689ccbb07ee55422f9d48d4957211777c7091ba9de28e7c1e28b  0001-rm-broken-whitespace-check.patch"
+sha512sums="41c18c11601c78043a9ae22d87e73c173971b19b62207e7bf058e29a452456d802bf89931324afd3a9848018d1ef2007e0915b41cfb8a97a44d3cebb559cefad  upx-3.93-src.tar.xz
+a41dd8b8e9e884c78c410a49b4486963f6dd90759ba49eb05123e81b8e4fbe3d23af2ba5c2acf64218b7edeec7df0793b4030d1375c167a183a4d70d21addf50  0001-rm-broken-whitespace-check.patch"


### PR DESCRIPTION
Note, upx seems to have issues compressing musl dynamic binaries in general. So while this "works", it fails to compress dynamic binaries for musl libc.

Static works fine however, and other binaries, e.g. glibc work as well. So its no less broken than it is on other platforms.

Note, I only tested on x86_64 and arm, but doubt this will fail on other platforms.