### PR TITLE
main/kbd: Bump to the latest version

### DIFF
--- a/main/kbd/APKBUILD
+++ b/main/kbd/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=kbd
-pkgver=2.0.3
-pkgrel=3
+pkgver=2.0.4
+pkgrel=0
 pkgdesc="Tools for configuring the console (keyboard, virtual terminals, etc.)"
 url="http://ftp.altlinux.org/pub/people/legion/kbd"
 arch="all"
@@ -11,7 +11,7 @@ depends="kbd-misc"
 makedepends="linux-headers bison flex autoconf automake linux-pam-dev check-dev"
 install=""
 subpackages="$pkgname-misc::noarch $pkgname-doc $pkgname-vlock"
-source="ftp://ftp.altlinux.org/pub/people/legion/kbd/kbd-$pkgver.tar.gz
+source="http://kbd-project.org/download/kbd-$pkgver.tar.gz
 	error.h
 	"
 
@@ -105,9 +105,5 @@ misc() {
 	done
 }
 
-md5sums="d636ee56f35233b5cd6f855c08372489  kbd-2.0.3.tar.gz
-1a5b152db18674deec07ab7c6209267a  error.h"
-sha256sums="1933a9a9607a88fddb798f4c1df44ca81257733756c480567ceb52a41de273b9  kbd-2.0.3.tar.gz
-0124ef103407469af4ea19884e2ed7e4546f08b58c129e1e8ef36569831f4b36  error.h"
-sha512sums="7d9a8aa74de45796b8045ddbeaacd1b8fb9e9fd297c18ff382817c40d86bca421978664b215de0b7f79f316437d0c8bc259a113bfb92eb06d106f044339012d8  kbd-2.0.3.tar.gz
+sha512sums="e37bc661c75a8363e9a5ba903310fa7f7ded4f381c2c77aa7edc0b1aca5a63224933fd113cddcf180e7fb85f55407e0d1f47be1cdf69dcf2787e83ac996bbf03  kbd-2.0.4.tar.gz
 c66f6b0d8c8b8d285c740bdbe7130dee272ac01cd5e73b35a58cedf1a77fe8d9e062631b804fb58014d8eb9861c8f28aed07bc022ef31662bcc61b5c85a21752  error.h"


### PR DESCRIPTION
Currently kbd is failing to build because the original URL is
returning 404 due to the project URL change.

This patch points $source to the new URL, and also, bump the version
to the latest 2.0.4 version.