### PR TITLE
testing/ghc: multiple cleanups/improvements

### DIFF
--- a/testing/ghc/APKBUILD
+++ b/testing/ghc/APKBUILD
@@ -32,7 +32,32 @@ license="custom:bsd3"
 # that version as it greatly simplifies the apkbuild process. The
 # apks built on 3.5 will not work on any prior version of alpine linux.
 depends="gmp-dev perl gcc>=6.2.1 llvm3.7"
-provides="ghc-bootstrap=$pkgver-r$pkgrel"
+provides="ghc-bootstrap=$pkgver-r$pkgrel
+	haskell-cabal=1.24.2.0
+	haskell-bytestring=0.10.8.1
+	haskell-containers=0.5.7.1
+	haskell-deepseq=1.4.2.0
+	haskell-directory=1.3.0.0
+	haskell-filepath=1.4.1.1
+	haskell-ghc=8.0.2
+	haskell-ghc-boot=8.0.2
+	haskell-ghc-boot-th=8.0.2
+	haskell-ghc-prim=0.5.0.0
+	haskell-ghci=8.0.2
+	haskell-haskeline=0.7.3.0
+	haskell-hoopl=3.10.2.1
+	haskell-hpc=0.6.0.3
+	haskell-integer-gmp=1.0.0.1
+	haskell-pretty=1.1.3.3
+	haskell-process=1.4.3.0
+	haskell-rts=1.0
+	haskell-template-haskell=2.11.1.0
+	haskell-terminfo=0.4.0.2
+	haskell-time=1.6.0.1
+	haskell-transformers=0.5.2.0
+	haskell-unix=2.7.2.1
+	haskell-xhtml=3000.2.1
+	"
 install="$pkgname.post-install"
 
 # ghc build dependencies

--- a/testing/ghc/APKBUILD
+++ b/testing/ghc/APKBUILD
@@ -5,7 +5,7 @@ pkgver=8.0.2
 pkgrel=0
 pkgdesc="The Glasgow Haskell Compiler"
 url="http://haskell.org"
-subpackages="$pkgname-doc"
+subpackages="$pkgname-doc $pkgname-dev"
 arch="x86_64"
 builddir="$srcdir/$pkgname-$pkgver"
 source="http://downloads.haskell.org/~ghc/${pkgver}/ghc-${pkgver}-src.tar.xz
@@ -39,10 +39,10 @@ install="$pkgname.post-install"
 makedepends="
 	$depends
 	autoconf
+	cpio
 	linux-headers
 	musl-dev
 	ncurses-dev
-	gmp-dev
 	libffi-dev
 	zlib-dev
 	binutils-dev
@@ -82,10 +82,23 @@ doc() {
 package() {
 	cd "$builddir"
 	make -j1 DESTDIR="$pkgdir" install || return 1
+	# Can't do a full strip on archives.
+	find "$pkgdir" -type f \( -name "*.so" -o -name "*.a" \) -exec strip --strip-unneeded {} \;
+	find "$pkgdir/usr/lib/ghc-$pkgver/bin" -type f -exec strip {} \;
 	paxmark -m "$pkgdir/usr/lib/ghc-$pkgver/bin/ghc"
 	paxmark -m "$pkgdir/usr/lib/ghc-$pkgver/bin/ghc-iserv"
 	paxmark -m "$pkgdir/usr/lib/ghc-$pkgver/bin/ghc-iserv-dyn"
 	paxmark -m "$pkgdir/usr/lib/ghc-$pkgver/bin/ghc-iserv-prof"
+}
+
+dev() {
+	# Like debian, we split apart the profiled archives/etc...
+	# This drastically reduces the install size of the ghc pkg.
+	cd "${pkgdir}" || return 1
+	install -dm755 "${subpkgdir}" || return 1
+	local PFILES=$(find . \( -type f -o -type l \) \( -name "*.p_*" -o -name "lib*_p.a" \))
+	echo "${PFILES}" | cpio -pamVd "${subpkgdir}" || return 1
+	echo "${PFILES}" | xargs rm -fr || return 1
 }
 
 sha512sums="58ea3853cd93b556ecdc4abd0be079b2621171b8491f59004ea4e036a4cba4470aaafe6591b942e0a50a64bdc47540e01fe6900212a1ef7087850112d9bfc5ef  ghc-8.0.2-src.tar.xz

--- a/testing/ghc/APKBUILD
+++ b/testing/ghc/APKBUILD
@@ -76,8 +76,6 @@ makedepends="
 	ghc-bootstrap
 	"
 
-_ghc_build_tmp="$builddir/tmp"
-
 build() {
 	cd "$builddir"
 	cp mk/build.mk.sample mk/build.mk || return 1

--- a/testing/ghc/APKBUILD
+++ b/testing/ghc/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Mitch Tishmack <mitch.tishmack@gmail.com>
 pkgname=ghc
 pkgver=8.0.2
-pkgrel=0
+pkgrel=1
 pkgdesc="The Glasgow Haskell Compiler"
 url="http://haskell.org"
 subpackages="$pkgname-doc $pkgname-dev"

--- a/testing/ghc/APKBUILD
+++ b/testing/ghc/APKBUILD
@@ -33,7 +33,7 @@ license="custom:bsd3"
 # apks built on 3.5 will not work on any prior version of alpine linux.
 depends="gmp-dev perl gcc>=6.2.1 llvm3.7"
 provides="ghc-bootstrap=$pkgver-r$pkgrel"
-install=""
+install="$pkgname.post-install"
 
 # ghc build dependencies
 makedepends="

--- a/testing/ghc/ghc.post-install
+++ b/testing/ghc/ghc.post-install
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Force ghc-pkg to recache the base installed packages. Necessary as we
+# did make install DESTDIR=... so the cache has invalid locations.
+
+ghc-pkg recache


### PR DESCRIPTION
Multiple commits/changes, consisting of:
- Add a post-install script to recache the ghc pkg db on install so we don't have a warning when running ghc-pkg list
- Split ghc into two disparate packages like in debian, ghc and ghc-prof, the latter being the profiled debugging libraries. Which means if one wants to debug ghc programs they'll need to install ghc-prof.
- Run strip --strip-unneeded on all shared libraries and archives to save some disk space, ~98MiB. There is likely more low hanging fruit here.
- Add provides for the ghc pkgs that ghc itself provides similar to how the arch linux build works.
- Remove a few redundant or unnecessary lines.

I bumped the release version as well due to the changes.