### PR TITLE
main/pidgin: upgrade to 2.12.0

### DIFF
--- a/main/pidgin/APKBUILD
+++ b/main/pidgin/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=pidgin
-pkgver=2.11.0
+pkgver=2.12.0
 pkgrel=0
 pkgdesc="graphical multi-protocol instant messaging client for X"
 url="http://pidgin.im/"
@@ -10,32 +10,19 @@ depends=
 makedepends="gtk+-dev intltool libsm-dev startup-notification-dev gtkspell-dev
 	libxml2-dev libidn-dev gnutls-dev avahi-dev
 	cyrus-sasl-dev ncurses-dev nss-dev
-	autoconf automake libtool"
+	"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang
 	libpurple-bonjour:_bonjour
-	libpurple-ymsg:_ymsg
 	libpurple-oscar:_oscar
 	libpurple-xmpp:_xmpp
 	finch libpurple
 	"
-source="http://downloads.sourceforge.net/pidgin/pidgin-$pkgver.tar.bz2
-	http://downloads.sourceforge.net/project/pidgin/Pidgin/$pkgver/pidgin-$pkgver.tar.bz2
-	"
-
-_builddir="$srcdir"/$pkgname-$pkgver
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case "$i" in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-	libtoolize || return 1
-	aclocal -I m4macros && autoconf && automake --add-missing || return 1
-}
+source="https://bitbucket.org/pidgin/main/downloads/$pkgname-$pkgver.tar.bz2"
+options="!check"
+builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -62,7 +49,7 @@ build() {
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
 
@@ -97,10 +84,6 @@ _bonjour() {
 	_mv_purple "bonjour plugin for libpurple" libbonjour
 }
 
-_ymsg() {
-	_mv_purple "yahoo plugins for libpurple" libymsg libyahoo libyahoojp
-}
-
 _oscar() {
 	_mv_purple "AIM, ICQ plugins for libpurple" liboscar libaim libicq
 }
@@ -109,9 +92,4 @@ _xmpp() {
 	_mv_purple "Jabber/XMPP plugins for libpurple" libxmpp libjabber
 }
 
-md5sums="7b167474db669aab2f71fa46835fb83f  pidgin-2.11.0.tar.bz2
-7b167474db669aab2f71fa46835fb83f  pidgin-2.11.0.tar.bz2"
-sha256sums="f72613440586da3bdba6d58e718dce1b2c310adf8946de66d8077823e57b3333  pidgin-2.11.0.tar.bz2
-f72613440586da3bdba6d58e718dce1b2c310adf8946de66d8077823e57b3333  pidgin-2.11.0.tar.bz2"
-sha512sums="d6a9bb8075b475e5204d730075b432ca0f1cb91b6337f98e506587132581e6928a826b47e0b94fb9eaedc79c5be0a8237c4671fc26dba97dedad1adb74c9abfa  pidgin-2.11.0.tar.bz2
-d6a9bb8075b475e5204d730075b432ca0f1cb91b6337f98e506587132581e6928a826b47e0b94fb9eaedc79c5be0a8237c4671fc26dba97dedad1adb74c9abfa  pidgin-2.11.0.tar.bz2"
+sha512sums="e87b39888432982ee36332fd14b272f49f7974de9e8694f7fe3bec2821748d6e6026ac5a63615a93386a033d6ee7c4de5ae0a86b725f63b9cc55650f0ab94b06  pidgin-2.12.0.tar.bz2"


### PR DESCRIPTION
* Fixes CVE-2017-2640
* Remove libpurple-ymsg: Officially removed
* Modernize abuild
* Use another official (faster) download mirror
* Remove unnecessary makedepends