### PR TITLE
community/vigra: fix when creating cmake folder

### DIFF
--- a/community/vigra/APKBUILD
+++ b/community/vigra/APKBUILD
@@ -40,7 +40,7 @@ package() {
 	make install DESTDIR="$pkgdir" || return 1
 
 	# relocate cmake include files
-	mkdir -p "$kgdir"/usr/lib/cmake
+	mkdir -p "$pkgdir"/usr/lib/cmake
 	mv "$pkgdir"/usr/lib/vigra "$pkgdir"/usr/lib/cmake
 }
 md5sums="7f80d289e03a2f2e8c8e85f3ff29d988  vigra-1.11.0-src.tar.gz"


### PR DESCRIPTION
fix the path when creating cmake folder. It had a typo
in $pkgdir variable.