### PR TITLE
Enable alsa-lib to build on ppc64le

### DIFF
--- a/main/alsa-lib/APKBUILD
+++ b/main/alsa-lib/APKBUILD
@@ -13,6 +13,7 @@ source="ftp://ftp.alsa-project.org/pub/lib/$pkgname-$pkgver.tar.bz2
 	alsa-lib-poll.patch
 	alsa-lib-stdint.patch
 	ucm_add_limits_h.patch
+	ppc64le_symbols.patch
 	"
 
 _builddir="$srcdir/$pkgname-$pkgver"
@@ -54,12 +55,15 @@ package() {
 md5sums="eefe5992567ba00d6110a540657aaf5c  alsa-lib-1.1.3.tar.bz2
 8005b9b9c2aad55912f87e0829437c17  alsa-lib-poll.patch
 1349b595ef97c42873b917b2cf7c0e37  alsa-lib-stdint.patch
-c552ede907722a4fccf5217f7f5e97ba  ucm_add_limits_h.patch"
+c552ede907722a4fccf5217f7f5e97ba  ucm_add_limits_h.patch
+0f21ec0b673d5f5c08bfa6a908cd1255  ppc64le_symbols.patch"
 sha256sums="71282502184c592c1a008e256c22ed0ba5728ca65e05273ceb480c70f515969c  alsa-lib-1.1.3.tar.bz2
 b4f5c664756868ba68b170b8b74f5deebdade3b83349e2073a500caece6e0af1  alsa-lib-poll.patch
 5cd15e2bbccf72d04a20db9f11bdd4dee3342f5c365d8141450916e263d9aebc  alsa-lib-stdint.patch
-9663e66579fd15901c52b72815612035565b793fa3d9b6cca0d774dab1b4b4c9  ucm_add_limits_h.patch"
+9663e66579fd15901c52b72815612035565b793fa3d9b6cca0d774dab1b4b4c9  ucm_add_limits_h.patch
+5ff12f03a2453d70f142735c5a42983006ac1a7ce50e50a1531e47fce525a346  ppc64le_symbols.patch"
 sha512sums="f5dbe2375a8c66af14378314a5238284d4ed63dfc86a750c0c6e8f6cdb6b1ea2d8ef26f870b5d152dc0b77d9b40821cab523f6734902b91583beb08e28c66850  alsa-lib-1.1.3.tar.bz2
 bdf86a1b76b2e6e9b43af33989fe51e4900fa0c6f317d8d746f30c540df647dbe0f6d41ec35b36b1cf7e46cc5e910e0a62bc39c765f849356ecd6e98d1de5885  alsa-lib-poll.patch
 2351262dade9a3c1a3de1b7d1a3a53a634a438b9b8aae7cc69e2b981500051f039e6381359b81392114ec6236e3d513b577bd4bf12c3d2ce1f871cd7651b2cab  alsa-lib-stdint.patch
-3b37652d50809443b5f8e80f8d447108195b0cd66fd917805bb393fc091584b6f3dad4414f568742b61745617e7a695862058a0a0f93dcc31e4c97177a520352  ucm_add_limits_h.patch"
+3b37652d50809443b5f8e80f8d447108195b0cd66fd917805bb393fc091584b6f3dad4414f568742b61745617e7a695862058a0a0f93dcc31e4c97177a520352  ucm_add_limits_h.patch
+4ca096065be0666f6dba84cde6fe6e18615991e94142fde264d70d16c6af751db8b53e7ea942e21497c4b05b61b8098f96cefbdf854d5c6f66898c3a06866dc3  ppc64le_symbols.patch"

--- a/main/alsa-lib/APKBUILD
+++ b/main/alsa-lib/APKBUILD
@@ -12,6 +12,7 @@ makedepends="linux-headers"
 source="ftp://ftp.alsa-project.org/pub/lib/$pkgname-$pkgver.tar.bz2
 	alsa-lib-poll.patch
 	alsa-lib-stdint.patch
+	ucm_add_limits_h.patch
 	"
 
 _builddir="$srcdir/$pkgname-$pkgver"
@@ -52,10 +53,13 @@ package() {
 
 md5sums="eefe5992567ba00d6110a540657aaf5c  alsa-lib-1.1.3.tar.bz2
 8005b9b9c2aad55912f87e0829437c17  alsa-lib-poll.patch
-1349b595ef97c42873b917b2cf7c0e37  alsa-lib-stdint.patch"
+1349b595ef97c42873b917b2cf7c0e37  alsa-lib-stdint.patch
+c552ede907722a4fccf5217f7f5e97ba  ucm_add_limits_h.patch"
 sha256sums="71282502184c592c1a008e256c22ed0ba5728ca65e05273ceb480c70f515969c  alsa-lib-1.1.3.tar.bz2
 b4f5c664756868ba68b170b8b74f5deebdade3b83349e2073a500caece6e0af1  alsa-lib-poll.patch
-5cd15e2bbccf72d04a20db9f11bdd4dee3342f5c365d8141450916e263d9aebc  alsa-lib-stdint.patch"
+5cd15e2bbccf72d04a20db9f11bdd4dee3342f5c365d8141450916e263d9aebc  alsa-lib-stdint.patch
+9663e66579fd15901c52b72815612035565b793fa3d9b6cca0d774dab1b4b4c9  ucm_add_limits_h.patch"
 sha512sums="f5dbe2375a8c66af14378314a5238284d4ed63dfc86a750c0c6e8f6cdb6b1ea2d8ef26f870b5d152dc0b77d9b40821cab523f6734902b91583beb08e28c66850  alsa-lib-1.1.3.tar.bz2
 bdf86a1b76b2e6e9b43af33989fe51e4900fa0c6f317d8d746f30c540df647dbe0f6d41ec35b36b1cf7e46cc5e910e0a62bc39c765f849356ecd6e98d1de5885  alsa-lib-poll.patch
-2351262dade9a3c1a3de1b7d1a3a53a634a438b9b8aae7cc69e2b981500051f039e6381359b81392114ec6236e3d513b577bd4bf12c3d2ce1f871cd7651b2cab  alsa-lib-stdint.patch"
+2351262dade9a3c1a3de1b7d1a3a53a634a438b9b8aae7cc69e2b981500051f039e6381359b81392114ec6236e3d513b577bd4bf12c3d2ce1f871cd7651b2cab  alsa-lib-stdint.patch
+3b37652d50809443b5f8e80f8d447108195b0cd66fd917805bb393fc091584b6f3dad4414f568742b61745617e7a695862058a0a0f93dcc31e4c97177a520352  ucm_add_limits_h.patch"

--- a/main/alsa-lib/ppc64le_symbols.patch
+++ b/main/alsa-lib/ppc64le_symbols.patch
@@ -1,0 +1,44 @@
+--- a/include/alsa-symbols.h
++++ b/include/alsa-symbols.h
+@@ -29,19 +29,10 @@
+ #define INTERNAL_CONCAT2_2(Pre, Post) Pre##Post
+ #define INTERNAL(Name) INTERNAL_CONCAT2_2(__, Name)
+ 
+-#ifdef __powerpc64__
+-# define symbol_version(real, name, version) 			\
+-	__asm__ (".symver " ASM_NAME(#real) "," ASM_NAME(#name) "@" #version);	\
+-	__asm__ (".symver ." ASM_NAME(#real) ",." ASM_NAME(#name) "@" #version)
+-# define default_symbol_version(real, name, version) 		\
+-	__asm__ (".symver " ASM_NAME(#real) "," ASM_NAME(#name) "@@" #version);	\
+-	__asm__ (".symver ." ASM_NAME(#real) ",." ASM_NAME(#name) "@@" #version)
+-#else
+ # define symbol_version(real, name, version) \
+ 	__asm__ (".symver " ASM_NAME(#real) "," ASM_NAME(#name) "@" #version)
+ # define default_symbol_version(real, name, version) \
+ 	__asm__ (".symver " ASM_NAME(#real) "," ASM_NAME(#name) "@@" #version)
+-#endif
+ 
+ #ifdef USE_VERSIONED_SYMBOLS
+ #define use_symbol_version(real, name, version) \
+@@ -50,13 +41,6 @@
+ 		default_symbol_version(real, name, version)
+ #else
+ #define use_symbol_version(real, name, version) /* nothing */
+-#ifdef __powerpc64__
+-#define use_default_symbol_version(real, name, version) \
+-	__asm__ (".weak " ASM_NAME(#name)); 			\
+-	__asm__ (".weak ." ASM_NAME(#name)); 			\
+-	__asm__ (".set " ASM_NAME(#name) "," ASM_NAME(#real));		\
+-	__asm__ (".set ." ASM_NAME(#name) ",." ASM_NAME(#real))
+-#else
+ #if defined(__alpha__) || defined(__mips__)
+ #define use_default_symbol_version(real, name, version) \
+         __asm__ (".weak " ASM_NAME(#name)); \
+@@ -65,7 +49,6 @@
+ #define use_default_symbol_version(real, name, version) \
+ 	__asm__ (".weak " ASM_NAME(#name)); \
+ 	__asm__ (".set " ASM_NAME(#name) "," ASM_NAME(#real))
+-#endif
+ #endif
+ #endif
+ 

--- a/main/alsa-lib/ucm_add_limits_h.patch
+++ b/main/alsa-lib/ucm_add_limits_h.patch
@@ -1,0 +1,10 @@
+--- a/src/ucm/parser.c
++++ b/src/ucm/parser.c
+@@ -31,6 +31,7 @@
+  */
+ 
+ #include "ucm_local.h"
++#include <limits.h>
+ #include <dirent.h>
+ 
+ /** The name of the environment variable containing the UCM directory */


### PR DESCRIPTION
These two patches are required to build on ppc64le