### PR TITLE
main/cups: Fix ppc64le break

### DIFF
--- a/main/cups/APKBUILD
+++ b/main/cups/APKBUILD
@@ -74,7 +74,10 @@ package() {
 	install -D -m644 ../cups.logrotate "$pkgdir"/etc/logrotate.d/cups
 	install -D -m755 ../cupsd.initd "$pkgdir"/etc/init.d/cupsd
 
-	sed -i 's|^Exec=htmlview http://localhost:631/|Exec=xdg-open http://localhost:631/|g' "$pkgdir"/usr/share/applications/cups.desktop
+	if [ -e "$pkgdir"/usr/share/applications/cups.desktop ] ; then
+		sed -i 's|^Exec=htmlview http://localhost:631/|Exec=xdg-open http://localhost:631/|g' \
+			"$pkgdir"/usr/share/applications/cups.desktop
+	fi
 	find "$pkgdir"/usr/share/cups/model -name "*.ppd" | xargs gzip -n9f
 }
 


### PR DESCRIPTION
There are some cases that the desktop file is not copied into
$pkgdir.
This change only runs 'sed' on this file if the file exists.