### PR TITLE
main/mesa: Do not fail on file move

### DIFF
--- a/main/mesa/APKBUILD
+++ b/main/mesa/APKBUILD
@@ -103,8 +103,8 @@ dricore() {
 	pkgdesc="Mesa dricore runtime libraries"
 	install -d "$subpkgdir"/usr/lib "$subpkgdir"/etc
 	mv "$pkgdir"/usr/lib/libdricore*.so.* \
-		"$subpkgdir"/usr/lib/
-	mv "$pkgdir"/etc/drirc "$subpkgdir"/etc/drirc
+		"$subpkgdir"/usr/lib/ || true
+	mv "$pkgdir"/etc/drirc "$subpkgdir"/etc/drirc || true
 }
 
 egl() {
@@ -112,7 +112,7 @@ egl() {
 	pkgdesc="Mesa libEGL runtime libraries"
 	install -d "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/lib/libEGL.so* \
-		"$subpkgdir"/usr/lib/
+		"$subpkgdir"/usr/lib/ || true
 }
 
 gl() {
@@ -120,7 +120,7 @@ gl() {
 	pkgdesc="Mesa libGL runtime libraries"
 	install -d "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/lib/libGL.so* \
-		"$subpkgdir"/usr/lib/
+		"$subpkgdir"/usr/lib/ || true
 }
 
 glapi() {
@@ -128,7 +128,7 @@ glapi() {
 	pkgdesc="Mesa shared glapi"
 	install -d "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/lib/libglapi.so.* \
-		"$subpkgdir"/usr/lib/
+		"$subpkgdir"/usr/lib/ || true
 }
 
 gles() {
@@ -136,21 +136,21 @@ gles() {
 	pkgdesc="Mesa libGLESv2 runtime libraries"
 	install -d "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/lib/libGLES*.so* \
-		"$subpkgdir"/usr/lib/
+		"$subpkgdir"/usr/lib/ || true
 }
 
 xatracker() {
 	pkgdesc="Mesa XA state tracker for vmware"
 	install -d "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/lib/libxatracker*.so.* \
-		"$subpkgdir"/usr/lib/
+		"$subpkgdir"/usr/lib/ || true
 }
 
 osmesa() {
 	pkgdesc="Mesa offscreen rendering libraries"
 	install -d "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/lib/libOSMesa.so.* \
-		"$subpkgdir"/usr/lib/
+		"$subpkgdir"/usr/lib/ || true
 }
 
 gbm() {
@@ -158,7 +158,7 @@ gbm() {
 	replaces="mesa"
 	install -d "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/lib/libgbm.so.* \
-		"$subpkgdir"/usr/lib/
+		"$subpkgdir"/usr/lib/ || true
 }
 
 _mv_dri() {


### PR DESCRIPTION
Currently mesa is failing to build on ppc64le due to a file that
does not exist, and APKBUILD tries to move it.

Adding some changes in the script to let it pass if the source file
does not exists.