### PR TITLE
testing/bloaty: new aport

### DIFF
--- a/testing/bloaty/APKBUILD
+++ b/testing/bloaty/APKBUILD
@@ -1,0 +1,42 @@
+#-*-mode: Shell-script; coding: utf-8;-*-
+# Maintainer: Mitch Tishmack <mitch.tishmack@gmail.com>
+_commitid=2234386bcee7297dfa1b6d8a5d20f95ea4ed9bb0
+_commitid_libfuzzer=e9387f0b6d411e18ca75f08aecfec1238b8e113f
+pkgname=bloaty
+# Fake a version until upstream does one
+# format is simply 0.0.0.0.${commit_count}
+pkgver=0.0_git20170301
+pkgrel=0
+pkgdesc="A size profiler for binaries"
+url="https://github.com/google/bloaty"
+arch="all"
+license="apache"
+depends=""
+makedepends="gcc git"
+# This software has no releases yet, and has git submodules for 3 things
+# I managed to get everything but libFuzzer from a released tarball.
+# Upstream already has an issue from an arch AUR maintainer to fix this.
+source="https://github.com/google/bloaty/archive/${_commitid}.tar.gz
+	https://github.com/google/re2/archive/2017-01-01.tar.gz
+	https://github.com/google/googletest/archive/release-1.8.0.tar.gz
+	byteswap.patch
+	"
+builddir="$srcdir/${pkgname}-${_commitid}"
+
+build() {
+	rmdir third_party/re2 third_party/googletest || return 1	
+	ln -s ../../re2-2017-01-01 third_party/re2 || return 1
+	ln -s ../../googletest-release-1.8.0 third_party/googletest || return 1
+	git clone https://chromium.googlesource.com/chromium/llvm-project/llvm/lib/Fuzzer third_party/libFuzzer || return 1
+	(cd third_party/libFuzzer && git checkout ${_commitid_libfuzzer}) || return 1
+	make || return 1
+}
+
+package() {
+	install -Dm0755 "${builddir}/bloaty" "${pkgdir}/usr/bin/bloaty" || return 1
+	strip "${pkgdir}/usr/bin/bloaty" || return 1
+}
+sha512sums="2e9545623ce4e20318cf8c8a13f006993318841769ebfee62910659c7c66b6099e228975739c70dd6499cbb109b5440aa559a3d384c0f1574748565eeeda7333  2234386bcee7297dfa1b6d8a5d20f95ea4ed9bb0.tar.gz
+52ec99fe1bfb2754e11e3767a561208f14c3e5c03142c37b43df7cf5a406896396854a3776ae536ddf293a770d8ca80f9c761c2c476394693a5954c15550a731  2017-01-01.tar.gz
+1dbece324473e53a83a60601b02c92c089f5d314761351974e097b2cf4d24af4296f9eb8653b6b03b1e363d9c5f793897acae1f0c7ac40149216035c4d395d9d  release-1.8.0.tar.gz
+e768ecb3660364ee18c85e6aacdabf3a83b5961b9b0d684a8766e8a5545c058580456d1732609bde07c89ff37bdc5448efa40ded24d14a96cc03575a53bfef45  byteswap.patch"

--- a/testing/bloaty/APKBUILD
+++ b/testing/bloaty/APKBUILD
@@ -1,7 +1,5 @@
 #-*-mode: Shell-script; coding: utf-8;-*-
 # Maintainer: Mitch Tishmack <mitch.tishmack@gmail.com>
-_commitid=2234386bcee7297dfa1b6d8a5d20f95ea4ed9bb0
-_commitid_libfuzzer=e9387f0b6d411e18ca75f08aecfec1238b8e113f
 pkgname=bloaty
 # Fake a version until upstream does one
 # format is simply 0.0.0.0.${commit_count}
@@ -12,31 +10,38 @@ url="https://github.com/google/bloaty"
 arch="all"
 license="apache"
 depends=""
-makedepends="gcc git"
+makedepends="gcc cmake git"
 # This software has no releases yet, and has git submodules for 3 things
