### PR TITLE
community/go: upgrade to 1.8

### DIFF
--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Eivind Uggedal <eivind@uggedal.com>
 pkgname=go
-pkgver=1.7.4
+pkgver=1.8.1
 # This should be the latest commit on the corresponding release branch
-_toolsver="26c35b4dcf6dfcb924e26828ed9f4d028c5ce05a"
-pkgrel=2
+_toolsver="5682db0e919ed9cfc6f52ac32e170511a106eb3b"
+pkgrel=0
 pkgdesc="Go programming language compiler"
 url="http://www.golang.org/"
 arch="all"
@@ -19,6 +19,7 @@ subpackages="$pkgname-doc"
 source="http://golang.org/dl/go${pkgver/_/}.src.tar.gz
 	go-tools-${pkgver/_/}.tar.gz::https://github.com/golang/tools/archive/${_toolsver}.tar.gz
 	default-buildmode-pie.patch
+	set-external-linker.patch
 	"
 
 # NOTE: building go for x86 with grsec kernel requires:
@@ -72,10 +73,11 @@ build() {
 		fi
 	done
 
-	./make.bash --no-clean || return 1
+	./make.bash
 	for os in $_gocross; do
+                local hostarch="$GOARCH"
 		for arch in "386" "amd64"; do
-			GOARCH=$arch GOOS=$os ./make.bash --no-clean || return 1
+			GOHOSTARCH=$hostarch GOARCH=$arch GOOS=$os ./make.bash
 		done
 	done
 
@@ -165,6 +167,7 @@ _crosspkg() {
 		"$subpkgdir"/usr/lib/go/pkg/ || return 1
 }
 
-sha512sums="dc9950c3ea7100e536ad58fd93505d584276b7c50d4b8fe2ba7f20fd043dcf0d315b735c48945302055e91517594cc2b0061ccec9478a8ab48f1f2836c20afb3  go1.7.4.src.tar.gz
-553be713d03f1a53605c41f67822c75d86dacf9ccba9f2329e111b4178287aee1ddccd3ccc4ab76b9dbcff34f11aeddebce5deac47e715ea75d032bc9ab0355c  go-tools-1.7.4.tar.gz
-13cd386c38875b951da4057586007f3c67503dc79ddf57befbf763af85ec2cd2a2e6b00614450c179c93f1f8747ee7456ee412adccd08a5f115b33812598a148  default-buildmode-pie.patch"
+sha512sums="f01fe7b35ac23101610f6fc169b88dafe2edc49b3b044d5d0aff771b05dcb2c8d2e7a5090ed6dbe67f861e78e792ace32e209ed464399ca02dcd186b13ec8037  go1.8.1.src.tar.gz
+343fca47f250278b22df1c1cd92cce91e01009043d05d8ccce095e4386fa0f5ca8ccaa58232635332c7288ceca9d2a240f774f8bb3b08129a681a582cba60248  go-tools-1.8.1.tar.gz
+13cd386c38875b951da4057586007f3c67503dc79ddf57befbf763af85ec2cd2a2e6b00614450c179c93f1f8747ee7456ee412adccd08a5f115b33812598a148  default-buildmode-pie.patch
+cd2926e40fae14448fef7cb86d37004ede71bc920b0ba21a82bf0917f3359b08224dc0a017d779e11091da27623ee24e68aed0fd37dc1f24b8ce1d2cced9d72e  set-external-linker.patch"

--- a/community/go/set-external-linker.patch
+++ b/community/go/set-external-linker.patch
@@ -1,0 +1,11 @@
+--- go/src/cmd/link/internal/amd64/obj.go.orig	2017-03-06 23:55:57.000000000 +0000
++++ go/src/cmd/link/internal/amd64/obj.go	2017-03-06 23:56:16.000000000 +0000
+@@ -67,7 +67,7 @@ func Init() {
+ 	ld.Thearch.Append64 = ld.Append64l
+ 	ld.Thearch.TLSIEtoLE = tlsIEtoLE
+ 
+-	ld.Thearch.Linuxdynld = "/lib64/ld-linux-x86-64.so.2"
++	ld.Thearch.Linuxdynld = "/lib/ld-musl-x86_64.so.1"
+ 	ld.Thearch.Freebsddynld = "/libexec/ld-elf.so.1"
+ 	ld.Thearch.Openbsddynld = "/usr/libexec/ld.so"
+ 	ld.Thearch.Netbsddynld = "/libexec/ld.elf_so"


### PR DESCRIPTION
default-buildmode-pie.patch has been removed since is addressed upstream
by golang/go@53aec79

set-external-linker.patch adresses golang/go#18243