### PR TITLE
main/pmacct: Copy recursive directories

### DIFF
--- a/main/pmacct/APKBUILD
+++ b/main/pmacct/APKBUILD
@@ -66,7 +66,7 @@ package() {
 	ln -s /etc/init.d/pmacctd "$pkgdir"/etc/init.d/uacctd &>/dev/null
 	mkdir -p $pkgdir/usr/share/doc/pmacct/examples
 	mkdir -p $pkgdir/usr/share/doc/pmacct/sql
-	cp examples/* $pkgdir/usr/share/doc/pmacct/examples
+	cp -pr examples/* $pkgdir/usr/share/doc/pmacct/examples
 	cp sql/README.* $pkgdir/usr/share/doc/pmacct
 	cp sql/* $pkgdir/usr/share/doc/pmacct/sql
 }


### PR DESCRIPTION
During the build script, there is a command that tries to copy all
the files from inside a directory, which happens to have a sub-directory
, thus failing the build.

This patch just execute a recursive copy, copying the sub-directory, and
not failing the build.