### PR TITLE
main/nodejs: fix compilation on ppc when libc musl is used instead of glibc

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -23,7 +23,8 @@ provides="nodejs-lts=$pkgver"  # for backward compatibility
 replaces="nodejs-current nodejs-lts"  # nodejs-lts for backward compatibility
 source="https://nodejs.org/dist/v$pkgver/node-v$pkgver.tar.gz
 	use-system-ca-certs.patch
-	dont-run-gyp-files-for-bundled-deps.patch"
+	dont-run-gyp-files-for-bundled-deps.patch
+	ppc-fix-musl-mcontext.patch"
 builddir="$srcdir/node-v$pkgver"
 
 prepare() {
@@ -87,4 +88,5 @@ npm() {
 
 sha512sums="1bf5b64445b9e4f2d26ca1081f42e554dc10b540332bc45fb5ceeed4b3df0ec3ff4127a3685ca3ae89eadc17561d0f6f0f8024498d13a4461836620802eb647f  node-v6.10.1.tar.gz
 316a09f697e244c48d4dcf26ca2bb7e2441fc01ed61ad6b987e24741f93cfcf29f2e6de736ab9e4c014355cd14dd63ae7de1f8c28b5274e3225b1b3412db11d4  use-system-ca-certs.patch
-a8be538158b7c96341a407acba30450ddc5c3ad764e7efe728d1ceff64efc3067b177855b9ef91b54400be6a02600d83da4c21a07ae9d7dc0774f92b2006ea8b  dont-run-gyp-files-for-bundled-deps.patch"
+a8be538158b7c96341a407acba30450ddc5c3ad764e7efe728d1ceff64efc3067b177855b9ef91b54400be6a02600d83da4c21a07ae9d7dc0774f92b2006ea8b  dont-run-gyp-files-for-bundled-deps.patch
+96cf41da97f60b1ae655d095a122135b67543c18fe639519dd37c8b5bb25b67f0a9f7080f8d082f4e9123144d5d412679b6300ba7843490d27c21278d17dc61a  ppc-fix-musl-mcontext.patch"

--- a/main/nodejs/ppc-fix-musl-mcontext.patch
+++ b/main/nodejs/ppc-fix-musl-mcontext.patch
@@ -1,0 +1,20 @@
+--- a/deps/v8/src/profiler/sampler.cc
++++ b/deps/v8/src/profiler/sampler.cc
+@@ -487,9 +487,17 @@
+   state.sp = reinterpret_cast<Address>(mcontext.gregs[29]);
+   state.fp = reinterpret_cast<Address>(mcontext.gregs[30]);
+ #elif V8_HOST_ARCH_PPC
++#if V8_LIBC_GLIBC
+   state.pc = reinterpret_cast<Address>(ucontext->uc_mcontext.regs->nip);
+   state.sp = reinterpret_cast<Address>(ucontext->uc_mcontext.regs->gpr[PT_R1]);
+   state.fp = reinterpret_cast<Address>(ucontext->uc_mcontext.regs->gpr[PT_R31]);
++#else
++  // Some C libraries, notably Musl, define the regs member as a void pointer,
++  // hence we use the gp_regs member instead.
++  state.pc = reinterpret_cast<Address>(ucontext->uc_mcontext.gp_regs[32]);
++  state.sp = reinterpret_cast<Address>(ucontext->uc_mcontext.gp_regs[1]);
++  state.fp = reinterpret_cast<Address>(ucontext->uc_mcontext.gp_regs[31]);
++#endif
+ #elif V8_HOST_ARCH_S390
+ #if V8_TARGET_ARCH_32_BIT
+   // 31-bit target will have bit 0 (MSB) of the PSW set to denote addressing


### PR DESCRIPTION
Musl on Power does not define regs member as a pt_regs pointer type,
hence it's necessary to use member gp_regs instead.