### PR TITLE
main/gdb: fix gdb 7.12.1 build with musl on ppc

### DIFF
--- a/main/gdb/APKBUILD
+++ b/main/gdb/APKBUILD
@@ -11,7 +11,9 @@ makedepends="ncurses-dev expat-dev texinfo readline-dev python2-dev
 	zlib-dev autoconf automake libtool linux-headers perl"
 subpackages="$pkgname-doc"
 source="https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.xz
-	s390x-use-elf-gdb_fpregset_t.patch"
+	s390x-use-elf-gdb_fpregset_t.patch
+	ppc-musl.patch"
+
 builddir="$srcdir"/$pkgname-$pkgver
 
 build () {
@@ -36,6 +38,9 @@ build () {
 	# gdb server does not compile with musl
 	[ "$CTARGET_LIBC" = musl ] &&  _config="$_config --disable-gdbserver"
 
+        # avoid generation of mangled and non-mangled objects on ppc64
+        [ "$CARCH" = ppc64le ] && _config="$_config --enable-build-with-cxx=no"
+
 	./configure $_config || return 1
 	(cd opcodes && ./configure $_config) || return 1
 	make || return 1
@@ -55,4 +60,5 @@ package() {
 }
 
 sha512sums="0ac8d0a495103611ef41167a08313a010dce6ca4c6d827cbe8558a0c1a1a8a6bfa53f1b7704251289cababbfaaf9e075550cdf741a54d6cd9ca3433d910efcd8  gdb-7.12.1.tar.xz
-c3872eb51b3a42c5a33f8b7542c37fab7b0548560202e5eda740a2176cdfadff9bf73c6d26bceb225829dcb509c823acae2ccc796237ac97ebe552b82582bdf5  s390x-use-elf-gdb_fpregset_t.patch"
+c3872eb51b3a42c5a33f8b7542c37fab7b0548560202e5eda740a2176cdfadff9bf73c6d26bceb225829dcb509c823acae2ccc796237ac97ebe552b82582bdf5  s390x-use-elf-gdb_fpregset_t.patch
+04911f87904b62dd7662435f9182b20485afb29ddb3d6398a9d31fef13495f7b70639c77fdae3a40e2775e270d7cd40d0cfd7ddf832372b506808d33c8301e01  ppc-musl.patch"

--- a/main/gdb/ppc-musl.patch
+++ b/main/gdb/ppc-musl.patch
@@ -1,0 +1,93 @@
+--- a/gdb/nat/ppc-linux.h
++++ b/gdb/nat/ppc-linux.h
+@@ -18,7 +18,90 @@
+ #ifndef PPC_LINUX_H
+ #define PPC_LINUX_H 1
+ 
++#if defined(__GLIBC__) || defined(__UCLIBC__)
+ #include <asm/ptrace.h>
++#else // Musl
++// Do not include ptrace.h from Linux headers and since
++// Musl does not define PT_*, define them:
++
++#define PT_R0   0
++#define PT_R1   1
++#define PT_R2   2
++#define PT_R3   3
++#define PT_R4   4
++#define PT_R5   5
++#define PT_R6   6
++#define PT_R7   7
++#define PT_R8   8
++#define PT_R9   9
++#define PT_R10  10
++#define PT_R11  11
++#define PT_R12  12
++#define PT_R13  13
++#define PT_R14  14
++#define PT_R15  15
++#define PT_R16  16
++#define PT_R17  17
++#define PT_R18  18
++#define PT_R19  19
++#define PT_R20  20
++#define PT_R21  21
++#define PT_R22  22
++#define PT_R23  23
++#define PT_R24  24
++#define PT_R25  25
++#define PT_R26  26
++#define PT_R27  27
++#define PT_R28  28
++#define PT_R29  29
++#define PT_R30  30
++#define PT_R31  31
++
++#define PT_NIP  32
++#define PT_MSR  33
++#define PT_ORIG_R3 34
++#define PT_CTR  35
++#define PT_LNK  36
++#define PT_XER  37
++#define PT_CCR  38
++#ifndef __powerpc64__
++#define PT_MQ   39
++#else
++#define PT_SOFTE 39
++#endif
++#define PT_TRAP 40
++#define PT_DAR  41
++#define PT_DSISR 42
++#define PT_RESULT 43
++#define PT_DSCR 44
++#define PT_REGS_COUNT 44
++
++#define PT_FPR0 48      /* each FP reg occupies 2 slots in this space */
++
++#ifndef __powerpc64__
++
++#define PT_FPR31 (PT_FPR0 + 2*31)
++#define PT_FPSCR (PT_FPR0 + 2*32 + 1)
++
++#else /* __powerpc64__ */
++
++#define PT_FPSCR (PT_FPR0 + 32) /* each FP reg occupies 1 slot in 64-bit space */
++
++
++#define PT_VR0 82       /* each Vector reg occupies 2 slots in 64-bit */
++#define PT_VSCR (PT_VR0 + 32*2 + 1)
++#define PT_VRSAVE (PT_VR0 + 33*2)
++
++
++/*
++ * Only store first 32 VSRs here. The second 32 VSRs in VR0-31
++  */
++#define PT_VSR0 150     /* each VSR reg occupies 2 slots in 64-bit */
++#define PT_VSR31 (PT_VSR0 + 2*31)
++#endif /* __powerpc64__ */
++
++#endif // Libc 
++
+ #include <asm/cputable.h>
+ 
+ /* This sometimes isn't defined.  */


### PR DESCRIPTION
GDB (as other applications) relies on a libc that includes Linux
headers by default, like <asm/ptrace.h>. However Musl does not rely
on these headers and instead decided to define them also. As a
consequence build brakes due to redefinitions.

That commit fixes GDB build on ppc by excluding the problematic
dependency on Linux headers and also addresses an issue that
appeared from GDB 7.11.1 to 7.12.1, when GDB started to be built
as a C++ program by default [1, 2], generating mangled and
non-mangled objects.

[1] https://goo.gl/HYL82h
[2] https://sourceware.org/ml/gdb/2016-04/msg00041.html