### PR TITLE
main/chrony: create doc folder before installing examples

### DIFF
--- a/main/chrony/APKBUILD
+++ b/main/chrony/APKBUILD
@@ -58,6 +58,7 @@ package() {
 	mkdir -p "$pkgdir"/etc/logrotate.d
 	install -Dm644 "$srcdir"/chrony.logrotate "$pkgdir"/etc/logrotate.d/chrony || return 1
 
+	mkdir -p "$pkgdir"/usr/share/doc/chrony
 	install -Dm644 examples/*.example "$pkgdir"/usr/share/doc/chrony/
 	install -Dm755 "$srcdir"/chronyd.initd "$pkgdir"/etc/init.d/chronyd
 	install -Dm644 "$srcdir"/chronyd.confd "$pkgdir"/etc/conf.d/chronyd


### PR DESCRIPTION
create doc/chrony before installing examples