### PR TITLE
main/ltrace: add ppc64le support

### DIFF
--- a/main/ltrace/APKBUILD
+++ b/main/ltrace/APKBUILD
@@ -12,7 +12,8 @@ subpackages="$pkgname-doc"
 # you find latest release here, but need a login:
 # https://alioth.debian.org/frs/?group_id=30892
 source="http://dev.alpinelinux.org/archive/ltrace/ltrace-$pkgver.tar.bz2
-	musl.patch"
+	musl.patch
+	add_ppc64le.patch"
 
 _builddir="$srcdir"/$pkgname-$pkgver
 prepare() {
@@ -42,8 +43,11 @@ package() {
 	make install INSTALL=install DESTDIR="$pkgdir" || return 1
 }
 md5sums="b3dd199af8f18637f7d4ef97fdfb9d14  ltrace-0.7.3.tar.bz2
-cb921b7749a7452f9561325dec5a7662  musl.patch"
+cb921b7749a7452f9561325dec5a7662  musl.patch
+7e1f190d42cb8d2f282fa20217cfaa9e  add_ppc64le.patch"
 sha256sums="0e6f8c077471b544c06def7192d983861ad2f8688dd5504beae62f0c5f5b9503  ltrace-0.7.3.tar.bz2
-4a074b796ab9b020b42c4704549a07e6d57f15606b2942a5261859c5a4f7aaf8  musl.patch"
+4a074b796ab9b020b42c4704549a07e6d57f15606b2942a5261859c5a4f7aaf8  musl.patch
+ce38d40c2a996b5fe7774de43e5124b52836c3b62944b9f635734f4265a60f9c  add_ppc64le.patch"
 sha512sums="a842b16dcb81da869afa0bddc755fdff0d57b35672505bf2c7164fd983b1938d28b126714128930994cc1230ced69d779456d0cfc16f4008c9b6d19f0852285d  ltrace-0.7.3.tar.bz2
-c53e05471c52e161a7f7389994c6467e8f3671c5d8478546bc1897f067c62aeab848d728295f339a241a3fc186e180d47bcc2872a6335877c3813b1b62834698  musl.patch"
+c53e05471c52e161a7f7389994c6467e8f3671c5d8478546bc1897f067c62aeab848d728295f339a241a3fc186e180d47bcc2872a6335877c3813b1b62834698  musl.patch
+987c6d18bdb559e8fe739f09cfb0b567dafcf79b2bd5db7ca32ebb205f3b1d74a8008576e4d73ea90873c1ab9bed17d96ddb7ad8752bf0a160ea0638c955eb1f  add_ppc64le.patch"

--- a/main/ltrace/add_ppc64le.patch
+++ b/main/ltrace/add_ppc64le.patch
@@ -1,0 +1,54 @@
+--- ltrace-0.7.3.orig/configure.ac
++++ ltrace-0.7.3/configure.ac
+@@ -43,7 +43,7 @@
+     arm*|sa110)		HOST_CPU="arm" ;;
+     cris*)		HOST_CPU="cris" ;;
+     mips*)		HOST_CPU="mips" ;;
+-    powerpc|powerpc64)	HOST_CPU="ppc" ;;
++    powerpc|powerpc64|powerpc64le)	HOST_CPU="ppc" ;;
+     sun4u|sparc64)	HOST_CPU="sparc" ;;
+     s390x)		HOST_CPU="s390" ;;
+     i?86|x86_64)	HOST_CPU="x86" ;;
+@@ -159,7 +159,7 @@
+       arm*|sa110)         UNWIND_ARCH="arm" ;;
+       i?86)               UNWIND_ARCH="x86" ;;
+       powerpc)            UNWIND_ARCH="ppc32" ;;
+-      powerpc64)          UNWIND_ARCH="ppc64" ;;
++      powerpc64|powerpc64le)          UNWIND_ARCH="ppc64" ;;
+       mips*)              UNWIND_ARCH="mips" ;;
+       *)                  UNWIND_ARCH="${host_cpu}" ;;
+   esac
+--- ltrace-0.7.3.orig/sysdeps/linux-gnu/ppc/ptrace.h
++++ ltrace-0.7.3/sysdeps/linux-gnu/ppc/ptrace.h
+@@ -18,4 +18,5 @@
+  * 02110-1301 USA
+  */
+ 
++#include <asm/ptrace.h>
+ #include <sys/ptrace.h>
+--- ltrace-0.7.3.orig/sysdeps/linux-gnu/ppc/regs.c
++++ ltrace-0.7.3/sysdeps/linux-gnu/ppc/regs.c
+@@ -26,7 +26,9 @@
+ #include <sys/ptrace.h>
+ #include <asm/ptrace.h>
+ #include <errno.h>
++#ifdef HAVE_ERROR_H
+ #include <error.h>
++#endif
+ 
+ #include "proc.h"
+ #include "common.h"
+@@ -47,8 +49,11 @@
+ void
+ set_instruction_pointer(Process *proc, void *addr)
+ {
+-	if (ptrace(PTRACE_POKEUSER, proc->pid, sizeof(long)*PT_NIP, addr) != 0)
+-		error(0, errno, "set_instruction_pointer");
++	if (ptrace(PTRACE_POKEUSER, proc->pid, sizeof(long)*PT_NIP, addr) != 0){
++		strerror(0, errno, "set_instruction_pointer");
++		report_global_error("%s: set_instruction_pointer",
++			strerror(errno));
++	}
+ }
+ 
+ void *


### PR DESCRIPTION
Current ltrace version does not have ppc64le support, but the
upstream version has, so, I backported commit-id
eea6091f8672b01f7f022b0fc367e0f568225ffc.

I also did some changes related to musl lack of error().