### PR TITLE
main/freeradius: Bump version to 3.0.13

### DIFF
--- a/main/freeradius/APKBUILD
+++ b/main/freeradius/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=freeradius
 _realname=freeradius
-pkgver=3.0.12
+pkgver=3.0.13
 pkgrel=2
 pkgdesc="RADIUS (Remote Authentication Dial-In User Service) server"
 url="http://freeradius.org/"
@@ -31,6 +31,7 @@ source="ftp://ftp.freeradius.org/pub/freeradius/$_realname-server-$pkgver.tar.gz
 	musl-fix-headers.patch
 	freeradius-305-default-config.patch
 	fix-scopeid.patch
+	libressl.patch
 	"
 
 _builddir="$srcdir"/$_realname-server-$pkgver
@@ -291,21 +292,10 @@ redis() {
 		|| return 1
 }
 
-md5sums="823b28430792b66fb076fe9f3aefa849  freeradius-server-3.0.12.tar.gz
-fc6693f3df5a0694610110287a28568a  freeradius.confd
-e27f11a11fa167b5185d3e11de79d3bc  freeradius.initd
-d86558365a1deea4914ed139797805b0  musl-fix-headers.patch
-f8a7b00835f2108acc06af212cede16e  freeradius-305-default-config.patch
-5171fca6629baeb274a9b17e02683163  fix-scopeid.patch"
-sha256sums="4a5af6efcf7fef08ea9bb02979200131e1332a48341c529da73bea76d3b25da0  freeradius-server-3.0.12.tar.gz
-2d5b3e1af1299373182f2c8021bdf45c29db5d82b0a077b965a16ded32cb6292  freeradius.confd
-a5208f13420c28446b85dfc48cb9193a4651c994d15cc2c9b0bc43734c66e8f0  freeradius.initd
-872aaebf86a663f819460d98924a9dc1f3e428facac6930dc98d1e442df1633f  musl-fix-headers.patch
-02cad546ffaf3f9be531cb45b96c7fb31f83c717e40ece4ff28a73c86f921f33  freeradius-305-default-config.patch
-aad4796f06a5891b3d48d6ded926ffeb7b9fa84cc1c4a1f1be76bced02694023  fix-scopeid.patch"
-sha512sums="69258da3976f75aa74a9ceb24e08bd5ae0aac2398cd8051368dea7f26a1c969f613a1c94f507e9ec3213f22a60b0b9e194dc68fe7807de501e56880b2fa52604  freeradius-server-3.0.12.tar.gz
+sha512sums="b4cb6203ca34ec459ea0f4f7960b4c5039ecd1be3de005251213ab6a9254d11fa9534b96d222eb83e6b35966aaeb6081362fd103eb73e0d76c009a655a47277f  freeradius-server-3.0.13.tar.gz
 e248159c0a44f722e405c51c8015d9ad672e42ad0d38ca28f8a051ff911aa4d3e630b9bd4543e9d610940bc4ae50c022594e219ce341b36abe85c572acad418b  freeradius.confd
 ba3c424d4eabb147c7aa3e31575a87ddb26b6a792d2a8714e73d8763e07854326a03a83991a7420246ca06bf0b93d0a6f23ec198f5e48647f9d25b40067e852a  freeradius.initd
 c49e5eec7497fccde5fd09dba1ea9b846e57bc88015bd81640aa531fb5c9b449f37136f42c85fe1d7940c5963aed664b85da28442b388c9fb8cc27873df03b2d  musl-fix-headers.patch
-b69b899da6f80dbdb7422847536e37461315ba587a07fedc1eee28b96be7d16993b758ccd34e3a271ce2937d72c6ddff878aec61a3a4c0750deaaa959d10ed5e  freeradius-305-default-config.patch
-41d478c0e40ff82fc36232964037c1ab8ffca9fdbb7dca02ed49319906e751c133b5d7bc7773c645cec6d9d39d1de69cba25e8d59afa8d6662563dd17f35f234  fix-scopeid.patch"
+370714f4ea157059dbbad7ae377c7382bcc7b029edd83d49071ce7cbd6c495fda5bc55ae276195a37cd4d742a25fbdd3d271d54d5dc8b1deff9e1c2940bf4deb  freeradius-305-default-config.patch
+41d478c0e40ff82fc36232964037c1ab8ffca9fdbb7dca02ed49319906e751c133b5d7bc7773c645cec6d9d39d1de69cba25e8d59afa8d6662563dd17f35f234  fix-scopeid.patch
+fe01236aa82cf3b73951693f97f1dd3f7bc53dc192e8fd7e2e5496971873e0cf64fd2ad9c8c1f12199b4344f46187428ce442064eadc535d23306e5789df39b8  libressl.patch"