-# I managed to get everything but libFuzzer from a released tarball.
-# Upstream already has an issue from an arch AUR maintainer to fix this.
-source="https://github.com/google/bloaty/archive/${_commitid}.tar.gz
-	https://github.com/google/re2/archive/2017-01-01.tar.gz
-	https://github.com/google/googletest/archive/release-1.8.0.tar.gz
-	byteswap.patch
-	"
-builddir="$srcdir/${pkgname}-${_commitid}"
+#
+# Note, this is just from the snapshot function
+source="https://mitchty.net/bloaty-9572093.tar.xz byteswap.patch"
+builddir="$srcdir/${pkgname}.git"
 
 build() {
-	rmdir third_party/re2 third_party/googletest || return 1	
-	ln -s ../../re2-2017-01-01 third_party/re2 || return 1
-	ln -s ../../googletest-release-1.8.0 third_party/googletest || return 1
-	git clone https://chromium.googlesource.com/chromium/llvm-project/llvm/lib/Fuzzer third_party/libFuzzer || return 1
-	(cd third_party/libFuzzer && git checkout ${_commitid_libfuzzer}) || return 1
 	make || return 1
+}
+
+check() {
+	make test || return 1
 }
 
 package() {
 	install -Dm0755 "${builddir}/bloaty" "${pkgdir}/usr/bin/bloaty" || return 1
 	strip "${pkgdir}/usr/bin/bloaty" || return 1
 }
-sha512sums="2e9545623ce4e20318cf8c8a13f006993318841769ebfee62910659c7c66b6099e228975739c70dd6499cbb109b5440aa559a3d384c0f1574748565eeeda7333  2234386bcee7297dfa1b6d8a5d20f95ea4ed9bb0.tar.gz
-52ec99fe1bfb2754e11e3767a561208f14c3e5c03142c37b43df7cf5a406896396854a3776ae536ddf293a770d8ca80f9c761c2c476394693a5954c15550a731  2017-01-01.tar.gz
-1dbece324473e53a83a60601b02c92c089f5d314761351974e097b2cf4d24af4296f9eb8653b6b03b1e363d9c5f793897acae1f0c7ac40149216035c4d395d9d  release-1.8.0.tar.gz
+
+snapshot() {
+	local dir="bloaty.git"
+	git clone --recursive https://github.com/google/bloaty ${dir}
+	cd ${dir}
+	local commit=$(git rev-parse --short HEAD)
+	rm -fr .git
+	cd ..
+	tar -cf - ${dir} | xz -9 -c - > bloaty-${commit}.tar.xz
+}
+md5sums="3e11665eb48069adcf0cbcdf2c6be419  bloaty-9572093.tar.xz
+2df8e3a50216c21db98fd2a77ccd0599  byteswap.patch"
+sha256sums="cffdcb9f8be6b79bb4d8e42e676fc3b96aee84749e5cf419496731f7cba77a2a  bloaty-9572093.tar.xz
+c47ec9bf72d3c344aa909168710be3dd639bb9324d5e013ead6de7ba94bf731a  byteswap.patch"
+sha512sums="02ab601d0c21c575320c9425caab30b9991083ff131facd00fd57c4cce64a4c9072526091c6899d1280aa966e1609b4d36c2834074d9eb681b822fdb93dbe9cf  bloaty-9572093.tar.xz
 e768ecb3660364ee18c85e6aacdabf3a83b5961b9b0d684a8766e8a5545c058580456d1732609bde07c89ff37bdc5448efa40ded24d14a96cc03575a53bfef45  byteswap.patch"

--- a/testing/bloaty/byteswap.patch
+++ b/testing/bloaty/byteswap.patch
@@ -1,0 +1,15 @@
+diff --git a/src/bloaty.h b/src/bloaty.h
+index df900cc..827002f 100644
+--- a/src/bloaty.h
++++ b/src/bloaty.h
+@@ -34,6 +34,10 @@
+ 
+ #include "re2/re2.h"
+ 
++#ifndef __bswap_16
++#include <byteswap.h>
++#endif
++
+ #define BLOATY_DISALLOW_COPY_AND_ASSIGN(class_name) \
+   class_name(const class_name&) = delete; \
+   void operator=(const class_name&) = delete;


### PR DESCRIPTION
Note, this entire apkbuild is a hack, there is no upstream source
tarball anywhere. So I hacked in the build function to git clone
the source and checkout at a specific known version for now.

Not sure what the best option is in cases like these.