### PR TITLE
community/openjdk8: fix build on PPC when musl is used instead of glibc

### DIFF
--- a/community/openjdk8/APKBUILD
+++ b/community/openjdk8/APKBUILD
@@ -56,6 +56,7 @@ source="http://icedtea.classpath.org/download/source/icedtea-$_icedteaver.tar.gz
 	fix-paxmark.patch
 
 	icedtea-hotspot-musl.patch
+	icedtea-hotspot-musl-ppc.patch
 	icedtea-hotspot-noagent-musl.patch
 	icedtea-hotspot-uclibc-fixes.patch
 	icedtea-jdk-execinfo.patch
@@ -250,44 +251,6 @@ demos() {
 		"$subpkgdir"/$_java_home/
 }
 
-md5sums="eb6fc764df734e284cb485de909d7a31  icedtea-3.3.0.tar.gz
-2d1c5467d3c7818ee7ec81d37c1bbbd4  openjdk-3.3.0.tar.xz
-1bc8c5b63eca3918f1c4c934bf66b233  corba-3.3.0.tar.xz
-2b3559177fead9ccb56db07191102870  jaxp-3.3.0.tar.xz
-92612fa7cfecf27357743c932a091b9b  jaxws-3.3.0.tar.xz
-2a732b3f46453fb45b1a37b7c1ab3db8  jdk-3.3.0.tar.xz
-b10431e5823ac859de631e183b1d0b67  langtools-3.3.0.tar.xz
-e600f285d00ee367b4129450c35f113a  hotspot-3.3.0.tar.xz
-9cc3887801b7ad6c290c4adf4a742130  nashorn-3.3.0.tar.xz
-5ac9306bf404251111cee6b9eff26bd4  fix-paxmark.patch
-2f4a5b0ec7a2bf7ab609da10b86dca4c  icedtea-hotspot-musl.patch
-bd148291e75d536972cb2b1b68e5cb05  icedtea-hotspot-noagent-musl.patch
-43023861c5f6efc3139a834aa3ec0476  icedtea-hotspot-uclibc-fixes.patch
-bdea7060a067faf1c2de5f4eb6e8525d  icedtea-jdk-execinfo.patch
-250b0807b59762670954b132e8f8dfba  icedtea-jdk-fix-ipv6-init.patch
-4dcba8ae18346298c0d0b817f6922415  icedtea-jdk-fix-libjvm-load.patch
-ae8b8d44db2ef9a1ee112823957d0ebd  icedtea-jdk-musl.patch
-da4b0b67d9b5c7f742bcea70722acd94  icedtea-jdk-includes.patch
-d13bf1213635a702611af295d3977fe1  icedtea-autoconf-config.patch"
-sha256sums="ce74a343759bfe6a7332301835e7c6e77d01db588a1dab672816c9ce338474b1  icedtea-3.3.0.tar.gz
-887c5bc24b068efced7d5209367149ca27d8fea330cd5a5fff7767c353b00921  openjdk-3.3.0.tar.xz
-19492bdd85166ce55d0f85f96e1d3d0b21e61f4604349ea0b94f6a0aa1388b61  corba-3.3.0.tar.xz
-ba5933a2bbf04b0786fd5f046d43314f1b1b2bf2888c586521b37410783bccef  jaxp-3.3.0.tar.xz
-a443f3243978a87a055ab103468878e5e072706ab0c82d1949ba869fc63571b6  jaxws-3.3.0.tar.xz
-688e962ab13055eb6b8668bb48b50eecc7f02f5120b541cfa58f516f875f9f9d  jdk-3.3.0.tar.xz
-1b0b0fb49c81955573ce509e1801530faa6477e606192fec4b0f951904fb8ac0  langtools-3.3.0.tar.xz
-280f706bb0aaada0903e9e907811ea12bc1c216fdaeb2694910f3a99217f6e89  hotspot-3.3.0.tar.xz
-0ec045c9c4506f63602d86e72b0c3fdccd75fa95c47ee6a1238639274dc8e92d  nashorn-3.3.0.tar.xz
-79bff0b02da899cdc14040443f254a742bdd599ca21357e6c28a4ec35da0e2ac  fix-paxmark.patch
-ed114e8d00d6ed1295f5995df02ad13d3d0cd242f7a904600d93b6564856f8df  icedtea-hotspot-musl.patch
-c14529a29bfdfb51bf5b4a41c977039073f470758e31235d043d373b48d46a11  icedtea-hotspot-noagent-musl.patch
-0ef7592b8f2c954eda0a6cf4dc4a4010942f35ea426f44e34412be6c9a949745  icedtea-hotspot-uclibc-fixes.patch
-a35d40f24098747cdb73d9c3742cfb4aecafa0f72c9dfdfe2cb460f9706ff665  icedtea-jdk-execinfo.patch
-632683ec88a6fb250ef043aae9cace605d0c669b7058f8c47b62b09b03ecc6c5  icedtea-jdk-fix-ipv6-init.patch
-c0f7e07293883142d7d7776c9e43a3bba7d45e4abbce6dc0fb531d25ed836ed4  icedtea-jdk-fix-libjvm-load.patch
-f6965fb31ec44389acec74c98b438a43ee2349c18586b66c71baf6a0b5ccdc50  icedtea-jdk-musl.patch
-8f4edc784fd70b27f91a0acf05a1de19fc300a35852b74668332ed747ec52073  icedtea-jdk-includes.patch
-51ced4c77b97744fd0ecfbeca3f94e2da1fc5072dac7830c141f70887c503c33  icedtea-autoconf-config.patch"
 sha512sums="a419e71ff68d89dafc8ab4f98f81f01f199aa835a64ff9c34777fc3dcb9c0ba72bc3ab55ca39995e06c20d1e63df885f6bfc3dc7e6dff6f6efc24c6834fb51ab  icedtea-3.3.0.tar.gz
 d98790823408e09f3fa9946ceeeda48187dddd3302625fc546d64a4ecc89967235c550af23c05368a90d8dd2ceb38c092cd3130958132d18d30692342bd1151e  openjdk-3.3.0.tar.xz
 b1f44e1e41b3565bd45176f726e4d1c2999c5ff25a5f2e973f0e5836b7fd2cf6540eae83d3944b303677797e052abd950bb9748fb3e218e4c71b1ea059bf1209  corba-3.3.0.tar.xz
