### PR TITLE
testing/etckeeper: moved from github due to the updated TOS

### DIFF
--- a/testing/etckeeper/APKBUILD
+++ b/testing/etckeeper/APKBUILD
@@ -1,19 +1,18 @@
 # Contributor: Henrik Riomar <henrik.riomar@gmail.com>
+# Maintainer: Henrik Riomar <henrik.riomar@gmail.com>
 
 pkgname=etckeeper
 pkgver=1.18.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Store /etc in git."
-url="https://github.com/joeyh/etckeeper"
+url="http://etckeeper.branchable.com"
 arch="noarch"
 license="GPL2"
 depends="findutils git perl"
 subpackages="$pkgname-doc"
 install="$pkgname.post-install $pkgname.pre-deinstall"
-source="$pkgname-$pkgver.tar.gz::https://github.com/joeyh/etckeeper/$_pkgname/archive/$pkgver.tar.gz
+source="https://git.joeyh.name/index.cgi/etckeeper.git/snapshot/$pkgname-$pkgver.tar.gz
 	apk-commit_hook
-	$pkgname.post-install
-	$pkgname.pre-deinstall
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -38,6 +37,4 @@ package() {
 }
 
 sha512sums="a5a3a4677f31cf1d010ab40ed37ce602c71c2e8ebf2273bf8be6dc8209f603ae0fc6a2c0d5d60d9a9d9aa4f3e7b7c0037534890cbc67b38132e5f654abcda04c  etckeeper-1.18.6.tar.gz
-2b1a29d31b6e7cf4ddb05de9b5e088b5747c2abfb2d63f9bddd25f4b7dc8503d457df7fd644afe5bd6fea6a5285a111a47c0489d24378b483c1e026cc11c6bf7  apk-commit_hook
-6662bcc15aa9815578442e175c2edaf76f4eba4e73caa739887df9182c2cf6c640709d392087c2c28a8efca5c8fd9369cad4ad1e1c84fa5ccbf52af2bd1751fb  etckeeper.post-install
-5a49895ac126150f2939486c4a736339847cc79bee8bb84797a063c924aa643d2b1a8721c91e1fb7107947e817fe4c19f3c55f1d22b29a566daf668bbbb77dc6  etckeeper.pre-deinstall"
+2b1a29d31b6e7cf4ddb05de9b5e088b5747c2abfb2d63f9bddd25f4b7dc8503d457df7fd644afe5bd6fea6a5285a111a47c0489d24378b483c1e026cc11c6bf7  apk-commit_hook"


### PR DESCRIPTION
More info here:
 https://joeyh.name/blog/entry/what_I_would_ask_my_lawyers_about_the_new_Github_TOS/
 https://joeyh.name/blog/entry/removing_everything_from_github/