### PR TITLE
community/qemu: fix build on PPC when musl is used instead of glibc

### DIFF
--- a/main/qemu/0001-linux-user-fix-build-with-musl-on-ppc64le.patch
+++ b/main/qemu/0001-linux-user-fix-build-with-musl-on-ppc64le.patch
@@ -1,0 +1,67 @@
+--- a/linux-user/host/ppc64/hostdep.h
++++ b/linux-user/host/ppc64/hostdep.h
+@@ -25,7 +25,11 @@
+ static inline void rewind_if_in_safe_syscall(void *puc)
+ {
+     struct ucontext *uc = puc;
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+     unsigned long *pcreg = &uc->uc_mcontext.gp_regs[PT_NIP];
++#else // Musl
++    unsigned long *pcreg = &uc->uc_mcontext.gp_regs[32];
++#endif
+
+     if (*pcreg > (uintptr_t)safe_syscall_start
+         && *pcreg < (uintptr_t)safe_syscall_end) {
+--- a/user-exec.c
++++ a/user-exec.c
+@@ -228,6 +228,7 @@
+  */
+ #ifdef linux
+ /* All Registers access - only for local access */
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+ #define REG_sig(reg_name, context)              \
+     ((context)->uc_mcontext.regs->reg_name)
+ /* Gpr Registers access  */
+@@ -245,15 +246,42 @@
+ /* Condition register */
+ #define CR_sig(context)                        REG_sig(ccr, context)
+
++#else // Musl
++#define REG_sig(reg_num, context)              \
++    ((context)->uc_mcontext.gp_regs[reg_num])
++/* Gpr Registers access  */
++#define GPR_sig(reg_num, context)              REG_sig(gpr[reg_num], context)
++/* Program counter */
++#define IAR_sig(context)                       REG_sig(32, context)
++/* Machine State Register (Supervisor) */
++#define MSR_sig(context)                       REG_sig(33, context)
++/* Count register */
++#define CTR_sig(context)                       REG_sig(35, context)
++/* User's integer exception register */
++#define XER_sig(context)                       REG_sig(37, context)
++/* Link register */
++#define LR_sig(context)                        REG_sig(36, context)
++/* Condition register */
++#define CR_sig(context)                        REG_sig(38, context)
++#endif
++
++
+ /* Float Registers access  */
+ #define FLOAT_sig(reg_num, context)                                     \
+     (((double *)((char *)((context)->uc_mcontext.regs + 48 * 4)))[reg_num])
+ #define FPSCR_sig(context) \
+     (*(int *)((char *)((context)->uc_mcontext.regs + (48 + 32 * 2) * 4)))
+ /* Exception Registers access */
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+ #define DAR_sig(context)                       REG_sig(dar, context)
+ #define DSISR_sig(context)                     REG_sig(dsisr, context)
+ #define TRAP_sig(context)                      REG_sig(trap, context)
++#else // Musl
++#define DAR_sig(context)                       REG_sig(41, context)
++#define DSISR_sig(context)                     REG_sig(42, context)
++#define TRAP_sig(context)                      REG_sig(40, context)
++#endif
++
+ #endif /* linux */
+
+ #if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)

--- a/main/qemu/APKBUILD
+++ b/main/qemu/APKBUILD
@@ -126,6 +126,7 @@ source="http://wiki.qemu-project.org/download/$pkgname-$pkgver.tar.bz2
 	xattr_size_max.patch
 	ncurses.patch
 	ignore-signals-33-and-64-to-allow-golang-emulation.patch
+	0001-linux-user-fix-build-with-musl-on-ppc64le.patch
 	$pkgname-guest-agent.confd
 	$pkgname-guest-agent.initd
 	80-kvm.rules
@@ -303,32 +304,6 @@ guest() {
 		"$subpkgdir"/etc/conf.d/$pkgname-guest-agent || return 1
 }
 
-md5sums="17940dce063b6ce450a12e719a6c9c43  qemu-2.8.0.tar.bz2
-672727bb1d8c8ab7b5def65dd1793c33  0001-elfload-load-PIE-executables-to-right-address.patch
-d364208c4847ad2baeb237900befecd1  0006-linux-user-signal.c-define-__SIGRTMIN-MAX-for-non-GN.patch
-38fbaee6f2913993169e5b39d96927a1  0001-linux-user-fix-build-with-musl-on-aarch64.patch
-19a26bd596f0a1c55d2e831106ce96f5  musl-F_SHLCK-and-F_EXLCK.patch
-18f3194bdb0751d1c96140bd4d98b86f  fix-sigevent-and-sigval_t.patch
-36b835d7f00aa99f69d909bcdff9b1cf  xattr_size_max.patch
-4b3b899ebc67accff89ace306d48668e  ncurses.patch
-b4fa458e13a97c8938c3d527606aea56  ignore-signals-33-and-64-to-allow-golang-emulation.patch
-1663bc6977f6886a58394155b1bf3676  qemu-guest-agent.confd
-ea972f2fc5505488f68320bf386106bb  qemu-guest-agent.initd
-66660f143235201249dc0648b39b86ee  80-kvm.rules
-a2f5570453f2489b6e4023e96f70cb7e  bridge.conf"
-sha256sums="dafd5d7f649907b6b617b822692f4c82e60cf29bc0fc58bc2036219b591e5e62  qemu-2.8.0.tar.bz2
-af35304b165622a53f7557b59ffd8da5030f5fd444e669c862f9410131f3b987  0001-elfload-load-PIE-executables-to-right-address.patch
-6af6cf9044997710a6d0fbdba30a35c8d775e30d30c032ec97db672f75ec88ac  0006-linux-user-signal.c-define-__SIGRTMIN-MAX-for-non-GN.patch
-1086ee9ea9411b3bacaf58bc72630a159260ef873a66710b7edb7223be1ea2c0  0001-linux-user-fix-build-with-musl-on-aarch64.patch
-ec5e2bd34636c47f464c6b9efd01e487a7b81602c8b598df6efe8d8ceed0c2e5  musl-F_SHLCK-and-F_EXLCK.patch
-5bd5723873af643406b250641e7eaa248ce728b8caf8e761e219728f59ce6072  fix-sigevent-and-sigval_t.patch
-a0c21e70495ac249e3dfcba7420eebe044c6cccc5a8bdc5b635d89ca2e2eac7f  xattr_size_max.patch
-f24b9492f208d386edc5a7a5222906e4816733348e0c557c09ce813bbd80be92  ncurses.patch
-d093d1261760ac5d60419cf5ba4a180f3b216931d700c792cddd24fe0076e865  ignore-signals-33-and-64-to-allow-golang-emulation.patch
-d84e53a94584f37f3bd1b21f44077b5de0d07094c6729f26ae20ab1f7b9cc298  qemu-guest-agent.confd
-5bef90ccab2e743868fd562eee9a3ded35c8d3e01fa387367ed55a0da95570d5  qemu-guest-agent.initd
-37f666f1cdb7d8a62171de69b531681dcb0fba74236729dac8b6c019232eba84  80-kvm.rules
-2f05021990014a5f832aa17317c1464806dc97c278f88d8284db88378f53cb32  bridge.conf"
 sha512sums="50f2988d822388ba9fd1bf5dbe68359033ed7432d7f0f9790299f32f63faa6dc72979256b5632ba572d47ee3e74ed40e3e8e331dc6303ec1599f1b4367cb78c2  qemu-2.8.0.tar.bz2
 405008589cad1c8b609eca004d520bf944366e8525f85a19fc6e283c95b84b6c2429822ba064675823ab69f1406a57377266a65021623d1cd581e7db000134fd  0001-elfload-load-PIE-executables-to-right-address.patch
 ec84b27648c01c6e58781295dcd0c2ff8e5a635f9836ef50c1da5d0ed125db1afc4cb5b01cb97606d6dd8f417acba93e1560d9a32ca29161a4bb730b302440ea  0006-linux-user-signal.c-define-__SIGRTMIN-MAX-for-non-GN.patch
@@ -338,6 +313,7 @@ ec84b27648c01c6e58781295dcd0c2ff8e5a635f9836ef50c1da5d0ed125db1afc4cb5b01cb97606
 4b1e26ba4d53f9f762cbd5cea8ef6f8062d827ae3ae07bc36c5b0c0be4e94fc1856ad2477e8e791b074b8a25d51ed6d0ddd75e605e54600e5dd0799143793ce4  xattr_size_max.patch
 b6ed02aaf95a9bb30a5f107d35371207967edca058f3ca11348b0b629ea7a9c4baa618db68a3df72199eea6d86d14ced74a5a229d17604cc3f0adedcfeae7a73  ncurses.patch
 fd178f2913639a0c33199b3880cb17536961f2b3ff171c12b27f4be6bca032d6b88fd16302d09c692bb34883346babef5c44407a6804b20a39a465bb2bc85136  ignore-signals-33-and-64-to-allow-golang-emulation.patch
+dd7a4616e22d9d6b04c6d81d95d17af0d638645c1aa306306fb0ed3a12b2de0fdd32d55c8142960cf22d3a705695a95f022b34ae18712678722c53cd163a5a32  0001-linux-user-fix-build-with-musl-on-ppc64le.patch
 d90c034cae3f9097466854ed1a9f32ab4b02089fcdf7320e8f4da13b2b1ff65067233f48809911485e4431d7ec1a22448b934121bc9522a2dc489009e87e2b1f  qemu-guest-agent.confd
 316b40d97587fea717821852859d81039cfdcb276a658bb6e6fb554e321d5856a833ebb3778149c4732cea625bac320b1008d374c88a9aae35c0fb67977c01b7  qemu-guest-agent.initd
 9b7a89b20fcf737832cb7b4d5dc7d8301dd88169cbe5339eda69fbb51c2e537d8cb9ec7cf37600899e734209e63410d50d0821bce97e401421db39c294d97be2  80-kvm.rules


### PR DESCRIPTION
Musl on Power does not define regs member as a pt_regs pointer type,
so need to use gp_regs member instead.