### PR TITLE
community/shadow: useradd with usergroups

### DIFF
--- a/community/shadow/APKBUILD
+++ b/community/shadow/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=shadow
 pkgver=4.2.1
-pkgrel=7
+pkgrel=8
 pkgdesc="PAM-using login and passwd utilities (usermod, useradd, ...)"
 url="http://pkg-shadow.alioth.debian.org/"
 arch="all"
@@ -18,6 +18,7 @@ source="http://pkg-shadow.alioth.debian.org/releases/shadow-$pkgver.tar.xz
 	verbose-error-when-uid-doesnt-match.patch
 	301-CVE-2017-2616-su-properly-clear-child-PID.patch
 	302-CVE-2016-6252-fix-integer-overflow.patch
+	useradd-usergroups.patch
 	"
 # secfixes:
 #     - CVE-2016-6252
@@ -61,9 +62,9 @@ package() {
 	# However, install our own for login.
 	cp "$srcdir"/login.pamd "$pkgdir"/etc/pam.d/login || return 1
 
-	# /etc/login.defs is not very useful - replace it with a blank file.
+	# /etc/login.defs is not very useful - replace it with an *almost* blank file.
 	rm "$pkgdir"/etc/login.defs
-	touch "$pkgdir"/etc/login.defs
+	echo "USERGROUPS_ENAB yes" > "$pkgdir"/etc/login.defs
 
 	# Avoid conflict with man-pages.
 	rm "$pkgdir"/usr/share/man/man3/getspnam.3* \
@@ -91,4 +92,5 @@ sha512sums="7a14bf8e08126f0402e37b6e4c559615ced7cf829e39156d929ed05cd8813de48a77
 c46760254439176babeef24d93900914092655af3a48f54385adf6ef5a3af76799fb7e96083acd27853d6ab6d7392543dbaf70bb26f164519e92f677da7851a4  cross-size-checks.patch
 1b3513772a7a0294b587723213e4464cc5a1a42ae6a79e9b9f9ea20083684a21d81e362f44d87ce2e6de2daf396d8422b39019923c0b0cbb44fa4c4c24613c0c  verbose-error-when-uid-doesnt-match.patch
 0954920ce9307948848d8f9ca5ea5bba4db8394793ef314ab5c6770948e96071748192b52ba8c31d543fe71ce0e6e2a7f3a2a92862966a940639a19df1048634  301-CVE-2017-2616-su-properly-clear-child-PID.patch
-36f494347cb980d85ea82331ec620a949be45f5f2c400a3b13f409a8d9c932c0f822cb0baa2ee78c6f356e7bf93de51c1b0f20730e8f3af36a746a5632d19bbe  302-CVE-2016-6252-fix-integer-overflow.patch"
+36f494347cb980d85ea82331ec620a949be45f5f2c400a3b13f409a8d9c932c0f822cb0baa2ee78c6f356e7bf93de51c1b0f20730e8f3af36a746a5632d19bbe  302-CVE-2016-6252-fix-integer-overflow.patch
+49f1d5ded82d2d479805c77d7cc6274c30233596e375b28306b31a33f8fbfc3611dbc77d606081b8300247908c267297dbb6c5d1a30d56095dda53c6a636fb56  useradd-usergroups.patch"

--- a/community/shadow/useradd-usergroups.patch
+++ b/community/shadow/useradd-usergroups.patch
@@ -1,0 +1,8 @@
+--- a/etc/useradd
++++ b/etc/useradd
+@@ -1,5 +1,4 @@
+ # useradd defaults file
+-GROUP=1000
+ HOME=/home
+ INACTIVE=-1
+ EXPIRE=


### PR DESCRIPTION
group = 1000 is not a good default as that can be any group and in
most cases gid=1000 is the chrony group.

adduser in alpine creates usergroups so make use useradd does as well.