### PR TITLE
testing/nginx-naxsi: => 1.11.10 / naxsi 0.55.3 / use supervise-daemon

### DIFF
--- a/testing/nginx-naxsi/APKBUILD
+++ b/testing/nginx-naxsi/APKBUILD
@@ -5,7 +5,7 @@
 
 pkgname=nginx-naxsi
 _pkgname=nginx
-pkgver=1.11.9
+pkgver=1.11.10
 pkgrel=0
 pkgdesc="Lightweight HTTP and reverse proxy server with Naxsi WAF support, see also 'nxapi'"
 url="http://www.nginx.org | https://github.com/nbs-system/naxsi"
@@ -14,7 +14,7 @@ license="custom"
 
 # Modules
 _ngx_naxsi_name=naxsi
-_ngx_naxsi_ver=0.55.1
+_ngx_naxsi_ver=0.55.3
 _ngx_naxsi_dir="$srcdir/$_ngx_naxsi_name-$_ngx_naxsi_ver/naxsi_src"
 
 _ngx_cache_purge_name=ngx_cache_purge
@@ -37,6 +37,7 @@ _grp_ngx="nginx"
 _grp_www="www-data"
 pkggroups="$_grp_ngx $_grp_www"
 install="$pkgname.pre-install $pkgname.pre-upgrade"
+options="!check"
 subpackages="$pkgname-doc"
 source="http://nginx.org/download/$_pkgname-$pkgver.tar.gz
 	naxsi-$_ngx_naxsi_ver.tar.gz::https://github.com/nbs-system/$_ngx_naxsi_name/archive/$_ngx_naxsi_ver.tar.gz
@@ -50,6 +51,8 @@ source="http://nginx.org/download/$_pkgname-$pkgver.tar.gz
 
 	nginx.initd
 	nginx.logrotate
+	nginx.conf
+	default.conf
 	"
 builddir="$srcdir"/$_pkgname-$pkgver
 
