### PR TITLE
main/jemalloc: update to 4.4.0

### DIFF
--- a/main/jemalloc/APKBUILD
+++ b/main/jemalloc/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=jemalloc
-pkgver=4.2.1
+pkgver=4.4.0
 pkgrel=0
 pkgdesc="A general purpose malloc(3) implementation"
 url="http://www.canonware.com/jemalloc/"
@@ -10,8 +10,9 @@ license="BSD"
 depends=""
 makedepends=""
 subpackages="$pkgname-dev $pkgname-doc"
-source="http://www.canonware.com/download/jemalloc/$pkgname-$pkgver.tar.bz2
-	jemalloc-no-pprof.patch"
+source="$pkgname-$pkgver.tar.bz2::https://github.com/$pkgname/$pkgname/releases/download/$pkgver/$pkgname-$pkgver.tar.bz2
+	jemalloc-no-pprof.patch
+	"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -24,6 +25,7 @@ build() {
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--localstatedir=/var \
+		--disable-syscall \
 		|| return 1
 	make || return 1
 }
@@ -33,9 +35,5 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-md5sums="094b0a7b8c77c464d0dc8f0643fd3901  jemalloc-4.2.1.tar.bz2
-4619ff9178f3218dd142d43e5d9f5c46  jemalloc-no-pprof.patch"
-sha256sums="5630650d5c1caab95d2f0898de4fe5ab8519dc680b04963b38bb425ef6a42d57  jemalloc-4.2.1.tar.bz2
-a001510da976d20ba13a9e0d027212a1a62cf574e462850f6764636f23b6a79c  jemalloc-no-pprof.patch"
-sha512sums="a0bbf2150371bf31b386c668bc636a56e82145a8a81586d0898cdeed707bf1b694e777ea2afba521584998a60663bb4734e8a83697a337ea13e6ade4de737c18  jemalloc-4.2.1.tar.bz2
+sha512sums="2f88fb17ede3bf87e334e9c80949870e0dd85b5adcdd89a1750ccf6df5240f35293159ac0a360d3a29cf0b1d17edf86dcc7997c6bf3190ae7da7442d3a3cc14e  jemalloc-4.4.0.tar.bz2
 a97c4eb504f8eb725fdd65683b512ea69773f1a183020a785cd02c5ac7e174a7206bf921a30ce63e5b183ef7bef34cec28ccdb57e16dfebd33f5a8161af2989d  jemalloc-no-pprof.patch"


### PR DESCRIPTION
added `--disable-syscall` configure option

[ for use on systems that place security-motivated limitations on `syscall(2)` ]