### PR TITLE
testing/cabal: new aport

### DIFF
--- a/testing/cabal/APKBUILD
+++ b/testing/cabal/APKBUILD
@@ -1,0 +1,208 @@
+#-*-mode: Shell-script; coding: utf-8;-*-
+# Maintainer: Mitch Tishmack <mitch.tishmack@gmail.com>
+pkgname=cabal
+pkgver=1.24.0.2
+pkgrel=0
+pkgdesc="The Haskell Cabal"
+url="http://haskell.org"
+arch="x86_64"
+license="bsd3"
+depends="musl zlib gmp"
+# Note, this is a temporary state of affairs using the bootstrap.sh script.
+#
+# Once apkbuilds for ghc pkgs are working the pkg sources can be moved into
+# the makedepends lines.
+makedepends="ghc ghc-dev gmp-dev libffi-dev zlib-dev binutils-gold chrpath"
+install=""
+subpackages="$pkgname-doc"
+source="
+	https://hackage.haskell.org/package/$pkgname-install-$pkgver/$pkgname-install-$pkgver.tar.gz
+	https://hackage.haskell.org/package/mtl-2.2.1/mtl-2.2.1.tar.gz
+	https://hackage.haskell.org/package/mtl-2.2.1/mtl.cabal
+	https://hackage.haskell.org/package/text-1.2.2.1/text-1.2.2.1.tar.gz
+	https://hackage.haskell.org/package/text-1.2.2.1/text.cabal
+	https://hackage.haskell.org/package/parsec-3.1.9/parsec-3.1.9.tar.gz
+	https://hackage.haskell.org/package/parsec-3.1.9/parsec.cabal
+	https://hackage.haskell.org/package/network-2.6.3.1/network-2.6.3.1.tar.gz
+	https://hackage.haskell.org/package/network-2.6.3.1/network.cabal
+	https://hackage.haskell.org/package/network-uri-2.6.1.0/network-uri-2.6.1.0.tar.gz
+	https://hackage.haskell.org/package/network-uri-2.6.1.0/network-uri.cabal
+	https://hackage.haskell.org/package/old-locale-1.0.0.7/old-locale-1.0.0.7.tar.gz
+	https://hackage.haskell.org/package/old-locale-1.0.0.7/old-locale.cabal
+	https://hackage.haskell.org/package/old-time-1.1.0.3/old-time-1.1.0.3.tar.gz
+	https://hackage.haskell.org/package/old-time-1.1.0.3/old-time.cabal
+	https://hackage.haskell.org/package/HTTP-4000.3.3/HTTP-4000.3.3.tar.gz
+	https://hackage.haskell.org/package/HTTP-4000.3.3/HTTP.cabal
+	https://hackage.haskell.org/package/zlib-0.6.1.2/zlib-0.6.1.2.tar.gz
+	https://hackage.haskell.org/package/zlib-0.6.1.2/zlib.cabal
+	https://hackage.haskell.org/package/random-1.1/random-1.1.tar.gz
+	https://hackage.haskell.org/package/random-1.1/random.cabal
+	https://hackage.haskell.org/package/stm-2.4.4.1/stm-2.4.4.1.tar.gz
+	https://hackage.haskell.org/package/stm-2.4.4.1/stm.cabal
+	https://hackage.haskell.org/package/async-2.1.0/async-2.1.0.tar.gz
+	https://hackage.haskell.org/package/async-2.1.0/async.cabal
+	https://hackage.haskell.org/package/base16-bytestring-0.1.1.6/base16-bytestring-0.1.1.6.tar.gz
+	https://hackage.haskell.org/package/base16-bytestring-0.1.1.6/base16-bytestring.cabal
+	https://hackage.haskell.org/package/base64-bytestring-1.0.0.1/base64-bytestring-1.0.0.1.tar.gz
+	https://hackage.haskell.org/package/base64-bytestring-1.0.0.1/base64-bytestring.cabal
+	https://hackage.haskell.org/package/cryptohash-sha256-0.11.100.1/cryptohash-sha256-0.11.100.1.tar.gz
+	https://hackage.haskell.org/package/cryptohash-sha256-0.11.100.1/cryptohash-sha256.cabal
+	https://hackage.haskell.org/package/ed25519-0.0.5.0/ed25519-0.0.5.0.tar.gz
+	https://hackage.haskell.org/package/ed25519-0.0.5.0/ed25519.cabal
+	https://hackage.haskell.org/package/tar-0.5.0.3/tar-0.5.0.3.tar.gz
+	https://hackage.haskell.org/package/tar-0.5.0.3/tar.cabal
+	https://hackage.haskell.org/package/hashable-1.2.4.0/hashable-1.2.4.0.tar.gz
+	https://hackage.haskell.org/package/hashable-1.2.4.0/hashable.cabal
+	https://hackage.haskell.org/package/hackage-security-0.5.2.2/hackage-security-0.5.2.2.tar.gz
+	https://hackage.haskell.org/package/hackage-security-0.5.2.2/hackage-security.cabal
+	cabal-0001-force-ld.gold.patch
+	cabal-0002-busybox-od.patch
+	cabal-0003-use-apkbuild-downloads.patch
+	"
+builddir="$srcdir/$pkgname-install-$pkgver"
+
+build() {
+	cd "$builddir"
+	(
+		export HOME="$builddir"
+		export NO_DOCUMENTATION=1
+		export EXTRA_BUILD_OPTS="--ghc-option=-fllvm"
+		./bootstrap.sh || return 1
+	) || return 1
+}
+
+doc() {
+	default_doc
+	install -Dm644 "$builddir/LICENSE" "$subpkgdir/usr/share/licenses/$pkgname/LICENSE" || return 1
+}
+
+package() {
+	install -Dm755 "$builddir/dist/build/cabal/cabal" "$pkgdir/usr/bin/cabal" || return 1
+	chrpath -d "$pkgdir/usr/bin/cabal" || return 1
+}
+md5sums="2577c3d7712a74614bf7cc63a5341cab  cabal-install-1.24.0.2.tar.gz
+96a2f12b94ea8d7cb0aea999cd2e3802  mtl-2.2.1.tar.gz
+f8af722835c85e469308c1f2090a6715  mtl.cabal
+c9fedfc2e292c869b7139a592922d56a  text-1.2.2.1.tar.gz
+175197b1dbc672476158e5758eb2f9b0  text.cabal
+6ec46302afa68518bac5f1117b6349f5  parsec-3.1.9.tar.gz
+fc209a167c45c3b7d9ce42f06bbd8c64  parsec.cabal
+6144fe9ff2edf2cfb2ce73f1c49c199c  network-2.6.3.1.tar.gz
+cec609eb57cfd649aba119c474f8d68a  network.cabal
+c6ed1e8314a9b1674a3d118d9019a229  network-uri-2.6.1.0.tar.gz
+08b68241f803185c9f431fb23a7d46a3  network-uri.cabal
+507bd2d3ce2407403e2a2d1136c3d149  old-locale-1.0.0.7.tar.gz
+bf9c7168c28e0fa46e740bd840cc2c33  old-locale.cabal
+1868eaf39e616176d898bcd5510e1f09  old-time-1.1.0.3.tar.gz
+067e6da36eb00a9509ddaf6f289b4c3c  old-time.cabal
+3f2d84d59e36476ca02c882419632d7d  HTTP-4000.3.3.tar.gz
+22dcebd57f21e955053ba77ac26dfdb5  HTTP.cabal
+909b3f6ece5884c084ee5c62719d75cd  zlib-0.6.1.2.tar.gz
+c9c02fb05e738b71520db6152548f18c  zlib.cabal
+474f10b9389b316e4472b71d20298993  random-1.1.tar.gz
+ed87f4f2849499a7e8c16f5eae9318dc  random.cabal
+480b37cce3d35c11fd67bf9df957ae19  stm-2.4.4.1.tar.gz
+e456b4eb592ba248249ff8b6f4cd57fc  stm.cabal
+8e10f5773417b8e3da61a702e00b3e4e  async-2.1.0.tar.gz
+4f57815727d88178237d9b3afe8e72d6  async.cabal
+b6aac9d679d7dd84c3cd23cbc143eb29  base16-bytestring-0.1.1.6.tar.gz
+8e765c25722c4d4b58b55efb79280efb  base16-bytestring.cabal
+bfe70cca4c75f09f02a8299e19421afc  base64-bytestring-1.0.0.1.tar.gz
+c7ea1c3faf18ebdb4868df0fcbf205c9  base64-bytestring.cabal
+b9921fda93a5a6e97095c87d001c5df0  cryptohash-sha256-0.11.100.1.tar.gz
+c852f6eb6459fb488e66c381c912043c  cryptohash-sha256.cabal
+5dd00a5576601dd8e0cd851762a5545c  ed25519-0.0.5.0.tar.gz
+d8181b822a053c701520b224441e0554  ed25519.cabal
+7ffff63b185395f8bebcb5407a551363  tar-0.5.0.3.tar.gz
+6c3ce8c889209808bfecde96cda7a1aa  tar.cabal
+55c2b3ce96fb4861e1f6e6b50a8182cc  hashable-1.2.4.0.tar.gz
+5894aa2ffdb18995fcb195e305feb441  hashable.cabal
+7bbcd32f60b445d7246f67a37cac6f46  hackage-security-0.5.2.2.tar.gz
+d04fa81a8923d45017b8655a93d4b176  hackage-security.cabal
+dbdcab13dfd1c0afac66ad5213885fc0  cabal-0001-force-ld.gold.patch
+b0925fd8578a470b832eee55ba219947  cabal-0002-busybox-od.patch
+9cfa5a6f911bf81e4aec67a2178dd6ec  cabal-0003-use-apkbuild-downloads.patch"
+sha256sums="2ac8819238a0e57fff9c3c857e97b8705b1b5fef2e46cd2829e85d96e2a00fe0  cabal-install-1.24.0.2.tar.gz
+cae59d79f3a16f8e9f3c9adc1010c7c6cdddc73e8a97ff4305f6439d855c8dc5  mtl-2.2.1.tar.gz
+4b5a800fe9edf168fc7ae48c7a3fc2aab6b418ac15be2f1dad43c0f48a494a3b  mtl.cabal
+1addb1bdf36293c996653c9a0a320b5491714495862d997a23fb1ecd41ff395b  text-1.2.2.1.tar.gz
+80a2cd9cd9a28be71554bfb70118d0dad758f69bf56da7a0d26684a1bf9802fd  text.cabal
+71f711d24c89581a43b8bc2d3ed56a1a802bbf1cd0b083bc34636c232b0342c9  parsec-3.1.9.tar.gz
+1a5fa970387ef40c68f46e817704b305c1f6ff5d45a5c4fde386144cefe3346b  parsec.cabal
+57045f5e2bedc095670182130a6d1134fcc65d097824ac5b03933876067d82e6  network-2.6.3.1.tar.gz
+a27e6da69052aa584fbbcaebbfa630afe09650bc39739a766fb339282943b459  network.cabal
+423e0a2351236f3fcfd24e39cdbc38050ec2910f82245e69ca72a661f7fc47f0  network-uri-2.6.1.0.tar.gz
+fd8a39c99060632e6bb106e36e3e6cfbf57e420b4cf998bd6087529ac339b64d  network-uri.cabal
+dbaf8bf6b888fb98845705079296a23c3f40ee2f449df7312f7f7f1de18d7b50  old-locale-1.0.0.7.tar.gz
+f87c7c0495bf863c82ca051e68b10b3133a286aed11f0291253385a5856a6ceb  old-locale.cabal
+1ccb158b0f7851715d36b757c523b026ca1541e2030d02239802ba39b4112bc1  old-time-1.1.0.3.tar.gz
+c1a016dd23d38e879b7972ce95f22b1498d39fc62a7b755ff5f344bfeeaf796e  old-time.cabal
+bbada3c2088dc1384234cdbc1bb6089ea588da068a6a38878ea259dd19de9bf2  HTTP-4000.3.3.tar.gz
+146f0a10b70788f012c1c69675866a2d5f236d1cbcfefb5d0293f847929a6073  HTTP.cabal
+e4eb4e636caf07a16a9730ce469a00b65d5748f259f43edd904dd457b198a2bb  zlib-0.6.1.2.tar.gz
+a0ac2b650ec3c38ff041e4da5a3b6969c1ca68a730fcd95d9ed78294305c6768  zlib.cabal
+b718a41057e25a3a71df693ab0fe2263d492e759679b3c2fea6ea33b171d3a5a  random-1.1.tar.gz
+7b67624fd76ddf97c206de0801dc7e888097e9d572974be9b9ea6551d76965df  random.cabal
+8f999095ed8d50d2056fc6e185035ee8166c50751e1af8de02ac38d382bf3384  stm-2.4.4.1.tar.gz
+d472f408cf790bcccf81a97b53c429dbfefaa4ffbde48a9588e52520f0568dac  stm.cabal
+93c37611f9c68b5cdc8cd9960ae77a7fbc25da83cae90137ef1378d857f22c2f  async-2.1.0.tar.gz
+2b23aa16ab74b2f87487bdf2d2321f43dcd9222ba3291a742c9443dbf20a42fe  async.cabal
+5afe65a152c5418f5f4e3579a5e0d5ca19c279dc9bf31c1a371ccbe84705c449  base16-bytestring-0.1.1.6.tar.gz
+ead535a30f93189068b3457496e30e3cb8a55d48b2d46f39325233d0d9987d2c  base16-bytestring.cabal
+ab25abf4b00a2f52b270bc3ed43f1d59f16c8eec9d7dffb14df1e9265b233b50  base64-bytestring-1.0.0.1.tar.gz
+40e088e357790fe3709ff7b9dd18d79b866e2936b13ade184bc9355315fb3ab5  base64-bytestring.cabal
+57b02338e9648639335788b422dd4c744543cb0991347472e2e3628a33c2f5d6  cryptohash-sha256-0.11.100.1.tar.gz
+f25348d77bf493f08cad42d6df91dafa8fda3c67ea99c716423eae2211e7818d  cryptohash-sha256.cabal
+d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d  ed25519-0.0.5.0.tar.gz
+2e051ab9d98bc22e0c4afe09e763d3e8e0571ea51a3ae952db33ac89e58006b3  ed25519.cabal
+d8d9ad876365f88bdccd02073049e58715cd5ba94de06eb98e21d595244918a3  tar-0.5.0.3.tar.gz
+bd1f49caeff1cedfbf0e290491b8b8af6ec399980bfe5fa3ced445ba6646554e  tar.cabal
+fb9671db0c39cd48d38e2e13e3352e2bf7dfa6341edfe68789a1753d21bb3cf3  hashable-1.2.4.0.tar.gz
+33a49b3ea87cc4a0c89a4fd48f19e4807d8c620aff710a048a28cf7d9c9b4620  hashable.cabal
+507a837851264a774c8f4d400f798c3dac5be11dc428fe72d33ef594ca533c41  hackage-security-0.5.2.2.tar.gz
+678fde798c4291a66cc8d0497c1df558292dd8526b46132d6c651dc090ef0e5a  hackage-security.cabal
+9b376e1743e4a8cc6b422bd6cef6c08a4e74d83ec2712a4d5a66c2aaccb482d6  cabal-0001-force-ld.gold.patch
+30f1ebb9833352dc1ca679890ecf2b847f312e4a76aab1577d1b6c39c7d4acd0  cabal-0002-busybox-od.patch
+169cb037d964c422af816163bc7684fb6ef608209ae5f79f429b048c4e459cd6  cabal-0003-use-apkbuild-downloads.patch"
+sha512sums="bd055a52ff0ac697e6f21a588d53dd811d50ee9410659a242c00a5665b360ef10c024df4872b9070c33aa49f779c8817b883b40087d3f4e0be4096a54b2ad5f0  cabal-install-1.24.0.2.tar.gz
+5c31626b15551ee1757ad701b8e5552202bb6fe1dbd002039e3b78c6d01108a5c50f565c4993d165a00eb564d9d72fb8d2aae891b6242f0ca8cb11f7b95c5c6b  mtl-2.2.1.tar.gz
+f3e4665db8aba4aa85c5fc504d7e3aec4474aa497cbf081d8c73bf0bf46b54a00de60acc2b42c821cc4d3f4f5c12c65f7fa421181827c75b09def7d9fb7bf843  mtl.cabal
+f0615f7614127d86dbfb3fba5dd1753af3d0774c46e11ee4a99d4510f73b59cf1bd8c73ca0387dba4fbcea3936aaaf0e92561cf6aab1a98d08fcad481d3795e4  text-1.2.2.1.tar.gz
+a90e248e697f853f813db9e6278a394c991a41ceb40e92a9713f453abf3463cd5d38dcd6214c7cf1e2bfc2291972766f788226d520e5283f75871975e1cee193  text.cabal
+bc5209813ad0742c68c275f0ecd3e284b6249d2651f75daf16ad9a776003591217eb7d47fdaad88530af90455fe7d3e014c3c1d7d0893482721d4997b23a2d16  parsec-3.1.9.tar.gz
+59f5265437bac81f555065e3434bca5a0ccb88512c1c4339b8b7b3da26fcb12fff7a8f99e4202ada02d4d0f0fd3eed99457679ccb6b815e682577841fcebe0be  parsec.cabal
+3c23ef0a1bf5383cc2479a517875037f9de38c79c1293734cc723111ab880a5842e091ee91a612090d0a2e422d53028d17cf5b0800af0d1d6c983d564197b9a6  network-2.6.3.1.tar.gz
+a0c5deb6fa450d3f368cb6578ed7c1139509e8279bac18d25b0094544eaccf2f429c6e65ea454efc20576d316057c3b02a3e5622ed58bb9014297fa09183fde1  network.cabal
+c1b6e516cd19875aab0da325dcb8f5c6b98d43c3952bda4f96bd9c798882357c724b2facbef09e2e98d29b696a9e5518a2de9463fb0af4c5df0734fe2654cc24  network-uri-2.6.1.0.tar.gz
+03e07ba42e7e0699b77e78fe4c3fc76dc1f8840d8478ecb804c9d33e48323fce3f9bccad70e9ef12dda855a503d86209b9039854a0a1e577525b43b43098dd49  network-uri.cabal
+34d018cb040de9adce3ddb8cffabe2a0610f6cd0ff5340ee721b7076671bd5cc3e830f58d16e73240df4b068510f7a24fd1995efc38f002b52d228abc4581d6a  old-locale-1.0.0.7.tar.gz
+5efe4be2b309bf30e7ff6796e84a9dabc0106f64046cd1aa6ace67abf39cfd47dcf3e9a6c3b4f44f47b1f5fce7a1b928524052d5e16afbd77c8200f8f02ab090  old-locale.cabal
+a701c62266f9f3c6dc60eba970b6c25a61bf82b6b8bb6b0073e0e44908598926fe7813a7ae1b1f9da98e4861a8f0565d0bd025cb97307b71c08cb9b0b2e321bb  old-time-1.1.0.3.tar.gz
+9d287b87bad23ab46c1692b81c14996e04742b77d1949c2aecfd60a9399db3dcd84603c3e122635beb19d56b31ef3e93d9cf501e0f9133e88222f4c614e0734a  old-time.cabal
+4e43efef355f4194ff7a29542babc9dd873f73b1a94092c83a882d79533704ba47be9320bd715425c56515d1709d729adc9ed1e5c273d39e9879f03304eeb7e7  HTTP-4000.3.3.tar.gz
+87f02cc9fc5eec9114c269c8448f7450c8e926fd1e64a227a7b9d03c40714afb075e061fb26f3395d0ccee90321a919796c4ed2ebd8c03bb99f5193fea485e60  HTTP.cabal
+0034eb1297eaf20ab64e5cbfc835cee1985d34bc248325bf57f7bf5cdf2918ab72f339fe5b8b3f5f16dee862f190e0c71612960b9021cf2ca70c951788b73fc1  zlib-0.6.1.2.tar.gz
+8df23c6989663d1abd8aa5854bafeb8496188f1dcacbecab21343c122fae518941bf05a7d80e6ca4c5333a4e71dc6739f0dad96a8c1866353875d663a5e460b3  zlib.cabal
+7f128b1c88adfe7ee6405578d3c999bb77e9e3c21e16f82a5197c0ad1d6731851e99e08d8169c6a8b1068ad8a1614c1c0ef8c04c1958337a6e325f1de0c718a3  random-1.1.tar.gz
+cccc9fe05ec22db1e9e1399c9807e49f1312211fb9739a2ae3a455cc2fd00c1d9a74e64380541d83bb9b34fb02f00d80c67f2c1368ff7d1d631b7152b981d175  random.cabal
+12a8edb7489995245fb21d9f0782cad87e992f56343d4492eef788370ebc2dcb934193d8602b85b5f3935c4bdb4c9426717b6149437cd7b0bb5311bda4b237eb  stm-2.4.4.1.tar.gz
+3ee1168e333402123d35561a7f81467bc23d2cfc4d31180eb610e76d3d4017fea8401ebf6c9b0c602247c3f6929f4205ef823d5d4af6553828ed1ba23b6056db  stm.cabal
+7c68218c7d63e6db31e626dbe7bacb44b0c24ba5a224afc70c09ed1f7b9d8ff8e1f932a97e34657b48db2d1ab4ed76d69c0ea6101cfc9afb8e8d40d617f37648  async-2.1.0.tar.gz
+dba826ec9fdbf546e2bbd686d93fefe23c2f5a764ac80d0d932575e23d2ba44b5d932822e7d41e2520b59e0972c26b1476b5fb02397d842692de70007468547a  async.cabal
+699bc1f7819a1c0cea0154626f8799301bc9360bc997a5e9313a605ec33ea04d77219b100693021fd43e01d8d979374db07e6e3fabef5301c411f335e30a8cba  base16-bytestring-0.1.1.6.tar.gz
+7245e3101ef496313bab5e27f72a8fd8fde3942e838092b8a54b3a7cf918b3c818a88f73c96271c059fd97255fd513074b6c121132d9c3e6157da490be9150fa  base16-bytestring.cabal
+6936b34955b89a275f5bd71c74bbad2be6ff9e2023ac652bdbc9c5b10dd624e3862fc348849858fdb5c7b8aacc36ab4cda8bc6ea797c129b6b28d7e2e2e610e7  base64-bytestring-1.0.0.1.tar.gz
+f535e3bb7142c57b6f2e22e1f53f9e70f231568a7e3f2e574d49454604fa81be5c108cbff876d6027302b8b46a6524548f4cb290dc93d3e9fe324b1ab1746c9d  base64-bytestring.cabal
+df6a8c7a4796f3b94faf0c1073b552eccf7dfbe6ab1489fef391e6342f34b3cb29991d1313aa5da11a90cb37bcd43c23eea12073ad4c7190926005de952c39e2  cryptohash-sha256-0.11.100.1.tar.gz
+af2caec148a302861aa93decbf91a987bb3e10e60d97a2643da0ec08b1bcbd88f265b6196af75e9a5e92a80894249e9694e8a51ec0273ce6d5f482c5526f5398  cryptohash-sha256.cabal
+cd2bb28de905c6d659f80f15e82970a9634c959432c73b6fd3b10ebca42a1ce734429e7ac861d0ab328904d99651a6d2fcaaf4d74ab75a3c0be68607e8f54ce9  ed25519-0.0.5.0.tar.gz
+9e10bb302e48899dd80256a6ec76debc70a6c0789d2cd8694f413a2880fd3f14e3a3d40d5506ae0fa75c663f5dfa3a8eff612dae2249b4641a29fbfa62219035  ed25519.cabal
+f90899e3a5fe097645e29b143cbf25ccf131f8b794bfea655e5b562369e4d7d492df78e53710d3ca4776233f07ace9335242eafbd3b4ba8d0e1d4664fd24a27d  tar-0.5.0.3.tar.gz
+ba0dfcfa2211fd7ae41ef25492a5d1cee25f0e5a55779f9e6c2387a47e663402a5d59f46af4b22cc3148eb027183f9f060b9aa06189d1ce926ebad9fd4daa780  tar.cabal
+992027ce617e347414e328e05afe69b8621fb1af21fef58836761d2002a1f9f7f97c981ff3c4fe8699a1da124771df575717ed4e3fd0bbe5c62d81be1322dbf6  hashable-1.2.4.0.tar.gz
+7cd8b8a8998ef3d3bd6093c1b872fe0ba8a438abb7189d22df5bae291b5a3987a36cc647c43545ba7d2275512d31e9b77e9823da2431cf7402bfe3d26da77fc6  hashable.cabal
+5adab3c46d7aada8668128ad8c9389ca65489eec776f8571b8ee5834d74b961f19b558cb6642cbb1891ee381b2d4f2019dddf29bad13607fe23bef49a3d6f535  hackage-security-0.5.2.2.tar.gz
+844853ea8ebadad034f0ac7f59f2e800b87ee4b3625220a07b12212d8f83db320e8767cacb8e9d23afe41265e4eade63d20d78329cb009703d0f7de6b4278c21  hackage-security.cabal
+cb83ea703c3d0d5124a9f35606250c5bc71b67c141512bcdaa285b8a9bb99c5ca34ad1c3cf0c73ea0486215bb46285989ada4967f7e7a972e58cefdbc4eab8a9  cabal-0001-force-ld.gold.patch
+103f404ed135e14118ee41c1ce960597912998792af520ab3314cda3db4d4285cbd4c44b2fcc8cea7beee07d2cb0bfd6b2d3e8978e3bdb9897ec2f56e814f7b0  cabal-0002-busybox-od.patch
+2931021267f601427a3ad2a1a6589f9ab2dce75de3f9fa06e53c8a93748d45fb87c1f76e23ab080f2100c29dd89d4c542f8f78f149ba116ffd4ebb47730c9726  cabal-0003-use-apkbuild-downloads.patch"

