### PR TITLE
main/pingu: Fix build with abuild version 3

### DIFF
--- a/main/pingu/APKBUILD
+++ b/main/pingu/APKBUILD
@@ -48,7 +48,7 @@ prepare() {
 
 package() {
 	cd "$_builddir"
-	make DESTDIR="$pkgdir" install install-lua
+	make DESTDIR="$pkgdir" install
 	install -m644 -D pingu.conf "$pkgdir"/etc/pingu/pingu.conf
 	install -m755 -D "$srcdir"/$pkgname.initd "$pkgdir"/etc/init.d/$pkgname
 }


### PR DESCRIPTION
pingu does not build on abuild version 3, because it calls a
Makefile target install-lua that fails.

This target is completely broken upstream and depends on other
non-existing targets. Just removing this target invocation