### PR TITLE
main/fail2ban: Add ip6tables to fail2ban dependencies

### DIFF
--- a/main/fail2ban/APKBUILD
+++ b/main/fail2ban/APKBUILD
@@ -8,7 +8,7 @@ pkgdesc="Scans log files for login failures then updates iptables to reject orig
 url="http://www.fail2ban.org"
 arch="noarch"
 license="GPL2+"
-depends="python2 iptables logrotate"
+depends="python2 iptables ip6tables logrotate"
 makedepends="python2-dev py-setuptools"
 source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/$pkgver.tar.gz
 		fail2ban.confd


### PR DESCRIPTION
Fail2ban added ipv6 support in version 0.10.0 and the default ban actions (such as iptables-common.conf) use ip6tables as well as iptables. Not having the ip6tables installed results in errors during jail start