### PR TITLE
testing/cabal: Add armhf to architectures

### DIFF
--- a/testing/cabal/APKBUILD
+++ b/testing/cabal/APKBUILD
@@ -5,7 +5,7 @@ pkgver=1.24.0.2
 pkgrel=0
 pkgdesc="The Haskell Cabal"
 url="http://haskell.org"
-arch="x86_64"
+arch="armhf x86_64"
 license="BSD3"
 depends="gmp zlib"
 # Note, this is a temporary state of affairs using the bootstrap.sh script.


### PR DESCRIPTION
Since we have a ghc for armhf, also build cabal for that arch.

Do I need to bump the release to add architectures? I presume not.