### PR TITLE
main/qemu: remove strip action from APKBUILD

### DIFF
--- a/main/qemu/APKBUILD
+++ b/main/qemu/APKBUILD
@@ -41,7 +41,7 @@ makedepends="
 depends=""
 pkggroups="qemu"
 install="$pkgname.pre-install $pkgname.post-install"
-options="suid"  # needed for qemu-bridge-helper
+options="suid !strip"  # needed for qemu-bridge-helper
 subpackages="$pkgname-doc $pkgname-guest-agent:guest"
 
 _subsystems="


### PR DESCRIPTION
APKBUILD was stripping qemu binaries and also a .img file and this was making
the build fail. As qemu Makefile already strip the generated binaries, APKBUILD
does not need to strip them again, so this patch removes the strip from APKBUILD.