### PR TITLE
main/tinc: Create intermediate directories

### DIFF
--- a/main/tinc/APKBUILD
+++ b/main/tinc/APKBUILD
@@ -47,7 +47,7 @@ package() {
 	cd "$_builddir"
 	make DESTDIR="$pkgdir" install || return 1
 
-	mkdir "$pkgdir"/etc/tinc
+	mkdir -p "$pkgdir"/etc/tinc
 	install -m755 -D "$srcdir"/tincd.initd "$pkgdir"/etc/init.d/tincd
 	install -m755 -D "$srcdir"/tincd.lo.initd \
 		"$pkgdir"/etc/init.d/tincd.lo


### PR DESCRIPTION
Currently tinc tries to create $pkgdir/etc/tinc without creating
$pkgdir/etc first, which causes a failure.

This patch allows the creation of the directory chain if it does not
exists.