### PR TITLE
main/ruby: Just remove files if they exist

### DIFF
--- a/main/ruby/APKBUILD
+++ b/main/ruby/APKBUILD
@@ -94,7 +94,7 @@ package() {
 	rm -R "$pkgdir"$_gemdir/cache/*
 
 	# Remove bundled CA certificates.
-	rm -R "$pkgdir"$_rubydir/rubygems/ssl_certs/*.pem
+	rm -R "$pkgdir"$_rubydir/rubygems/ssl_certs/*.pem || true
 
 	if [ -d "$pkgdir"/usr/local ]; then
 		local f=$(cd "$pkgdir" ; find usr/local -type f)


### PR DESCRIPTION
With the new abuild version, ruby is not able to build because it tries
to remove some files that might not exist, returning error.

this patch checks if the files to be removed before removing them.