### PR TITLE
main/live-media: Update version to 2017.01.26

### DIFF
--- a/main/live-media/APKBUILD
+++ b/main/live-media/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=live-media
-pkgver=2016.10.21
+pkgver=2017.01.26
 pkgrel=0
 pkgdesc="A set of C++ libraries for multimedia streaming"
 url="http://live555.com/liveMedia"
@@ -33,7 +33,7 @@ package() {
 	for f in BasicUsageEnvironment UsageEnvironment liveMedia groupsock; do
 		mkdir -p "$pkgdir"/usr/include/$f
 		cp $f/include/*.h* "$pkgdir"/usr/include/$f
-		cp $f/lib${f}.a "$pkgdir"/usr/lib
+		cp $f/lib${f}.a "$pkgdir"/usr/lib || true
 		for so in $f/lib*.so.*; do
 			soname=$(scanelf -B --format "#F%S" $so)
 			cp $so "$pkgdir"/usr/lib/ || return 1
@@ -55,6 +55,6 @@ utils() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-md5sums="3b1f04f17ac5206d9d1930fcc998a94e  live.2016.10.21.tar.gz"
-sha256sums="65b1aa7ec7c487466020e980d1fd68007390f7575b384c1d0fed49b94ba2c240  live.2016.10.21.tar.gz"
-sha512sums="10846fd6d5482bbea131ae805137077997e9dec242665e3c01d699d5584154c65049e8c520ea855599e554154a148e61fea77b592d97c814a4a98c773658d8f5  live.2016.10.21.tar.gz"
+md5sums="9656e2e818cb2f34987ded2593802fba  live.2017.01.26.tar.gz"
+sha256sums="3c4d440b79e415eb3a86d30d0cd061d3edcaaa0281909e8629e9756c2c375458  live.2017.01.26.tar.gz"
+sha512sums="2123d78c18cb2a0f522450aa426beceefe7f70b659ec9c9f04045cbde8e53a927b7909172a42da3967be73989b16f444f02e0b70dab671d4c75e567d8939ad23  live.2017.01.26.tar.gz"


### PR DESCRIPTION
Update live-media package version to 2017.01.26 (that is the
last available version) and fix problem when coping .a files that
does not exist because it is breaking with version 2017.01.26.