### PR TITLE
testing/ghc: Add libffi-dev to depends

### DIFF
--- a/testing/ghc/APKBUILD
+++ b/testing/ghc/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Mitch Tishmack <mitch.tishmack@gmail.com>
 pkgname=ghc
 pkgver=8.0.2
-pkgrel=2
+pkgrel=4
 pkgdesc="The Glasgow Haskell Compiler"
 url="http://haskell.org"
 subpackages="$pkgname-doc $pkgname-dev"
@@ -35,7 +35,7 @@ license="custom:bsd3"
 # Note, gcc supports --no-pie on alpine linux 3.5+ only. We test for
 # that version as it greatly simplifies the apkbuild process. The
 # apks built on 3.5 will not work on any prior version of alpine linux.
-depends="gmp-dev perl gcc>=6.2.1 llvm3.7"
+depends="gmp-dev perl gcc>=6.2.1 llvm3.7 libffi-dev"
 provides="ghc-bootstrap=$pkgver-r$pkgrel
 	haskell-cabal=1.24.2.0
 	haskell-bytestring=0.10.8.1


### PR DESCRIPTION
While not strictly necessary generally, when passing in linker args to ghc
to compile the c rts invokes some ffi calls that the shared library
alone doesn't suffice.

Simple example demonstrating the issue, should I add this test into the check() fuction? Its a stupid simple check that ghc can build ok.
```
# echo 'main = putStrLn "hi"' > hi.hs
# ghc --make hi.hs
[1 of 1] Compiling Main             ( hi.hs, hi.o )                                                                                         Linking hi ...                                                                                                                              /usr/lib/gcc/armv6-alpine-linux-muslgnueabihf/6.2.1/../../../../armv6-alpine-linux-muslgnueabihf/bin/ld.gold: error: cannot find -lffi
/usr/lib/ghc-8.0.2/rts/libHSrts.a(Interpreter.o):function interpretBCO: error: undefined reference to 'ffi_call'
collect2: error: ld returned 1 exit status
`gcc' failed in phase `Linker'. (Exit code: 1)
# apk add libffi-dev
(1/1) Installing libffi-dev (3.2.1-r2)
OK: 1631 MiB in 114 packages
# ghc --make hi.hs
Linking hi ...
# file hi
hi: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-armhf.so.1, not stripped
# ./hi
hi
```