### PR TITLE
main/smokeping: Add perl in makedepends

### DIFF
--- a/main/smokeping/APKBUILD
+++ b/main/smokeping/APKBUILD
@@ -29,6 +29,7 @@ depends="perl fping rrdtool perl-rrd
 	perl-cgi
 	perl-cgi-fast
 	"
+makedepends="perl-dev perl-try-tiny"
 arch="noarch"
 license="GPL"
 subpackages="$pkgname-doc"


### PR DESCRIPTION
smokeping fails to build on a clean build machine due to the lack
of perl-dev package, which provides pod2man. Adding this package
as a make-dependency.