### PR TITLE
main/uwsgi : enable jansson support

### DIFF
--- a/main/uwsgi/APKBUILD
+++ b/main/uwsgi/APKBUILD
@@ -17,6 +17,7 @@ makedepends="
 	attr-dev
 	curl-dev
 	geoip-dev
+	jansson-dev
 	libcap-dev
 	linux-headers
 	linux-pam-dev


### PR DESCRIPTION
Adds build dependency jansson-dev and install dependency jansson.

Compalation with jansson-dev enables the --json option.
Please see uwsgi docs:
http://uwsgi-docs.readthedocs.io/en/latest/Configuration.html#json-files