### PR TITLE
main/valgrind: fix when stripping binaries

### DIFF
--- a/main/valgrind/APKBUILD
+++ b/main/valgrind/APKBUILD
@@ -58,7 +58,8 @@ package() {
 	# we have options=!strip above so we strip the /usr/bin/* manually
 	if [ -z "$DEBUG" ]; then
 		strip "$pkgdir"/usr/bin/valgrind \
-			"$pkgdir"/usr/bin/no_op_client_for_valgrind \
+			"$pkgdir"/usr/bin/valgrind-di-server \
+			"$pkgdir"/usr/bin/vgdb \
 			"$pkgdir"/usr/bin/valgrind-listener \
 			"$pkgdir"/usr/bin/cg_merge
 	fi


### PR DESCRIPTION
APKBUILD was trying to strip a binary (no_op_client_for_valgrind)
that was deprecated and no longer exists. This patch removes this binary
from strip list and add two valgrind binaries (valgrind-di-server and
vgdb) that were not being stripped.