### PR TITLE
main/nano: fix errors while parsing color syntax files

### DIFF
--- a/main/nano/APKBUILD
+++ b/main/nano/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nano
 pkgver=2.8.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Text Editor. GNU nano is designed to be a free replacement for the Pico text editor."
 url="http://www.nano-editor.org/"
 arch="all"
@@ -22,6 +22,7 @@ build() {
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--disable-nls \
+		--with-wordbounds \
 		|| return 1
 	make || return 1
 }


### PR DESCRIPTION
See https://savannah.gnu.org/bugs/?50705

TL;DR: seems like a bug in configure which ends up wrongly assuming it
needs to use an alternative word-boundary regex syntax [[:<:]] - which
the resulting binary doesn't actually support, and so it spawns a lot of
errors while trying to load and parse color syntax files.

As a workaround until it's resolved upstream, adding --with-wordbounds
forces it to use a regex syntax which the binary does support, and color
syntax files are now loaded and used correctly and without errors.