@@ -299,6 +262,7 @@ b1f44e1e41b3565bd45176f726e4d1c2999c5ff25a5f2e973f0e5836b7fd2cf6540eae83d3944b30
 c0aec36e921288b6ad11e71daa32111a4ee45302a2bbe407229cc143f05869372993f7b0dd366c07ecb31fac47e1d3cdb0c59cc1a48375d3719656c2159fee95  nashorn-3.3.0.tar.xz
 1f470432275d5beaa8b4e4352a2f24a4a00593546dc4f3bd857794c89e521e8e6d6abc540762bbd769be3e1e3da058e134dc5dc066d12b9b8a1f0656040a795c  fix-paxmark.patch
 ada3bc4024682bfb86ebf3850d3a36cf4c0f0677a6d56eac2e0959b92bfe759010d5b9c801b043cae3ca8418d7819546ae245ac163df83e48c5d4b34478daeb0  icedtea-hotspot-musl.patch
+e5cf4d70f96fc1e72ae8b97a887adb96092ff36584711cbb8de9d9fa9e859cb8731d638838de0d9591239fc44ffe5c74422d1842bd9f10a0c00dff1627bdeeef  icedtea-hotspot-musl-ppc.patch
 3c592a14f1806a431290a96a8c1413ca1cc621e73a87ed778fa98878c82809bd924072210d4e4127a6c0c32ff557d749f6c9b3ce31cbca083b013240b618b224  icedtea-hotspot-noagent-musl.patch
 822eee0dc4d3ba677a289dfeb3668b536d2d626708390a9d9702fb4144a481fd443a215a0d2041c6026113837aafa4ba0b5e9ead8589d2da6717a238bbc95a5a  icedtea-hotspot-uclibc-fixes.patch
 f6365cfafafa008bd6c1bf0ccec01a63f8a39bd1a8bc87baa492a27234d47793ba02d455e5667a873ef50148df3baaf6a8421e2da0b15faac675867da714dd5f  icedtea-jdk-execinfo.patch

