### PR TITLE
testing/wireguard: various small fixes

### DIFF
--- a/testing/wireguard-grsec/APKBUILD
+++ b/testing/wireguard-grsec/APKBUILD
@@ -8,7 +8,7 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 _ver=0.0.20170223
-_mypkgrel=0
+_mypkgrel=1
 _name=wireguard
 
 # verify the kernel version before entering chroot
@@ -30,7 +30,9 @@ pkgdesc="Next generation secure network tunnel: kernel modules for $_flavor"
 arch='all !aarch64'
 url='https://www.wireguard.io'
 license="GPLv2"
-makedepends="linux-grsec-dev=$_kpkgver libmnl-dev sparse"
+makedepends="linux-grsec-dev=$_kpkgver libmnl-dev"
+install_if="wireguard-tools linux-grsec-$_kver"
+options="!check"
 source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$_ver.tar.xz"
 builddir="$srcdir"/WireGuard-$_ver
 
@@ -45,23 +47,12 @@ build() {
 
 package() {
 	cd "$builddir/src"
-	install_if="linux-${_flavor}=${_kver} $pkgname"
 
 	local module=
 	for module in *.ko; do
 		install -v -D -m644 ${module} \
 			"$pkgdir/lib/modules/$_abi_release/extra/${module}"
 	done
-}
-
-check() {
-	return 0
-	# currently failing: attribute 'nocapture': unknown attribute
-	# not part of musl libc ?
-	make -C src/ \
-		KERNELDIR=/lib/modules/${_abi_release}/build \
-		check \
-		|| return 1
 }
 
 sha512sums="273ef6463d447cb04b608a0379cce5c0ed4065f988b3f449995593592b42f2fc269fc249a8e3c22c28bfa682430ee20b5b7a46a96803c9c67d1b6fed7b800455  WireGuard-0.0.20170223.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -3,14 +3,14 @@
 
 pkgname=wireguard-tools
 pkgver=0.0.20170223
-pkgrel=0
+pkgrel=1
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
 url='https://www.wireguard.io'
 license="GPLv2"
-makedepends="libmnl-dev sparse"
-subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch \
-		$pkgname-tests:tests:noarch"
+makedepends="libmnl-dev"
+subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch"
+options="!check"
 source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$pkgver.tar.xz"
 builddir="$srcdir"/WireGuard-$pkgver
 
@@ -21,8 +21,6 @@ build() {
 
 package() {
 	cd "$builddir"
-
-	install_if="linux-${_flavor}=${_kver} $pkgname"
 	mkdir -p "$pkgdir"/usr/share/doc/$_name
 
 	make -C src/tools \
@@ -42,24 +40,6 @@ bashcomp() {
 
 	mkdir -p "$subpkgdir"/usr
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
-}
-
-tests() {
-	pkgdesc="Wireguard test suites"
-
-	mkdir -p "$subpkgdir"/usr/share/wireguard
-	mv "$builddir"/src/tests "$subpkgdir"/usr/share/wireguard
-	cp -rf "$builddir"/contrib/external-tests "$subpkgdir"/usr/share/wireguard
-}
-
-check() {
-	return 0
-	# currently failing: attribute 'nocapture': unknown attribute
-	# not part of musl libc ?
-	make -C src/ \
-		KERNELDIR=/lib/modules/${_abi_release}/build \
-		check \
-		|| return 1
 }
 
 sha512sums="273ef6463d447cb04b608a0379cce5c0ed4065f988b3f449995593592b42f2fc269fc249a8e3c22c28bfa682430ee20b5b7a46a96803c9c67d1b6fed7b800455  WireGuard-0.0.20170223.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,7 +8,7 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 _ver=0.0.20170223
-_mypkgrel=0
+_mypkgrel=1
 _name=wireguard
 
 # verify the kernel version before entering chroot
@@ -30,7 +30,9 @@ pkgdesc="Next generation secure network tunnel: kernel modules for $_flavor"
 arch='all'
 url='https://www.wireguard.io'
 license="GPLv2"
-makedepends="linux-vanilla-dev=$_kpkgver libmnl-dev sparse"
+makedepends="linux-vanilla-dev=$_kpkgver libmnl-dev"
+install_if="wireguard-tools linux-vanilla-$_kver"
+options="!check"
 source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$_ver.tar.xz"
 builddir="$srcdir"/WireGuard-$_ver
 
@@ -45,23 +47,12 @@ build() {
 
 package() {
 	cd "$builddir/src"
-	install_if="linux-${_flavor}=${_kver} $pkgname"
 
 	local module=
 	for module in *.ko; do
 		install -v -D -m644 ${module} \
 			"$pkgdir/lib/modules/$_abi_release/extra/${module}"
 	done
-}
-
-check() {
-	return 0
-	# currently failing: attribute 'nocapture': unknown attribute
-	# not part of musl libc ?
-	make -C src/ \
-		KERNELDIR=/lib/modules/${_abi_release}/build \
-		check \
-		|| return 1
 }
 
 sha512sums="273ef6463d447cb04b608a0379cce5c0ed4065f988b3f449995593592b42f2fc269fc249a8e3c22c28bfa682430ee20b5b7a46a96803c9c67d1b6fed7b800455  WireGuard-0.0.20170223.tar.xz"


### PR DESCRIPTION
* fixes `$install_if` so the kernel modules install automatically when adding `wireguard-tools`
* test subpkg removed at the [request of the author](https://github.com/alpinelinux/aports/pull/948)
* `make check` removed & `sparse` removed from `makedepends` at the [request of the author](https://github.com/alpinelinux/aports/pull/948)