### PR TITLE
main/iptables: Does not install libiptc.a if it does not exists

### DIFF
--- a/main/iptables/APKBUILD
+++ b/main/iptables/APKBUILD
@@ -66,7 +66,9 @@ package() {
 	install -m644 include/iptables.h include/ip6tables.h \
 		"$pkgdir"/usr/include/ || return 1
 	install include/libiptc/*.h "$pkgdir"/usr/include/libiptc/
-	install -m644 libiptc/libiptc.a "$pkgdir"/usr/lib
+	if [ -e libiptc/libiptc.a ]; then
+		install -m644 libiptc/libiptc.a "$pkgdir"/usr/lib
+	fi
 	install -m755 "$startdir"/iptables.initd "$pkgdir"/etc/init.d/iptables
 	install -m644 "$startdir"/iptables.confd "$pkgdir"/etc/conf.d/iptables
 }


### PR DESCRIPTION
Currently iptables is not being built on ppc64le because it tries to
install libiptc.a, that was not generated.

This is breaking only on abuild version 3. On version 2, it is
still working fine.

This patch simply checks if the file exists before installing it.