### PR TITLE
community/wait4ports: new aport

### DIFF
--- a/community/wait4ports/APKBUILD
+++ b/community/wait4ports/APKBUILD
@@ -1,0 +1,28 @@
+# Contributor: Erik Ogan <erik@stealthymonkeys.com>
+# Maintainer: Erik Ogan <erik@stealthymonkeys.com>
+pkgname=wait4ports
+pkgver=0.0.4
+pkgrel=0
+pkgdesc="A small utility to wait for network peer availability."
+url="https://github.com/erikogan/wait4ports"
+arch="all"
+license="MPL-2.0"
+depends=""
+makedepends=""
+install=""
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/erikogan/wait4ports/archive/v${pkgver}.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	make || return 1
+}
+
+package() {
+	cd "$builddir"
+	make PREFIX="$pkgdir" install || return 1
+}
+
+md5sums="540262422fc204037bb2315bcfb438e5  wait4ports-0.0.4.tar.gz"
+sha256sums="c94789f1c353c87d0a14fea88ef565cef8807bde2903e5020565f86c656e2597  wait4ports-0.0.4.tar.gz"
+sha512sums="a3f0df9fcfde0c49626327f19a5ba71d8c59311f04a874f3470d92503d577a4eedcc46f4432ddf9386b966ce5bee522f3c9a2c4d88b037ffd0caf7022358a461  wait4ports-0.0.4.tar.gz"


### PR DESCRIPTION
wait4ports is a small binary that waits for network peers to be ready for connections.

I wrote [wait4ports](https://github.com/erikogan/wait4ports) in 2015 when I could not find a small tool to reliably poll for a list of network peers to be ready for connections. This is mostly for use in docker environments. It expects arguments in a format similar to docker network link `<prefix>_PORT` environment variables (`[name=]<proto>://<addr>:<port>`)

If there is a better way in Alpine Linux, I would love to use that instead.