### PR TITLE
main/tcpdump: Fixing the url

### DIFF
--- a/main/tcpdump/APKBUILD
+++ b/main/tcpdump/APKBUILD
@@ -9,8 +9,7 @@ license="BSD"
 depends=""
 makedepends="libpcap-dev libressl-dev perl"
 subpackages="$pkgname-doc"
-#source="http://www.tcpdump.org/release/$pkgname-$pkgver.tar.gz"
-source="http://www.tcpdump.org/4.9.0-u82xFZBjZxWv/tcpdump-$pkgver.tar.gz"
+source="http://www.tcpdump.org/release/$pkgname-$pkgver.tar.gz"
 
 builddir="$srcdir"/$pkgname-$pkgver
 prepare() {


### PR DESCRIPTION
Currently tcpdump does not build because the source download URL
returns 404.

Commit 71a35ed373786a483254518b4799ed12bf423087 changed the source
URL to something temporary probably, but, it seems to be fixed
upstream now, so, reverting the source location.

No impact on the package checksum.