### PR TITLE
main/libquvi-scripts: update config.guess

### DIFF
--- a/main/libquvi-scripts/APKBUILD
+++ b/main/libquvi-scripts/APKBUILD
@@ -23,6 +23,7 @@ prepare() {
 		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
 		esac
 	done
+	update_config_guess || return 1
 }
 
 build() {


### PR DESCRIPTION
Libquvi-scripts does not have reference for ppc64le. Updating it
before build, otherwise it fails to build on ppc64le.