### PR TITLE
main/apg: Getting package from a mirror

### DIFF
--- a/main/apg/APKBUILD
+++ b/main/apg/APKBUILD
@@ -9,7 +9,8 @@ license="BSD"
 depends=""
 makedepends=""
 subpackages="$pkgname-doc"
-source="http://www.adel.nursat.kz/apg/download/$pkgname-$pkgver.tar.gz"
+#source="http://www.adel.nursat.kz/apg/download/$pkgname-$pkgver.tar.gz"
+source="ftp://ftp.netbsd.org/pub/pkgsrc/distfiles/$pkgname-$pkgver.tar.gz"
 
 _builddir="$srcdir"/$pkgname-$pkgver
 build() {


### PR DESCRIPTION
Official apg website is not online, grabbing the package from a
mirror temporarily. This patch should be reverted when the address
www.adel.nursat.kz is being resolved.