### PR TITLE
aports/mariadb: remove glibc dep on ppc

### DIFF
--- a/main/mariadb/APKBUILD
+++ b/main/mariadb/APKBUILD
@@ -21,6 +21,7 @@ source="https://downloads.mariadb.org/interstitial/mariadb-$pkgver/source/mariad
 	$pkgname.initd
 	fix-mysql-install-db-path.patch
 	fix-ucontext-check.patch
+	ppc_remove_glibc_dep.patch
 	"
 
 # secfixes:
@@ -206,4 +207,5 @@ _compat_bench() { _compat mysql-bench mariadb-client; }
 sha512sums="cf02044b7531f83618eeb42bbddce7b761c6530d22fc69701b3efe7461a1e932510cee923aa59044dcf0bbb5a9edf7bc76d3568f300b648f4983848f5975f7b2  mariadb-10.1.22.tar.gz
 06751768cb00d2e433655635c38d267ef25084a5830ff40e719ac579223c7192dc34b43f919ab6faf480094632327511cbd22456064dde2d04dc15648b9e3b9f  mariadb.initd
 f85e96490de56aa4e6115f931bf256bef4e1b93cadbe4ac947d6abdc03072bf2d0872e0268ae37cd98edf13538ece73e9f8b6efa8133bab23168a825c5066ab1  fix-mysql-install-db-path.patch
-82fa93411483f5d1b57d978087a891bcab6a011e45c2d79b08d28718f5717994b423fc81d2170dad2fe65303153ac29655a81ce5039e73e37cebb159392a86cf  fix-ucontext-check.patch"
+82fa93411483f5d1b57d978087a891bcab6a011e45c2d79b08d28718f5717994b423fc81d2170dad2fe65303153ac29655a81ce5039e73e37cebb159392a86cf  fix-ucontext-check.patch
+25a6dd5a9719087290e65001d0293e02c230785c6846852ed79c64fc6808f99d89fd21bee12c578cc641aaa150daff37393ca08586ca2732d734aefe8ed12d9f  ppc_remove_glibc_dep.patch"

--- a/main/mariadb/ppc_remove_glibc_dep.patch
+++ b/main/mariadb/ppc_remove_glibc_dep.patch
@@ -1,0 +1,48 @@
+--- a/storage/xtradb/include/ut0ut.h
++++ b/storage/xtradb/include/ut0ut.h
+@@ -86,8 +86,7 @@
+    independent way by using YieldProcessor. */
+ #  define UT_RELAX_CPU() YieldProcessor()
+ # elif defined(__powerpc__)
+-#include <sys/platform/ppc.h>
+-#  define UT_RELAX_CPU() __ppc_get_timebase()
++#  define UT_RELAX_CPU() __builtin_ppc_get_timebase()
+ # else
+ #  define UT_RELAX_CPU() ((void)0) /* avoid warning for an empty statement */
+ # endif
+@@ -101,9 +100,8 @@
+ #endif
+ 
+ # if defined(HAVE_HMT_PRIORITY_INSTRUCTION)
+-#include <sys/platform/ppc.h>
+-#  define UT_LOW_PRIORITY_CPU() __ppc_set_ppr_low()
+-#  define UT_RESUME_PRIORITY_CPU() __ppc_set_ppr_med()
++#  define UT_LOW_PRIORITY_CPU()    __asm__ __volatile__ ("or 1,1,1")
++#  define UT_RESUME_PRIORITY_CPU() __asm__ __volatile__ ("or 2,2,2")
+ # else
+ #  define UT_LOW_PRIORITY_CPU() ((void)0)
+ #  define UT_RESUME_PRIORITY_CPU() ((void)0)
+--- a/storage/innobase/include/ut0ut.h
++++ b/storage/innobase/include/ut0ut.h
+@@ -89,8 +89,7 @@
+    independent way by using YieldProcessor. */
+ #  define UT_RELAX_CPU() YieldProcessor()
+ # elif defined(__powerpc__)
+-#include <sys/platform/ppc.h>
+-#  define UT_RELAX_CPU() __ppc_get_timebase()
++#  define UT_RELAX_CPU() __builtin_ppc_get_timebase()
+ # else
+ #  define UT_RELAX_CPU() ((void)0) /* avoid warning for an empty statement */
+ # endif
+@@ -104,9 +103,8 @@
+ #endif
+ 
+ # if defined(HAVE_HMT_PRIORITY_INSTRUCTION)
+-#include <sys/platform/ppc.h>
+-#  define UT_LOW_PRIORITY_CPU() __ppc_set_ppr_low()
+-#  define UT_RESUME_PRIORITY_CPU() __ppc_set_ppr_med()
++#  define UT_LOW_PRIORITY_CPU()    __asm__ __volatile__ ("or 1,1,1")
++#  define UT_RESUME_PRIORITY_CPU() __asm__ __volatile__ ("or 2,2,2")
+ # else
+ #  define UT_LOW_PRIORITY_CPU() ((void)0)
+ #  define UT_RESUME_PRIORITY_CPU() ((void)0)


### PR DESCRIPTION
Remove dependency on glibc by using gcc builtin function and no glibc
wrappers.

Currently there are no surrogates in musl for:

  __ppc_get_timebase()
  __ppc_set_ppr_low()
  __ppc_set_ppr_med()

however glibc __ppc_get_timebase() is just a wrapper for GCC builtin
__builtin_get_timebase() available since GCC 4.8 [1], so assuming that
aports on ppc64le will never be built using GCC < 4.8 we can just
switch directly to the GCC builtin function.

Also __ppc_set_ppr_{low,med}() are not available on musl but both
are simple glibc wrappers on a single asm instruction, hence there
is no harm in using asm directly instead. Actually, using asm
directly was the first solution adopted in MariaDB [2].

[1] https://goo.gl/jxLV6O
[2] https://goo.gl/9bjuVC