--- a/community/openjdk8/icedtea-hotspot-musl-ppc.patch
+++ b/community/openjdk8/icedtea-hotspot-musl-ppc.patch
@@ -1,0 +1,169 @@
+--- openjdk.orig/hotspot/src/os_cpu/linux_ppc/vm/os_linux_ppc.cpp
++++ openjdk/hotspot/src/os_cpu/linux_ppc/vm/os_linux_ppc.cpp
+@@ -110,11 +110,19 @@
+   //   it because the volatile registers are not needed to make setcontext() work.
+   //   Hopefully it was zero'd out beforehand.
+   guarantee(uc->uc_mcontext.regs != NULL, "only use ucontext_get_pc in sigaction context");
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+   return (address)uc->uc_mcontext.regs->nip;
++#else // Musl
++  return (address)uc->uc_mcontext.gp_regs[32];
++#endif
+ }
+ 
+ intptr_t* os::Linux::ucontext_get_sp(ucontext_t * uc) {
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+   return (intptr_t*)uc->uc_mcontext.regs->gpr[1/*REG_SP*/];
++#else // Musl
++  return (intptr_t*)uc->uc_mcontext.gp_regs[1/*REG_SP*/];
++#endif
+ }
+ 
+ intptr_t* os::Linux::ucontext_get_fp(ucontext_t * uc) {
+@@ -213,7 +221,11 @@
+   if (uc) {
+     address const pc = os::Linux::ucontext_get_pc(uc);
+     if (pc && StubRoutines::is_safefetch_fault(pc)) {
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+       uc->uc_mcontext.regs->nip = (unsigned long)StubRoutines::continuation_for_safefetch_fault(pc);
++#else // Musl
++      uc->uc_mcontext.gp_regs[32] = (unsigned long)StubRoutines::continuation_for_safefetch_fault(pc);
++#endif
+       return true;
+     }
+   }
+@@ -364,7 +376,11 @@
+           // continue at the next instruction after the faulting read. Returning
+           // garbage from this read is ok.
+           thread->set_pending_unsafe_access_error();
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+           uc->uc_mcontext.regs->nip = ((unsigned long)pc) + 4;
++#else // Musl
++          uc->uc_mcontext.gp_regs[32] = ((unsigned long)pc) + 4;
++#endif
+           return true;
+         }
+       }
+@@ -383,7 +399,11 @@
+         // continue at the next instruction after the faulting read. Returning
+         // garbage from this read is ok.
+         thread->set_pending_unsafe_access_error();
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+         uc->uc_mcontext.regs->nip = ((unsigned long)pc) + 4;
++#else // Musl
++        uc->uc_mcontext.gp_regs[32] = ((unsigned long)pc) + 4;
++#endif
+         return true;
+       }
+     }
+@@ -406,7 +426,11 @@
+   if (stub != NULL) {
+     // Save all thread context in case we need to restore it.
+     if (thread != NULL) thread->set_saved_exception_pc(pc);
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+     uc->uc_mcontext.regs->nip = (unsigned long)stub;
++#else
++    uc->uc_mcontext.gp_regs[32] = (unsigned long)stub;
++#endif
+     return true;
+   }
+ 
+@@ -564,6 +588,7 @@
+   ucontext_t* uc = (ucontext_t*)context;
+ 
+   st->print_cr("Registers:");
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+   st->print("pc =" INTPTR_FORMAT "  ", uc->uc_mcontext.regs->nip);
+   st->print("lr =" INTPTR_FORMAT "  ", uc->uc_mcontext.regs->link);
+   st->print("ctr=" INTPTR_FORMAT "  ", uc->uc_mcontext.regs->ctr);
+@@ -572,8 +597,18 @@
+     st->print("r%-2d=" INTPTR_FORMAT "  ", i, uc->uc_mcontext.regs->gpr[i]);
+     if (i % 3 == 2) st->cr();
+   }
++#else // Musl
++  st->print("pc =" INTPTR_FORMAT "  ", uc->uc_mcontext.gp_regs[32]);
++  st->print("lr =" INTPTR_FORMAT "  ", uc->uc_mcontext.gp_regs[36]);
++  st->print("ctr=" INTPTR_FORMAT "  ", uc->uc_mcontext.gp_regs[35]);
+   st->cr();
++  for (int i = 0; i < 32; i++) {
++    st->print("r%-2d=" INTPTR_FORMAT "  ", i, uc->uc_mcontext.gp_regs[i]);
++    if (i % 3 == 2) st->cr();
++  }
++#endif
+   st->cr();
++  st->cr();
+ 
+   intptr_t *sp = (intptr_t *)os::Linux::ucontext_get_sp(uc);
+   st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));
+@@ -600,7 +635,11 @@
+   // this is only for the "general purpose" registers
+   for (int i = 0; i < 32; i++) {
+     st->print("r%-2d=", i);
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+     print_location(st, uc->uc_mcontext.regs->gpr[i]);
++#else // Musl
++    print_location(st, uc->uc_mcontext.gp_regs[i]);
++#endif
+   }
+   st->cr();
+ }
+--- openjdk.orig/hotspot.orig/src/cpu/ppc/vm/macroAssembler_ppc.cpp
++++ openjdk/hotspot/src/cpu/ppc/vm/macroAssembler_ppc.cpp
+@@ -1242,7 +1242,11 @@
+   // the safepoing polling page.
+   ucontext_t* uc = (ucontext_t*) ucontext;
+   // Set polling address.
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+   address addr = (address)uc->uc_mcontext.regs->gpr[ra] + (ssize_t)ds;
++#else // Musl
++  address addr = (address)uc->uc_mcontext.gp_regs[ra] + (ssize_t)ds;
++#endif
+   if (polling_address_ptr != NULL) {
+     *polling_address_ptr = addr;
+   }
+@@ -1263,15 +1267,24 @@
+     int rb = inv_rb_field(instruction);
+ 
+     // look up content of ra and rb in ucontext
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+     address ra_val=(address)uc->uc_mcontext.regs->gpr[ra];
+     long rb_val=(long)uc->uc_mcontext.regs->gpr[rb];
++#else // Musl
++    address ra_val=(address)uc->uc_mcontext.gp_regs[ra];
++    long rb_val=(long)uc->uc_mcontext.gp_regs[rb];
++#endif
+     return os::is_memory_serialize_page(thread, ra_val+rb_val);
+   } else if (is_stw(instruction) || is_stwu(instruction)) {
+     int ra = inv_ra_field(instruction);
+     int d1 = inv_d1_field(instruction);
+ 
+     // look up content of ra in ucontext
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+     address ra_val=(address)uc->uc_mcontext.regs->gpr[ra];
++#else // Musl
++    address ra_val=(address)uc->uc_mcontext.gp_regs[ra];
++#endif
+     return os::is_memory_serialize_page(thread, ra_val+d1);
+   } else {
+     return false;
+@@ -1334,11 +1347,20 @@
+       || (is_stdu(instruction) && rs == 1)) {
+     int ds = inv_ds_field(instruction);
+     // return banged address
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+     return ds+(address)uc->uc_mcontext.regs->gpr[ra];
++#else // Musl
++    return ds+(address)uc->uc_mcontext.gp_regs[ra];
++#endif
+   } else if (is_stdux(instruction) && rs == 1) {
+     int rb = inv_rb_field(instruction);
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+     address sp = (address)uc->uc_mcontext.regs->gpr[1];
+     long rb_val = (long)uc->uc_mcontext.regs->gpr[rb];
++#else // Musl
++    address sp = (address)uc->uc_mcontext.gp_regs[1];
++    long rb_val = (long)uc->uc_mcontext.gp_regs[rb];
++#endif
+     return ra != 1 || rb_val >= 0 ? NULL         // not a stack bang
+                                   : sp + rb_val; // banged address
+   }


### PR DESCRIPTION
Musl on Power does not define regs member as a pt_regs pointer type,
hence it's necessary to use member gp_regs instead.