### PR TITLE
testing/etcd: subpackage etcdctl

### DIFF
--- a/testing/etcd/APKBUILD
+++ b/testing/etcd/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=etcd
 pkgver=3.1.5
-pkgrel=0
+pkgrel=1
 pkgdesc="A highly-available key value store for shared configuration and service discovery"
 url="https://github.com/coreos/etcd"
 arch="x86_64"
@@ -12,7 +12,7 @@ options="!strip"
 install="$pkgname.pre-install"
 pkgusers="$pkgname"
 pkggroups="$pkgname"
-subpackages="$pkgname-doc"
+subpackages="$pkgname-doc $pkgname-etcdctl"
 source="$pkgname-$pkgver.tar.gz::https://github.com/coreos/etcd/archive/v$pkgver.tar.gz
 	$pkgname.confd
 	$pkgname.initd"
@@ -35,11 +35,15 @@ package() {
 	cd "$builddir"
 	mkdir -p "$pkgdir"/var/lib/$pkgname
 	chown -R $pkgusers:$pkggroups "$pkgdir"/var/lib/$pkgname
-	install -Dm755 bin/etcdctl "$pkgdir"/usr/bin/etcdctl
 	install -Dm755 bin/etcd "$pkgdir"/usr/bin/etcd
 	install -Dm755 $srcdir/$pkgname.confd "$pkgdir"/etc/conf.d/$pkgname
 	install -Dm755 $srcdir/$pkgname.initd "$pkgdir"/etc/init.d/$pkgname
 	install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+}
+
+etcdctl() {
+	cd "$builddir"
+	install -Dm755 bin/etcdctl "$subpkgdir"/usr/bin/etcdctl
 }
 
 sha512sums="6a91be81721179579fbe2b054c23c196aae3c10e3af2ff4e3472e501c7dbbb3dd1adc796d9d2c9f91d46fff7caab45d2cab082a5275c1b90a0f7ded8e67985bb  etcd-3.1.5.tar.gz


### PR DESCRIPTION
etcdctl can be a useful utility to have
without etcd itself, when connecting to
a remote cluster, or from within a container.

Equaly it might not be needed when installing
the server.