### PR TITLE
main/nagios-plugins: Disable copy of check-game

### DIFF
--- a/main/nagios-plugins/APKBUILD
+++ b/main/nagios-plugins/APKBUILD
@@ -76,7 +76,7 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 
 	# Remove plugins that are useless or doesn't work on Alpine.
-	local name; for name in apt flexlm game oracle; do
+	local name; for name in apt flexlm oracle; do
 		rm "$pkgdir/$_plugins_dir"/check_$name
 	done
 


### PR DESCRIPTION
Nagios-plugins is not building check-game plugin anymore, thus,
abuild is failing to build this package because it tries to remove
(it is not important for Alpine) a package that is not being built
anymore.