### PR TITLE
community/pdns: init crashed process tracking

### DIFF
--- a/community/pdns/pdns.initd
+++ b/community/pdns/pdns.initd
@@ -16,8 +16,10 @@ PDNS_CONFIG=""
 if [ -n "${PDNS_INSTANCE}" ] && [ "${PDNS_INSTANCE}" != "pdns" ]
 then
 	PDNS_CONFIG="--config-name=${PDNS_INSTANCE}"
+	PDNS_PIDFILE="/run/pdns-${PDNS_INSTANCE}.pid"
 else
 	PDNS_INSTANCE="default"
+	PDNS_PIDFILE="/run/pdns.pid"
 fi
 
 depend() {
@@ -27,7 +29,8 @@ depend() {
 
 start() {
 	ebegin "Starting PowerDNS (${PDNS_INSTANCE})"
-	${daemon} \
+	start-stop-daemon --start --exec ${daemon} \
+		--pidfile ${PDNS_PIDFILE} -- \
 		${PDNS_CONFIG} \
 		--daemon=yes \
 		--guardian=yes

--- a/community/pdns/pdns.initd
+++ b/community/pdns/pdns.initd
@@ -3,12 +3,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/net-dns/pdns/files/pdns,v 1.10 2007/05/07 20:19:18 swegener Exp $
 
-name=pdns
-daemon=/usr/sbin/pdns_server
 pdns_control=/usr/bin/pdns_control
-
-extra_started_commands="dump reload"
-extra_commands="monitor"
 
 PDNS_INSTANCE="${SVCNAME#pdns[.-]}"
 PDNS_CONFIG=""
@@ -22,25 +17,15 @@ else
 	PDNS_PIDFILE="/run/pdns.pid"
 fi
 
+command=/usr/sbin/pdns_server
+command_args="--guardian=no --daemon=no $PDNS_CONFIG"
+command_background=yes
+extra_started_commands="dump reload"
+pidfile="$PDNS_PIDFILE"
+
 depend() {
 	need net
 	after firewall
-}
-
-start() {
-	ebegin "Starting PowerDNS (${PDNS_INSTANCE})"
-	start-stop-daemon --start --exec ${daemon} \
-		--pidfile ${PDNS_PIDFILE} -- \
-		${PDNS_CONFIG} \
-		--daemon=yes \
-		--guardian=yes
-	eend $?
-}
-
-stop() {
-	ebegin "Stopping PowerDNS (${PDNS_INSTANCE})"
-	${pdns_control} ${PDNS_CONFIG} quit &>/dev/null
-	eend $?
 }
 
 reload() {
@@ -52,18 +37,5 @@ reload() {
 dump() {
 	ebegin "Dumping PowerDNS (${PDNS_INSTANCE}) variables"
 	${pdns_control} ${PDNS_CONFIG} list
-	eend $?
-}
-
-monitor() {
-	ebegin "Starting PowerDNS (${PDNS_INSTANCE}) in monitor mode"
-	${daemon} \
-		${PDNS_CONFIG} \
-		--daemon=no \
-		--guardian=no \
-		--control-console=yes \
-		--loglevel=9 \
-		--log-dns-details=yes \
-		--query-logging=yes
 	eend $?
 }

--- a/community/pdns/pdns.initd
+++ b/community/pdns/pdns.initd
@@ -11,17 +11,15 @@ PDNS_CONFIG=""
 if [ -n "${PDNS_INSTANCE}" ] && [ "${PDNS_INSTANCE}" != "pdns" ]
 then
 	PDNS_CONFIG="--config-name=${PDNS_INSTANCE}"
-	PDNS_PIDFILE="/run/pdns-${PDNS_INSTANCE}.pid"
 else
 	PDNS_INSTANCE="default"
-	PDNS_PIDFILE="/run/pdns.pid"
 fi
 
 command=/usr/sbin/pdns_server
 command_args="--guardian=no --daemon=no $PDNS_CONFIG"
 command_background=yes
 extra_started_commands="dump reload"
-pidfile="$PDNS_PIDFILE"
+pidfile="/run/${RC_SVCNAME/./-}.pid"
 
 depend() {
 	need net


### PR DESCRIPTION
Start via start-stop-daemon to allow init to catch crashed procs. Without this change a killed process does not show as crashed in rc-status.