--- a/main/freeradius/freeradius-305-default-config.patch
+++ b/main/freeradius/freeradius-305-default-config.patch
@@ -1,6 +1,8 @@
---- a/raddb/radiusd.conf.in
-+++ b/raddb/radiusd.conf.in
-@@ -436,8 +436,8 @@
+Index: freeradius-server-3.0.13/raddb/radiusd.conf.in
+===================================================================
+--- freeradius-server-3.0.13.orig/raddb/radiusd.conf.in
++++ freeradius-server-3.0.13/raddb/radiusd.conf.in
+@@ -436,8 +436,8 @@ security {
  	#  member.  This can allow for some finer-grained access
  	#  controls.
  	#
@@ -11,22 +13,25 @@
  
  	#  Core dumps are a bad thing.  This should only be set to
  	#  'yes' if you're debugging a problem with the server.
---- a/raddb/sites-available/default
-+++ b/raddb/sites-available/default
-@@ -343,9 +343,9 @@
- 	#  for the many packets that go back and forth to set up TTLS
- 	#  or PEAP.  The load on those servers will therefore be reduced.
+Index: freeradius-server-3.0.13/raddb/sites-available/default
+===================================================================
+--- freeradius-server-3.0.13.orig/raddb/sites-available/default
++++ freeradius-server-3.0.13/raddb/sites-available/default
+@@ -379,10 +379,10 @@ authorize {
+ 	#  uncomment it as well; this will further reduce the number of
+ 	#  LDAP and/or SQL queries for TTLS or PEAP.
  	#
 -	eap {
 -		ok = return
--	}
 +#	eap {
 +#		ok = return
+ #		updated = return
+-	}
 +#	}
  
  	#
  	#  Pull crypt'd passwords from /etc/passwd or /etc/shadow,
-@@ -486,7 +486,7 @@
+@@ -529,7 +529,7 @@ authenticate {
  
  	#
  	#  Allow EAP authentication.
@@ -35,7 +40,7 @@
  
  	#
  	#  The older configurations sent a number of attributes in
-@@ -792,7 +792,7 @@
+@@ -846,7 +846,7 @@ post-auth {
  		# Insert EAP-Failure message if the request was
  		# rejected by policy instead of because of an
  		# authentication failure
@@ -44,7 +49,7 @@
  
  		#  Remove reply message if the response contains an EAP-Message
  		remove_reply_message_if_eap
-@@ -861,7 +861,7 @@
+@@ -924,7 +924,7 @@ post-proxy {
  	#  hidden inside of the EAP packet, and the end server will
  	#  reject the EAP request.
  	#
@@ -53,9 +58,11 @@
  
  	#
  	#  If the server tries to proxy a request and fails, then the
---- a/raddb/sites-available/inner-tunnel
-+++ b/raddb/sites-available/inner-tunnel
-@@ -116,9 +116,9 @@
+Index: freeradius-server-3.0.13/raddb/sites-available/inner-tunnel
+===================================================================
+--- freeradius-server-3.0.13.orig/raddb/sites-available/inner-tunnel
++++ freeradius-server-3.0.13/raddb/sites-available/inner-tunnel
+@@ -131,9 +131,9 @@ authorize {
  	#  for the many packets that go back and forth to set up TTLS
  	#  or PEAP.  The load on those servers will therefore be reduced.
  	#
@@ -68,7 +75,7 @@
  
  	#
  	#  Read the 'users' file
-@@ -227,7 +227,7 @@
+@@ -247,7 +247,7 @@ authenticate {
  
  	#
  	#  Allow EAP authentication.
@@ -77,7 +84,7 @@
  }
  
  ######################################################################
-@@ -393,7 +393,7 @@
+@@ -426,7 +426,7 @@ post-proxy {
  	#  hidden inside of the EAP packet, and the end server will
  	#  reject the EAP request.
  	#
@@ -85,4 +92,4 @@
 +#	eap
  }
  
- } # inner-tunnel server block 
+ } # inner-tunnel server block

--- a/main/freeradius/libressl.patch
+++ b/main/freeradius/libressl.patch
@@ -1,0 +1,28 @@
+Author: Breno Leitao <breno.leitao@gmail.com>
+Date:   Thu Mar 30 10:36:43 2017 -0300
+
+    Freeradius fails to build on systems with LibreSSL.
+    
+    FreeRadius try to link against function X509_get0_extensions() that does
+    not exist on LibreSSl, so the following "if" clausure does not work
+    correct for LibreSSL, since OpenSSL has a defined macro
+    OPENSSL_VERSION_NUMBER for LibreSSL bigger than
+    0x10100000, and does not have X509_get0_extensions():
+    
+     #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+                    ext_list = X509_get0_extensions(client_cert);
+    
+    This patch guarantee that this check is not valid for LibreSSL, thus,
+    using the fall back.
+
+--- a/src/main/tls.c	2017-03-29 21:01:55.660935694 +0000
++++ b/src/main/tls.c	2017-03-29 21:02:28.900936152 +0000
+@@ -2131,7 +2131,7 @@ int cbtls_verify(int ok, X509_STORE_CTX
+ 	}
+ 
+ 	if (lookup == 0) {
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+ 		ext_list = X509_get0_extensions(client_cert);
+ #else
+ 		X509_CINF	*client_inf;


### PR DESCRIPTION
Current version (3.0.12) it not available in the $source URL anymore,
thus, cauing a FTBFS. This patch bumpts version to 3.0.13.

This new version is crashing to be built with LibreSSL, thus fixing
it also. This patch was already sent to upstream and accepted on version
4. I also needed to rebase freeradius-305-default-config.patch.