### PR TITLE
testing/libwrap && testing/tcp-wrappers: new aport

### DIFF
--- a/testing/libwrap/00-tcpw7.2-config.patch
+++ b/testing/libwrap/00-tcpw7.2-config.patch
@@ -1,0 +1,94 @@
+diff -up tcp_wrappers_7.6/Makefile.patch1 tcp_wrappers_7.6/Makefile
+--- tcp_wrappers_7.6/Makefile.patch1	1997-03-21 19:27:21.000000000 +0100
++++ tcp_wrappers_7.6/Makefile	2008-08-29 09:45:12.000000000 +0200
+@@ -44,7 +44,7 @@ what:
+ #REAL_DAEMON_DIR=/usr/etc
+ #
+ # SysV.4 Solaris 2.x OSF AIX
+-#REAL_DAEMON_DIR=/usr/sbin
++REAL_DAEMON_DIR=/usr/sbin
+ #
+ # BSD 4.4
+ #REAL_DAEMON_DIR=/usr/libexec
+@@ -144,7 +144,7 @@ freebsd:
+ linux:
+ 	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
+ 	LIBS= RANLIB=ranlib ARFLAGS=rv AUX_OBJ=setenv.o \
+-	NETGROUP= TLI= EXTRA_CFLAGS="-DBROKEN_SO_LINGER -DUSE_STRERROR" all
++	NETGROUP= TLI= EXTRA_CFLAGS="$(RPM_OPT_FLAGS) -DUSE_STRERROR -DSYS_ERRLIST_DEFINED -DBROKEN_SO_LINGER" all
+ 
+ # This is good for many SYSV+BSD hybrids with NIS, probably also for HP-UX 7.x.
+ hpux hpux8 hpux9 hpux10:
+@@ -491,7 +491,7 @@ VSYSLOG	= -Dvsyslog=myvsyslog
+ # Uncomment the next definition to turn on the language extensions
+ # (examples: allow, deny, banners, twist and spawn).
+ # 
+-#STYLE	= -DPROCESS_OPTIONS	# Enable language extensions.
++STYLE	= -DPROCESS_OPTIONS	# Enable language extensions.
+ 
+ ################################################################
+ # Optional: Changing the default disposition of logfile records
+@@ -514,7 +514,8 @@ VSYSLOG	= -Dvsyslog=myvsyslog
+ #
+ # The LOG_XXX names below are taken from the /usr/include/syslog.h file.
+ 
+-FACILITY= LOG_MAIL	# LOG_MAIL is what most sendmail daemons use
++#FACILITY= LOG_MAIL 	# LOG_MAIL is what most sendmail daemons use
++FACILITY= LOG_AUTHPRIV	# LOG_AUTHPRIV is more appropriate for RH 2.0
+ 
+ # The syslog priority at which successful connections are logged.
+ 
+@@ -531,7 +532,7 @@ SEVERITY= LOG_INFO	# LOG_INFO is normall
+ # and with Solaris < 2.4. APPEND_DOT will not work with hostnames taken
+ # from /etc/hosts or from NIS maps. It does work with DNS through NIS.
+ #
+-# DOT= -DAPPEND_DOT
++DOT= -DAPPEND_DOT
+ 
+ ##################################################
+ # Optional: Always attempt remote username lookups
+@@ -551,7 +552,7 @@ SEVERITY= LOG_INFO	# LOG_INFO is normall
+ # still do selective username lookups as documented in the hosts_access.5
+ # and hosts_options.5 manual pages (`nroff -man' format).
+ #
+-#AUTH	= -DALWAYS_RFC931
++AUTH	= #-DALWAYS_RFC931
+ #
+ # The default username lookup timeout is 10 seconds. This may not be long
+ # enough for slow hosts or networks, but is enough to irritate PC users.
+@@ -610,7 +611,7 @@ TABLES	= -DHOSTS_DENY=\"/etc/hosts.deny\
+ # Paranoid mode implies hostname lookup. In order to disable hostname
+ # lookups altogether, see the next section.
+ 
+-PARANOID= -DPARANOID
++PARANOID= #-DPARANOID
+ 
+ ########################################
+ # Optional: turning off hostname lookups
+@@ -623,7 +624,7 @@ PARANOID= -DPARANOID
+ # In order to perform selective hostname lookups, disable paranoid
+ # mode (see previous section) and comment out the following definition.
+ 
+-HOSTNAME= -DALWAYS_HOSTNAME
++HOSTNAME= #-DALWAYS_HOSTNAME
+ 
+ #############################################
+ # Optional: Turning on host ADDRESS checking
+@@ -649,7 +650,7 @@ HOSTNAME= -DALWAYS_HOSTNAME
+ # source-routed traffic in the kernel. Examples: 4.4BSD derivatives,
+ # Solaris 2.x, and Linux. See your system documentation for details.
+ #
+-# KILL_OPT= -DKILL_IP_OPTIONS
++KILL_OPT= -DKILL_IP_OPTIONS
+ 
+ ## End configuration options
+ ############################
+@@ -659,7 +660,7 @@ HOSTNAME= -DALWAYS_HOSTNAME
+ SHELL	= /bin/sh
+ .c.o:;	$(CC) $(CFLAGS) -c $*.c
+ 
+-CFLAGS	= -O -DFACILITY=$(FACILITY) $(ACCESS) $(PARANOID) $(NETGROUP) \
++CFLAGS	= -DFACILITY=$(FACILITY) $(ACCESS) $(PARANOID) $(NETGROUP) \
+ 	$(BUGS) $(SYSTYPE) $(AUTH) $(UMASK) \
+ 	-DREAL_DAEMON_DIR=\"$(REAL_DAEMON_DIR)\" $(STYLE) $(KILL_OPT) \
+ 	-DSEVERITY=$(SEVERITY) -DRFC931_TIMEOUT=$(RFC931_TIMEOUT) \

--- a/testing/libwrap/01-tcpw7.2-setenv.patch
+++ b/testing/libwrap/01-tcpw7.2-setenv.patch
@@ -1,0 +1,12 @@
+diff -up tcp_wrappers_7.6/Makefile.patch2 tcp_wrappers_7.6/Makefile
+--- tcp_wrappers_7.6/Makefile.patch2	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/Makefile	2008-08-29 09:45:12.000000000 +0200
+@@ -143,7 +143,7 @@ freebsd:
+ 
+ linux:
+ 	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
+-	LIBS= RANLIB=ranlib ARFLAGS=rv AUX_OBJ=setenv.o \
++	LIBS= RANLIB=ranlib ARFLAGS=rv AUX_OBJ= \
+ 	NETGROUP= TLI= EXTRA_CFLAGS="$(RPM_OPT_FLAGS) -DUSE_STRERROR -DSYS_ERRLIST_DEFINED -DBROKEN_SO_LINGER" all
+ 
+ # This is good for many SYSV+BSD hybrids with NIS, probably also for HP-UX 7.x.

--- a/testing/libwrap/02-tcpw7.6-netgroup.patch
+++ b/testing/libwrap/02-tcpw7.6-netgroup.patch
@@ -1,0 +1,14 @@
+diff -up tcp_wrappers_7.6/Makefile.patch3 tcp_wrappers_7.6/Makefile
+--- tcp_wrappers_7.6/Makefile.patch3	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/Makefile	2008-08-29 09:45:12.000000000 +0200
+@@ -143,8 +143,8 @@ freebsd:
+ 
+ linux:
+ 	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
+-	LIBS= RANLIB=ranlib ARFLAGS=rv AUX_OBJ= \
+-	NETGROUP= TLI= EXTRA_CFLAGS="$(RPM_OPT_FLAGS) -DUSE_STRERROR -DSYS_ERRLIST_DEFINED -DBROKEN_SO_LINGER" all
++	LIBS="-lnsl" RANLIB=ranlib ARFLAGS=rv AUX_OBJ= \
++	NETGROUP="-DNETGROUP" TLI= EXTRA_CFLAGS="$(RPM_OPT_FLAGS) -DUSE_STRERROR -DSYS_ERRLIST_DEFINED -DBROKEN_SO_LINGER" all
+ 
+ # This is good for many SYSV+BSD hybrids with NIS, probably also for HP-UX 7.x.
+ hpux hpux8 hpux9 hpux10:

