### PR TITLE
community/elasticsearch: update to 5.2.1 / use supervise-daemon 

### DIFF
--- a/community/elasticsearch/APKBUILD
+++ b/community/elasticsearch/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=elasticsearch
-pkgver=2.3.5
+pkgver=5.2.1
 pkgrel=0
 pkgdesc="Open Source, Distributed, RESTful Search Engine"
 url="https://www.elastic.co/products/elasticsearch"
@@ -10,13 +10,16 @@ license="ASL-2.0"
 depends="java-jna-native>=4.1 openjdk8-jre"
 makedepends=""
 install="$pkgname.pre-install"
-source="https://download.elasticsearch.org/$pkgname/release/org/$pkgname/distribution/tar/$pkgname/$pkgver/$pkgname-$pkgver.tar.gz
+subpackages="$pkgname-doc"
+source="https://artifacts.elastic.co/downloads/$pkgname/$pkgname-$pkgver.tar.gz
 	$pkgname.initd
 	$pkgname.confd
+	README.alpine
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
-_modules="lang-expression lang-groovy reindex"
+default_module=transport-netty4
+_modules=$(find $builddir/modules -mindepth 1 -maxdepth 1 -type d ! -name $default_module -exec basename {} \;)
 for _mod in $_modules; do
 	subpackages="$subpackages $pkgname-$_mod:_${_mod//-/_}"
 	eval "_${_mod//-/_}() { _builtin_module $_mod; }"
