### PR TITLE
testing/cockroach: new aport

### DIFF
--- a/testing/cockroach/APKBUILD
+++ b/testing/cockroach/APKBUILD
@@ -1,0 +1,59 @@
+# Contributor: Nathan Johnson <nathan@nathanjohnson.info>
+# Maintainer: Nathan Johnson <nathan@nathanjohnson.info>
+pkgname=cockroach
+pkgver=1.0
+pkgrel=0
+pkgdesc="Distributed SQL database"
+url="https://www.cockroachlabs.com"
+arch="all"
+license="ASL 2.0"
+depends=""
+depends_dev=""
+makedepends="$depends_dev go go-tools cmake xz bash linux-headers"
+install="$pkgname.pre-install"
+subpackages="$pkgname-doc"
+pkgusers="cockroach"
+pkgroups="cockroach"
+source="$pkgname-$pkgver.tar.gz::https://binaries.cockroachdb.com/$pkgname-v$pkgver.src.tgz
+	$pkgname.initd
+	$pkgname.confd"
+builddir="$srcdir/$pkgname-v$pkgver"
+options="!strip"
+
+build() {
+	cd "$builddir"
+	make build GIT_DIR= || return 1
+}
+
+check() {
+	cd "$builddir"
+	make test TESTTIMEOUT=15m GIT_DIR= || return 1
+}
+
+package() {
+	cd "$builddir/src/github.com/cockroachdb/cockroach"
+	mkdir -p "$pkgdir"/usr/bin \
+		  "$pkgdir"/var/lib/cockroach-data \
+		  "$pkgdir"/var/log/cockroach
+	install -p -m644 -D cockroach "$pkgdir"/usr/bin/$pkgname || return 1
+	chown -R $pkgusers:$pkggroups "$pkgdir"/var/lib/cockroach-data
+	chown -R $pkgusers:$pkggroups "$pkgdir"/var/log/cockroach
+	install -m755 -D "$srcdir"/$pkgname.initd \
+		"$pkgdir"/etc/init.d/$pkgname || return 1
+	install -m644 -D "$srcdir"/$pkgname.confd \
+		"$pkgdir"/etc/conf.d/$pkgname || return 1
+	for manpage in man/man1/*.1; do
+		install -m644 -D "$man" "$pkgdir"/usr/man/man1/"$manpage".1 || return 1
+	done
+
+}
+
+md5sums="dff8a8f57075f7db4c5628bd2ee1fc58  cockroach-1.0.tar.gz
+d41f8f34b500fd75c1f0adfb0e9cd980  cockroach.initd
+89bdd0280976461556178f7aef7af320  cockroach.confd"
+sha256sums="ca87b10eec688195e0df4f85431b019f2980ae4b511ee321f91f945315efeb76  cockroach-1.0.tar.gz
+7ec3ab5f537cd9a73f0bb58edf02d74a91bccbd455c82885af1d68580fde850a  cockroach.initd
+79b225e04417e2082a6de87208ac95cf3a0a20c0b897168d4ec3ccf45082c354  cockroach.confd"
+sha512sums="d74ad9546908535f9a7ad4172a04a5f86f5ed22698bbb005aec7478a52632e0497a966b859fd68b40894eb7ee68bfa80dc4188d198f2f23725b9cadd50a55191  cockroach-1.0.tar.gz
+7a81671fabe503d1eefef43eb965fa861eda5f5d563535fce5e2efb0fc7e5d6dbbc7a45bf16bb6395442e9cd2810d367173b5ff8ee9b6dcb8720e23e8409da1c  cockroach.initd
+68aaae691f5afa4b51e89107def04534f394cc51bb0bb62df36a026e6505007c58e5e9d7034a5917ef91cbac2991da15596882eb490f4a012b5ad6c3b713ba2a  cockroach.confd"

--- a/testing/cockroach/cockroach.confd
+++ b/testing/cockroach/cockroach.confd
@@ -1,0 +1,5 @@
+cockroach_user="cockroach"
+cockroach_group="cockroach"
+cockroach_store="/var/lib/cockroach-data/"
+cockroach_log_dir="/var/log/cockroach"
+cockroach_start_flags="start --log-dir $cockroach_log_dir --store=$cockroach_store"

--- a/testing/cockroach/cockroach.initd
+++ b/testing/cockroach/cockroach.initd
@@ -1,0 +1,20 @@
+#!/sbin/openrc-run
+
+name="cockroach"
+description="Cockroach DB Server"
+pidfile="/run/cockroach/cockroach.pid"
+
+command="/usr/bin/cockroach"
+command_args="$cockroach_start_flags"
+command_background="yes"
+start_stop_daemon_args="-u $cockroach_user -g $cockroach_group"
+
+pidfile="/run/cockroach/cockroach.pid"
+start_pre() {
+	checkpath -m 755 -o $cockroach_user:$cockroach_group -d "$(dirname "$pidfile")"
+}
+
+depend() {
+	need net localmount
+	after firewall
+}

--- a/testing/cockroach/cockroach.pre-install
+++ b/testing/cockroach/cockroach.pre-install
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+addgroup -S cockroach 2>/dev/null
+adduser -S -D -H -s /sbin/nologin -h /var/lib/cockroach-data -G cockroach \
+		-g 'CockroachDB server' cockroach 2>/dev/null
+exit 0
+


### PR DESCRIPTION
https://www.cockroachlabs.com/
An open source, survivable, strongly-consistent SQL database.

This is a rebase of #358 that uses the latest CockroachDB beta, which shipped with numerous packageability improvements. Even with these improvements, the recipe still requires a few patches to convince Cockroach's C dependencies to build on Alpine Linux. We'll hopefully have these patches integrated upstream by next week's beta release.

Please let me know if any of these files doesn't conform to Alpine standards. I'm unfamiliar with Alpine, so I've left most of @nathanejohnson's original work changed.

@nathanejohnson, thanks again for all your work! I've left you listed as the contributor and the maintainer. Let me know if you'd rather I take responsibility.

Also worth noting that this PR is blocked on having Go 1.8 available (#983). I wanted to put this up for review in the meantime, though.

+cc @tamird @knz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alpinelinux/aports/1183)
<!-- Reviewable:end -->