--- a/testing/libwrap/03-tcp_wrappers-7.6-bug11881.patch
+++ b/testing/libwrap/03-tcp_wrappers-7.6-bug11881.patch
@@ -1,0 +1,37 @@
+diff -up tcp_wrappers_7.6/eval.c.patch4 tcp_wrappers_7.6/eval.c
+--- tcp_wrappers_7.6/eval.c.patch4	1995-01-30 19:51:46.000000000 +0100
++++ tcp_wrappers_7.6/eval.c	2008-08-29 09:45:12.000000000 +0200
+@@ -111,7 +111,7 @@ struct request_info *request;
+ 	return (hostinfo);
+ #endif
+     if (STR_NE(eval_user(request), unknown)) {
+-	sprintf(both, "%s@%s", request->user, hostinfo);
++	snprintf(both, sizeof(both), "%s@%s", request->user, hostinfo);
+ 	return (both);
+     } else {
+ 	return (hostinfo);
+@@ -128,7 +128,7 @@ struct request_info *request;
+     char   *daemon = eval_daemon(request);
+ 
+     if (STR_NE(host, unknown)) {
+-	sprintf(both, "%s@%s", daemon, host);
++	snprintf(both, sizeof(both), "%s@%s", daemon, host);
+ 	return (both);
+     } else {
+ 	return (daemon);
+diff -up tcp_wrappers_7.6/tcpd.c.patch4 tcp_wrappers_7.6/tcpd.c
+--- tcp_wrappers_7.6/tcpd.c.patch4	1996-02-11 17:01:33.000000000 +0100
++++ tcp_wrappers_7.6/tcpd.c	2008-08-29 09:45:12.000000000 +0200
+@@ -60,10 +60,10 @@ char  **argv;
+      */
+ 
+     if (argv[0][0] == '/') {
+-	strcpy(path, argv[0]);
++	strncpy(path, argv[0], sizeof(path));
+ 	argv[0] = strrchr(argv[0], '/') + 1;
+     } else {
+-	sprintf(path, "%s/%s", REAL_DAEMON_DIR, argv[0]);
++	snprintf(path, sizeof(path), "%s/%s", REAL_DAEMON_DIR, argv[0]);
+     }
+ 
+     /*

--- a/testing/libwrap/04-tcp_wrappers-7.6-bug17795.patch
+++ b/testing/libwrap/04-tcp_wrappers-7.6-bug17795.patch
@@ -1,0 +1,56 @@
+diff -up tcp_wrappers_7.6/hosts_access.5.patch5 tcp_wrappers_7.6/hosts_access.5
+--- tcp_wrappers_7.6/hosts_access.5.patch5	1995-01-30 19:51:47.000000000 +0100
++++ tcp_wrappers_7.6/hosts_access.5	2008-08-29 09:45:12.000000000 +0200
+@@ -89,6 +89,13 @@ An expression of the form `n.n.n.n/m.m.m
+ bitwise AND of the address and the `mask\'. For example, the net/mask
+ pattern `131.155.72.0/255.255.254.0\' matches every address in the
+ range `131.155.72.0\' through `131.155.73.255\'.
++.IP \(bu
++A string that begins with a `/\' character is treated as a file
++name. A host name or address is matched if it matches any host name
++or address pattern listed in the named file. The file format is
++zero or more lines with zero or more host name or address patterns
++separated by whitespace.  A file name pattern can be used anywhere
++a host name or address pattern can be used.
+ .SH WILDCARDS
+ The access control language supports explicit wildcards:
+ .IP ALL
+diff -up tcp_wrappers_7.6/hosts_access.c.patch5 tcp_wrappers_7.6/hosts_access.c
+--- tcp_wrappers_7.6/hosts_access.c.patch5	1997-02-12 02:13:23.000000000 +0100
++++ tcp_wrappers_7.6/hosts_access.c	2008-08-29 09:45:12.000000000 +0200
+@@ -240,6 +240,26 @@ struct request_info *request;
+     }
+ }
+ 
++/* hostfile_match - look up host patterns from file */
++
++static int hostfile_match(path, host)
++char   *path;
++struct hosts_info *host;
++{
++    char    tok[BUFSIZ];
++    int     match = NO;
++    FILE   *fp;
++
++    if ((fp = fopen(path, "r")) != 0) {
++	while (fscanf(fp, "%s", tok) == 1 && !(match = host_match(tok, host)))
++	     /* void */ ;
++	fclose(fp);
++    } else if (errno != ENOENT) {
++	tcpd_warn("open %s: %m", path);
++    }
++    return (match);
++}
++
+ /* host_match - match host name and/or address against pattern */
+ 
+ static int host_match(tok, host)
+@@ -267,6 +287,8 @@ struct host_info *host;
+ 	tcpd_warn("netgroup support is disabled");	/* not tcpd_jump() */
+ 	return (NO);
+ #endif
++    } else if (tok[0] == '/') {			/* /file hack */
++	return (hostfile_match(tok, host));
+     } else if (STR_EQ(tok, "KNOWN")) {		/* check address and name */
+ 	char   *name = eval_hostname(host);
+ 	return (STR_NE(eval_hostaddr(host), unknown) && HOSTNAME_KNOWN(name));

--- a/testing/libwrap/05-tcp_wrappers-7.6-bug17847.patch
+++ b/testing/libwrap/05-tcp_wrappers-7.6-bug17847.patch
@@ -1,0 +1,102 @@
+--- tcp_wrappers_7.6/hosts_access.5.patch6	2013-01-23 11:10:00.545081410 +0100
++++ tcp_wrappers_7.6/hosts_access.5	2013-01-23 11:10:00.549081436 +0100
+@@ -96,6 +96,10 @@ or address pattern listed in the named f
+ zero or more lines with zero or more host name or address patterns
+ separated by whitespace.  A file name pattern can be used anywhere
+ a host name or address pattern can be used.
++.IP \(bu
++Wildcards `*\' and `?\' can be used to match hostnames or IP addresses.  This
++method of matching cannot be used in conjunction with `net/mask\' matching,
++hostname matching beginning with `.\' or IP address matching ending with `.\'.
+ .SH WILDCARDS
+ The access control language supports explicit wildcards:
+ .IP ALL
+--- tcp_wrappers_7.6/hosts_access.c.patch6	2013-01-23 11:10:00.546081416 +0100
++++ tcp_wrappers_7.6/hosts_access.c	2013-01-23 11:12:28.519925230 +0100
+@@ -376,6 +376,11 @@ char   *string;
+ {
+     int     n;
+ 
++#ifndef DISABLE_WILDCARD_MATCHING
++    if (strchr(tok, '*') || strchr(tok,'?')) {  /* contains '*' or '?' */
++        return (match_pattern_ylo(string,tok)); 	       
++    } else 
++#endif    
+     if (tok[0] == '.') {			/* suffix */
+ 	n = strlen(string) - strlen(tok);
+ 	return (n > 0 && STR_EQ(tok, string + n));
+@@ -417,6 +422,74 @@ char   *string;
+     return ((addr & mask) == net);
+ }
+ 
++#ifndef DISABLE_WILDCARD_MATCHING
++/* Note: this feature has been adapted in a pretty straightforward way
++   from Tatu Ylonen's last SSH version under free license by 
++   Pekka Savola <pekkas@netcore.fi>.
++
++   Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
++*/
++
++/* Returns true if the given string matches the pattern (which may contain
++   ? and * as wildcards), and zero if it does not match. */
++	  
++int match_pattern_ylo(const char *s, const char *pattern)
++{
++  while (1)
++    {
++      /* If at end of pattern, accept if also at end of string. */
++      if (!*pattern)
++        return !*s;
++
++      /* Process '*'. */
++      if (*pattern == '*')
++        {
++	  /* Skip the asterisk. */
++	  pattern++;
++
++	  /* If at end of pattern, accept immediately. */
++          if (!*pattern)
++            return 1;
++
++	  /* If next character in pattern is known, optimize. */
++          if (*pattern != '?' && *pattern != '*')
++            {
++	      /* Look instances of the next character in pattern, and try
++		 to match starting from those. */
++              for (; *s; s++)
++                if (*s == *pattern &&
++                    match_pattern_ylo(s + 1, pattern + 1))
++                  return 1;
++	      /* Failed. */
++              return 0;
++            }
++
++	  /* Move ahead one character at a time and try to match at each
++	     position. */
++          for (; *s; s++)
++            if (match_pattern_ylo(s, pattern))
++              return 1;
++	  /* Failed. */
++          return 0;
++        }
++
++      /* There must be at least one more character in the string.  If we are
++	 at the end, fail. */
++      if (!*s)
++        return 0;
++
++      /* Check if the next character of the string is acceptable. */
++      if (*pattern != '?' && *pattern != *s)
++	return 0;
++      
++      /* Move to the next character, both in string and in pattern. */
++      s++;
++      pattern++;
++    }
++  /*NOTREACHED*/
++}
++#endif /* DISABLE_WILDCARD_MATCHING */
++
+ #ifdef HAVE_IPV6
+ /*
+  * Function that zeros all but the first "maskbits" bits of the IPV6 address

--- a/testing/libwrap/06-tcp_wrappers-7.6-fixgethostbyname.patch
+++ b/testing/libwrap/06-tcp_wrappers-7.6-fixgethostbyname.patch
@@ -1,0 +1,27 @@
+--- tcp_wrappers_7.6-ipv6.4/socket.c.patch7	1999-10-27 15:23:14.000000000 +0200
++++ tcp_wrappers_7.6-ipv6.4/socket.c	2013-01-23 11:41:48.776857327 +0100
+@@ -54,6 +54,8 @@ int af;
+ {
+     char    dot_name[MAXHOSTNAMELEN + 1];
+ 
++    struct hostent *hp;
++
+     /*
+      * Don't append dots to unqualified names. Such names are likely to come
+      * from local hosts files or from NIS.
+@@ -62,8 +64,13 @@ int af;
+     if (strchr(name, '.') == 0 || strlen(name) >= MAXHOSTNAMELEN - 1) {
+ 	return (tcpd_gethostbyname(name, af));
+     } else {
+-	sprintf(dot_name, "%s.", name);
+-	return (tcpd_gethostbyname(dot_name, af));
++        sprintf(dot_name, "%s.", name);
++        hp = tcpd_gethostbyname(dot_name, af);
++        if (hp)
++            return hp;
++
++        else
++            return tcpd_gethostbyname(name, af);
+     }
+ }
+ 

--- a/testing/libwrap/07-tcp_wrappers-7.6-docu.patch
+++ b/testing/libwrap/07-tcp_wrappers-7.6-docu.patch
@@ -1,0 +1,12 @@
+diff -up tcp_wrappers_7.6/hosts_access.5.patch8 tcp_wrappers_7.6/hosts_access.5
+--- tcp_wrappers_7.6/hosts_access.5.patch8	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/hosts_access.5	2008-08-29 09:45:12.000000000 +0200
+@@ -333,7 +333,7 @@ in.tftpd: LOCAL, .my.domain
+ /etc/hosts.deny:
+ .in +3
+ .nf
+-in.tftpd: ALL: (/some/where/safe_finger -l @%h | \\
++in.tftpd: ALL: spawn (/some/where/safe_finger -l @%h | \\
+ 	/usr/ucb/mail -s %d-%h root) &
+ .fi
+ .PP

--- a/testing/libwrap/08-tcp_wrappers-7.6-man.patch
+++ b/testing/libwrap/08-tcp_wrappers-7.6-man.patch
@@ -1,0 +1,71 @@
+diff -up tcp_wrappers_7.6/Makefile.man tcp_wrappers_7.6/Makefile
+diff -up tcp_wrappers_7.6/safe_finger.8.man tcp_wrappers_7.6/safe_finger.8
+--- tcp_wrappers_7.6/safe_finger.8.man	2010-02-05 09:19:38.000000000 +0100
++++ tcp_wrappers_7.6/safe_finger.8	2010-02-05 09:11:12.000000000 +0100
+@@ -0,0 +1,34 @@
++.TH SAFE_FINGER 8 "21th June 1997" Linux "Linux Programmer's Manual"
++.SH NAME
++safe_finger \- finger client wrapper that protects against nasty stuff
++from finger servers
++.SH SYNOPSIS
++.B safe_finger [finger_options]
++.SH DESCRIPTION
++The
++.B safe_finger
++command protects against nasty stuff from finger servers. Use this
++program for automatic reverse finger probes from the
++.B tcp_wrapper
++.B (tcpd)
++, not the raw finger command. The
++.B safe_finger
++command makes sure that the finger client is not run with root
++privileges. It also runs the finger client with a defined PATH
++environment.
++.B safe_finger
++will also protect you from problems caused by the output of some
++finger servers. The problem: some programs may react to stuff in
++the first column. Other programs may get upset by thrash anywhere
++on a line. File systems may fill up as the finger server keeps
++sending data. Text editors may bomb out on extremely long lines.
++The finger server may take forever because it is somehow wedged.
++.B safe_finger
++takes care of all this badness.
++.SH SEE ALSO
++.BR hosts_access (5),
++.BR hosts_options (5),
++.BR tcpd (8)
++.SH AUTHOR
++Wietse Venema, Eindhoven University of Technology, The Netherlands.
++
+diff -up tcp_wrappers_7.6/try-from.8.man tcp_wrappers_7.6/try-from.8
+--- tcp_wrappers_7.6/try-from.8.man	2010-02-05 09:20:00.000000000 +0100
++++ tcp_wrappers_7.6/try-from.8	2010-02-05 09:12:54.000000000 +0100
+@@ -0,0 +1,28 @@
++.TH TRY-FROM 8 "21th June 1997" Linux "Linux Programmer's Manual"
++.SH NAME
++try-from \- test program for the tcp_wrapper
++.SH SYNOPSIS
++.B try-from
++.SH DESCRIPTION
++The
++.B try\-from
++command can be called via a remote shell command to find out
++if the hostname and address are properly recognized
++by the
++.B tcp_wrapper
++library, if username lookup works, and (SysV only) if the TLI
++on top of IP heuristics work. Diagnostics are reported through
++.BR syslog (3)
++and redirected to stderr.
++
++Example:
++
++rsh host /some/where/try\-from
++
++.SH SEE ALSO
++.BR hosts_access (5),
++.BR hosts_options (5),
++.BR tcpd (8)
++.SH AUTHOR
++Wietse Venema, Eindhoven University of Technology, The Netherlands.
++

--- a/testing/libwrap/09-tcp_wrappers.usagi-ipv6.patch
+++ b/testing/libwrap/09-tcp_wrappers.usagi-ipv6.patch
@@ -1,0 +1,271 @@
+diff -up tcp_wrappers_7.6/fix_options.c.patch9 tcp_wrappers_7.6/fix_options.c
+--- tcp_wrappers_7.6/fix_options.c.patch9	1997-04-08 02:29:19.000000000 +0200
++++ tcp_wrappers_7.6/fix_options.c	2008-08-29 09:45:12.000000000 +0200
+@@ -11,6 +11,9 @@ static char sccsid[] = "@(#) fix_options
+ 
+ #include <sys/types.h>
+ #include <sys/param.h>
++#ifdef HAVE_IPV6
++#include <sys/socket.h>
++#endif
+ #include <netinet/in.h>
+ #include <netinet/in_systm.h>
+ #include <netinet/ip.h>
+@@ -41,6 +44,22 @@ struct request_info *request;
+     unsigned int opt;
+     int     optlen;
+     struct in_addr dummy;
++#ifdef HAVE_IPV6
++    struct sockaddr_storage ss;
++    int sslen;
++
++    /*
++     * check if this is AF_INET socket
++     * XXX IPv6 support?
++     */
++    sslen = sizeof(ss);
++    if (getsockname(fd, (struct sockaddr *)&ss, &sslen) < 0) {
++	syslog(LOG_ERR, "getpeername: %m");
++	clean_exit(request);
++    }
++    if (ss.ss_family != AF_INET)
++	return;
++#endif
+ 
+     if ((ip = getprotobyname("ip")) != 0)
+ 	ipproto = ip->p_proto;
+diff -up tcp_wrappers_7.6/hosts_access.5.patch9 tcp_wrappers_7.6/hosts_access.5
+--- tcp_wrappers_7.6/hosts_access.5.patch9	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/hosts_access.5	2008-08-29 09:45:12.000000000 +0200
+@@ -85,11 +85,18 @@ member of the specified netgroup. Netgro
+ for daemon process names or for client user names.
+ .IP \(bu
+ An expression of the form `n.n.n.n/m.m.m.m\' is interpreted as a
+-`net/mask\' pair. A host address is matched if `net\' is equal to the
++`net/mask\' pair. An IPv4 host address is matched if `net\' is equal to the
+ bitwise AND of the address and the `mask\'. For example, the net/mask
+ pattern `131.155.72.0/255.255.254.0\' matches every address in the
+ range `131.155.72.0\' through `131.155.73.255\'.
+ .IP \(bu
++An expression of the form `[n:n:n:n:n:n:n:n/m]\' is interpreted as a
++`[net/prefixlen]\' pair. An IPv6 host address is matched if
++`prefixlen\' bits of `net\' is equal to the `prefixlen\' bits of the
++address. For example, the [net/prefixlen] pattern
++`[3ffe:505:2:1::/64]\' matches every address in the range
++`3ffe:505:2:1::\' through `3ffe:505:2:1:ffff:ffff:ffff:ffff\'.
++.IP \(bu
+ A string that begins with a `/\' character is treated as a file
+ name. A host name or address is matched if it matches any host name
+ or address pattern listed in the named file. The file format is
+diff -up tcp_wrappers_7.6/inetcf.c.patch9 tcp_wrappers_7.6/inetcf.c
+--- tcp_wrappers_7.6/inetcf.c.patch9	1997-02-12 02:13:24.000000000 +0100
++++ tcp_wrappers_7.6/inetcf.c	2008-08-29 09:45:12.000000000 +0200
+@@ -26,6 +26,9 @@ extern void exit();
+   * guesses. Shorter names follow longer ones.
+   */
+ char   *inet_files[] = {
++#ifdef HAVE_IPV6
++    "/usr/local/v6/etc/inet6d.conf",	/* KAME */
++#endif
+     "/private/etc/inetd.conf",		/* NEXT */
+     "/etc/inet/inetd.conf",		/* SYSV4 */
+     "/usr/etc/inetd.conf",		/* IRIX?? */
+diff -up tcp_wrappers_7.6/Makefile.patch9 tcp_wrappers_7.6/Makefile
+--- tcp_wrappers_7.6/Makefile.patch9	2013-01-25 10:53:33.891349937 +0100
++++ tcp_wrappers_7.6/Makefile	2013-01-25 11:00:57.362801588 +0100
+@@ -21,7 +21,7 @@ what:
+ 	@echo "	dynix epix esix freebsd hpux irix4 irix5 irix6 isc iunix"
+ 	@echo "	linux machten mips(untested) ncrsvr4 netbsd next osf power_unix_211"
+ 	@echo "	ptx-2.x ptx-generic pyramid sco sco-nis sco-od2 sco-os5 sinix sunos4"
+-	@echo "	sunos40 sunos5 sysv4 tandem ultrix unicos7 unicos8 unixware1 unixware2"
++	@echo "	sunos40 sunos5 solaris8 sysv4 tandem ultrix unicos7 unicos8 unixware1 unixware2"
+ 	@echo "	uts215 uxp"
+ 	@echo
+ 	@echo "If none of these match your environment, edit the system"
+@@ -138,13 +138,25 @@ epix:
+ 
+ freebsd:
+ 	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
++	LIBS="-L/usr/local/v6/lib -linet6" \
+ 	LIBS= RANLIB=ranlib ARFLAGS=rv AUX_OBJ= NETGROUP= TLI= \
+-	EXTRA_CFLAGS=-DUSE_STRERROR VSYSLOG= all
++	EXTRA_CFLAGS="-DUSE_STRERROR -Dss_family=__ss_family -Dss_len=__ss_len" VSYSLOG= all
++
++netbsd:
++	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
++	LIBS= RANLIB=ranlib ARFLAGS=rv AUX_OBJ= NETGROUP= TLI= \
++	EXTRA_CFLAGS="-DSYS_ERRLIST_DEFINED -Dss_family=__ss_family -Dss_len=__ss_len" VSYSLOG= all
+ 
+ linux:
+ 	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
+ 	LIBS="-lnsl" RANLIB=ranlib ARFLAGS=rv AUX_OBJ= \
+-	NETGROUP="-DNETGROUP" TLI= EXTRA_CFLAGS="$(RPM_OPT_FLAGS) -DUSE_STRERROR -DSYS_ERRLIST_DEFINED -DBROKEN_SO_LINGER" all
++	NETGROUP="-DNETGROUP" TLI= EXTRA_CFLAGS="$(RPM_OPT_FLAGS) -DUSE_STRERROR -DSYS_ERRLIST_DEFINED -DBROKEN_SO_LINGER -Dss_family=__ss_family -Dss_len=__ss_len" all
++
++linux-old:
++	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
++	LIBS="/usr/inet6/lib/libinet6.a -lresolv" \
++	RANLIB=ranlib ARFLAGS=rv AUX_OBJ=setenv.o NETGROUP= TLI= \
++	EXTRA_CFLAGS="-DSYS_ERRLIST_DEFINED -DBROKEN_SO_LINGER -Dss_family=sin6_family -Dsockaddr_storage=sockaddr_in6 -I/usr/inet6/include" all
+ 
+ # This is good for many SYSV+BSD hybrids with NIS, probably also for HP-UX 7.x.
+ hpux hpux8 hpux9 hpux10:
+@@ -197,6 +209,13 @@ sunos5:
+ 	BUGS="$(BUGS) -DSOLARIS_24_GETHOSTBYNAME_BUG" IPV6="$(IPV6)" \
+ 	EXTRA_CFLAGS=-DUSE_STRERROR all
+ 
++# SunOS 5.8 is another SYSV4 variant, but has IPv6 support
++solaris8:
++	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
++	LIBS="-lsocket -lnsl" RANLIB=echo ARFLAGS=rv VSYSLOG= \
++	NETGROUP=-DNETGROUP AUX_OBJ=setenv.o TLI=-DTLI \
++	EXTRA_CFLAGS="-DNO_CLONE_DEVICE -DINT32_T" all
++
+ # Generic SYSV40
+ esix sysv4:
+ 	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
+@@ -392,7 +411,7 @@ AR	= ar
+ # the ones provided with this source distribution. The environ.c module
+ # implements setenv(), getenv(), and putenv().
+ 
+-AUX_OBJ= setenv.o
++#AUX_OBJ= setenv.o
+ #AUX_OBJ= environ.o
+ #AUX_OBJ= environ.o strcasecmp.o
+ 
+@@ -455,7 +474,7 @@ AUX_OBJ= setenv.o
+ # host name aliases. Compile with -DSOLARIS_24_GETHOSTBYNAME_BUG to work
+ # around this. The workaround does no harm on other Solaris versions.
+ 
+-BUGS = -DGETPEERNAME_BUG -DBROKEN_FGETS -DLIBC_CALLS_STRTOK
++#BUGS = -DGETPEERNAME_BUG -DBROKEN_FGETS -DLIBC_CALLS_STRTOK
+ #BUGS = -DGETPEERNAME_BUG -DBROKEN_FGETS -DINET_ADDR_BUG
+ #BUGS = -DGETPEERNAME_BUG -DBROKEN_FGETS -DSOLARIS_24_GETHOSTBYNAME_BUG
+ 
+@@ -473,7 +492,7 @@ BUGS = -DGETPEERNAME_BUG -DBROKEN_FGETS
+ # If your system supports vsyslog(), comment out the following definition.
+ # If in doubt leave it in, it won't harm.
+ 
+-VSYSLOG	= -Dvsyslog=myvsyslog
++#VSYSLOG	= -Dvsyslog=myvsyslog
+ 
+ ###############################################################
+ # System dependencies: whether or not your system has IPV6
+@@ -485,7 +504,7 @@ VSYSLOG	= -Dvsyslog=myvsyslog
+ 
+ # If your system does not have getipnodebyname() but uses the obsolete
+ # gethostbyname2() instead, use this (AIX)
+-# IPV6 = -DHAVE_IPV6 -DUSE_GETHOSTBYNAME2
++IPV6 = -DHAVE_IPV6 -DUSE_GETHOSTBYNAME2
+ 
+ # End of the system dependencies.
+ #################################
+diff -up tcp_wrappers_7.6/misc.c.patch9 tcp_wrappers_7.6/misc.c
+--- tcp_wrappers_7.6/misc.c.patch9	1996-02-11 17:01:30.000000000 +0100
++++ tcp_wrappers_7.6/misc.c	2008-08-29 09:45:12.000000000 +0200
+@@ -58,9 +58,31 @@ int     delimiter;
+ {
+     char   *cp;
+ 
++#ifdef HAVE_IPV6
++    int bracket = 0;
++
++    for (cp = string; cp && *cp; cp++) {
++	switch (*cp) {
++	case '[':
++	    bracket++;
++	    break;
++	case ']':
++	    bracket--;
++	    break;
++	default:
++	    if (bracket == 0 && *cp == delimiter) {
++		*cp++ = 0;
++		return cp;
++	    }
++	    break;
++	}
++    }
++    return (NULL);
++#else
+     if ((cp = strchr(string, delimiter)) != 0)
+ 	*cp++ = 0;
+     return (cp);
++#endif
+ }
+ 
+ /* dot_quad_addr - convert dotted quad to internal form */
+diff -up tcp_wrappers_7.6/refuse.c.patch9 tcp_wrappers_7.6/refuse.c
+--- tcp_wrappers_7.6/refuse.c.patch9	1994-12-28 17:42:40.000000000 +0100
++++ tcp_wrappers_7.6/refuse.c	2008-08-29 09:45:12.000000000 +0200
+@@ -25,7 +25,12 @@ static char sccsid[] = "@(#) refuse.c 1.
+ void    refuse(request)
+ struct request_info *request;
+ {
++#ifdef HAVE_IPV6
++    syslog(deny_severity, "refused connect from %s (%s)",
++	   eval_client(request), eval_hostaddr(request->client));
++#else
+     syslog(deny_severity, "refused connect from %s", eval_client(request));
++#endif
+     clean_exit(request);
+     /* NOTREACHED */
+ }
+diff -up tcp_wrappers_7.6/rfc931.c.patch9 tcp_wrappers_7.6/rfc931.c
+--- tcp_wrappers_7.6/rfc931.c.patch9	2004-05-04 16:01:01.000000000 +0200
++++ tcp_wrappers_7.6/rfc931.c	2013-01-25 11:08:26.690292897 +0100
+@@ -94,6 +94,12 @@ char   *dest;
+      * sockets.
+      */
+ 
++    /* address family must be the same */
++    if (SGFAM(rmt_sin) != SGFAM(our_sin)) {
++	STRN_CPY(dest, result, STRING_LENGTH);
++	return;
++    }
++
+     if ((fp = fsocket(SGFAM(rmt_sin), SOCK_STREAM, 0)) != 0) {
+ 	setbuf(fp, (char *) 0);
+ 
+diff -up tcp_wrappers_7.6/tcpd.c.patch9 tcp_wrappers_7.6/tcpd.c
+--- tcp_wrappers_7.6/tcpd.c.patch9	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/tcpd.c	2008-08-29 09:45:12.000000000 +0200
+@@ -120,7 +120,12 @@ char  **argv;
+ 
+     /* Report request and invoke the real daemon program. */
+ 
++#ifdef HAVE_IPV6
++    syslog(allow_severity, "connect from %s (%s)",
++	   eval_client(&request), eval_hostaddr(request.client));
++#else
+     syslog(allow_severity, "connect from %s", eval_client(&request));
++#endif
+     closelog();
+     (void) execv(path, argv);
+     syslog(LOG_ERR, "error: cannot execute %s: %m", path);
+diff -up tcp_wrappers_7.6/workarounds.c.patch9 tcp_wrappers_7.6/workarounds.c
+--- tcp_wrappers_7.6/workarounds.c.patch9	1996-03-19 16:22:26.000000000 +0100
++++ tcp_wrappers_7.6/workarounds.c	2008-08-29 09:45:12.000000000 +0200
+@@ -166,11 +166,22 @@ struct sockaddr *sa;
+ int    *len;
+ {
+     int     ret;
++#ifdef HAVE_IPV6
++    struct sockaddr *sin = sa;
++#else
+     struct sockaddr_in *sin = (struct sockaddr_in *) sa;
++#endif
+ 
+     if ((ret = getpeername(sock, sa, len)) >= 0
++#ifdef HAVE_IPV6
++	&& ((sin->su_si.si_family == AF_INET6
++	     && IN6_IS_ADDR_UNSPECIFIED(&sin->su_sin6.sin6_addr))
++	    || (sin->su_si.si_family == AF_INET
++		&& sin->su_sin.sin_addr.s_addr == 0))) {
++#else
+ 	&& sa->sa_family == AF_INET
+ 	&& sin->sin_addr.s_addr == 0) {
++#endif
+ 	errno = ENOTCONN;
+ 	return (-1);
+     } else {

--- a/testing/libwrap/11-tcp_wrappers-7.6-shared.patch
+++ b/testing/libwrap/11-tcp_wrappers-7.6-shared.patch
@@ -1,0 +1,267 @@
+diff -up tcp_wrappers_7.6/Makefile.patch11 tcp_wrappers_7.6/Makefile
+--- tcp_wrappers_7.6/Makefile.patch11	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/Makefile	2008-08-29 09:45:12.000000000 +0200
+@@ -150,8 +150,8 @@ netbsd:
+ 
+ linux:
+ 	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
+-	LIBS="-lnsl" RANLIB=ranlib ARFLAGS=rv AUX_OBJ= \
+-	NETGROUP="-DNETGROUP" TLI= EXTRA_CFLAGS="$(RPM_OPT_FLAGS) -DUSE_STRERROR -DSYS_ERRLIST_DEFINED -DBROKEN_SO_LINGER -Dss_family=__ss_family -Dss_len=__ss_len" all
++	LIBS="-lnsl" RANLIB=ranlib ARFLAGS=rv AUX_OBJ=weak_symbols.o \
++	NETGROUP="-DNETGROUP" TLI= EXTRA_CFLAGS="$(RPM_OPT_FLAGS)  -fPIC -DPIC -D_REENTRANT -DUSE_STRERROR -DSYS_ERRLIST_DEFINED -DBROKEN_SO_LINGER -Dss_family=__ss_family -Dss_len=__ss_len -DHAVE_WEAKSYMS" all
+ 
+ linux-old:
+ 	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
+@@ -249,7 +249,7 @@ tandem:
+ 
+ # Amdahl UTS 2.1.5 (Richard.Richmond@bridge.bst.bls.com)
+ uts215:
+-	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \   
++	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
+ 	LIBS="-lsocket" RANLIB=echo \
+ 	ARFLAGS=rv AUX_OBJ=setenv.o NETGROUP=-DNO_NETGROUP TLI= all
+ 
+@@ -706,8 +706,9 @@ KIT	= README miscd.c tcpd.c fromhost.c h
+ 	scaffold.h tcpdmatch.8 README.NIS
+ 
+ LIB	= libwrap.a
++SHLIB 	= libwrap.so
+ 
+-all other: config-check tcpd tcpdmatch try-from safe_finger tcpdchk
++all other: config-check tcpd tcpdmatch try-from safe_finger tcpdchk $(SHLIB)
+ 
+ # Invalidate all object files when the compiler options (CFLAGS) have changed.
+ 
+@@ -724,6 +725,12 @@ $(LIB):	$(LIB_OBJ)
+ 	$(AR) $(ARFLAGS) $(LIB) $(LIB_OBJ)
+ 	-$(RANLIB) $(LIB)
+ 
++$(SHLIB): $(LIB_OBJ)
++	gcc -shared -fPIC -Wl,-soname -Wl,$(SHLIB).$(MAJOR) \
++		-o $(SHLIB).$(MAJOR).$(MINOR).$(REL) $^ $(LIBS)
++	ln -s $(SHLIB).$(MAJOR).$(MINOR).$(REL) $(SHLIB).$(MAJOR)
++	ln -s $(SHLIB).$(MAJOR).$(MINOR).$(REL) $(SHLIB)
++
+ tcpd:	tcpd.o $(LIB)
+ 	$(CC) $(CFLAGS) -o $@ tcpd.o $(LIB) $(LIBS)
+ 
+@@ -906,5 +913,6 @@ update.o: cflags
+ update.o: mystdarg.h
+ update.o: tcpd.h
+ vfprintf.o: cflags
++weak_symbols.o: tcpd.h
+ workarounds.o: cflags
+ workarounds.o: tcpd.h
+diff -up tcp_wrappers_7.6/tcpd.h.patch11 tcp_wrappers_7.6/tcpd.h
+--- tcp_wrappers_7.6/tcpd.h.patch11	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/tcpd.h	2008-08-29 09:45:12.000000000 +0200
+@@ -4,6 +4,25 @@
+   * Author: Wietse Venema, Eindhoven University of Technology, The Netherlands.
+   */
+ 
++#ifndef _TCPWRAPPERS_TCPD_H
++#define _TCPWRAPPERS_TCPD_H
++
++/* someone else may have defined this */
++#undef  __P
++
++/* use prototypes if we have an ANSI C compiler or are using C++ */
++#if defined(__STDC__) || defined(__cplusplus)
++#define __P(args)       args
++#else
++#define __P(args)       ()
++#endif
++
++/* Need definitions of struct sockaddr_in and FILE. */
++#include <netinet/in.h>
++#include <stdio.h>
++
++__BEGIN_DECLS
++
+ /* Structure to describe one communications endpoint. */
+ 
+ #define STRING_LENGTH	128		/* hosts, users, processes */
+@@ -92,10 +111,10 @@ struct request_info {
+     char    pid[10];			/* access via eval_pid(request) */
+     struct host_info client[1];		/* client endpoint info */
+     struct host_info server[1];		/* server endpoint info */
+-    void  (*sink) ();			/* datagram sink function or 0 */
+-    void  (*hostname) ();		/* address to printable hostname */
+-    void  (*hostaddr) ();		/* address to printable address */
+-    void  (*cleanup) ();		/* cleanup function or 0 */
++    void  (*sink) __P((int));		/* datagram sink function or 0 */
++    void  (*hostname) __P((struct host_info *)); /* address to printable hostname */
++    void  (*hostaddr) __P((struct host_info *)); /* address to printable address */
++    void  (*cleanup) __P((struct request_info *)); /* cleanup function or 0 */
+     struct netconfig *config;		/* netdir handle */
+ };
+ 
+@@ -132,33 +151,38 @@ extern char paranoid[];
+ /* Global functions. */
+ 
+ #if defined(TLI) || defined(PTX) || defined(TLI_SEQUENT)
+-extern void fromhost();			/* get/validate client host info */
++extern void fromhost __P((struct request_info *));			/* get/validate client host info */
+ #else
+ #define fromhost sock_host		/* no TLI support needed */
+ #endif
+ 
+-extern int hosts_access();		/* access control */
+-extern void shell_cmd();		/* execute shell command */
+-extern char *percent_x();		/* do %<char> expansion */
+-extern void rfc931();			/* client name from RFC 931 daemon */
+-extern void clean_exit();		/* clean up and exit */
+-extern void refuse();			/* clean up and exit */
+-extern char *xgets();			/* fgets() on steroids */
+-extern char *split_at();		/* strchr() and split */
+-extern unsigned long dot_quad_addr();	/* restricted inet_addr() */
+-extern int numeric_addr();		/* IP4/IP6 inet_addr (restricted) */
+-extern struct hostent *tcpd_gethostbyname();
++extern void shell_cmd __P((char *));		/* execute shell command */
++extern char *percent_x __P((char *, int, char *, struct request_info *));		/* do %<char> expansion */
++extern void rfc931 __P((struct sockaddr_gen *, struct sockaddr_gen *, char *));			/* client name from RFC 931 daemon */
++extern void clean_exit __P((struct request_info *));		/* clean up and exit */
++extern void refuse __P((struct request_info *));			/* clean up and exit */
++extern char *xgets __P((char *, int, FILE *));			/* fgets() on steroids */
++extern char *split_at __P((char *, int));		/* strchr() and split */
++extern unsigned long dot_quad_addr __P((char *));	/* restricted inet_addr() */
++extern int numeric_addr __P((char *, union gen_addr *, int *, int *));		/* IP4/IP6 inet_addr (restricted) */
++extern struct hostent *tcpd_gethostbyname __P((char *, int));
+ 					/* IP4/IP6 gethostbyname */
+ #ifdef HAVE_IPV6
+-extern char *skip_ipv6_addrs();		/* skip over colons in IPv6 addrs */
++extern char *skip_ipv6_addrs __P((char *));		/* skip over colons in IPv6 addrs */
+ #else
+ #define skip_ipv6_addrs(x)	x
+ #endif
+ 
+ /* Global variables. */
+ 
++#ifdef HAVE_WEAKSYMS
++extern int allow_severity __attribute__ ((weak)); /* for connection logging */
++extern int deny_severity __attribute__ ((weak)); /* for connection logging */
++#else
+ extern int allow_severity;		/* for connection logging */
+ extern int deny_severity;		/* for connection logging */
++#endif
++
+ extern char *hosts_allow_table;		/* for verification mode redirection */
+ extern char *hosts_deny_table;		/* for verification mode redirection */
+ extern int hosts_access_verbose;	/* for verbose matching mode */
+@@ -171,9 +195,14 @@ extern int resident;			/* > 0 if residen
+   */
+ 
+ #ifdef __STDC__
++extern int hosts_access(struct request_info *request);
++extern int hosts_ctl(char *daemon, char *client_name, char *client_addr, 
++                     char *client_user);
+ extern struct request_info *request_init(struct request_info *,...);
+ extern struct request_info *request_set(struct request_info *,...);
+ #else
++extern int hosts_access();
++extern int hosts_ctl();
+ extern struct request_info *request_init();	/* initialize request */
+ extern struct request_info *request_set();	/* update request structure */
+ #endif
+@@ -196,27 +225,31 @@ extern struct request_info *request_set(
+   * host_info structures serve as caches for the lookup results.
+   */
+ 
+-extern char *eval_user();		/* client user */
+-extern char *eval_hostname();		/* printable hostname */
+-extern char *eval_hostaddr();		/* printable host address */
+-extern char *eval_hostinfo();		/* host name or address */
+-extern char *eval_client();		/* whatever is available */
+-extern char *eval_server();		/* whatever is available */
++extern char *eval_user __P((struct request_info *));	/* client user */
++extern char *eval_hostname __P((struct host_info *));	/* printable hostname */
++extern char *eval_hostaddr __P((struct host_info *));	/* printable host address */
++extern char *eval_hostinfo __P((struct host_info *));	/* host name or address */
++extern char *eval_client __P((struct request_info *));	/* whatever is available */
++extern char *eval_server __P((struct request_info *));	/* whatever is available */
+ #define eval_daemon(r)	((r)->daemon)	/* daemon process name */
+ #define eval_pid(r)	((r)->pid)	/* process id */
+ 
+ /* Socket-specific methods, including DNS hostname lookups. */
+ 
+-extern void sock_host();		/* look up endpoint addresses */
+-extern void sock_hostname();		/* translate address to hostname */
+-extern void sock_hostaddr();		/* address to printable address */
++/* look up endpoint addresses */
++extern void sock_host __P((struct request_info *));
++/* translate address to hostname */
++extern void sock_hostname __P((struct host_info *));
++/* address to printable address */
++extern void sock_hostaddr __P((struct host_info *));
++
+ #define sock_methods(r) \
+ 	{ (r)->hostname = sock_hostname; (r)->hostaddr = sock_hostaddr; }
+ 
+ /* The System V Transport-Level Interface (TLI) interface. */
+ 
+ #if defined(TLI) || defined(PTX) || defined(TLI_SEQUENT)
+-extern void tli_host();			/* look up endpoint addresses etc. */
++extern void tli_host __P((struct request_info *));	/* look up endpoint addresses etc. */
+ #endif
+ 
+  /*
+@@ -257,7 +290,7 @@ extern struct tcpd_context tcpd_context;
+   * behavior.
+   */
+ 
+-extern void process_options();		/* execute options */
++extern void process_options __P((char *, struct request_info *)); /* execute options */
+ extern int dry_run;			/* verification flag */
+ 
+ /* Bug workarounds. */
+@@ -296,3 +329,7 @@ extern char *fix_strtok();
+ #define strtok	my_strtok
+ extern char *my_strtok();
+ #endif
++
++__END_DECLS
++
++#endif /* tcpd.h */
+diff -up /dev/null tcp_wrappers_7.6/weak_symbols.c
+--- /dev/null	2008-08-29 10:35:15.589003986 +0200
++++ tcp_wrappers_7.6/weak_symbols.c	2008-08-29 09:45:12.000000000 +0200
+@@ -0,0 +1,11 @@
++ /*
++  * @(#) weak_symbols.h 1.5 99/12/29 23:50
++  * 
++  * Author: Anthony Towns <ajt@debian.org>
++  */
++
++#ifdef HAVE_WEAKSYMS
++#include <syslog.h>
++int deny_severity = LOG_WARNING;
++int allow_severity = SEVERITY; 
++#endif
+diff -up tcp_wrappers_7.6/scaffold.c.patch11 tcp_wrappers_7.6/scaffold.c
+--- tcp_wrappers_7.6/scaffold.c.patch11	2013-01-28 11:08:48.598273563 +0100
++++ tcp_wrappers_7.6/scaffold.c	2013-01-28 11:08:56.069316992 +0100
+@@ -25,7 +25,7 @@ static char sccs_id[] = "@(#) scaffold.c
+ #define	INADDR_NONE	(-1)		/* XXX should be 0xffffffff */
+ #endif
+ 
+-extern char *malloc();
++extern void *malloc(size_t);
+ 
+ /* Application-specific. */
+ 
+@@ -180,10 +180,12 @@ struct request_info *request;
+ 
+ /* ARGSUSED */
+ 
+-void    rfc931(request)
+-struct request_info *request;
++void    rfc931(rmt_sin, our_sin, dest)
++struct sockaddr_gen *rmt_sin;
++struct sockaddr_gen *our_sin;
++char   *dest;
+ {
+-    strcpy(request->user, unknown);
++    strcpy(dest, unknown);
+ }
+ 
+ /* check_path - examine accessibility */

--- a/testing/libwrap/12-tcp_wrappers-7.6-sig.patch
+++ b/testing/libwrap/12-tcp_wrappers-7.6-sig.patch
@@ -1,0 +1,40 @@
+diff -up tcp_wrappers_7.6/hosts_access.c.patch12 tcp_wrappers_7.6/hosts_access.c
+--- tcp_wrappers_7.6/hosts_access.c.patch12	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/hosts_access.c	2008-08-29 09:45:12.000000000 +0200
+@@ -66,6 +66,7 @@ static char sep[] = ", \t\r\n";
+ 
+ #define	YES		1
+ #define	NO		0
++#define ERR             -1
+ 
+  /*
+   * These variables are globally visible so that they can be redirected in
+@@ -106,7 +107,6 @@ int     hosts_access(request)
+ struct request_info *request;
+ {
+     int     verdict;
+-
+     /*
+      * If the (daemon, client) pair is matched by an entry in the file
+      * /etc/hosts.allow, access is granted. Otherwise, if the (daemon,
+@@ -129,9 +129,9 @@ struct request_info *request;
+ 	return (verdict == AC_PERMIT);
+     if (table_match(hosts_allow_table, request))
+ 	return (YES);
+-    if (table_match(hosts_deny_table, request))
+-	return (NO);
+-    return (YES);
++    if (table_match(hosts_deny_table, request) == NO)
++	return (YES);
++    return (NO);
+ }
+ 
+ /* table_match - match table entries with (daemon, client) pair */
+@@ -175,6 +175,7 @@ struct request_info *request;
+ 	(void) fclose(fp);
+     } else if (errno != ENOENT) {
+ 	tcpd_warn("cannot open %s: %m", table);
++	match = ERR;
+     }
+     if (match) {
+ 	if (hosts_access_verbose > 1)

--- a/testing/libwrap/14-tcp_wrappers-7.6-ldflags.patch
+++ b/testing/libwrap/14-tcp_wrappers-7.6-ldflags.patch
@@ -1,0 +1,36 @@
+diff -up tcp_wrappers_7.6/Makefile.patch14 tcp_wrappers_7.6/Makefile
+--- tcp_wrappers_7.6/Makefile.patch14	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/Makefile	2008-08-29 09:45:12.000000000 +0200
+@@ -732,26 +732,26 @@ $(SHLIB): $(LIB_OBJ)
+ 	ln -s $(SHLIB).$(MAJOR).$(MINOR).$(REL) $(SHLIB)
+ 
+ tcpd:	tcpd.o $(LIB)
+-	$(CC) $(CFLAGS) -o $@ tcpd.o $(LIB) $(LIBS)
++	$(CC) $(CFLAGS) -o $@ tcpd.o $(LDFLAGS) $(LIB) $(LIBS)
+ 
+ miscd:	miscd.o $(LIB)
+-	$(CC) $(CFLAGS) -o $@ miscd.o $(LIB) $(LIBS)
++	$(CC) $(CFLAGS) -o $@ miscd.o $(LDFLAGS) $(LIB) $(LIBS)
+ 
+ safe_finger: safe_finger.o $(LIB)
+-	$(CC) $(CFLAGS) -o $@ safe_finger.o $(LIB) $(LIBS)
++	$(CC) $(CFLAGS) -o $@ safe_finger.o $(LDFLAGS) $(LIB) $(LIBS)
+ 
+ TCPDMATCH_OBJ = tcpdmatch.o fakelog.o inetcf.o scaffold.o
+ 
+ tcpdmatch: $(TCPDMATCH_OBJ) $(LIB)
+-	$(CC) $(CFLAGS) -o $@ $(TCPDMATCH_OBJ) $(LIB) $(LIBS)
++	$(CC) $(CFLAGS) -o $@ $(TCPDMATCH_OBJ) $(LDFLAGS) $(LIB) $(LIBS)
+ 
+ try-from: try-from.o fakelog.o $(LIB)
+-	$(CC) $(CFLAGS) -o $@ try-from.o fakelog.o $(LIB) $(LIBS)
++	$(CC) $(CFLAGS) -o $@ try-from.o fakelog.o $(LDFLAGS) $(LIB) $(LIBS)
+ 
+ TCPDCHK_OBJ = tcpdchk.o fakelog.o inetcf.o scaffold.o
+ 
+ tcpdchk: $(TCPDCHK_OBJ) $(LIB)
+-	$(CC) $(CFLAGS) -o $@ $(TCPDCHK_OBJ) $(LIB) $(LIBS)
++	$(CC) $(CFLAGS) -o $@ $(TCPDCHK_OBJ) $(LDFLAGS) $(LIB) $(LIBS)
+ 
+ shar:	$(KIT)
+ 	@shar $(KIT)

--- a/testing/libwrap/15-tcp_wrappers-7.6-fix_sig-bug141110.patch
+++ b/testing/libwrap/15-tcp_wrappers-7.6-fix_sig-bug141110.patch
@@ -1,0 +1,21 @@
+diff -up tcp_wrappers_7.6/hosts_access.c.patch15 tcp_wrappers_7.6/hosts_access.c
+--- tcp_wrappers_7.6/hosts_access.c.patch15	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/hosts_access.c	2008-08-29 09:45:12.000000000 +0200
+@@ -127,7 +127,7 @@ struct request_info *request;
+     verdict = setjmp(tcpd_buf);
+     if (verdict != 0)
+ 	return (verdict == AC_PERMIT);
+-    if (table_match(hosts_allow_table, request))
++    if (table_match(hosts_allow_table, request) == YES)
+ 	return (YES);
+     if (table_match(hosts_deny_table, request) == NO)
+ 	return (YES);
+@@ -177,7 +177,7 @@ struct request_info *request;
+ 	tcpd_warn("cannot open %s: %m", table);
+ 	match = ERR;
+     }
+-    if (match) {
++    if (match == YES) {
+ 	if (hosts_access_verbose > 1)
+ 	    syslog(LOG_DEBUG, "matched:  %s line %d",
+ 		   tcpd_context.file, tcpd_context.line);

--- a/testing/libwrap/16-tcp_wrappers-7.6-162412.patch
+++ b/testing/libwrap/16-tcp_wrappers-7.6-162412.patch
@@ -1,0 +1,12 @@
+diff -up tcp_wrappers_7.6/inetcf.c.patch16 tcp_wrappers_7.6/inetcf.c
+--- tcp_wrappers_7.6/inetcf.c.patch16	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/inetcf.c	2008-08-29 09:45:12.000000000 +0200
+@@ -61,7 +61,7 @@ char   *inet_cfg(conf)
+ char   *conf;
+ {
+     char    buf[BUFSIZ];
+-    FILE   *fp;
++    FILE   *fp = NULL;
+     char   *service;
+     char   *protocol;
+     char   *user;

--- a/testing/libwrap/17-tcp_wrappers-7.6-220015.patch
+++ b/testing/libwrap/17-tcp_wrappers-7.6-220015.patch
@@ -1,0 +1,88 @@
+diff -up tcp_wrappers_7.6/hosts_ctl.c.patch17 tcp_wrappers_7.6/hosts_ctl.c
+--- tcp_wrappers_7.6/hosts_ctl.c.patch17	1994-12-28 17:42:28.000000000 +0100
++++ tcp_wrappers_7.6/hosts_ctl.c	2008-08-29 09:45:12.000000000 +0200
+@@ -29,10 +29,12 @@ char   *user;
+ {
+     struct request_info request;
+ 
+-    return (hosts_access(request_init(&request,
+-				      RQ_DAEMON, daemon,
+-				      RQ_CLIENT_NAME, name,
+-				      RQ_CLIENT_ADDR, addr,
+-				      RQ_USER, user,
+-				      0)));
++    request_init(&request, RQ_DAEMON, daemon,
++			   RQ_CLIENT_NAME, name,
++			   RQ_CLIENT_ADDR, addr,
++			   RQ_USER, user,
++			   0);
++    sock_hostnofd(&request);
++
++    return (hosts_access(&request));
+ }
+diff -up tcp_wrappers_7.6/socket.c.patch17 tcp_wrappers_7.6/socket.c
+--- tcp_wrappers_7.6/socket.c.patch17	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/socket.c	2008-08-29 09:45:12.000000000 +0200
+@@ -130,6 +130,51 @@ struct request_info *request;
+     request->server->sin = &server;
+ }
+ 
++/* sock_hostnofd - look up endpoint addresses and install conversion methods */
++
++void    sock_hostnofd(request)
++struct request_info *request;
++{
++    static struct sockaddr_storage client;
++    struct addrinfo hints, *res;
++    int     ret;
++    char    *host;
++
++    /* If the address field is non-empty and non-unknown and if the hostname
++     * field is empty or unknown, use the address field to get the sockaddr
++     * and hostname. */
++    if (strlen(request->client->addr) &&
++	    HOSTNAME_KNOWN(request->client->addr) &&
++	    (!strlen(request->client->name) ||
++		!HOSTNAME_KNOWN(request->client->name)))
++	host = request->client->addr;
++    else
++	return;
++
++    memset(&hints, 0, sizeof(hints));
++    hints.ai_family = AF_INET6;
++    hints.ai_socktype = SOCK_STREAM;
++    hints.ai_flags = AI_PASSIVE | AI_NUMERICHOST;
++
++    ret = getaddrinfo(host, NULL, &hints, &res);
++    if (ret != 0) {
++	hints.ai_family = AF_INET;
++	ret = getaddrinfo(host, NULL, &hints, &res);
++    }
++
++    if (ret != 0) {
++	tcpd_warn("can't resolve hostname (%s): %s", host, gai_strerror(ret));
++    } else {
++	sock_methods(request);
++
++	memcpy(&client, res->ai_addr, res->ai_addrlen);
++	request->client->sin = (struct sockaddr *)&client;
++	freeaddrinfo(res);
++
++	request->client->name[0] = 0;
++    }
++}
++
+ /* sock_hostaddr - map endpoint address to printable form */
+ 
+ void    sock_hostaddr(host)
+diff -up tcp_wrappers_7.6/tcpd.h.patch17 tcp_wrappers_7.6/tcpd.h
+--- tcp_wrappers_7.6/tcpd.h.patch17	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/tcpd.h	2008-08-29 09:45:12.000000000 +0200
+@@ -167,6 +167,7 @@ extern char *eval_server __P((struct req
+ 
+ /* look up endpoint addresses */
+ extern void sock_host __P((struct request_info *));
++extern void sock_hostnofd __P((struct request_info *));
+ /* translate address to hostname */
+ extern void sock_hostname __P((struct host_info *));
+ /* address to printable address */

--- a/testing/libwrap/19-tcp_wrappers-7.6-siglongjmp.patch
+++ b/testing/libwrap/19-tcp_wrappers-7.6-siglongjmp.patch
@@ -1,0 +1,30 @@
+diff -up tcp_wrappers_7.6/rfc931.c.patch19 tcp_wrappers_7.6/rfc931.c
+--- tcp_wrappers_7.6/rfc931.c.patch19	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/rfc931.c	2008-08-29 09:45:12.000000000 +0200
+@@ -33,7 +33,7 @@ static char sccsid[] = "@(#) rfc931.c 1.
+ 
+ int     rfc931_timeout = RFC931_TIMEOUT;/* Global so it can be changed */
+ 
+-static jmp_buf timebuf;
++static sigjmp_buf timebuf;
+ 
+ /* fsocket - open stdio stream on top of socket */
+ 
+@@ -62,7 +62,7 @@ int     protocol;
+ static void timeout(sig)
+ int     sig;
+ {
+-    longjmp(timebuf, sig);
++    siglongjmp(timebuf, sig);
+ }
+ 
+ /* rfc931 - return remote user name, given socket structures */
+@@ -135,7 +135,7 @@ char   *dest;
+ 	 * Set up a timer so we won't get stuck while waiting for the server.
+ 	 */
+ 
+-	if (setjmp(timebuf) == 0) {
++	if (sigsetjmp(timebuf, 1) == 0) {
+ 	    /* Save SIGALRM timer and handler. Sudheer Abdul-Salam, SUN. */
+ 	    saved_timeout = alarm(0);
+ 	    nact.sa_handler = timeout;

--- a/testing/libwrap/20-tcp_wrappers-7.6-sigchld.patch
+++ b/testing/libwrap/20-tcp_wrappers-7.6-sigchld.patch
@@ -1,0 +1,88 @@
+diff -up tcp_wrappers_7.6/shell_cmd.c.patch20 tcp_wrappers_7.6/shell_cmd.c
+--- tcp_wrappers_7.6/shell_cmd.c.patch20	1994-12-28 17:42:44.000000000 +0100
++++ tcp_wrappers_7.6/shell_cmd.c	2008-08-29 09:45:12.000000000 +0200
+@@ -20,6 +20,11 @@ static char sccsid[] = "@(#) shell_cmd.c
+ #include <stdio.h>
+ #include <syslog.h>
+ #include <string.h>
++#include <errno.h>
++#include <unistd.h>
++#include <sys/wait.h>
++#include <sys/stat.h>
++#include <fcntl.h>
+ 
+ extern void exit();
+ 
+@@ -31,13 +36,42 @@ extern void exit();
+ 
+ static void do_child();
+ 
++/*
++ * The sigchld handler. If there is a SIGCHLD caused by a child other than
++ * ours, we set a flag and raise the signal later.
++ */
++volatile static int foreign_sigchld;
++volatile static int our_child_pid;
++static void sigchld(int sig, siginfo_t *si, void *unused)
++{
++    if (si && si->si_pid != our_child_pid)
++	foreign_sigchld = 1;
++}
++
+ /* shell_cmd - execute shell command */
+ 
+ void    shell_cmd(command)
+ char   *command;
+ {
+     int     child_pid;
+-    int     wait_pid;
++
++    struct sigaction new_action, old_action;
++    sigset_t new_mask, old_mask, empty_mask;
++
++    new_action.sa_sigaction = &sigchld;
++    new_action.sa_flags = SA_SIGINFO;
++    sigemptyset(&new_action.sa_mask);
++    sigemptyset(&new_mask);
++    sigemptyset(&empty_mask);
++    sigaddset(&new_mask, SIGCHLD);
++
++    /*
++     * Set the variables for handler, set the handler and block the signal
++     * until we have the pid.
++     */
++    foreign_sigchld = 0; our_child_pid = 0;
++    sigprocmask(SIG_BLOCK, &new_mask, &old_mask);
++    sigaction(SIGCHLD, &new_action, &old_action);
+ 
+     /*
+      * Most of the work is done within the child process, to minimize the
+@@ -49,12 +83,26 @@ char   *command;
+ 	tcpd_warn("cannot fork: %m");
+ 	break;
+     case 00:					/* child */
++	/* Clear the blocked mask for the child not to be surprised. */
++	sigprocmask(SIG_SETMASK, &empty_mask, 0);
+ 	do_child(command);
+ 	/* NOTREACHED */
+     default:					/* parent */
+-	while ((wait_pid = wait((int *) 0)) != -1 && wait_pid != child_pid)
+-	     /* void */ ;
++	our_child_pid = child_pid;
++	sigprocmask(SIG_UNBLOCK, &new_mask, 0);
++	while (waitpid(child_pid, (int *) 0, 0) == -1 && errno == EINTR);
+     }
++
++    /*
++     * Revert the signal mask and the SIGCHLD handler.
++     */
++    sigprocmask(SIG_SETMASK, &old_mask, 0);
++    sigaction(SIGCHLD, &old_action, 0);
++
++    /* If there was a foreign SIGCHLD, raise it after we have restored the old
++     * mask and handler. */
++    if (foreign_sigchld)
++	raise(SIGCHLD);
+ }
+ 
+ /* do_child - exec command with { stdin, stdout, stderr } to /dev/null */

--- a/testing/libwrap/21-tcp_wrappers-7.6-196326.patch
+++ b/testing/libwrap/21-tcp_wrappers-7.6-196326.patch
@@ -1,0 +1,13 @@
+diff -up tcp_wrappers_7.6/hosts_access.c.patch21 tcp_wrappers_7.6/hosts_access.c
+--- tcp_wrappers_7.6/hosts_access.c.patch21	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/hosts_access.c	2008-08-29 09:45:12.000000000 +0200
+@@ -391,6 +391,9 @@ char   *string;
+ 	return (STR_NE(string, unknown));
+     } else if (tok[(n = strlen(tok)) - 1] == '.') {	/* prefix */
+ 	return (STRN_EQ(tok, string, n));
++    } else if ((STR_EQ(tok, "localhost") || STR_EQ(tok, "localhost.localdomain"))
++	    && (STR_EQ(string, "localhost") || STR_EQ(string, "localhost.localdomain"))) {
++	return (YES); /* these localhosts are equivalent */
+     } else {					/* exact match */
+ 	return (STR_EQ(tok, string));
+     }

--- a/testing/libwrap/22-tcp_wrappers_7.6-249430.patch
+++ b/testing/libwrap/22-tcp_wrappers_7.6-249430.patch
@@ -1,0 +1,14 @@
+diff -up tcp_wrappers_7.6/hosts_access.c.patch22 tcp_wrappers_7.6/hosts_access.c
+--- tcp_wrappers_7.6/hosts_access.c.patch22	2008-08-29 09:45:12.000000000 +0200
++++ tcp_wrappers_7.6/hosts_access.c	2008-08-29 09:45:12.000000000 +0200
+@@ -419,7 +419,9 @@ char   *string;
+     if ((addr = dot_quad_addr(string)) == INADDR_NONE)
+ 	return (NO);
+     if ((net = dot_quad_addr(net_tok)) == INADDR_NONE
+-	|| (mask = dot_quad_addr(mask_tok)) == INADDR_NONE) {
++	|| ((mask = dot_quad_addr(mask_tok)) == INADDR_NONE
++	    && strcmp(mask_tok, "255.255.255.255"))) {
++	/* 255.255.255.255 == INADDR_NONE, separate check needed. TJ. */
+ 	tcpd_warn("bad net/mask expression: %s/%s", net_tok, mask_tok);
+ 	return (NO);				/* not tcpd_jump() */
+     }

--- a/testing/libwrap/23-tcp_wrappers-7.6-inetdconf.patch
+++ b/testing/libwrap/23-tcp_wrappers-7.6-inetdconf.patch
@@ -1,0 +1,79 @@
+diff -up tcp_wrappers_7.6/tcpdmatch.8.inetdconf tcp_wrappers_7.6/tcpdmatch.8
+--- tcp_wrappers_7.6/tcpdmatch.8.inetdconf	2010-06-16 14:39:32.000000000 +0200
++++ tcp_wrappers_7.6/tcpdmatch.8	2010-06-16 14:42:25.000000000 +0200
+@@ -2,9 +2,9 @@
+ .SH NAME
+ tcpdmatch \- tcp wrapper oracle
+ .SH SYNOPSYS
+-tcpdmatch [-d] [-i inet_conf] daemon client
++tcpdmatch [-d] daemon client
+ .sp
+-tcpdmatch [-d] [-i inet_conf] daemon[@server] [user@]client
++tcpdmatch [-d] daemon[@server] [user@]client
+ .SH DESCRIPTION
+ .PP
+ \fItcpdmatch\fR predicts how the tcp wrapper would handle a specific
+@@ -48,10 +48,6 @@ The default user name is `unknown'.
+ .IP -d
+ Examine \fIhosts.allow\fR and \fIhosts.deny\fR files in the current
+ directory instead of the default ones.
+-.IP "-i inet_conf"
+-Specify this option when \fItcpdmatch\fR is unable to find your
+-\fIinetd.conf\fR or \fItlid.conf\fR network configuration file, or when
+-you suspect that the program uses the wrong one.
+ .SH EXAMPLES
+ To predict how \fItcpd\fR would handle a telnet request from the local
+ system:
+@@ -82,11 +78,8 @@ The default locations of the \fItcpd\fR 
+ .SH SEE ALSO
+ .na
+ .nf
+-tcpdchk(8), tcpd configuration checker
+ hosts_access(5), format of the tcpd access control tables.
+ hosts_options(5), format of the language extensions.
+-inetd.conf(5), format of the inetd control file.
+-tlid.conf(5), format of the tlid control file.
+ .SH AUTHORS
+ .na
+ .nf
+diff -up tcp_wrappers_7.6/tcpdmatch.c.inetdconf tcp_wrappers_7.6/tcpdmatch.c
+--- tcp_wrappers_7.6/tcpdmatch.c.inetdconf	2010-06-16 14:37:09.000000000 +0200
++++ tcp_wrappers_7.6/tcpdmatch.c	2010-06-16 14:39:18.000000000 +0200
+@@ -140,25 +140,6 @@ char  **argv;
+     }
+ 
+     /*
+-     * Analyze the inetd (or tlid) configuration file, so that we can warn
+-     * the user about services that may not be wrapped, services that are not
+-     * configured, or services that are wrapped in an incorrect manner. Allow
+-     * for services that are not run from inetd, or that have tcpd access
+-     * control built into them.
+-     */
+-    inetcf = inet_cfg(inetcf);
+-    inet_set("portmap", WR_NOT);
+-    inet_set("rpcbind", WR_NOT);
+-    switch (inet_get(daemon)) {
+-    case WR_UNKNOWN:
+-	tcpd_warn("%s: no such process name in %s", daemon, inetcf);
+-	break;
+-    case WR_NOT:
+-	tcpd_warn("%s: service possibly not wrapped", daemon);
+-	break;
+-    }
+-
+-    /*
+      * Check accessibility of access control files.
+      */
+     (void) check_path(hosts_allow_table, &st);
+@@ -319,10 +300,9 @@ char  **argv;
+ static void usage(myname)
+ char   *myname;
+ {
+-    fprintf(stderr, "usage: %s [-d] [-i inet_conf] daemon[@host] [user@]host\n",
++    fprintf(stderr, "usage: %s [-d] daemon[@host] [user@]host\n",
+ 	    myname);
+     fprintf(stderr, "	-d: use allow/deny files in current directory\n");
+-    fprintf(stderr, "	-i: location of inetd.conf file\n");
+     exit(1);
+ }
+ 

--- a/testing/libwrap/24-tcp_wrappers-7.6-bug698464.patch
+++ b/testing/libwrap/24-tcp_wrappers-7.6-bug698464.patch
@@ -1,0 +1,69 @@
+--- tcp_wrappers_7.6/hosts_access.5.orig	2011-04-20 16:10:25.000000000 -0600
++++ tcp_wrappers_7.6/hosts_access.5	2011-04-20 16:29:50.000000000 -0600
+@@ -90,6 +90,9 @@ bitwise AND of the address and the `mask
+ pattern `131.155.72.0/255.255.254.0\' matches every address in the
+ range `131.155.72.0\' through `131.155.73.255\'.
+ .IP \(bu
++An expression of the form `n.n.n.n/m\' is interpreted as a
++`net/prefixlen\' pair, as below, for IPv4 addresses.
++.IP \(bu
+ An expression of the form `[n:n:n:n:n:n:n:n/m]\' is interpreted as a
+ `[net/prefixlen]\' pair. An IPv6 host address is matched if
+ `prefixlen\' bits of `net\' is equal to the `prefixlen\' bits of the
+--- tcp_wrappers_7.6/tcpd.h.orig	2011-04-20 16:10:25.000000000 -0600
++++ tcp_wrappers_7.6/tcpd.h	2011-04-20 16:11:56.000000000 -0600
+@@ -164,6 +164,7 @@ extern void refuse __P((struct request_i
+ extern char *xgets __P((char *, int, FILE *));			/* fgets() on steroids */
+ extern char *split_at __P((char *, int));		/* strchr() and split */
+ extern unsigned long dot_quad_addr __P((char *));	/* restricted inet_addr() */
++extern unsigned long prefix_to_netmask __P((char *)); /* 0-32 prefix length */
+ extern int numeric_addr __P((char *, union gen_addr *, int *, int *));		/* IP4/IP6 inet_addr (restricted) */
+ extern struct hostent *tcpd_gethostbyname __P((char *, int));
+ 					/* IP4/IP6 gethostbyname */
+--- tcp_wrappers_7.6/misc.c.orig	2011-04-20 16:10:25.000000000 -0600
++++ tcp_wrappers_7.6/misc.c	2011-04-20 16:13:39.000000000 -0600
+@@ -16,6 +16,7 @@ static char sccsic[] = "@(#) misc.c 1.2
+ #include <string.h>
+ #include <ctype.h>
+ #include <netdb.h>
++#include <stdlib.h>
+ 
+ #include "tcpd.h"
+ 
+@@ -214,3 +215,21 @@ char *str;
+     }
+ }
+ #endif /* HAVE_IPV6 */
++
++/* prefix_to_netmask - convert prefix (0-32) to netmask */
++
++unsigned long prefix_to_netmask(str)
++char   *str;
++{
++    unsigned long prefix;
++    char *endptr;
++
++    if (!isdigit(str[0]))
++	return INADDR_NONE;
++
++    prefix = strtoul(str, &endptr, 10);
++    if ((endptr == str) || (*endptr != '\0') || (prefix > 32))
++	return INADDR_NONE;
++
++    return htonl(~0UL << (32 - prefix));
++}
+--- tcp_wrappers_7.6/hosts_access.c.orig	2011-04-20 16:10:25.000000000 -0600
++++ tcp_wrappers_7.6/hosts_access.c	2011-04-20 16:21:07.000000000 -0600
+@@ -420,8 +420,11 @@ char   *string;
+ 	return (NO);
+     if ((net = dot_quad_addr(net_tok)) == INADDR_NONE
+ 	|| ((mask = dot_quad_addr(mask_tok)) == INADDR_NONE
+-	    && strcmp(mask_tok, "255.255.255.255"))) {
++	    && strcmp(mask_tok, "255.255.255.255")
++	    && (mask = prefix_to_netmask(mask_tok)) == INADDR_NONE
++	    && strcmp(mask_tok, "32"))) {
+ 	/* 255.255.255.255 == INADDR_NONE, separate check needed. TJ. */
++	/* 32 == INADDR_NONE, separate check needed. philipp */
+ 	tcpd_warn("bad net/mask expression: %s/%s", net_tok, mask_tok);
+ 	return (NO);				/* not tcpd_jump() */
+     }

--- a/testing/libwrap/25-tcp_wrappers-7.6-relro.patch
+++ b/testing/libwrap/25-tcp_wrappers-7.6-relro.patch
@@ -1,0 +1,12 @@
+diff -up tcp_wrappers_7.6/Makefile.relro tcp_wrappers_7.6/Makefile
+--- tcp_wrappers_7.6/Makefile.relro	2011-08-10 03:33:25.457892277 +0200
++++ tcp_wrappers_7.6/Makefile	2011-08-10 03:33:39.565892352 +0200
+@@ -726,7 +726,7 @@ $(LIB):	$(LIB_OBJ)
+ 	-$(RANLIB) $(LIB)
+ 
+ $(SHLIB): $(LIB_OBJ)
+-	gcc -shared -fPIC -Wl,-soname -Wl,$(SHLIB).$(MAJOR) \
++	gcc -shared -fPIC -Wl,-z,relro -Wl,-soname -Wl,$(SHLIB).$(MAJOR) \
+ 		-o $(SHLIB).$(MAJOR).$(MINOR).$(REL) $^ $(LIBS)
+ 	ln -s $(SHLIB).$(MAJOR).$(MINOR).$(REL) $(SHLIB).$(MAJOR)
+ 	ln -s $(SHLIB).$(MAJOR).$(MINOR).$(REL) $(SHLIB)

--- a/testing/libwrap/26-tcp_wrappers-7.6-xgets.patch
+++ b/testing/libwrap/26-tcp_wrappers-7.6-xgets.patch
@@ -1,0 +1,49 @@
+commit 3ae65dc9a1c78c3088a08091f5d948fbbb8929af
+Author: Jakub Jelen <jjelen@redhat.com>
+Date:   Tue Feb 23 17:28:15 2016 +0100
+
+    tcp_wrappers-7.6-xgets.patch
+
+diff --git a/misc.c b/misc.c
+index b248a5d..204546c 100644
+--- a/misc.c
++++ b/misc.c
+@@ -35,20 +35,32 @@ FILE   *fp;
+ {
+     int     got;
+     char   *start = ptr;
++    int     c, last;
+ 
+-    while (fgets(ptr, len, fp)) {
++    while (len && fgets(ptr, len, fp)) {
+ 	got = strlen(ptr);
+ 	if (got >= 1 && ptr[got - 1] == '\n') {
+ 	    tcpd_context.line++;
+ 	    if (got >= 2 && ptr[got - 2] == '\\') {
+-		got -= 2;
++			got -= 2;
+ 	    } else {
+-		return (start);
++			return (start);
+ 	    }
++		ptr += got;
++		len -= got;
++		ptr[0] = 0;
++	} else {
++		/* over buffer len */
++		last = (got >= 1) ? ptr[got - 1] : '\0';
++		while ((c = fgetc(fp)) != EOF) {
++			if (c == '\n') {
++				tcpd_context.line++;
++				if (last != '\\')
++					return (start);
++			}
++			last = c;
++		}
+ 	}
+-	ptr += got;
+-	len -= got;
+-	ptr[0] = 0;
+     }
+     return (ptr > start ? start : 0);
+ }

--- a/testing/libwrap/27-tcp_wrappers-7.6-initgroups.patch
+++ b/testing/libwrap/27-tcp_wrappers-7.6-initgroups.patch
@@ -1,0 +1,62 @@
+diff -up tcp_wrappers_7.6/options.c.initgroups tcp_wrappers_7.6/options.c
+--- tcp_wrappers_7.6/options.c.initgroups	2011-08-11 23:10:43.610418714 +0200
++++ tcp_wrappers_7.6/options.c	2011-08-12 05:51:17.748481294 +0200
+@@ -256,8 +256,12 @@ struct request_info *request;
+ 	tcpd_jump("unknown group: \"%s\"", value);
+     endgrent();
+ 
+-    if (dry_run == 0 && setgid(grp->gr_gid))
+-	tcpd_jump("setgid(%s): %m", value);
++    if (dry_run != 0) {
++        if (setgid(grp->gr_gid))
++	   tcpd_jump("setgid(%s): %m", value);
++        if (setgroups(0, NULL))
++	   tcpd_jump("setgroups(%s): %m", value);
++    }
+ }
+ 
+ /* user_option - switch user id */
+@@ -271,15 +275,26 @@ struct request_info *request;
+     struct passwd *pwd;
+     struct passwd *getpwnam();
+     char   *group;
++    int    defaultgroup = 0;
+ 
+     if ((group = split_at(value, '.')) != 0)
+ 	group_option(group, request);
++    else
++	defaultgroup = 1;
+     if ((pwd = getpwnam(value)) == 0)
+ 	tcpd_jump("unknown user: \"%s\"", value);
+     endpwent();
+ 
+-    if (dry_run == 0 && setuid(pwd->pw_uid))
+-	tcpd_jump("setuid(%s): %m", value);
++    if (dry_run != 0) {
++        if (setuid(pwd->pw_uid))
++	    tcpd_jump("setuid(%s): %m", value);
++	if (defaultgroup) {
++            if (setgid(pwd->pw_gid))
++	       tcpd_jump("setgid(%s): %m", value);
++            if (initgroups(value, pwd->pw_gid))
++	       tcpd_jump("initgroups(%s): %m", value);
++	}
++    }
+ }
+ 
+ /* umask_option - set file creation mask */
+diff -up tcp_wrappers_7.6/safe_finger.c.initgroups tcp_wrappers_7.6/safe_finger.c
+--- tcp_wrappers_7.6/safe_finger.c.initgroups	2011-08-12 05:54:06.068606291 +0200
++++ tcp_wrappers_7.6/safe_finger.c	2011-08-12 05:55:34.835483785 +0200
+@@ -66,9 +66,11 @@ char  **argv;
+     if (getuid() == 0 || geteuid() == 0) {
+ 	if ((pwd = getpwnam(UNPRIV_NAME)) && pwd->pw_uid > 0) {
+ 	    setgid(pwd->pw_gid);
++	    initgroups(UNPRIV_NAME, pwd->pw_gid);
+ 	    setuid(pwd->pw_uid);
+ 	} else {
+ 	    setgid(UNPRIV_UGID);
++	    setgroups(0, NULL);
+ 	    setuid(UNPRIV_UGID);
+ 	}
+     }

--- a/testing/libwrap/28-tcp_wrappers-7.6-warnings.patch
+++ b/testing/libwrap/28-tcp_wrappers-7.6-warnings.patch
@@ -1,0 +1,568 @@
+diff -up tcp_wrappers_7.6-ipv6.4/clean_exit.c.warnings tcp_wrappers_7.6-ipv6.4/clean_exit.c
+--- tcp_wrappers_7.6-ipv6.4/clean_exit.c.warnings	1994-12-28 17:42:20.000000000 +0100
++++ tcp_wrappers_7.6-ipv6.4/clean_exit.c	2013-08-15 18:51:57.533244197 +0200
+@@ -13,6 +13,7 @@ static char sccsid[] = "@(#) clean_exit.
+ #endif
+ 
+ #include <stdio.h>
++#include <unistd.h>
+ 
+ extern void exit();
+ 
+diff -up tcp_wrappers_7.6-ipv6.4/fakelog.c.warnings tcp_wrappers_7.6-ipv6.4/fakelog.c
+--- tcp_wrappers_7.6-ipv6.4/fakelog.c.warnings	1994-12-28 17:42:22.000000000 +0100
++++ tcp_wrappers_7.6-ipv6.4/fakelog.c	2013-08-15 18:51:57.533244197 +0200
+@@ -17,6 +17,7 @@ static char sccsid[] = "@(#) fakelog.c 1
+ 
+ /* ARGSUSED */
+ 
++void
+ openlog(name, logopt, facility)
+ char   *name;
+ int     logopt;
+@@ -27,6 +28,7 @@ int     facility;
+ 
+ /* vsyslog - format one record */
+ 
++void
+ vsyslog(severity, fmt, ap)
+ int     severity;
+ char   *fmt;
+@@ -43,6 +45,7 @@ va_list ap;
+ 
+ /* VARARGS */
+ 
++void
+ VARARGS(syslog, int, severity)
+ {
+     va_list ap;
+@@ -56,6 +59,7 @@ VARARGS(syslog, int, severity)
+ 
+ /* closelog - dummy */
+ 
++void
+ closelog()
+ {
+     /* void */
+diff -up tcp_wrappers_7.6-ipv6.4/fix_options.c.warnings tcp_wrappers_7.6-ipv6.4/fix_options.c
+--- tcp_wrappers_7.6-ipv6.4/fix_options.c.warnings	2013-08-15 18:51:57.446243821 +0200
++++ tcp_wrappers_7.6-ipv6.4/fix_options.c	2013-08-15 18:51:57.534244202 +0200
+@@ -32,13 +32,15 @@ static char sccsid[] = "@(#) fix_options
+ 
+ /* fix_options - get rid of IP-level socket options */
+ 
++void
+ fix_options(request)
+ struct request_info *request;
+ {
+ #ifdef IP_OPTIONS
+     unsigned char optbuf[BUFFER_SIZE / 3], *cp;
+     char    lbuf[BUFFER_SIZE], *lp;
+-    int     optsize = sizeof(optbuf), ipproto;
++    unsigned int optsize = sizeof(optbuf);
++    int     ipproto;
+     struct protoent *ip;
+     int     fd = request->fd;
+     unsigned int opt;
+@@ -46,7 +48,7 @@ struct request_info *request;
+     struct in_addr dummy;
+ #ifdef HAVE_IPV6
+     struct sockaddr_storage ss;
+-    int sslen;
++    unsigned int sslen;
+ 
+     /*
+      * check if this is AF_INET socket
+diff -up tcp_wrappers_7.6-ipv6.4/hosts_access.c.warnings tcp_wrappers_7.6-ipv6.4/hosts_access.c
+--- tcp_wrappers_7.6-ipv6.4/hosts_access.c.warnings	2013-08-15 18:51:57.529244180 +0200
++++ tcp_wrappers_7.6-ipv6.4/hosts_access.c	2013-08-15 18:51:57.535244206 +0200
+@@ -33,6 +33,9 @@ static char sccsid[] = "@(#) hosts_acces
+ #include <errno.h>
+ #include <setjmp.h>
+ #include <string.h>
++#include <stdlib.h>
++#include <rpcsvc/ypclnt.h>
++#include <netdb.h>
+ 
+ extern char *fgets();
+ extern int errno;
+@@ -49,6 +52,8 @@ extern int errno;
+ 
+ extern jmp_buf tcpd_buf;
+ 
++int match_pattern_ylo(const char *, const char *);
++
+ /* Delimiters for lists of daemons or clients. */
+ 
+ static char sep[] = ", \t\r\n";
+diff -up tcp_wrappers_7.6-ipv6.4/inetcf.c.warnings tcp_wrappers_7.6-ipv6.4/inetcf.c
+--- tcp_wrappers_7.6-ipv6.4/inetcf.c.warnings	2013-08-15 18:51:57.474243942 +0200
++++ tcp_wrappers_7.6-ipv6.4/inetcf.c	2013-08-15 18:51:57.535244206 +0200
+@@ -42,6 +42,8 @@ char   *inet_files[] = {
+ static void inet_chk();
+ static char *base_name();
+ 
++int     check_path(char *, struct stat *);
++
+  /*
+   * Structure with everything we know about a service.
+   */
+diff -up tcp_wrappers_7.6-ipv6.4/options.c.warnings tcp_wrappers_7.6-ipv6.4/options.c
+--- tcp_wrappers_7.6-ipv6.4/options.c.warnings	2013-08-15 18:51:57.520244141 +0200
++++ tcp_wrappers_7.6-ipv6.4/options.c	2013-08-15 18:51:57.536244211 +0200
+@@ -41,12 +41,14 @@ static char sccsid[] = "@(#) options.c 1
+ #include <netinet/in.h>
+ #include <netdb.h>
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <syslog.h>
+ #include <pwd.h>
+ #include <grp.h>
+ #include <ctype.h>
+ #include <setjmp.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ #ifndef MAXPATHNAMELEN
+ #define MAXPATHNAMELEN  BUFSIZ
+@@ -108,21 +110,21 @@ struct option {
+ /* List of known keywords. Add yours here. */
+ 
+ static struct option option_table[] = {
+-    "user", user_option, NEED_ARG,
+-    "group", group_option, NEED_ARG,
+-    "umask", umask_option, NEED_ARG,
+-    "linger", linger_option, NEED_ARG,
+-    "keepalive", keepalive_option, 0,
+-    "spawn", spawn_option, NEED_ARG | EXPAND_ARG,
+-    "twist", twist_option, NEED_ARG | EXPAND_ARG | USE_LAST,
+-    "rfc931", rfc931_option, OPT_ARG,
+-    "setenv", setenv_option, NEED_ARG | EXPAND_ARG,
+-    "nice", nice_option, OPT_ARG,
+-    "severity", severity_option, NEED_ARG,
+-    "allow", allow_option, USE_LAST,
+-    "deny", deny_option, USE_LAST,
+-    "banners", banners_option, NEED_ARG,
+-    0,
++    { "user", user_option, NEED_ARG },
++    { "group", group_option, NEED_ARG },
++    { "umask", umask_option, NEED_ARG },
++    { "linger", linger_option, NEED_ARG },
++    { "keepalive", keepalive_option, 0 },
++    { "spawn", spawn_option, NEED_ARG | EXPAND_ARG },
++    { "twist", twist_option, NEED_ARG | EXPAND_ARG | USE_LAST },
++    { "rfc931", rfc931_option, OPT_ARG },
++    { "setenv", setenv_option, NEED_ARG | EXPAND_ARG },
++    { "nice", nice_option, OPT_ARG },
++    { "severity", severity_option, NEED_ARG },
++    { "allow", allow_option, USE_LAST },
++    { "deny", deny_option, USE_LAST },
++    { "banners", banners_option, NEED_ARG },
++    { NULL, NULL, 0 }
+ };
+ 
+ /* process_options - process access control options */
+@@ -227,13 +229,13 @@ struct request_info *request;
+     sprintf(path, "%s/%s", value, eval_daemon(request));
+     if ((fp = fopen(path, "r")) != 0) {
+ 	while ((ch = fgetc(fp)) == 0)
+-	    write(request->fd, "", 1);
++	    if (write(request->fd, "", 1));
+ 	ungetc(ch, fp);
+ 	while (fgets(ibuf, sizeof(ibuf) - 1, fp)) {
+ 	    if (split_at(ibuf, '\n'))
+ 		strcat(ibuf, "\r\n");
+ 	    percent_x(obuf, sizeof(obuf), ibuf, request);
+-	    write(request->fd, obuf, strlen(obuf));
++	    if(write(request->fd, obuf, strlen(obuf)));
+ 	}
+ 	fclose(fp);
+     } else if (stat(value, &st) < 0) {
+@@ -462,85 +464,85 @@ struct syslog_names {
+ 
+ static struct syslog_names log_fac[] = {
+ #ifdef LOG_KERN
+-    "kern", LOG_KERN,
++    { "kern", LOG_KERN },
+ #endif
+ #ifdef LOG_USER
+-    "user", LOG_USER,
++    { "user", LOG_USER },
+ #endif
+ #ifdef LOG_MAIL
+-    "mail", LOG_MAIL,
++    { "mail", LOG_MAIL },
+ #endif
+ #ifdef LOG_DAEMON
+-    "daemon", LOG_DAEMON,
++    { "daemon", LOG_DAEMON },
+ #endif
+ #ifdef LOG_AUTH
+-    "auth", LOG_AUTH,
++    { "auth", LOG_AUTH },
+ #endif
+ #ifdef LOG_LPR
+-    "lpr", LOG_LPR,
++    { "lpr", LOG_LPR },
+ #endif
+ #ifdef LOG_NEWS
+-    "news", LOG_NEWS,
++    { "news", LOG_NEWS },
+ #endif
+ #ifdef LOG_UUCP
+-    "uucp", LOG_UUCP,
++    { "uucp", LOG_UUCP },
+ #endif
+ #ifdef LOG_CRON
+-    "cron", LOG_CRON,
++    { "cron", LOG_CRON },
+ #endif
+ #ifdef LOG_LOCAL0
+-    "local0", LOG_LOCAL0,
++    { "local0", LOG_LOCAL0 },
+ #endif
+ #ifdef LOG_LOCAL1
+-    "local1", LOG_LOCAL1,
++    { "local1", LOG_LOCAL1 },
+ #endif
+ #ifdef LOG_LOCAL2
+-    "local2", LOG_LOCAL2,
++    { "local2", LOG_LOCAL2 },
+ #endif
+ #ifdef LOG_LOCAL3
+-    "local3", LOG_LOCAL3,
++    { "local3", LOG_LOCAL3 },
+ #endif
+ #ifdef LOG_LOCAL4
+-    "local4", LOG_LOCAL4,
++    { "local4", LOG_LOCAL4 },
+ #endif
+ #ifdef LOG_LOCAL5
+-    "local5", LOG_LOCAL5,
++    { "local5", LOG_LOCAL5 },
+ #endif
+ #ifdef LOG_LOCAL6
+-    "local6", LOG_LOCAL6,
++    { "local6", LOG_LOCAL6 },
+ #endif
+ #ifdef LOG_LOCAL7
+-    "local7", LOG_LOCAL7,
++    { "local7", LOG_LOCAL7 },
+ #endif
+-    0,
++    { NULL, 0 }
+ };
+ 
+ static struct syslog_names log_sev[] = {
+ #ifdef LOG_EMERG
+-    "emerg", LOG_EMERG,
++    { "emerg", LOG_EMERG },
+ #endif
+ #ifdef LOG_ALERT
+-    "alert", LOG_ALERT,
++    { "alert", LOG_ALERT },
+ #endif
+ #ifdef LOG_CRIT
+-    "crit", LOG_CRIT,
++    { "crit", LOG_CRIT },
+ #endif
+ #ifdef LOG_ERR
+-    "err", LOG_ERR,
++    { "err", LOG_ERR },
+ #endif
+ #ifdef LOG_WARNING
+-    "warning", LOG_WARNING,
++    { "warning", LOG_WARNING },
+ #endif
+ #ifdef LOG_NOTICE
+-    "notice", LOG_NOTICE,
++    { "notice", LOG_NOTICE },
+ #endif
+ #ifdef LOG_INFO
+-    "info", LOG_INFO,
++    { "info", LOG_INFO },
+ #endif
+ #ifdef LOG_DEBUG
+-    "debug", LOG_DEBUG,
++    { "debug", LOG_DEBUG },
+ #endif
+-    0,
++    { NULL, 0 }
+ };
+ 
+ /* severity_map - lookup facility or severity value */
+@@ -601,7 +603,7 @@ char   *string;
+     if (src[0] == 0)
+ 	return (0);
+ 
+-    while (ch = *src) {
++    while ((ch = *src)) {
+ 	if (ch == ':') {
+ 	    if (*++src == 0)
+ 		tcpd_warn("rule ends in \":\"");
+diff -up tcp_wrappers_7.6-ipv6.4/percent_m.c.warnings tcp_wrappers_7.6-ipv6.4/percent_m.c
+--- tcp_wrappers_7.6-ipv6.4/percent_m.c.warnings	2003-04-16 16:12:24.000000000 +0200
++++ tcp_wrappers_7.6-ipv6.4/percent_m.c	2013-08-15 18:51:57.536244211 +0200
+@@ -29,7 +29,7 @@ char   *ibuf;
+     char   *bp = obuf;
+     char   *cp = ibuf;
+ 
+-    while (*bp = *cp)
++    while ((*bp = *cp))
+ 	if (*cp == '%' && cp[1] == 'm') {
+ #ifdef USE_STRERROR
+ 	    strcpy(bp, strerror(errno));
+diff -up tcp_wrappers_7.6-ipv6.4/percent_x.c.warnings tcp_wrappers_7.6-ipv6.4/percent_x.c
+--- tcp_wrappers_7.6-ipv6.4/percent_x.c.warnings	1994-12-28 17:42:38.000000000 +0100
++++ tcp_wrappers_7.6-ipv6.4/percent_x.c	2013-08-15 18:51:57.537244215 +0200
+@@ -19,6 +19,7 @@ static char sccsid[] = "@(#) percent_x.c
+ #include <stdio.h>
+ #include <syslog.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ extern void exit();
+ 
+diff -up tcp_wrappers_7.6-ipv6.4/rfc931.c.warnings tcp_wrappers_7.6-ipv6.4/rfc931.c
+--- tcp_wrappers_7.6-ipv6.4/rfc931.c.warnings	2013-08-15 18:51:57.484243985 +0200
++++ tcp_wrappers_7.6-ipv6.4/rfc931.c	2013-08-15 18:51:57.537244215 +0200
+@@ -23,6 +23,7 @@ static char sccsid[] = "@(#) rfc931.c 1.
+ #include <setjmp.h>
+ #include <signal.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ /* Local stuff. */
+ 
+@@ -81,7 +82,7 @@ char   *dest;
+     char   *cp;
+     char   *result = unknown;
+     FILE   *fp;
+-    unsigned saved_timeout;
++    unsigned saved_timeout = 0;
+     struct sigaction nact, oact;
+ 
+     /*
+@@ -165,7 +166,7 @@ char   *dest;
+ 		     * protocol, not part of the data.
+ 		     */
+ 
+-		    if (cp = strchr(user, '\r'))
++		    if ((cp = strchr(user, '\r')))
+ 			*cp = 0;
+ 		    result = user;
+ 		}
+diff -up tcp_wrappers_7.6-ipv6.4/safe_finger.c.warnings tcp_wrappers_7.6-ipv6.4/safe_finger.c
+--- tcp_wrappers_7.6-ipv6.4/safe_finger.c.warnings	2013-08-15 18:51:57.521244146 +0200
++++ tcp_wrappers_7.6-ipv6.4/safe_finger.c	2013-08-15 18:51:57.538244219 +0200
+@@ -24,8 +24,13 @@ static char sccsid[] = "@(#) safe_finger
+ #include <sys/stat.h>
+ #include <signal.h>
+ #include <stdio.h>
++#include <stdlib.h>
++#include <unistd.h>
++#include <fcntl.h>
++#include <sys/wait.h>
+ #include <ctype.h>
+ #include <pwd.h>
++#include <grp.h>
+ 
+ extern void exit();
+ 
+@@ -40,6 +45,8 @@ char    path[] = "PATH=/bin:/usr/bin:/us
+ #define	UNPRIV_NAME	"nobody"	/* Preferred privilege level */
+ #define	UNPRIV_UGID	32767		/* Default uid and gid */
+ 
++int     pipe_stdin(char  **);
++
+ int     finger_pid;
+ 
+ void    cleanup(sig)
+@@ -49,6 +56,7 @@ int     sig;
+     exit(0);
+ }
+ 
++int
+ main(argc, argv)
+ int     argc;
+ char  **argv;
+@@ -65,13 +73,17 @@ char  **argv;
+      */
+     if (getuid() == 0 || geteuid() == 0) {
+ 	if ((pwd = getpwnam(UNPRIV_NAME)) && pwd->pw_uid > 0) {
+-	    setgid(pwd->pw_gid);
++	    if (setgid(pwd->pw_gid) != 0)
++		    return 1;
+ 	    initgroups(UNPRIV_NAME, pwd->pw_gid);
+-	    setuid(pwd->pw_uid);
++	    if (setuid(pwd->pw_uid))
++		    return 1;
+ 	} else {
+-	    setgid(UNPRIV_UGID);
++	    if (setgid(UNPRIV_UGID))
++		    return 1;
+ 	    setgroups(0, NULL);
+-	    setuid(UNPRIV_UGID);
++	    if (setuid(UNPRIV_UGID))
++		    return 1;
+ 	}
+     }
+ 
+diff -up tcp_wrappers_7.6-ipv6.4/scaffold.c.warnings tcp_wrappers_7.6-ipv6.4/scaffold.c
+--- tcp_wrappers_7.6-ipv6.4/scaffold.c.warnings	2013-08-15 18:51:57.457243868 +0200
++++ tcp_wrappers_7.6-ipv6.4/scaffold.c	2013-08-15 18:51:57.538244219 +0200
+@@ -20,6 +20,8 @@ static char sccs_id[] = "@(#) scaffold.c
+ #include <syslog.h>
+ #include <setjmp.h>
+ #include <string.h>
++#include <unistd.h>
++#include <stdlib.h>
+ 
+ #ifndef INADDR_NONE
+ #define	INADDR_NONE	(-1)		/* XXX should be 0xffffffff */
+diff -up tcp_wrappers_7.6-ipv6.4/socket.c.warnings tcp_wrappers_7.6-ipv6.4/socket.c
+--- tcp_wrappers_7.6-ipv6.4/socket.c.warnings	2013-08-15 18:51:57.479243964 +0200
++++ tcp_wrappers_7.6-ipv6.4/socket.c	2013-08-15 18:52:32.346394921 +0200
+@@ -21,6 +21,7 @@ static char sccsid[] = "@(#) socket.c 1.
+ 
+ /* System libraries. */
+ 
++#include <arpa/inet.h>
+ #include <sys/types.h>
+ #include <sys/param.h>
+ #include <sys/socket.h>
+@@ -84,7 +85,7 @@ struct request_info *request;
+ {
+     static struct sockaddr_gen client;
+     static struct sockaddr_gen server;
+-    int     len;
++    unsigned len;
+     char    buf[BUFSIZ];
+     int     fd = request->fd;
+ 
+@@ -168,7 +169,7 @@ struct request_info *request;
+ 	sock_methods(request);
+ 
+ 	memcpy(&client, res->ai_addr, res->ai_addrlen);
+-	request->client->sin = (struct sockaddr *)&client;
++	request->client->sin = (struct sockaddr_gen *)&client;
+ 	freeaddrinfo(res);
+ 
+ 	request->client->name[0] = 0;
+@@ -293,7 +294,7 @@ int     fd;
+ {
+     char    buf[BUFSIZ];
+     struct sockaddr_in sin;
+-    int     size = sizeof(sin);
++    unsigned size = sizeof(sin);
+ 
+     /*
+      * Eat up the not-yet received datagram. Some systems insist on a
+diff -up tcp_wrappers_7.6-ipv6.4/tcpdchk.c.warnings tcp_wrappers_7.6-ipv6.4/tcpdchk.c
+--- tcp_wrappers_7.6-ipv6.4/tcpdchk.c.warnings	2013-08-15 18:51:57.529244180 +0200
++++ tcp_wrappers_7.6-ipv6.4/tcpdchk.c	2013-08-15 18:51:57.540244228 +0200
+@@ -30,6 +30,8 @@ static char sccsid[] = "@(#) tcpdchk.c 1
+ #include <errno.h>
+ #include <netdb.h>
+ #include <string.h>
++#include <unistd.h>
++#include <stdlib.h>
+ 
+ extern int errno;
+ extern void exit();
+@@ -199,13 +201,15 @@ struct request_info *request;
+     char    sv_list[BUFLEN];		/* becomes list of daemons */
+     char   *cl_list;			/* becomes list of requests */
+     char   *sh_cmd;			/* becomes optional shell command */
++#ifndef PROCESS_OPTIONS
+     char    buf[BUFSIZ];
++#endif
+     int     verdict;
+     struct tcpd_context saved_context;
+ 
+     saved_context = tcpd_context;		/* stupid compilers */
+ 
+-    if (fp = fopen(table, "r")) {
++    if ((fp = fopen(table, "r"))) {
+ 	tcpd_context.file = table;
+ 	tcpd_context.line = 0;
+ 	while (xgets(sv_list, sizeof(sv_list), fp)) {
+@@ -331,7 +335,7 @@ char   *list;
+ 	    clients = 0;
+ 	} else {
+ 	    clients++;
+-	    if (host = split_at(cp + 1, '@')) {	/* user@host */
++	    if ((host = split_at(cp + 1, '@'))) {	/* user@host */
+ 		check_user(cp);
+ 		check_host(host);
+ 	    } else {
+@@ -449,7 +453,7 @@ char   *pat;
+ 	    if (err)
+ 		tcpd_warn("bad IP6 address specification: %s", pat);
+ #endif
+-    } else if (mask = split_at(pat, '/')) {	/* network/netmask */
++    } else if ((mask = split_at(pat, '/'))) {	/* network/netmask */
+ 	if (dot_quad_addr(pat) == INADDR_NONE
+ 	    || dot_quad_addr(mask) == INADDR_NONE)
+ 	    tcpd_warn("%s/%s: bad net/mask pattern", pat, mask);
+diff -up tcp_wrappers_7.6-ipv6.4/tcpd.c.warnings tcp_wrappers_7.6-ipv6.4/tcpd.c
+--- tcp_wrappers_7.6-ipv6.4/tcpd.c.warnings	2013-08-15 18:51:57.450243838 +0200
++++ tcp_wrappers_7.6-ipv6.4/tcpd.c	2013-08-15 18:51:57.540244228 +0200
+@@ -24,6 +24,7 @@ static char sccsid[] = "@(#) tcpd.c 1.10
+ #include <stdio.h>
+ #include <syslog.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ #ifndef MAXPATHNAMELEN
+ #define MAXPATHNAMELEN	BUFSIZ
+@@ -38,9 +39,12 @@ static char sccsid[] = "@(#) tcpd.c 1.10
+ #include "patchlevel.h"
+ #include "tcpd.h"
+ 
++void fix_options(struct request_info *);
++
+ int     allow_severity = SEVERITY;	/* run-time adjustable */
+ int     deny_severity = LOG_WARNING;	/* ditto */
+ 
++int
+ main(argc, argv)
+ int     argc;
+ char  **argv;
+diff -up tcp_wrappers_7.6-ipv6.4/tcpdmatch.c.warnings tcp_wrappers_7.6-ipv6.4/tcpdmatch.c
+--- tcp_wrappers_7.6-ipv6.4/tcpdmatch.c.warnings	2013-08-15 18:51:57.503244068 +0200
++++ tcp_wrappers_7.6-ipv6.4/tcpdmatch.c	2013-08-15 18:51:57.541244232 +0200
+@@ -26,9 +26,11 @@ static char sccsid[] = "@(#) tcpdmatch.c
+ #include <arpa/inet.h>
+ #include <netdb.h>
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <syslog.h>
+ #include <setjmp.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ extern void exit();
+ extern int optind;
+diff -up tcp_wrappers_7.6-ipv6.4/try-from.c.warnings tcp_wrappers_7.6-ipv6.4/try-from.c
+--- tcp_wrappers_7.6-ipv6.4/try-from.c.warnings	1994-12-28 17:42:55.000000000 +0100
++++ tcp_wrappers_7.6-ipv6.4/try-from.c	2013-08-15 18:51:57.541244232 +0200
+@@ -37,6 +37,7 @@ static char sccsid[] = "@(#) try-from.c
+ int     allow_severity = SEVERITY;	/* run-time adjustable */
+ int     deny_severity = LOG_WARNING;	/* ditto */
+ 
++int
+ main(argc, argv)
+ int     argc;
+ char  **argv;
+diff -up tcp_wrappers_7.6-ipv6.4/update.c.warnings tcp_wrappers_7.6-ipv6.4/update.c
+--- tcp_wrappers_7.6-ipv6.4/update.c.warnings	1999-10-27 10:44:39.000000000 +0200
++++ tcp_wrappers_7.6-ipv6.4/update.c	2013-08-15 18:51:57.541244232 +0200
+@@ -22,6 +22,7 @@ static char sccsid[] = "@(#) update.c 1.
+ #include <stdio.h>
+ #include <syslog.h>
+ #include <string.h>
++#include <unistd.h>
+ 
+ /* Local stuff. */
+ 

--- a/testing/libwrap/29-tcp_wrappers-7.6-uchart_fix.patch
+++ b/testing/libwrap/29-tcp_wrappers-7.6-uchart_fix.patch
@@ -1,0 +1,21 @@
+diff -up tcp_wrappers_7.6-ipv6.4/hosts_access.c.ucharpatch tcp_wrappers_7.6-ipv6.4/hosts_access.c
+--- tcp_wrappers_7.6-ipv6.4/hosts_access.c.ucharpatch	2013-01-28 10:19:20.424857730 +0100
++++ tcp_wrappers_7.6-ipv6.4/hosts_access.c	2013-01-28 10:19:44.719991745 +0100
+@@ -514,7 +514,7 @@ static void ipv6_mask(in6p, maskbits)
+ struct in6_addr *in6p;
+ int maskbits;
+ {
+-    uchar_t *p = (uchar_t*) in6p;
++    unsigned char *p = (unsigned char*) in6p;
+ 
+     if (maskbits < 0 || maskbits >= IPV6_ABITS)
+ 	return;
+@@ -525,7 +525,7 @@ int maskbits;
+     if (maskbits != 0)
+ 	*p++ &= 0xff << (8 - maskbits);
+ 
+-    while (p < (((uchar_t*) in6p)) + sizeof(*in6p))
++    while (p < (((unsigned char*) in6p)) + sizeof(*in6p))
+ 	*p++ = 0;
+ }
+ #endif

--- a/testing/libwrap/30-tcp_wrappers-7.6-altformat.patch
+++ b/testing/libwrap/30-tcp_wrappers-7.6-altformat.patch
@@ -1,0 +1,33 @@
+diff -up tcp_wrappers_7.6-ipv6.4/hosts_access.c.altformat tcp_wrappers_7.6-ipv6.4/hosts_access.c
+--- tcp_wrappers_7.6-ipv6.4/hosts_access.c.altformat	2013-08-15 18:46:30.398827866 +0200
++++ tcp_wrappers_7.6-ipv6.4/hosts_access.c	2013-08-15 18:50:03.099748732 +0200
+@@ -326,11 +326,15 @@ struct host_info *host;
+ 	    if (cbr = strchr(tok, ']'))
+ 		*cbr = '\0';
+ 
++	    if (cbr == NULL) {
++		    tcpd_warn("bad IP6 address specification");
++		    return (NO);
++	    }
+ 	    /*
+ 	     * A /nnn prefix specifies how many bits of the address we
+ 	     * need to check. 
+ 	     */
+-	    if (slash = strchr(tok, '/')) {
++	    if ((slash = strchr(tok, '/')) || (slash = strchr(cbr+1, '/'))) {
+ 		*slash = '\0';
+ 		mask = atoi(slash+1);
+ 		if (mask < 0 || mask > IPV6_ABITS) {
+diff -up tcp_wrappers_7.6-ipv6.4/tcpdchk.c.altformat tcp_wrappers_7.6-ipv6.4/tcpdchk.c
+--- tcp_wrappers_7.6-ipv6.4/tcpdchk.c.altformat	1999-10-28 08:38:06.000000000 +0200
++++ tcp_wrappers_7.6-ipv6.4/tcpdchk.c	2013-08-15 18:46:30.399827870 +0200
+@@ -430,6 +430,9 @@ char   *pat;
+ 	    int err = 0;
+ 	    int mask = IPV6_ABITS;
+ 
++	    if (!slash)
++	      slash = strchr(cbr+1, '/');
++
+ 	    if (slash != NULL) {
+ 		*slash = '\0';
+ 		mask = atoi(slash + 1);

--- a/testing/libwrap/31-tcp_wrappers-7.6-aclexec.patch
+++ b/testing/libwrap/31-tcp_wrappers-7.6-aclexec.patch
@@ -1,0 +1,158 @@
+diff --git a/hosts_access.c b/hosts_access.c
+index dfff943..13ad9f9 100644
+--- a/hosts_access.c
++++ b/hosts_access.c
+@@ -78,6 +78,9 @@ int     hosts_access_verbose = 0;
+   */
+ 
+ int     resident = (-1);		/* -1, 0: unknown; +1: yes */
++#ifdef ACLEXEC
++int	aclexec_matched = 0;
++#endif
+ 
+ /* Forward declarations. */
+ 
+@@ -179,6 +182,12 @@ struct request_info *request;
+ 	if (sh_cmd) {
+ #ifdef PROCESS_OPTIONS
+ 	    process_options(sh_cmd, request);
++# ifdef ACLEXEC
++	    if (aclexec_matched) {
++		syslog(LOG_INFO, "aclexec returned %d", aclexec_matched);
++		match = NO;
++	    }
++# endif
+ #else
+ 	    char    cmd[BUFSIZ];
+ 	    shell_cmd(percent_x(cmd, sizeof(cmd), sh_cmd, request));
+diff --git a/hosts_options.5 b/hosts_options.5
+index 3bd189e..39c7fdd 100644
+--- a/hosts_options.5
++++ b/hosts_options.5
+@@ -54,6 +54,23 @@ ALL: ALL: ALLOW
+ .sp
+ Notice the leading dot on the domain name patterns.
+ .SH RUNNING OTHER COMMANDS
++.IP "aclexec shell_command"
++Execute, in a child process, the specified shell command, after
++performing the %<letter> expansions described in the hosts_access(5)
++manual page.  The command is executed with stdin, stdout and stderr
++connected to the null device, so that it won't mess up the
++conversation with the client host. Example:
++.sp
++.nf
++.ti +3
++smtp : ALL : aclexec checkdnsbl %a
++.fi
++.sp
++executes, in a background child process, the shell command "checkdnsbl %a"
++after replacing %a by the address of the remote host.
++.sp
++The connection will be allowed or refused depending on whether the
++command returns a true or false exit status.
+ .IP "spawn shell_command"
+ Execute, in a child process, the specified shell command, after
+ performing the %<letter> expansions described in the hosts_access(5)
+diff --git a/options.c b/options.c
+index 675c9b4..b01db51 100644
+--- a/options.c
++++ b/options.c
+@@ -49,6 +49,7 @@ static char sccsid[] = "@(#) options.c 1.17 96/02/11 17:01:31";
+ #include <setjmp.h>
+ #include <string.h>
+ #include <unistd.h>
++#include <sys/wait.h>
+ 
+ #ifndef MAXPATHNAMELEN
+ #define MAXPATHNAMELEN  BUFSIZ
+@@ -78,6 +79,7 @@ static void group_option();		/* execute "group name" option */
+ static void umask_option();		/* execute "umask mask" option */
+ static void linger_option();		/* execute "linger time" option */
+ static void keepalive_option();		/* execute "keepalive" option */
++static void aclexec_option();		/* execute "aclexec command" option */
+ static void spawn_option();		/* execute "spawn command" option */
+ static void twist_option();		/* execute "twist command" option */
+ static void rfc931_option();		/* execute "rfc931" option */
+@@ -115,6 +117,9 @@ static struct option option_table[] = {
+     { "umask", umask_option, NEED_ARG },
+     { "linger", linger_option, NEED_ARG },
+     { "keepalive", keepalive_option, 0 },
++#ifdef ACLEXEC
++    { "aclexec", aclexec_option, NEED_ARG | EXPAND_ARG },
++#endif
+     { "spawn", spawn_option, NEED_ARG | EXPAND_ARG },
+     { "twist", twist_option, NEED_ARG | EXPAND_ARG | USE_LAST },
+     { "rfc931", rfc931_option, OPT_ARG },
+@@ -327,6 +332,54 @@ struct request_info *request;
+ 	shell_cmd(value);
+ }
+ 
++#ifdef ACLEXEC
++/* aclexec_option - spawn a shell command and check status */
++
++/* ARGSUSED */
++
++static void aclexec_option(value, request)
++char   *value;
++struct request_info *request;
++{
++    int status, child_pid, wait_pid;
++    extern int aclexec_matched;
++
++    if (dry_run != 0)
++	    return;
++
++    child_pid = fork();
++
++    /* Something went wrong: we MUST terminate the process. */
++    if (child_pid < 0) {
++	tcpd_warn("aclexec_option: /bin/sh: %m");
++	clean_exit(request);
++    }
++
++    if (child_pid == 0) {
++	execl("/bin/sh", "sh", "-c", value, (char *) 0);
++
++        /* Something went wrong. We MUST terminate the child process. */
++        tcpd_warn("execl /bin/sh: %m");
++	_exit(0);
++    }
++
++    while ((wait_pid = wait(&status)) != -1 && wait_pid != child_pid)
++	/* void */ ;
++
++    aclexec_matched = 1;
++
++    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
++	aclexec_matched = 0;
++    }
++
++    if (WIFSIGNALED(status))
++	tcpd_warn("process %d exited with signal %d", child_pid,
++	    WTERMSIG(status));
++
++    return;
++}
++#endif
++
+ /* linger_option - set the socket linger time (Marc Boucher <marc@cam.org>) */
+ 
+ /* ARGSUSED */
+diff --git a/tcpdchk.c b/tcpdchk.c
+index e67ffb0..8c74df8 100644
+--- a/tcpdchk.c
++++ b/tcpdchk.c
+@@ -59,10 +59,6 @@ static char sep[] = ", \t\n";
+ 
+ #define	BUFLEN 2048
+ 
+-int     resident = 0;
+-int     hosts_access_verbose = 0;
+-char   *hosts_allow_table = HOSTS_ALLOW;
+-char   *hosts_deny_table = HOSTS_DENY;
+ extern jmp_buf tcpd_buf;
+ 
+  /*
+-- 
+2.1.0
+

--- a/testing/libwrap/40-remove-glibc.patch
+++ b/testing/libwrap/40-remove-glibc.patch
@@ -1,0 +1,19 @@
+--- tcp_wrappers_7.6-ipv6.4/tcpd.h
++++ tcp_wrappers_7.6-ipv6.4/tcpd.h.new
+@@ -21,8 +21,6 @@
+ #include <netinet/in.h>
+ #include <stdio.h>
+ 
+-__BEGIN_DECLS
+-
+ /* Structure to describe one communications endpoint. */
+ 
+ #define STRING_LENGTH	128		/* hosts, users, processes */
+@@ -331,7 +329,5 @@
+ #define strtok	my_strtok
+ extern char *my_strtok();
+ #endif
+-
+-__END_DECLS
+ 
+ #endif /* tcpd.h */

--- a/testing/libwrap/41-innetgr-stub.patch
+++ b/testing/libwrap/41-innetgr-stub.patch
@@ -1,0 +1,27 @@
+--- tcp_wrappers_7.6-ipv6.4/hosts_access.c
++++ tcp_wrappers_7.6-ipv6.4/hosts_access.c.new
+@@ -95,6 +95,9 @@
+ static void ipv6_mask();
+ #endif
+ 
++/* innetgr stub */
++int innetgr(const char *, const char *, const char *, const char *);
++
+ /* Size of logical line buffer. */
+ 
+ #define	BUFLEN 2048
+@@ -277,6 +280,14 @@
+     }
+     return (match);
+ }
++
++/* innetgr stub: http://www.openwall.com/lists/musl/2012/05/16/2 */
++int innetgr(const char *netgroup, const char *host,
++	const char *user, const char *domain)
++{
++	return 0;
++}
++
+ 
+ /* host_match - match host name and/or address against pattern */
+ 

--- a/testing/libwrap/42-fix-implicit-malloc.patch
+++ b/testing/libwrap/42-fix-implicit-malloc.patch
@@ -1,0 +1,10 @@
+--- tcp_wrappers_7.6-ipv6.4/inetcf.c
++++ tcp_wrappers_7.6-ipv6.4/inetcf.c.new
+@@ -14,6 +14,7 @@
+ #include <stdio.h>
+ #include <errno.h>
+ #include <string.h>
++#include <stdlib.h>
+ 
+ extern int errno;
+ extern void exit();

--- a/testing/libwrap/43-disable-netgroup.patch
+++ b/testing/libwrap/43-disable-netgroup.patch
@@ -1,0 +1,18 @@
+--- tcp_wrappers_7.6-ipv6.4/tcpdchk.c
++++ tcp_wrappers_7.6-ipv6.4/tcpdchk.c.new
+@@ -410,15 +410,6 @@
+ 	/* SCO has no *netgrent() support */
+ #else
+ #ifdef NETGROUP
+-	char   *machinep;
+-	char   *userp;
+-	char   *domainp;
+-
+-	setnetgrent(pat + 1);
+-	if (getnetgrent(&machinep, &userp, &domainp) == 0)
+-	    tcpd_warn("%s: unknown or empty netgroup", pat + 1);
+-	endnetgrent();
+-#else
+ 	tcpd_warn("netgroup support disabled");
+ #endif
+ #endif

--- a/testing/libwrap/APKBUILD
+++ b/testing/libwrap/APKBUILD
@@ -1,0 +1,144 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+pkgname=libwrap
+_pkgname=tcp_wrappers
+pkgver=7.6.26
+pkgrel=0
+pkgdesc="Monitors and Controls incoming TCP connections [ipv4 + ipv6]"
+url="ftp://ftp.porcupine.org/pub/security/index.html"
+arch="all"
+license="BSD"
+options="!check"
+makedepends="libnsl-dev bsd-compat-headers"
+subpackages="$pkgname-dev $pkgname-doc ${_pkgname/_/-} ${_pkgname/_/-}-doc"
+source="ftp://ftp.porcupine.org/pub/security/${_pkgname}_${pkgver%.*}-ipv6.4.tar.gz
+	00-tcpw7.2-config.patch
+	01-tcpw7.2-setenv.patch
+	02-tcpw7.6-netgroup.patch
+	03-tcp_wrappers-7.6-bug11881.patch
+	04-tcp_wrappers-7.6-bug17795.patch
+	05-tcp_wrappers-7.6-bug17847.patch
+	06-tcp_wrappers-7.6-fixgethostbyname.patch
+	07-tcp_wrappers-7.6-docu.patch
+	08-tcp_wrappers-7.6-man.patch
+	09-tcp_wrappers.usagi-ipv6.patch
+	11-tcp_wrappers-7.6-shared.patch
+	12-tcp_wrappers-7.6-sig.patch
+	14-tcp_wrappers-7.6-ldflags.patch
+	15-tcp_wrappers-7.6-fix_sig-bug141110.patch
+	16-tcp_wrappers-7.6-162412.patch
+	17-tcp_wrappers-7.6-220015.patch
+	19-tcp_wrappers-7.6-siglongjmp.patch
+	20-tcp_wrappers-7.6-sigchld.patch
+	21-tcp_wrappers-7.6-196326.patch
+	22-tcp_wrappers_7.6-249430.patch
+	23-tcp_wrappers-7.6-inetdconf.patch
+	24-tcp_wrappers-7.6-bug698464.patch
+	25-tcp_wrappers-7.6-relro.patch
+	26-tcp_wrappers-7.6-xgets.patch
+	27-tcp_wrappers-7.6-initgroups.patch
+	28-tcp_wrappers-7.6-warnings.patch
+	29-tcp_wrappers-7.6-uchart_fix.patch
+	30-tcp_wrappers-7.6-altformat.patch
+	31-tcp_wrappers-7.6-aclexec.patch
+	40-remove-glibc.patch
+	41-innetgr-stub.patch
+	42-fix-implicit-malloc.patch
+	43-disable-netgroup.patch
+	hosts.allow
+	hosts.deny
+	"
+
+builddir="$srcdir/"${_pkgname}_${pkgver%.*}-ipv6.4
+
+prepare() {
+	chmod 600 $builddir/*
+	default_prepare || return 1
+}
+
+build() {
+	cd "$builddir"
+	make \
+		COPTS="$CFLAGS" \
+		LDFLAGS="$LDFLAGS -pie -z relro -z now" \
+		REAL_DAEMON_DIR='/usr/sbin' \
+		STYLE='-DPROCESS_OPTIONS' \
+		MAJOR=0 \
+		MINOR=7 \
+		REL=6 \
+		linux || return 1
+}
+
+wrappers() {
+	cd "$builddir"
+
+	depends="libwrap"
+	pkgdesc="Wietse Venema's network logger, also known as TCPD or LOG_TCP."
+
+	# bin #
+	mkdir -p "$subpkgdir"/usr/sbin "$subpkgdir"/etc
+
+	install -Dm 755 safe_finger tcpd tcpdchk tcpdmatch try-from -t "$subpkgdir"/usr/sbin || return 1
+	install -Dm 644 "$srcdir"/hosts.allow -t "$subpkgdir"/etc || return 1
+	install -Dm 644 "$srcdir"/hosts.deny -t "$subpkgdir"/etc || return 1
+
+	# docs #
+	mkdir -p "$subpkgdir-doc"/usr/share/man/man3 "$subpkgdir-doc"/usr/share/man/man5 "$subpkgdir-doc"/usr/share/man/man8
+	mkdir -p "$subpkgdir-doc"/usr/share/licenses "$subpkgdir-doc"/usr/share/doc/tcp-wrappers
+
+	install -Dm 644 *.3 -t "$subpkgdir-doc"/usr/share/man/man3 || return 1
+	install -Dm 644 *.5 -t "$subpkgdir-doc"/usr/share/man/man5 || return 1
+	install -Dm 644 *.8 -t "$subpkgdir-doc"/usr/share/man/man8 || return 1
+	install -Dm 644 README -t "$subpkgdir-doc"/usr/share/doc/tcp-wrappers || return 1
+
+	ln -sf hosts_access.5 "$subpkgdir-doc"/usr/share/man/man5/hosts.allow.5
+	ln -sf hosts_access.5 "$subpkgdir-doc"/usr/share/man/man5/hosts.deny.5
+	ln -s libwrap "$subpkgdir-doc"/usr/share/licenses/tcp-wrappers
+}
+
+package() {
+	cd "$builddir"
+
+	mkdir -p "$pkgdir"/usr/include "$pkgdir"/usr/lib "$pkgdir"/usr/share/licenses/libwrap
+
+	cp -a libwrap.so* "$pkgdir"/usr/lib
+	install -Dm 644 tcpd.h -t "$pkgdir"/usr/include || return 1
+	install -Dm 644 DISCLAIMER -t "$pkgdir"/usr/share/licenses/libwrap || return 1
+}
+
+sha512sums="b753b2e54fe243fbcb403470b19fa1b08a912a6a65981dc1bf20288379b903701d4b5a477350cb3470cb6d908cf51ef653f44dc17daff17f34e59b6aa1b41c95  tcp_wrappers_7.6-ipv6.4.tar.gz
+45a7e2258d6d8d77d941098ef35899e4bdec6a4b209e460d5082dc6ed257f4fd0a464e424747b4cc77a09931d96978bb3bf44ed62e5e40598327561068fd5073  00-tcpw7.2-config.patch
+432252edda67bb31d40fb64a55efcc7200a3232482bf2943ef7ee1c1942eabf445558f7216f056afe3e6575a4fe1aa07e3b29d82e0e7a070e474dea7035efb2f  01-tcpw7.2-setenv.patch
+bd71dfc9ee9cef89a6dda920d273658fc754bd434606b91beb08f11cb01a2def7361b23e879e636235e00108eb82e279fd9c69a2b144248f8a5ee2b4c043cfd0  02-tcpw7.6-netgroup.patch
+8e354549d7cee514eabb20776450498e81d4e12ee460cabc58a5e4ca835400674391a5df1c116d3dcf1bd961a62cbe99f2722e7aaa7d9c03e2fed69712e3645c  03-tcp_wrappers-7.6-bug11881.patch
+119cb6dbc0c5c548a8fb6a1a62fd0e5e39ffa67a0340aaa4aaddf9b33f5ea5b7f37379a69d5dbdd00cfbb8ba796b67d9240cc79197cdafdc0fe95146526d3400  04-tcp_wrappers-7.6-bug17795.patch
+b2c3d10319d5255c509fe5c6e05818764346ba8c5794b802ae3b340a8ead21b26fbab18c0eaed2a3b44ee75e261d9ad5d26890a9e928039676de6813b85362dd  05-tcp_wrappers-7.6-bug17847.patch
+1ad58fa17d793f7c3f13402a0ec562aa35ac068dc3d043a5f44e9df3bd2463d01c42b14ea204e06474500c98a2c59f262eded7c7b0525db9123c790e7381e650  06-tcp_wrappers-7.6-fixgethostbyname.patch
+82ec0124c4a780f0bf15029a4865f0569e749563796396f96eab9315850c7fdcdee8c3caac49697abc407af358ef669b937054070cd75c53d0e9e96d96149958  07-tcp_wrappers-7.6-docu.patch
+3606994ddea614f4e469295e7e162c2a3798ce939f62a8ca0b530da52d6a37fb6da9687a3ebfe18c301952a399b519b0b84dc7fd6ebb9b76db2b038512e8deb1  08-tcp_wrappers-7.6-man.patch
+c2f25e751b5e54cb0e4c0467c7256dfcb43f132e4e1e51a9ed2b978110ed4732713548046ca9820c924f811b7486b32a9d476f2f0cc5a83a9971023ccb9dfd48  09-tcp_wrappers.usagi-ipv6.patch
+ced7d926929ff2491359e1502349373e52b0d1c8d1ef3ed167f926095d7e5f91d4d1b2ac36bfd855ef9f9a332a63472835e819df8f196106f71b64863d7b5d8e  11-tcp_wrappers-7.6-shared.patch
+65f7c7a18eb36ccae93a14e41966f9a4223568c31594b410dc97524047a1b367a9ecd65fd4f68d7cba022569459ed7da3fef692ecad28e3009eca9b708d86dd4  12-tcp_wrappers-7.6-sig.patch
+16a4157f41a250d5a9c9cad40686cf2359757fd81a816d72868b9dd71a1f1bea9599f84f46b790f3be82ca76a0efed374920e0c4e26870e4528fcfee41fcf3b9  14-tcp_wrappers-7.6-ldflags.patch
+8b0988d7a376521376a7953f431c4c12382bde86c9391a9ad538fd5694bc340cc619e957dd0ea5a03b118c3ab055a56f7992f6581e7fe98a472ada2182bd2c9c  15-tcp_wrappers-7.6-fix_sig-bug141110.patch
+ee5fd83a18b9fb8a26c3b99dfb2caadb349b09f71f21ad29b9cd1c51a2b938240c60d0373da4685085878da2e56ade47b2513e99d1b1a65bbefeb44c260a6b07  16-tcp_wrappers-7.6-162412.patch
+61602bd585412da5f34e816546df624aae38a4112ad247b9bad86993db433e2748250a439b4aed5ab19a97445152ff5290bf94c5b17502efa5f396431635d62a  17-tcp_wrappers-7.6-220015.patch
+7ebe75b579bda344dc4e994c4752678c8d6696fff21bdde26d3730b778c311d306bed5ecf0fb19c5115b9b507b966638ef7b2ac9e9498a471c5f3bc4b9f73419  19-tcp_wrappers-7.6-siglongjmp.patch
+69f94bcb53e143c3fbbf085dd75123e99c0539125e7683db897bab9f44ad3432652ed05b1d704519e08a0175ae93bc917f5a57d1bbe7b850651dadfea5dc5f72  20-tcp_wrappers-7.6-sigchld.patch
+8581b6ef5a37371a60b1709d0e219e6d1b6e1b5cbdec0528bdf5987ce5add1f7252bddcc8283943e8ed7a562b799e0fd4cac2ba62dc61f7e17df90ee03b0ed2d  21-tcp_wrappers-7.6-196326.patch
+fe8ad0aa1a528f84c52975c1dad83ba6758b2236dda072df8beab641d42e47684f2ad72afeb1ff9a988c6f24cb2a5144ac5cd15ef1e9f6773c3786a5fe8dc7c8  22-tcp_wrappers_7.6-249430.patch
+a629845874508a7362d761f9406373732a1c0e960196caa9a3001fe40f990f0c707fb3c7d03e2635e8b2135cec4d5866e0e265e7aa150fc50c66fa86ceddd3f7  23-tcp_wrappers-7.6-inetdconf.patch
+043a7394b57fb3f55c6abf1ff12dea9040f0f78513aa28f65195cb64655dd64465d7784c283110aa0455209b1872dd6a9f31ffcec1b903523ba788544ad987de  24-tcp_wrappers-7.6-bug698464.patch
+faeea18e604f9111b118c8ae7520fafc6a53f0ca2b02f8c433c1f52373f3972347e31d993c1609294d77da121a98fb255a3fdd5883469bde0106a887b1c5ddbf  25-tcp_wrappers-7.6-relro.patch
+1a28928bb5a5eac4350e63decdca313f701cf8cab5e55f5f58825bbec95ebb4c556308c17ec4f0bdc9e255791cdff5374b686c9b6bbd4e5a9dafbdeae1d13a13  26-tcp_wrappers-7.6-xgets.patch
+d1e6a84960215fdb1e5c6c530c43cd4faa18d5aed3838314d914477a655a810cf6ca28669b7082139a7e723eed9845801f86f4b7cece7e17e239faaec0e28c68  27-tcp_wrappers-7.6-initgroups.patch
+c7cdb6b8311568931412b23d92fb6e711a2ee338908eb6157ba38c34f8295c0961407141407749a80ccd47e0c1977e28d3f0241b608f2aacdd482e5ab6f93c61  28-tcp_wrappers-7.6-warnings.patch
+d87675146360b7743441702bcd649adee2f1090b2e7abf0bc4e1109ea0356dab25ab4d0e36c97aec2d51eedd14c1090d0b47412c2df413cd8023e225900f2aa4  29-tcp_wrappers-7.6-uchart_fix.patch
+f005ff45c190aa8f2a4972b37898ed8ad83ac502abc2351c87d2f28242a2eee70cdfdd620edbbacc1987d2ab53c2d35ef6dcad420eafa5f66b0c9b66fa018745  30-tcp_wrappers-7.6-altformat.patch
+aa7c82cee6f60b709ced8f757e4c0124081e6753d63aebd77317fa86dcc58aba922a2202debb542e51427fa3e12385112ff3790dfe987d2b6a6f27b7faf4b816  31-tcp_wrappers-7.6-aclexec.patch
+cd49ba0ae344c53d616cf91506bef2cb5f881d95c7d89b6f26ad0a0bf4a336067bb12cfa765c017ddd5d28b49110ddbf0d20de403eae00e8c5cf182df6e769d1  40-remove-glibc.patch
+df69d78fe2e6fd138f0cd7dff3493abf98a78b3842b9ff4dd2cc65706c1a827b927c89c8d2f32c83543c1d7e797890801e0ec8d7de4bf50a8beb114035028b32  41-innetgr-stub.patch
+3d8ebebf87eb50294c3777630153af0e3aa918e55e36b5fe8cac96ede803bd0b5538b08cb1c9d700d7059fc72cb74558399930ad8712e2e4de728f09c81356a1  42-fix-implicit-malloc.patch
+165ca939e606b0ec745e0a7070c8829e6b5b0ecf04a8a8e3181276fe2892072bbfad7180a3954b198905f559b98858b710e6068574bc664786f351bfcb3bf24a  43-disable-netgroup.patch
+43f0707078078d473c9cba9aa5a7a4e1f9b23387b3c6e544aca75c76285fbdebb62d0a57a9093dbd6d8329f5cc05b27634eb85025716a8722d8d76629dd1a1df  hosts.allow
+b5fdad37ea2e14d4f481cf8eede95db3e8052974d535d2db93c231913d0b95e6e66e0866edd5414a22d5b036545fef4b9dce2e9f4aa49538456847b2647eec39  hosts.deny"

--- a/testing/libwrap/hosts.allow
+++ b/testing/libwrap/hosts.allow
@@ -1,0 +1,6 @@
+#
+# /etc/hosts.allow
+#
+
+# End of file
+

--- a/testing/libwrap/hosts.deny
+++ b/testing/libwrap/hosts.deny
@@ -1,0 +1,8 @@
+#
+# /etc/hosts.deny
+#
+
+ALL: ALL : spawn /bin/echo `date` %c %d >> /var/log/hosts.deny.log
+
+# End of file
+


### PR DESCRIPTION
* patched ipv4 + ipv6 version used by [Red Hat](http://pkgs.fedoraproject.org/cgit/rpms/tcp_wrappers.git/commit/)

* built without linking to `glibc` libs that do not exist in `musl`

* hostname lookups are therefore disabled