### PR TITLE
main/zmap: Renaming files from upstream

### DIFF
--- a/main/zmap/APKBUILD
+++ b/main/zmap/APKBUILD
@@ -47,7 +47,7 @@ package() {
 	cd "$_builddir"
 	make DESTDIR="$pkgdir" install || return 1
 
-	for file in AUTHORS CHANGELOG INSTALL README; do
+	for file in AUTHORS CHANGELOG.md INSTALL.md README.md; do
 		install -Dm644 "$file" "$pkgdir"/usr/share/doc/zmap/"$file"
 	done
 


### PR DESCRIPTION
Upstream renamed the some files from plain text to markdown (.md), 
thus, renaming the files.

Adapting to these new file names on our scripts also, otherwise the
files won't be found and the build fails.