### PR TITLE
testing/ghc: Add testsuite

### DIFF
--- a/testing/ghc/APKBUILD
+++ b/testing/ghc/APKBUILD
@@ -2,13 +2,14 @@
 # Maintainer: Mitch Tishmack <mitch.tishmack@gmail.com>
 pkgname=ghc
 pkgver=8.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc="The Glasgow Haskell Compiler"
 url="http://haskell.org"
 subpackages="$pkgname-doc $pkgname-dev"
 arch="x86_64 armhf"
 builddir="$srcdir/$pkgname-$pkgver"
 source="http://downloads.haskell.org/~ghc/${pkgver}/ghc-${pkgver}-src.tar.xz
+	http://downloads.haskell.org/~ghc/${pkgver}/ghc-${pkgver}-testsuite.tar.xz
 	0000-alpine.patch
 	0000-bootstrap.patch
 	0001-rm-ghc-pwd.patch
@@ -69,6 +70,8 @@ makedepends_build="autoconf cpio binutils-gold paxmark ghc-bootstrap libffi-dev 
 makedepends_host="linux-headers musl-dev zlib-dev gmp-dev binutils-dev libffi-dev ncurses-dev"
 makedepends="$makedepends_build $makedepends_host"
 
+checkdepends="python"
+
 prepare() {
 	default_prepare || return 1
 	cp mk/build.mk.sample mk/build.mk || return 1
@@ -119,6 +122,10 @@ build() {
 		--with-ld.gold=${CROSS_COMPILE}ld.gold \
 		|| return 1
 	make || return 1
+}
+
+check() {
+	cd "$builddir/testsuite" && make fast THREADS=$JOBS || return 1
 }
 
 doc() {
@@ -172,6 +179,7 @@ dev() {
 }
 
 sha512sums="58ea3853cd93b556ecdc4abd0be079b2621171b8491f59004ea4e036a4cba4470aaafe6591b942e0a50a64bdc47540e01fe6900212a1ef7087850112d9bfc5ef  ghc-8.0.2-src.tar.xz
+1b35fc6a5f482dc1e33f21ddf4c4fe17591990f16a4105c787225980a5f4dbaa42205204faf547f8e1b53f6356aefde9d3ff50cc416c9bf1a9ac08feadd74a99  ghc-8.0.2-testsuite.tar.xz
 23a52467fe83322e7b1d5f3e17a9defd08969666acb5a40e40ad93aa4f3feec028389448d4620edbe3ee8b246b3b6e338b267dce09cb14bdd0949b98e75d7562  0000-alpine.patch
 82cecce9e42c12cc3c8d484331b76ac5c6d2529887cd73181d4798f95057883be47489919379e6ebf7daba95b7c25b5d9d689b30ed8d01b13dda20a3b921ce3d  0000-bootstrap.patch
 128eece1b103f286b915a1563a628b638f03509d18cdb2e6510957d26eb56a4ae66e33c946c0e6c2aac2f947b9646dc88c1f390c69ea21f9dc64e0bef4de4e97  0001-rm-ghc-pwd.patch


### PR DESCRIPTION
Note, while the other testsuites run fine, they're very long running.

fast ~ 10 min
normal ~45 min
long ~over an hour

This is on a skylake i7, so results may vary. So for now only run the
fast test suite.

(not sure if the release bump is necessary for this change or not, included to be on the safe side)