### PR TITLE
testing/ndctl: new aport

### DIFF
--- a/testing/ndctl/0001-util-Enable-ndctl-to-compile-on-non-glibc-envs.patch
+++ b/testing/ndctl/0001-util-Enable-ndctl-to-compile-on-non-glibc-envs.patch
@@ -1,0 +1,36 @@
+From da1d1cbbffe90aefe1579d2708bae43753c5afb4 Mon Sep 17 00:00:00 2001
+From: Breno Leitao <breno.leitao@gmail.com>
+Date: Sat, 11 Mar 2017 22:33:43 +0000
+Subject: [PATCH] util: Enable ndctl to compile on non-glibc envs
+
+Currently ndctl does not build on non-glibc environments, as musl.
+
+It fails because neither functions secure_getenv() nor
+_secure_getenv() are available. These functions are only available
+on systems with glibc version 2.17 or later.
+
+This patch just make a fallback to getenv() if the secure functions
+are missing.
+
+Signed-off-by: Breno Leitao <breno.leitao@gmail.com>
+---
+ util/log.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/util/log.h b/util/log.h
+index 5c5922f..5fc56e8 100644
+--- a/util/log.h
++++ b/util/log.h
+@@ -62,7 +62,8 @@ do { \
+ #  ifdef HAVE___SECURE_GETENV
+ #    define secure_getenv __secure_getenv
+ #  else
+-#    error neither secure_getenv nor __secure_getenv is available
++#    warning neither secure_getenv nor __secure_getenv is available.
++#    define secure_getenv getenv
+ #  endif
+ #endif
+ 
+-- 
+2.11.1
+

--- a/testing/ndctl/APKBUILD
+++ b/testing/ndctl/APKBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Breno Leitao <breno.leitao@gmail.com>
+pkgname=ndctl
+pkgver=56
+pkgrel=0
+pkgdesc="Utility library for managing the libnvdimm (non-volatile memory device) sub-system in the Linux kernel"
+url="https://github.com/pmem/ndctl"
+arch="all"
+license="GPL"
+depends="libuuid json-c kmod"
+makedepends="autoconf automake libtool asciidoc xmlto kmod-dev eudev-dev util-linux-dev json-c-dev linux-headers"
+install=""
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/pmem/ndctl/archive/v$pkgver.tar.gz
+0001-util-Enable-ndctl-to-compile-on-non-glibc-envs.patch"
+
+builddir="$srcdir"/ndctl-$pkgver
+
+build() {
+	cd "$builddir"
+
+	./autogen.sh || return 1
+
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--mandir=/usr/share/man \
+		|| return 1
+	make || return 1
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install || return 1
+}
+
+md5sums="bfd5a6f78e1d3589ba1372b176dc07bf  ndctl-56.tar.gz
+67c332d6666a1a3434fef0ff52d7151e  0001-util-Enable-ndctl-to-compile-on-non-glibc-envs.patch"
+sha256sums="76efc9b185ee9b3d9ef4dc6079899e039328595b6b2c88a040cc26308d4872ce  ndctl-56.tar.gz
+2e89bccc5ac72a0e25f7447aa4efe306184df61a1a9f7fe013539141c4c981f2  0001-util-Enable-ndctl-to-compile-on-non-glibc-envs.patch"
+sha512sums="1892bef09b013d5e4a82f0606e196bbba7b9a34fc3ef09a5e0241cc0ba813338148a23cc6e5fe7e951b819d528be9bdbc125753f85de2e864f0683394ce3ee3a  ndctl-56.tar.gz
+ff57687b0998b7f6b773a6f63a8cb034191c45b3f95b62be8709ee6b9b78f9289e102c4e1fa05118baf2aefb671b0967af0b54addcc26adfa271937a36dbc13a  0001-util-Enable-ndctl-to-compile-on-non-glibc-envs.patch"


### PR DESCRIPTION
ndctl is a utility for managing the libnvdimm (non-volatile
memory device) sub-system in the Linux kernel.

Adding it into Alpine Linux in the testing archive.