### PR TITLE
main/sqlite: increase SQLITE_MAX_VARIABLE_NUMBER

### DIFF
--- a/main/sqlite/APKBUILD
+++ b/main/sqlite/APKBUILD
@@ -17,7 +17,7 @@ esac
 [ $_d -lt 10 ] && _d=0$_d
 _ver=${_a}${_b}${_c}${_d}
 
-pkgrel=0
+pkgrel=1
 pkgdesc="A C library that implements an SQL database engine"
 url="http://www.sqlite.org/"
 arch="all"
@@ -37,6 +37,7 @@ _amalgamation="-DSQLITE_ENABLE_FTS4 \
 	-DSQLITE_ENABLE_RTREE \
 	-DSQLITE_USE_URI \
 	-DSQLITE_ENABLE_DBSTAT_VTAB \
+	-DSQLITE_MAX_VARIABLE_NUMBER=250000 \
 	-DSQLITE_ENABLE_JSON1"
 
 builddir="$srcdir/$pkgname-autoconf-$_ver"


### PR DESCRIPTION
To support large amount of variables in queries it needs to be up.

Debian/Ubuntu is 250000
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=717900