### PR TITLE
community/maven: remove openjdk depends

### DIFF
--- a/community/maven/APKBUILD
+++ b/community/maven/APKBUILD
@@ -4,12 +4,12 @@
 pkgname=maven
 pkgver=3.3.9
 _pkgname="$pkgname-${pkgver%%.*}"
-pkgrel=1
+pkgrel=2
 pkgdesc="A Java project management and project comprehension tool."
 url="http://maven.apache.org"
 arch="noarch"
 license="ASL-2.0"
-depends="openjdk8-jre"
+options="!check"
 source="http://mirror.hosting90.cz/apache/$pkgname/$_pkgname/$pkgver/binaries/apache-$pkgname-$pkgver-bin.tar.gz"
 builddir="$srcdir/apache-$pkgname-$pkgver"
 
@@ -42,6 +42,4 @@ package() {
 	EOF
 }
 
-md5sums="516923b3955b6035ba6b0a5b031fbd8b  apache-maven-3.3.9-bin.tar.gz"
-sha256sums="6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82  apache-maven-3.3.9-bin.tar.gz"
 sha512sums="9b4b22aba67af48648c634e30edbb03de2a7742b7d4e58b3d637fcd20358a51ccb288dcbd473169a58b9322f7c8fbedcf5336b87d06460d0b20ce37d4c3948b0  apache-maven-3.3.9-bin.tar.gz"


### PR DESCRIPTION
forcing a depends on `openjdk` breaks using `maven` with `oracle jdk`
in `docker`.