### PR TITLE
New aport libp8-platform

### DIFF
--- a/testing/libp8-platform/APKBUILD
+++ b/testing/libp8-platform/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Róbert Nagy <vrnagy@gmail.com>
+# Maintainer: Róbert Nagy <vrnagy@gmail.com>
+pkgname=p8-platform
+pkgver=2.1.0.1
+pkgrel=1
+pkgdesc="Platform support library used by libCEC and binary add-ons for Kodi"
+url="https://github.com/Pulse-Eight/platform"
+arch="all"
+license="GPL"
+depends=""
+depends_dev=""
+makedepends="$depends_dev cmake"
+install=""
+subpackages="$pkgname-dev"
+source="https://github.com/Pulse-Eight/platform/archive/p8-platform-$pkgver.tar.gz"
+builddir="$srcdir"/platform-p8-platform-$pkgver
+
+build() {
+	mkdir "$builddir/build"
+	cd "$builddir/build"
+	cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_PREFIX=/usr .. || return 1
+	make || return 1
+}
+
+package() {
+	cd "$builddir/build"
+	make DESTDIR="$pkgdir" install || return 1
+}
+
+md5sums="3b9b00b7e0bb43532518741c1e30a2d7  p8-platform-2.1.0.1.tar.gz"
+sha256sums="064f8d2c358895c7e0bea9ae956f8d46f3f057772cb97f2743a11d478a0f68a0  p8-platform-2.1.0.1.tar.gz"
+sha512sums="76e6f1ac64b61e4def7d99965708d0f05698379e0f3e846317174f0bc12a9654b3341afc84bd8a3a70f101ecab6c692dea96b57d7e000dfabf6cedee2b8dcd8a  p8-platform-2.1.0.1.tar.gz"


### PR DESCRIPTION
Platform support library used by libCEC and binary add-ons for Kodi
Required for newer libcec library