--- a/testing/cabal/cabal-0001-force-ld.gold.patch
+++ b/testing/cabal/cabal-0001-force-ld.gold.patch
@@ -1,0 +1,10 @@
+--- a/bootstrap.sh.original	2016-02-10 06:45:52.000000000 -0600
++++ a/bootstrap.sh	2016-03-18 23:28:06.000000000 -0500
+@@ -74,6 +74,7 @@
+ 
+ # Fall back to "ld"... might work.
+ [ -$LINK- = -""- ] && LINK=ld
++LINK="ld.gold"
+ 
+ # And finally, see if we can compile and link something.
+   echo 'int main(){}' | $CC -xc - -o /dev/null ||

--- a/testing/cabal/cabal-0002-busybox-od.patch
+++ b/testing/cabal/cabal-0002-busybox-od.patch
@@ -1,0 +1,11 @@
+--- a/bootstrap.sh
++++ b/bootstrap.sh
+@@ -53,7 +53,7 @@
+ 
+ # Try to respect $TMPDIR.
+ [ -"$TMPDIR"- = -""- ] &&
+-  export TMPDIR=/tmp/cabal-$(echo $(od -XN4 -An /dev/random)) && mkdir $TMPDIR
++  export TMPDIR=/tmp/cabal-$(echo $(od -tx2 -N4 -An /dev/random | tr -cd [0-9a-f])) && mkdir $TMPDIR
+ 
+ # Check for a C compiler, using user-set $CC, if any, first.
+ for c in $CC gcc clang cc icc; do

