### PR TITLE
comunity/libteam: fix path when changing directory

### DIFF
--- a/community/libteam/APKBUILD
+++ b/community/libteam/APKBUILD
@@ -49,7 +49,7 @@ py() {
         python2 ./setup.py build || return 1
         cd ../python3
         python3 ./setup.py build || return 1
-	cd binding/python
+	cd ../python
         python2 ./setup.py install --root "$subpkgdir" -O1 || return 1
         cd ../python3
         python3 ./setup.py install --root "$subpkgdir" -O1 || return 1


### PR DESCRIPTION
Adjust path to a valid one when changing directory