### PR TITLE
testing/ghc: Add libffi to depends

### DIFF
--- a/testing/ghc/APKBUILD
+++ b/testing/ghc/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Mitch Tishmack <mitch.tishmack@gmail.com>
 pkgname=ghc
 pkgver=8.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc="The Glasgow Haskell Compiler"
 url="http://haskell.org"
 subpackages="$pkgname-doc $pkgname-dev"
@@ -35,7 +35,7 @@ license="custom:bsd3"
 # Note, gcc supports --no-pie on alpine linux 3.5+ only. We test for
 # that version as it greatly simplifies the apkbuild process. The
 # apks built on 3.5 will not work on any prior version of alpine linux.
-depends="gmp-dev perl gcc>=6.2.1 llvm3.7"
+depends="gmp-dev perl gcc>=6.2.1 llvm3.7 libffi"
 provides="ghc-bootstrap=$pkgver-r$pkgrel
 	haskell-cabal=1.24.2.0
 	haskell-bytestring=0.10.8.1


### PR DESCRIPTION
While not strictly necessary generally, when passing in linker args to ghc
to compile the c rts invokes some ffi calls.

Not sure if I need to bump the release in cases like this or not. For now just bumped it if I don't have to I can just amend the commit.