### PR TITLE
main/valgrind: Add ppc64le as a supported arch

### DIFF
--- a/main/valgrind/APKBUILD
+++ b/main/valgrind/APKBUILD
@@ -4,7 +4,7 @@ pkgver=3.12.0
 pkgrel=0
 pkgdesc="A tool to help find memory-management problems in programs"
 url="http://valgrind.org/"
-arch="x86 x86_64 armhf"
+arch="x86 x86_64 armhf ppc64le"
 license="GPL2+"
 depends=""
 # it seems like busybox sed works but the configure script requires GNU sed


### PR DESCRIPTION
Valgrind is well supported on ppc64le. This patch just enable
valgrind on ppc64le. On my test, valgrind compiled and run fine on
Alpine/ppc64le.