@@ -25,29 +28,49 @@ done
 _basedir="/usr/share/java/$pkgname"
 
 build() {
-	sed "s/@@ES_VERSION@@/$pkgver/" "$srcdir"/$pkgname.initd \
-		> "$builddir"/$pkgname.initd
+	return 0
 }
 
 package() {
 	local destdir="$pkgdir/$_basedir"
 	local confdir="$pkgdir/etc/$pkgname"
-	local user="elastico"
-	local group="$user"
+	local docdir="$pkgdir/usr/share/doc/elasticsearch"
+	local heapsize="256m"
 
 	cd "$builddir"
 
-	install -dm755 "$destdir"/lib "$destdir"/modules
+	install -dm755 "$destdir"/lib "$destdir"/modules "$destdir"/bin
 	install -m644 -t "$destdir"/lib lib/* || return 1
 
+	install -dm755 "$docdir"
 	install -dm755 "$confdir"
 	install -m644 -t "$confdir" config/* || return 1
 
-	install -m755 -D $pkgname.initd \
+	# remove windows files
+	find bin -type f -name *.bat -exec rm -f {} \;
+	find bin -type f -name *.exe -exec rm -f {} \;
+
+	# ES bin script parses the new jvm.options file
+	install -m755 -t "$destdir"/bin bin/* || return 1
+
+	# ES does not run without a transport module
+	install -dm755 "$destdir/modules/$default_module"
+	install -m644 -t "$destdir/modules/$default_module" modules/"$default_module"/* || return 1
+
+	# reduce heap sizes
+	sed -i \
+	  -e "s|^-Xms.*|-Xms$heapsize|" \
+	  -e "s|^-Xmx.*|-Xmx$heapsize|" \
+	$confdir/jvm.options
+
+	install -m755 -D "$srcdir"/$pkgname.initd \
 		"$pkgdir"/etc/init.d/$pkgname || return 1
 
 	install -m644 -D "$srcdir"/$pkgname.confd \
-		"$pkgdir"/etc/conf.d/$pkgname
+		"$pkgdir"/etc/conf.d/$pkgname || return 1
+
+	install -m644 -D "$srcdir"/README.alpine \
+		"$docdir" || return 1
 }
 
 _builtin_module() {
@@ -58,12 +81,7 @@ _builtin_module() {
 	install -m644 -t "$destdir" "$builddir"/modules/$name/*
 }
 
-md5sums="8274f2a966bd888b108a834f64b99ce6  elasticsearch-2.3.5.tar.gz
-8588526df39a4d7fab06cf885edec731  elasticsearch.initd
-11ca8100933039b8433eac9342e9e326  elasticsearch.confd"
-sha256sums="1119a8c18620b98c4b85261318663a1f26dea92a26f34dfeb7f813fb7cbb468a  elasticsearch-2.3.5.tar.gz
-b4cacc84afac4f4d51cad888b0dca034a91e3aed96543d43126a86fa7c3f2bb6  elasticsearch.initd
-356989a74e111a50862712f877da1078ffbc77a4a2735090e2aa87bfa9cbf1e0  elasticsearch.confd"
-sha512sums="9c0cc8a9ae0fa2b52db583a5c006b05a84c1f84e1b8dbbafa88bec111190d056a23bd384d4241ce00dc8b56a6840857b296e4c0d2bf911f352ef67f128a87ca7  elasticsearch-2.3.5.tar.gz
-9fe933d6b1b53a02514d34377e6362d176148da3297edbea5902a1c4aff9762aa9c9cb00f053c9aec42db8dea22f722f8a3e16f5ed5b32f5b975e0b311a5e6ff  elasticsearch.initd
-e1e4b31f8bac2e79118e7bf9b25ca8a31eefa6fb00d35c57ccf2db718236a3255d5cbfe429009a98c6f4a8ded19d291e97e5a4d9c44fa044ed6f9961792f5d62  elasticsearch.confd"
+sha512sums="aa8734c1e1111987d45e8dd64b5f8a0473955c48e09e6f1875e877090c21070fc18768b413e7b0c20652cec9ebd9bb6836a2c014cf8159b041f0d22b28ad5a08  elasticsearch-5.2.1.tar.gz
+dc916861497d4a589d6b3ab70d90ff9970e4d57003ed82d08c5f90dec337f995dcabf2556b7a27ade926e846ad435392f7845acfe9280dce17b4c172d85328ae  elasticsearch.initd
+2ab1baf1b5c8782f3f371ba221aadd3e841abc62175f0b1ddcfc68d711e2370465124e076f8cc2e549c25a1da9db8c90172b2f410bd6bbe4153f0e831620b6ba  elasticsearch.confd
+6de81485cdc059afef58382862e4155482463fde0b604aaa8dbe904c778b841467c4a383a5e54acd09e3436f1fb7be9923e001fb77bd3d7894e113a5e0f4036b  README.alpine"

--- a/community/elasticsearch/README.alpine
+++ b/community/elasticsearch/README.alpine
@@ -1,0 +1,20 @@
+### Alpine Linux README for elasticsearch 5.x ###
+-------------------------------------------------
+
+For upgrading ES 2.x => ES 5.x see:
+
+https://www.elastic.co/guide/en/elasticsearch/reference/current/restart-upgrade.html
+
+------------------------------------------------------------------------------------
+
+The initd has changed: please use the new version
+
+------------------------------------------------------------------------------------
+
+Default Java options are now set via:
+
+ES_CONF_DIR/jvm.options
+
+Additional java options can also still be set in /etc/conf.d/elasticsearch
+
+------------------------------------------------------------------------------------

--- a/community/elasticsearch/elasticsearch.confd
+++ b/community/elasticsearch/elasticsearch.confd
@@ -17,6 +17,10 @@
 # Placeholder [INSTANCE_NAME] means that it's omitted for _default (for
 # user convenient when running just single instance).
 #
+# Java options are by default set in the environment variable ES_JVM_OPTIONS:
+#
+#   ES_CONF_DIR/jvm.options
+#
 
 # User to run this ElasticSearch instance.
 #user="elastico"
@@ -48,12 +52,11 @@
 # The maximum number of filedescriptors to be allowed.
 max_fd="65536"
 
-# Initial and maximum size of the heap in megabytes.
-# Note: This sets parameters -Xms and -Xmx.
-#java_heap_size="256"
-
 # Additional options to pass to the JVM.
-java_opts="-Djna.nosys=true"
+#java_opts=""
+
+# The maximum mapped memory areas [vm.max_map_count]
+max_map_count="262144"
 
 # Additional options to pass to the Elasticsearch.
 #elastic_opts=

--- a/community/elasticsearch/elasticsearch.initd
+++ b/community/elasticsearch/elasticsearch.initd
@@ -1,4 +1,5 @@
 #!/sbin/openrc-run
+supervisor=supervise-daemon
 
 description="A Distributed RESTful Search Engine."
 
@@ -10,7 +11,6 @@ name="Elasticsearch"
 
 : ${user:="elastico"}
 : ${group:="$(id -gn $user)"}
-: ${java_heap_size:="256"}
 
 : ${conf_dir:="/etc/elasticsearch/${instance_name#_default}"}
 : ${home_dir:="/var/lib/elasticsearch/$instance_name"}
@@ -21,57 +21,53 @@ name="Elasticsearch"
 : ${default_work_dir:="/var/tmp/elasticsearch/$instance_name"}
 : ${create_logs_dir:="yes"}
 
+elastic_opts="
+        -Epath.conf=$conf_dir
+        -Epath.data=$default_data_dir
+        -Epath.logs=$default_logs_dir
+        $elastic_opts
+        "
+
 java_opts="
-	-server
-	-XX:+DisableExplicitGC
-	-Djava.awt.headless=true
-	-Dfile.encoding=utf-8
-	-Xms${java_heap_size}M -Xmx${java_heap_size}M
-	${java_max_direct_mem_size:+"-XX:MaxDirectMemorySize=$java_max_direct_mem_size"}
-	$java_opts"
+        -Des.path.home='$home_dir'
+        -Des.default.path.plugins='$default_plugins_dir'
+        -Des.default.path.work='$default_work_dir'
+        -Des.default.path.script='$default_script_dir'
+        $java_opts
+        "
 
-lib_dir="/usr/share/java/elasticsearch/lib"
-classpath="$lib_dir/elasticsearch-@@ES_VERSION@@.jar:$lib_dir/*"
+# env variable for: -XX:MaxDirectMemorySize
+# export ES_DIRECT_SIZE=
+export ES_JAVA_OPTS="$java_opts"
+export ES_JVM_OPTIONS="$conf_dir/jvm.options"
 
-command="java"
-command_args="
-	$java_opts
-	-Des.path.conf='$conf_dir'
-	-Des.path.home='$home_dir'
-	-Des.default.path.data='$default_data_dir'
-	-Des.default.path.plugins='$default_plugins_dir'
-	-Des.default.path.work='$default_work_dir'
-	-Des.default.path.logs='$default_logs_dir'
-	-Des.default.path.script='$default_script_dir'
-	-cp $classpath
-	org.elasticsearch.bootstrap.Elasticsearch start
-	$elastic_opts"
-command_background="yes"
+nice="0"
+pidfile="/run/$SVCNAME.sd.pid"
+supervise_daemon_args="-u $user -g $group -p $pidfile -N $nice"
+command=/usr/share/java/elasticsearch/bin/elasticsearch
+command_args="$elastic_opts 1>/dev/null 2>>$default_logs_dir/error.log"
 
-start_stop_daemon_args="
-	--interpreted
-	--chdir '$home_dir'
-	--user $user:$group"
-pidfile="/run/$SVCNAME.pid"
-retry="TERM/20/KILL/5"
+depends() {
+        use net
+}
 
-required_files="$conf_dir/elasticsearch.yml $conf_dir/logging.yml"
-
-depend() {
-	use net
+in_contr() {
+        grep "container=" /proc/1/environ
 }
 
 start_pre() {
 	local dir
 
 	# Note: checkpath doesn't create intermediate directories.
-	for dir in "$home_dir" "$default_data_dir" "$default_work_dir" "$default_script_dir"; do
+	for dir in "$home_dir" "$default_data_dir" "$default_work_dir" "$default_plugins_dir" "$default_script_dir"; do
 		mkdir -p "$(dirname "$dir")"
 	done
 
 	checkpath -d -o $user:$group -m755 "$home_dir"
+	checkpath -d -o $user:$group -m700 "$(dirname "$home_dir")"
 	checkpath -d -o $user:$group -m700 "$default_data_dir"
 	checkpath -d -o $user:$group -m700 "$default_work_dir"
+	checkpath -d -o $user:$group -m700 "$default_plugins_dir"
 	checkpath -d "$default_script_dir"
 
 	if yesno "$create_logs_dir"; then
@@ -80,7 +76,18 @@ start_pre() {
 	fi
 
 	if [ -n "$max_fd" ]; then
-		ulimit -n "$max_fd" && einfo "Max open filedescriptors: $max_fd"
-		return 0
+		if [ -z "$(in_contr)" ]; then
+			ulimit -n "$max_fd" && einfo "Max open filedescriptors: $max_fd"
+		else
+			einfo "Run 'ulimit -n $max_fd' on the container host"
+		fi
 	fi
+
+	if [ -n "$max_map_count" ]; then
+		if [ -z "$(in_contr)" ]; then
+			sysctl -q -w vm.max_map_count="$max_map_count" && einfo "vm.max_map_count: $max_map_count"
+		else
+			einfo "Run 'sysctl -w vm.max_map_count=$max_map_count' on the container host"
+		fi
+        fi
 }


### PR DESCRIPTION
ES now uses `$ES_CONF_DIR/jvm.options` to set java options so duplicate
java options have been removed from the `initd` / `conf.d`.

service supervision with OpenRC's `supervise-daemon` added

added `README.alpine` with notes for upgrading ES `2.x` => `5.x`