### PR TITLE
main/mosh: fix build with muscl on ppc64le

### DIFF
--- a/main/mosh/APKBUILD
+++ b/main/mosh/APKBUILD
@@ -14,7 +14,8 @@ makedepends="ncurses-dev zlib-dev libressl-dev perl-dev perl-io-tty
 subpackages="$pkgname-doc $pkgname-client $pkgname-server
 	$pkgname-bash-completion:bashcomp:noarch"
 source="https://mosh.org/$pkgname-$pkgver.tar.gz
-	disable-utf8-check.patch"
+	disable-utf8-check.patch
+	fix-ppc64le-build-with-musl.patch"
 
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -75,4 +76,5 @@ client() {
 }
 
 sha512sums="2b43e3e3fb2ccf6c29a889f10dfc0d5504dbca6fabaf10419f4e355e4b73d64cc1e632324e447b25ac24ee18bb88d8a9a23f9c4824b267343fb86e26e7d5c54b  mosh-1.3.0.tar.gz
-802afc138a31155352e403e61204c552107c624cd4f1da3141a956ea68a4c652df9b02baf72397e97af032c70feb5396a4262a80d5d3762cba9afd9acf9da660  disable-utf8-check.patch"
+802afc138a31155352e403e61204c552107c624cd4f1da3141a956ea68a4c652df9b02baf72397e97af032c70feb5396a4262a80d5d3762cba9afd9acf9da660  disable-utf8-check.patch
+7d9af9bacf478288845b01a3020930982ef428bcf990415aca23da8452ddc54d242fa13d5888b7d6067e0fa9e617235e1fdce3003b308e91f39bb9bb442c1449  fix-ppc64le-build-with-musl.patch"

--- a/main/mosh/fix-ppc64le-build-with-musl.patch
+++ b/main/mosh/fix-ppc64le-build-with-musl.patch
@@ -1,0 +1,42 @@
+--- a/src/frontend/mosh-server.cc
++++ b/src/frontend/mosh-server.cc
+@@ -714,7 +714,12 @@
+ 	      }
+ 	      window_size.ws_col = res->width;
+ 	      window_size.ws_row = res->height;
+-	      if ( ioctl( host_fd, TIOCSWINSZ, &window_size ) < 0 ) {
++
++	      #if defined(__powerpc64__) && (!defined(__GLIBC__) && !defined(__UCLIBC__))
++	      if ( ioctl( host_fd, (int) TIOCSWINSZ, &window_size ) < 0 ) { 
++	      #else
++	      if ( ioctl( host_fd, TIOCSWINSZ, &window_size ) < 0 ) { 
++	      #endif
+ 		perror( "ioctl TIOCSWINSZ" );
+ 		network.start_shutdown();
+ 	      }
+--- a/src/examples/termemu.cc
++++ a/src/examples/termemu.cc
+@@ -226,7 +226,11 @@
+   }
+ 
+   /* tell child process */
++  #if defined(__powerpc64__) && (!defined(__GLIBC__) && !defined(__UCLIBC__))
++  if ( ioctl( fd, (int) TIOCSWINSZ, &window_size ) < 0 ) {
++  #else
+   if ( ioctl( fd, TIOCSWINSZ, &window_size ) < 0 ) {
++  #endif
+     perror( "ioctl TIOCSWINSZ" );
+     return;
+   }
+@@ -306,7 +310,11 @@
+       complete.act( &r );
+ 
+       /* tell child process */
++      #if defined(__powerpc64__) && (!defined(__GLIBC__) && !defined(__UCLIBC__))
++      if ( ioctl( fd, (int) TIOCSWINSZ, &window_size ) < 0 ) {
++      #else
+       if ( ioctl( fd, TIOCSWINSZ, &window_size ) < 0 ) {
++      #endif
+ 	perror( "ioctl TIOCSWINSZ" );
+ 	return;
+       }


### PR DESCRIPTION
mosh was breaking when building in ppc64le using musl, because ioctl() is defined
as ioctl(int, int) in musl and mosh is using TIOCSWINSZ macro as parameter. This was
triggering a gcc warning and make the build fail.

This patch does an explicit integer conversion in TIOCSWINSZ, as no bits get
lost.