### PR TITLE
main/newsbeuter: Compile without glibc

### DIFF
--- a/main/newsbeuter/APKBUILD
+++ b/main/newsbeuter/APKBUILD
@@ -16,6 +16,7 @@ source="http://newsbeuter.org/downloads/newsbeuter-$pkgver.tar.gz
 	0001-Remove-iconv-translit-references.patch
 	newsbeuter-2.9-ncurses6.patch
 	fix-segfault.patch
+	musl_const.patch
 	"
 
 _builddir="$srcdir"/newsbeuter-$pkgver
@@ -43,15 +44,8 @@ package() {
 	make DESTDIR="$pkgdir" prefix=/usr install || return 1
 }
 
-md5sums="9cf332dc7e591023147bda7add430835  newsbeuter-2.9.tar.gz
-2d158695303d3605425d5b30465408b8  0001-Remove-iconv-translit-references.patch
-6450d3794d543f9edae934f86a3ce7ef  newsbeuter-2.9-ncurses6.patch
-bbf607a93fa88d75a137e60b2b4d8eba  fix-segfault.patch"
-sha256sums="74a8bf019b09c3b270ba95adc29f2bbe48ea1f55cc0634276b21fcce1f043dc8  newsbeuter-2.9.tar.gz
-122613fd512a17f938d98ceb5aa3a1a9ddcff7dc4e7ac640e490637d2f645ba9  0001-Remove-iconv-translit-references.patch
-5ae54c463f44d91725da3be655d2b107d598ade6da86ab4a99b10b039b8dba27  newsbeuter-2.9-ncurses6.patch
-6359708ee01f5e1b773a6ed79b7369b30aad5397b85fd252c2fa7d0c2616ea86  fix-segfault.patch"
 sha512sums="b173008c8c8d3729f8ccef3ce62645a05c1803fb842d5c0afdf9ffd4ed3726030f9c359c20bc817402a6a0ea12af742d0ae7faf9b92d52c11f420f62b430b0aa  newsbeuter-2.9.tar.gz
 1cfbe93cd8ca5785b1c26ccfdf1ed467700046c8ca564f33752b0f04f91d37765f83bf82ad593eae41532edf79a8f6992283255f9a2aa8293d14728b175c9dd7  0001-Remove-iconv-translit-references.patch
 08f7125fd8f2b33fa5e36cbd947ec90bcd8b08be2df7961aced20ce031788b3970c1adeb027b1527ba06f18ddbc38518f2c22da6b5fdbc4b1cd5b0edda22ba0b  newsbeuter-2.9-ncurses6.patch
-da986beb12b0ba473fea55c067abcdcdae6c073bf4d66bc8913696a4da99c4072edaf3910769d8e4bcef3a0411875eb23fbc840e0e7572aa0e16e922cc3d2947  fix-segfault.patch"
+da986beb12b0ba473fea55c067abcdcdae6c073bf4d66bc8913696a4da99c4072edaf3910769d8e4bcef3a0411875eb23fbc840e0e7572aa0e16e922cc3d2947  fix-segfault.patch
+6ca96c058af22edd55afeda918aa36ccdf24afd0c4a2a971dca1b80c42fcc067b8d20c6ce86622fb56a5e0bdc0e739bcfee08d80418517cf774e50220d1439a4  musl_const.patch"

--- a/main/newsbeuter/musl_const.patch
+++ b/main/newsbeuter/musl_const.patch
@@ -1,0 +1,11 @@
+--- a/src/utils.cpp
++++ b/src/utils.cpp
+@@ -274,7 +274,7 @@
+ 	 * of all the Unix-like systems around there, only Linux/glibc seems to
+ 	 * come with a SuSv3-conforming iconv implementation.
+ 	 */
+-#if !(__linux) && !defined(__GLIBC__) && !defined(__APPLE__) && !defined(__OpenBSD__)
++#if (__linux)
+ 	const char * inbufp;
+ #else
+ 	char * inbufp;


### PR DESCRIPTION
If you try to compile newsbeuter without -fpermissive, as ppc64le,
it will not build due to a wrong argument type.

It is wrong because it sets the proper argument if you have Linux
with Glibc specifically. Since we use Musl, it uses the wrong
argument.

This patch assures that both Musl and Glibc uses the same argument
type, thus, not causing argument type mismatch.