--- a/testing/cabal/cabal-0003-use-apkbuild-downloads.patch
+++ b/testing/cabal/cabal-0003-use-apkbuild-downloads.patch
@@ -1,0 +1,24 @@
+--- a/bootstrap.sh
++++ b/bootstrap.sh
+@@ -392,18 +392,10 @@
+ 
+   if need_pkg ${PKG} ${VER_MATCH}
+   then
+-    echo
+-    if [ -r "${PKG}-${VER}.tar.gz" ]
+-    then
+-        echo "Using local tarball for ${PKG}-${VER}."
+-    else
+-        echo "Downloading ${PKG}-${VER}..."
+-        fetch_pkg ${PKG} ${VER}
+-    fi
+-    unpack_pkg ${PKG} ${VER}
+-    cd "${PKG}-${VER}"
++    cd "../${PKG}-${VER}"
++    cp "../${PKG}.cabal" .
+     install_pkg ${PKG} ${VER}
+-    cd ..
++    cd ../cabal-install-*
+   fi
+ }
+ 


### PR DESCRIPTION
Add an initial version of cabal-install, aka the cabal package manager
for ghc.

Note this version uses bootstrap.sh, this is a temporary measure until
I can get autogenerated APKBUILD files via updates to cblrepo.

Note, this relies on #914 with its ghc/ghc-dev separation.