### PR TITLE
smartmontools: Do not fail on directory removal

### DIFF
--- a/main/smartmontools/APKBUILD
+++ b/main/smartmontools/APKBUILD
@@ -28,7 +28,7 @@ build() {
 package() {
 	cd "$srcdir"/$pkgname-$pkgver
 	make DESTDIR="$pkgdir"/ install
-	rm -r "$pkgdir"/etc/rc.d
+	rm -r "$pkgdir"/etc/rc.d || true
 	install -Dm755 ../smartd.initd "$pkgdir"/etc/init.d/smartd
 	install -Dm644 ../smartd.confd "$pkgdir"/etc/conf.d/smartd
 }


### PR DESCRIPTION
This package is trying to remove a directory that does not exist
on current version. We do not want to fail if the directory does
not exists.