### PR TITLE
testing/ghc: Remove perf-llvm and -O3

### DIFF
--- a/testing/ghc/APKBUILD
+++ b/testing/ghc/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Mitch Tishmack <mitch.tishmack@gmail.com>
 pkgname=ghc
 pkgver=8.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc="The Glasgow Haskell Compiler"
 url="http://haskell.org"
 subpackages="$pkgname-doc $pkgname-dev"
@@ -73,11 +73,9 @@ prepare() {
 	default_prepare || return 1
 	cp mk/build.mk.sample mk/build.mk || return 1
 	cat >> mk/build.mk <<-EOF
-		BuildFlavour         = perf-llvm
 		INTEGER_LIBRARY      = integer-gmp
 		BeConservative       = YES
 		V                    = 0
-		GhcStage3HcOpts     += -O3
 		SplitSections        = YES
 	EOF
 


### PR DESCRIPTION
While it makes the resulting ghc compile faster, apparently its controversial.

So remove it, it isn't strictly necessary. Bumping release.