### PR TITLE
community/bitcoin: update to 0.14.0 / use supervise-daemon

### DIFF
--- a/community/bitcoin/APKBUILD
+++ b/community/bitcoin/APKBUILD
@@ -1,17 +1,18 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=bitcoin
-pkgver=0.13.1
+pkgver=0.14.0
 _ver=${pkgver/_/}
-pkgrel=1
+pkgrel=0
 pkgdesc="decentralized P2P electronic cash system"
 url="http://www.bitcoin.org/"
 arch="all"
 license="MIT"
 makedepends="autoconf automake libtool boost-dev libressl-dev db-dev miniupnpc-dev
 	qt5-qtbase-dev qt5-qttools-dev protobuf-dev libqrencode-dev libevent-dev chrpath"
-install="$pkgname.post-install $pkgname.pre-install"
-subpackages="$pkgname-dev $pkgname-qt $pkgname-cli $pkgname-tx $pkgname-tests $pkgname-bench"
+install="$pkgname.post-install $pkgname.post-upgrade $pkgname.pre-install"
+subpackages="$pkgname-dev $pkgname-qt $pkgname-cli $pkgname-tx $pkgname-tests $pkgname-bench
+	$pkgname-doc"
 source="$pkgname-$_ver.tar.gz::https://github.com/bitcoin/bitcoin/archive/v${_ver}.tar.gz
 	ssize_t.patch
 	$pkgname.initd
@@ -83,15 +84,11 @@ dev() {
 	mv "$pkgdir"/usr/include "$subpkgdir"/usr/ || return 1
 }
 
-md5sums="3ccb66404e6da9b995a607de997ca3bf  bitcoin-0.13.1.tar.gz
-716a88e668729e89d3eb929da86f7f04  ssize_t.patch
-fc93c580823d65a7f50c2518f0b63a4b  bitcoin.initd
-3e9b4a37bb46e6cd83b6824870c58484  bitcoin.conf"
-sha256sums="97d4a1aea7aed957e76f8f5e6ba2a2bfc66c1fcbdaf76ee46bd0650e5957eaa9  bitcoin-0.13.1.tar.gz
-f0a094c7b374338ad153ee06b7dd2369dad6b97b1f1bb0252da12c9aaace5321  ssize_t.patch
-0103f6961e0c9dd0ac73f6bce4d8035103c13db717391d6b56c0db8118dcfae9  bitcoin.initd
-b7a31bf251f1011ab6584b610acac8494612c2012e9771985228c36c08a315ac  bitcoin.conf"
-sha512sums="05c5d9454c3256912bab422ad79b289a7bd67730f7ff4f5f50d010ec5a1eda89b6eb84f688cda875e950a832f8c427b22119e8bb678fc4ee5213272e22bc45d5  bitcoin-0.13.1.tar.gz
+check() {
+	make check || return 1
+}
+
+sha512sums="3721700aa0ad2a36479d822320c71a4e51a0382f40bfac16376079c1cca891106523fc59de4687dfef9dc2c5dc84597df9605fef922190cfc419c6c3b6bb15f0  bitcoin-0.14.0.tar.gz
 98aa5ad81bdb4ae961b791bc978c39117cdf2d83c2181f92bebbb0db107d9b6e86eda265fb3f93ff8a5ca8a7754d7148818b98095d57201dff9363d60b97e7dd  ssize_t.patch
-87547359fe75d88906f8ea38ac3e40f7501779983d53d5e05fc8b29e0062e8b67f18dc587045c8699da9ffe57c55aa43c38de389a5476ddf1223bf90b78f4fe3  bitcoin.initd
-48abce0f0a5b088c957aa5cb2bcf9bb520593caa7a20019bdf785e43f7d2459968240d4529dfa30be2fca92891bf50c1253a513530511e99d8ee471d9ff6bd95  bitcoin.conf"
+71e5f3b5079a22b6ddecfad89363fc642d5ea7da18f1203057f626d214734467f4b933b839c269401be7af2c3dcc01afcb3b98198b7d580c56d8740b34451558  bitcoin.initd
+a31210d8db76c5a9b614a6de756c1678c0344898565ac3e5d6a34ac1bed66aec4964f1dc874294bc978f53b0e961df921655f7309df19b66c90aa6bd40379a09  bitcoin.conf"

--- a/community/bitcoin/bitcoin.conf
+++ b/community/bitcoin/bitcoin.conf
@@ -8,6 +8,9 @@ rpcallowip=127.0.0.1
 rpcuser=changeme
 rpcpassword=changeme
 rpcport=changeme
-daemon=1
+
+#### do not use daemon mode with new initd ####
+#### which now uses supervise-daemon ##########
+daemon=0
 #gen=1			#generate bitcoins
 

