### PR TITLE
community/makepasswd: fix non recognized command

### DIFF
--- a/community/makepasswd/APKBUILD
+++ b/community/makepasswd/APKBUILD
@@ -18,7 +18,7 @@ builddir="$srcdir"/$pkgname-$pkgver
 build() {
 	cd "$builddir"
 	make || return 1
-	pushd doc
+	cd doc
 	make || return 1
 }
 


### PR DESCRIPTION
change pushd command, that is a bash built-in command and is not
working, for cd command. As a popd is not being used, it can be
changed