### PR TITLE
main/privoxy: Do not fail on file removal

### DIFF
--- a/main/privoxy/APKBUILD
+++ b/main/privoxy/APKBUILD
@@ -50,7 +50,7 @@ build() {
 package() {
 	cd "$_builddir"
 	make DESTDIR="$pkgdir" install
-	rm $pkgdir/var/log/privoxy/*
+	rm $pkgdir/var/log/privoxy/* || true
 	install -D -m755 "$srcdir"/privoxy.initd "$pkgdir"/etc/init.d/privoxy
 	install -D -m644 "$srcdir"/privoxy.logrotate \
 		"$pkgdir"/etc/logrotate.d/privoxy


### PR DESCRIPTION
Privoxy is failing when it tries to remove a directory that does not
exist.

This patch just let the build continue if the directory-to-be-removed
does not exists anymore.