--- a/community/bitcoin/bitcoin.initd
+++ b/community/bitcoin/bitcoin.initd
@@ -1,38 +1,35 @@
 #!/sbin/openrc-run
+supervisor=supervise-daemon
 
-# Bitcoin init.d file for Alpine Linux.
-
+description="Bitcoin daemon"
 name=bitcoind
-daemon=/usr/bin/$name
+command=/usr/bin/$name
 config=/etc/bitcoin.conf
 user=bitcoin
 group=bitcoin
-## supercedes datadir set in $config ##
 datadir=/var/lib/bitcoin
-pidfile=/run/bitcoin/$name.pid
+pidfile="/run/bitcoin/$SVCNAME.sd.pid"
+command_args="-server -conf=$config -datadir=$datadir -pid=$pidfile"
+supervise_daemon_args="-u $user -g $group"
+nice="-19"
 
 depend() {
-        need net
-        after logger firewall
+	use net
+	after logger firewall
 }
 
-start() {
-        ebegin "Starting ${name}"
-        # enforce permissions
+in_contr() {
+	grep "container=" /proc/1/environ
+}
+
+start_pre() {
+	# enforce permissions
 	checkpath -q -d ${pidfile%/*} -o ${user}:${group}
-        checkpath -q -d ${datadir} -m 0700 -o ${user}:${group}
-        checkpath -q -f ${config} -m 0600 -o ${user}:${group}
-        start-stop-daemon --start --quiet \
-                        --pidfile ${pidfile} \
-                        --user ${user}:${group} \
-                        --exec ${daemon} -- -conf=${config} -datadir=${datadir} -pid=${pidfile}
-        eend $?
-}
+	checkpath -q -d ${datadir} -m 0700 -o ${user}:${group}
+	checkpath -q -f ${config} -m 0600 -o ${user}:${group}
 
-stop() {
-        ebegin "Stopping ${name}"
-                start-stop-daemon --stop --quiet \
-                        --pidfile ${pidfile} \
-                        --exec ${daemon}
-        eend $?
+	# in lxc sys_nice capability is dropped by default
+	if [ -z "$(in_contr)" ]; then
+		supervise_daemon_args="$supervise_daemon_args -N $nice"
+	fi
 }

--- a/community/bitcoin/bitcoin.post-install
+++ b/community/bitcoin/bitcoin.post-install
@@ -4,7 +4,7 @@ NORMAL="\033[1;0m"
 STRONG="\033[1;1m"
 GREEN="\033[1;32m"
 
-config=$(grep -F 'config=' /etc/init.d/bitcoin |sed 's/config=//')
+config=$(find /etc -maxdepth 1 -type f -name bitcoin.conf*)
 
 randgen() {
 	output=$(cat /dev/urandom | tr -dc '0-9a-zA-Z!@#$%^&*_+-' | head -c${1:-$1}) 2>/dev/null
@@ -17,19 +17,21 @@ findRandomTcpPort(){
 }
 
 GenPasswd(){
-	sed -i "/rpcuser=/ c \rpcuser=USER-"$(randgen 32)"" $config
-        sed -i "/rpcpassword=/ c \rpcpassword=PW-"$(randgen 64)"" $config
-        sed -i "/rpcport=/ c \rpcport="$(findRandomTcpPort)"" $config
-        print_green "Generated random user / password / port in:" " $config\n"
+	sed -i "/rpcuser=/ c \rpcuser=USER-"$(randgen 32)"" $1
+	sed -i "/rpcpassword=/ c \rpcpassword=PW-"$(randgen 64)"" $1
+	sed -i "/rpcport=/ c \rpcport="$(findRandomTcpPort)"" $1
+	print_green "Generated random user / password / port in:" " $1\n"
 }
 
 print_green() {
-        local prompt="${STRONG}$1${GREEN}$2${NORMAL}"
-        printf "${prompt}%s"
+	local prompt="${STRONG}$1${GREEN}$2${NORMAL}"
+	printf "${prompt}%s"
 }
 
-if grep -F "changeme" $config 1>/dev/null; then
-	GenPasswd
-fi
+for file in $config; do
+	if grep -F "changeme" $file 1>/dev/null; then
+		GenPasswd $file
+	fi
+done
 
 exit 0

--- a/community/bitcoin/bitcoin.post-upgrade
+++ b/community/bitcoin/bitcoin.post-upgrade
@@ -1,0 +1,1 @@
+bitcoin.post-install


### PR DESCRIPTION
* https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.14.0.md

* `initd` now uses `supervise-daemon` for service supervision.

**please note** the new `bitcoin.conf` format `=>` do **NOT** enable `daemon` mode
as `supervise-daemon` requires services to run in the foreground.