@@ -110,7 +113,6 @@ build() {
 		--with-http_secure_link_module \
 		--with-http_slice_module \
 		--with-http_stub_status_module \
-		--with-http_realip_module \
 		--with-http_xslt_module=dynamic \
 		--with-http_image_filter_module=dynamic \
 		--with-http_geoip_module=dynamic \
@@ -153,6 +155,8 @@ package() {
 	ln -sf /run/$_pkgname ./var/lib/$_pkgname/run
 
 	rm -rf ./run ./etc/$_pkgname/*.default
+	# scgi & uwsgi servers are disabled
+	rm ./etc/$_pkgname/scgi_params ./etc/$_pkgname/uwsgi_params
 }
 
 _module() {
@@ -172,33 +176,15 @@ _module() {
 	echo "load_module \"modules/$soname\";" > ./etc/nginx/modules/$name.conf
 }
 
-md5sums="7aeca793819c2b8df134c0b1cfe98361  nginx-1.11.9.tar.gz
-b894ea5327a3d102a56aeddb79d2e047  naxsi-0.55.1.tar.gz
-dedef1e47a26500993a88c96112d5d0f  ngx_cache_purge-2.3.0.1.tar.gz
-233861df4dc0872f727fc4c7e5c72dca  upstream-fair-0.1.1.tar.gz
-3a72f075bb114f1a97976c088a81c7f7  sysguard-2.2.0.tar.gz
-31d29937da95b31714faa399aeb07407  anonymise.patch
-f478d8391dafa32a8b0b3a9f21d7a080  ipv6.patch
-50357b75049d878c0bcce10d0c60f9ed  sysguard.patch
-2e56b3f21f19aecc5500c9efc9222782  nginx.initd
-8823274a834332d3db4f62bf7dd1fb7d  nginx.logrotate"
-sha256sums="dc22b71f16b551705930544dc042f1ad1af2f9715f565187ec22c7a4b2625748  nginx-1.11.9.tar.gz
-45dd0df7a6b0b6aa9c64eb8c39a8e294d659d87fb18e192cf58f1402f3cdb0a8  naxsi-0.55.1.tar.gz
-5da9360cd805a432ea7a08832ec3dd3a5d9f1574f71b3acdd53210610aee94e5  ngx_cache_purge-2.3.0.1.tar.gz
-e8aec578f03259c6f457575360f70d57aea385a1864562b0ba6e57d6a75d52c7  upstream-fair-0.1.1.tar.gz
-6051eb52361d602011b4c7e88b63384bcc8ebc4b004bd4b12eec3e5dce953f1d  sysguard-2.2.0.tar.gz
-28adf3605875197d5822fa382f5fd3c9c80f7d3a561e904fee223fa051f98810  anonymise.patch
-4a1a24a92657432012f08c52e8099c7abae390c9c4cb76483cacd012e26a57ac  ipv6.patch
-18090329435c32d91621a5943acc5b8bbe89aaa3c2fa334c3a4cdeb00efb6226  sysguard.patch
-decb084e29b584fb54b57a199f5a480dd77a4c1b3ef3da515c2eb76bd32172c5  nginx.initd
-cea0c6f8de55a4c3a3eccc57910de1c3116634082c8e5b660630fb927a29f38d  nginx.logrotate"
-sha512sums="95247d5db3e23a0ea22686cc3fe4295f8854948a6f168a783082fdbb2acbecdad61cd9c8cadd84c1f74c1e87becdca8d6664622ff9cebc72687f20b29cc09fd0  nginx-1.11.9.tar.gz
-aebda20e5b78e9111b7bac1e15829258e6b85b80e4ce333e4dba8caead36287b3f0fcb453c51d7c59f07d637fa62f5c6b23aecd3bf6a3c3da4abebf1a6689f14  naxsi-0.55.1.tar.gz
+sha512sums="b6437d8305547a834a0f3ad076ac591b90189eb922f48759094efaa9618e39fc249600ab13650113fe841fc9af0b736acc61a9b9baba7bacd35224c34df1bbc9  nginx-1.11.10.tar.gz
+9e8f41a5cd1342cc9b8aa334a603842d14a256aab1f4a21205bb1278aecbb0c49e39c889d8113a5b41aad2efeaa2ed9f11cba6929173f50add91f54c4c59c8a0  naxsi-0.55.3.tar.gz
 c49c81dbdb8bd507fccf31295e603cea8f0a964867c27eff0436dcea3b4a547c8ae2f11ecf49c4d82c693cf8138c17ebbed395738539d0d61254951e5f0db7e3  ngx_cache_purge-2.3.0.1.tar.gz
 fd305b859c868ef55171b05f64071a2836c12073bcd89d6197af4946a3d1177f77c6708d4d589d460c84967273dee87ca9de97ab0f0d47e6d65f86b465d70316  upstream-fair-0.1.1.tar.gz
 2743d9aea60bd4984b650213e571cf27e6ff5b3db708242ccb53b8fc669d1cc82ee224ba79aee2f6969b6e13821cfdd3df7b412541e1fdbb867ecc95326e07e1  sysguard-2.2.0.tar.gz
-f8e46dafcf553edd35699dc2a47a54756e0a4c690fc13f81436ad9db1026739ba331ad99d3d05d8a7c089a5c067bf45f4aca3a98fdd9483b7b0123a837e695be  anonymise.patch
+1117ca5887822e002d9995c041435fda53890614fd7309ea011a59bfb0df3261fc7ba8670e93aaee9116cda16b9806921a85f52c9959b093f2e5ac5df4d9b0fb  anonymise.patch
 cae9f842c3d1188730d4355440476ad2338b19c027c4b329efe88d4487e90d96bf60dea6feb4be6a6f96d4b356fc154345e32c2bb643d70f68e428df26330a49  ipv6.patch
 2dca2ac74fb92e330fde7b6b6120b2fd2565c377a629c9536cf77beebe41aa4b092d4229d5b487b0fb02be4f2cc5b897c429c87bbbbc7b0d31e1cbb94231ddce  sysguard.patch
-6c27d605536a31159b65776098926ede0b5045210b190e803681a10c06a10556283d873e772fd635642b18846549ec3a18989ca9fe6466f120ce9e1327dcacd5  nginx.initd
-01b77cff16f6e8bfd7fa1d4d20f625bbcddd08f0509173452d060c342c93dc315a7b0560f4734323a5d29ea294de0491f2e3f32e5337574e1a28ebc005eceea8  nginx.logrotate"
+e0784764d509589a9626e20bd800787583573314293caf0ebc135bbfc50346f86847d4a93b91cb01d7b8f6e1b00285569ae8088e35ed9bc3ae8278cad3ba320e  nginx.initd
+01b77cff16f6e8bfd7fa1d4d20f625bbcddd08f0509173452d060c342c93dc315a7b0560f4734323a5d29ea294de0491f2e3f32e5337574e1a28ebc005eceea8  nginx.logrotate
+a1a1d9dbd65955b458d17918138fc65bf8990c46909ef43940b1633458c8f119eb485939179b6a9a3dac0c3b58c1eb0c5aec44e7b25ea7a34969c4a0807d4788  nginx.conf
+9bd5145762a5040a6b5494d31f216d1db7c52921142275f26eed67aff746270526caad8e34eae65ec6390975ce603b35f6add05eb857f1670bf28ab5049b97d8  default.conf"

--- a/testing/nginx-naxsi/anonymise.patch
+++ b/testing/nginx-naxsi/anonymise.patch
@@ -1,35 +1,47 @@
---- nginx-1.6.1/src/http/ngx_http_header_filter_module.c
-+++ nginx-1.6.1/src/http/ngx_http_header_filter_module.c
-@@ -46,8 +46,8 @@
+--- nginx-1.11.10/src/http/ngx_http_header_filter_module.c
++++ nginx-1.11.10/src/http/ngx_http_header_filter_module.c.new
+@@ -46,9 +46,9 @@
  };
  
  
--static char ngx_http_server_string[] = "Server: nginx" CRLF;
--static char ngx_http_server_full_string[] = "Server: " NGINX_VER CRLF;
-+static char ngx_http_server_string[] = "";
-+static char ngx_http_server_full_string[] = "";
+-static u_char ngx_http_server_string[] = "Server: nginx" CRLF;
+-static u_char ngx_http_server_full_string[] = "Server: " NGINX_VER CRLF;
+-static u_char ngx_http_server_build_string[] = "Server: " NGINX_VER_BUILD CRLF;
++static u_char ngx_http_server_string[] = "";
++static u_char ngx_http_server_full_string[] = "";
++static u_char ngx_http_server_build_string[] = "";
  
  
  static ngx_str_t ngx_http_status_lines[] = {
-@@ -278,8 +278,8 @@
-     clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+@@ -276,10 +276,10 @@
  
      if (r->headers_out.server == NULL) {
--        len += clcf->server_tokens ? sizeof(ngx_http_server_full_string) - 1:
--                                     sizeof(ngx_http_server_string) - 1;
-+        len += clcf->server_tokens ? sizeof(ngx_http_server_full_string) - 0:
-+                                     sizeof(ngx_http_server_string) - 0;
-     }
+         if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
+-            len += sizeof(ngx_http_server_full_string) - 1;
++            len += sizeof(ngx_http_server_full_string) - 0;
  
-     if (r->headers_out.date == NULL) {
---- nginx-1.6.1/src/http/ngx_http_special_response.c
-+++ nginx-1.6.1/src/http/ngx_http_special_response.c
-@@ -19,14 +19,14 @@
+         } else if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_BUILD) {
+-            len += sizeof(ngx_http_server_build_string) - 1;
++            len += sizeof(ngx_http_server_build_string) - 0;
+ 
+         } else {
+             len += sizeof(ngx_http_server_string) - 1;
+--- nginx-1.11.10/src/http/ngx_http_special_response.c
++++ nginx-1.11.10/src/http/ngx_http_special_response.c.new
+@@ -19,21 +19,21 @@
  
  
  static u_char ngx_http_error_full_tail[] =
 -"<hr><center>" NGINX_VER "</center>" CRLF
 +"<hr><center>127.0.0.1</center>" CRLF
+ "</body>" CRLF
+ "</html>" CRLF
+ ;
+ 
+ 
+ static u_char ngx_http_error_build_tail[] =
+-"<hr><center>" NGINX_VER_BUILD "</center>" CRLF
++"<hr><center>1.0.0</center>" CRLF
  "</body>" CRLF
  "</html>" CRLF
  ;
@@ -41,36 +53,23 @@
  "</body>" CRLF
  "</html>" CRLF
  ;
---- nginx-1.9.12/src/http/v2/ngx_http_v2_filter_module.c
-+++ nginx-1.9.12/src/http/v2/ngx_http_v2_filter_module.c.new
-@@ -229,9 +229,9 @@
- 
+--- nginx-1.11.10/src/http/v2/ngx_http_v2_filter_module.c
++++ nginx-1.11.10/src/http/v2/ngx_http_v2_filter_module.c.new
+@@ -236,16 +236,7 @@
      clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
  
--    if (r->headers_out.server == NULL) {
-+/*  if (r->headers_out.server == NULL) {
-         len += 1 + (clcf->server_tokens ? nginx_ver_len : sizeof(nginx));
--    }
-+    } */
- 
-     if (r->headers_out.date == NULL) {
-         len += 1 + ngx_http_v2_literal_size("Wed, 31 Dec 1986 18:00:00 GMT");
-@@ -434,7 +434,7 @@
-         pos = ngx_sprintf(pos, "%03ui", r->headers_out.status);
+     if (r->headers_out.server == NULL) {
+-
+-        if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_ON) {
+-            len += 1 + nginx_ver_len;
+-
+-        } else if (clcf->server_tokens == NGX_HTTP_SERVER_TOKENS_BUILD) {
+-            len += 1 + nginx_ver_build_len;
+-
+-        } else {
+-            len += 1 + sizeof(nginx);
+-        }
++	len += 1 + sizeof(nginx);
      }
  
--    if (r->headers_out.server == NULL) {
-+/*  if (r->headers_out.server == NULL) {
-         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, fc->log, 0,
-                        "http2 output header: \"server: %s\"",
-                        clcf->server_tokens ? NGINX_VER : "nginx");
-@@ -453,7 +453,7 @@
-         } else {
-             pos = ngx_cpymem(pos, nginx, sizeof(nginx));
-         }
--    }
-+    } */
- 
      if (r->headers_out.date == NULL) {
-         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, fc->log, 0,
-

--- a/testing/nginx-naxsi/nginx.initd
+++ b/testing/nginx-naxsi/nginx.initd
@@ -1,12 +1,14 @@
 #!/sbin/openrc-run
+supervisor=supervise-daemon
 
 description="Nginx http and reverse proxy server"
 extra_started_commands="reload reopen upgrade"
 
 cfgfile=${cfgfile:-/etc/nginx/nginx.conf}
-pidfile=/run/nginx/nginx.pid
+pidfile=/run/nginx/$RC_SVCNAME.sd.pid
 command=/usr/sbin/nginx
 command_args="-c $cfgfile"
+command_args_foreground='-g "daemon off;"'
 required_files="$cfgfile"
 
 depend() {
@@ -23,45 +25,24 @@ start_pre() {
 
 reload() {
 	ebegin "Reloading ${SVCNAME} configuration"
-	start_pre && start-stop-daemon --signal HUP --pidfile $pidfile
+	start_pre && $command -s reload
 	eend $?
 }
 
 reopen() {
 	ebegin "Reopening ${SVCNAME} log files"
-	start-stop-daemon --signal USR1 --pidfile $pidfile
+	$command -s reopen
 	eend $?
 }
 
 upgrade() {
-	start_pre || return 1
+	restart
+}
 
-	ebegin "Upgrading ${SVCNAME} binary"
-
-	einfo "Sending USR2 to old binary"
-	start-stop-daemon --signal USR2 --pidfile $pidfile
-
-	einfo "Sleeping 3 seconds before pid-files checking"
-	sleep 3
-
-	if [ ! -f $pidfile.oldbin ]; then
-		eerror "File with old pid ($pidfile.oldbin) not found"
-		return 1
-	fi
-
-	if [ ! -f $pidfile ]; then
-		eerror "New binary failed to start"
-		return 1
-	fi
-
-	einfo "Sleeping 3 seconds before WINCH"
-	sleep 3 ; start-stop-daemon --signal 28 --pidfile $pidfile.oldbin
-
-	einfo "Sending QUIT to old binary"
-	start-stop-daemon --signal QUIT --pidfile $pidfile.oldbin
-
-	einfo "Upgrade completed"
-
-	eend $? "Upgrade failed"
+restart() {
+	stop
+	# prevents bind() failed (98: Address in use) error msg
+	sleep 0.05
+	start
 }
 


### PR DESCRIPTION
* `initd` now uses `supervise-daemon` for service supervision
* removes duplicate `--with-http_realip_module`
* removes `scgi_params` & `uwsgi_params` as the servers are disabled