### PR TITLE
testing/php7-memcached: upgrade to 3.0.2

### DIFF
--- a/testing/php7-memcached/APKBUILD
+++ b/testing/php7-memcached/APKBUILD
@@ -2,8 +2,7 @@
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
 pkgname=php7-memcached
 _pkgname=php-memcached
-_gitrev=583ecd68faec886ac9233277531f78fb6e2043c7
-pkgver=3.0_pre20160808
+pkgver=3.0.2
 pkgrel=0
 pkgdesc="PHP extension for interfacing with memcached via libmemcached library"
 url="https://github.com/php-memcached-dev/php-memcached"
@@ -12,8 +11,8 @@ license="PHP"
 depends="php7-session"
 pecldepends="php7-dev autoconf zlib-dev"
 makedepends="$pecldepends libmemcached-dev cyrus-sasl-dev"
-source="$pkgname-$pkgver.tar.gz::https://github.com/$_pkgname-dev/$_pkgname/archive/$_gitrev.tar.gz"
-builddir="$srcdir/$_pkgname-$_gitrev"
+source="$pkgname-$pkgver.tar.gz::https://github.com/$_pkgname-dev/$_pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
@@ -34,6 +33,6 @@ package() {
 	echo "extension=memcached.so" > "$pkgdir"/etc/php7/conf.d/20_memcached.ini
 }
 
-md5sums="081d43caf5a5cb4f70348280014e3da9  php7-memcached-3.0_pre20160808.tar.gz"
-sha256sums="a770003ebc6bb2a4976dd9ebaa9304552575c5ed9e0c998d941bdd087fee106e  php7-memcached-3.0_pre20160808.tar.gz"
-sha512sums="3e38885bb43aa26a69d101ad890fe73a4f545c76210450da25c067699b06c2ce7c94f900f8956ff38b5d68376bc2fadfd8c18e32a83df907a3437698c1c6ae84  php7-memcached-3.0_pre20160808.tar.gz"
+md5sums="27648455da9cc42f2f2de2a3c3e4c4f5  php7-memcached-3.0.2.tar.gz"
+sha256sums="efe75831a393410b71a2e1e06030ed9e49b7a0a3570877bd73fce15037a52ffe  php7-memcached-3.0.2.tar.gz"
+sha512sums="ec60d099357cc0a2ad366bd090393b0f29eac70d3683ec1962e7a05f4f37c1a76ae6a189a53e7c03566efa650f072abfc0ba5d21a9b3170dd0e2d5da3630f93b  php7-memcached-3.0.2.tar.gz"


### PR DESCRIPTION
Finally stable version for 1.0.18 of libmemcached 
https://pecl.php.net/package-changelog.php?package=memcached&release=3.0.2