### PR TITLE
testing/opensmtpd-extras: new aport

### DIFF
--- a/testing/opensmtpd-extras/APKBUILD
+++ b/testing/opensmtpd-extras/APKBUILD
@@ -1,0 +1,92 @@
+# Contributor: Shiz <hi@shiz.me>
+# Maintainer: Shiz <hi@shiz.me>
+pkgname=opensmtpd-extras
+pkgver=201703132115
+pkgrel=0
+pkgdesc="OpenSMTPD addons"
+url="https://opensmtpd.org/"
+arch="all"
+license="ISC"
+depends=""
+_depends_filter_monkey="libressl"
+_depends_queue_python="python2"
+_depends_scheduler_python="python2"
+_depends_table_mysql="mariadb-client-libs"
+_depends_table_postgres="libpq"
+_depends_table_python="python2"
+_depends_table_redis="hiredis"
+_depends_table_sqlite="sqlite-libs"
+makedepends="libressl-dev libevent-dev python2-dev mariadb-dev postgresql-dev hiredis-dev sqlite-dev"
+subpackages="$pkgname-doc"
+source="https://www.opensmtpd.org/archives/opensmtpd-extras-$pkgver.tar.gz
+	remove-decls.patch"
+builddir="$srcdir/opensmtpd-extras-$pkgver"
+
+_extras="
+	filter-monkey
+	filter-stub
+	filter-trace
+	filter-void
+	queue-null
+	queue-python
+	queue-ram
+	queue-stub
+	scheduler-python
+	scheduler-ram
+	scheduler-stub
+	table-ldap
+	table-mysql
+	table-passwd
+	table-postgres
+	table-python
+	table-redis
+	table-socketmap
+	table-sqlite
+	table-stub
+"
+
+for _extra in $_extras; do
+	subpackages="$subpackages opensmtpd-$_extra:_package_extra"
+	depends="$depends opensmtpd-$_extra"
+done
+
+build() {
+	cd "$builddir"
+	local with_extras
+	local extra; for extra in $_extras; do
+		with_extras="$with_extras --with-$extra"
+	done
+
+	./configure \
+		--prefix=/usr \
+		--sysconfdir=/etc/smtpd \
+		--mandir=/usr/share/man \
+		--libexecdir=/usr/lib \
+		--with-pie \
+		--with-mantype=man \
+		$with_extras
+	# the Redis table expects <hiredis.h> without subdirectory, so indulge it
+	make REDIS_CPPFLAGS='-I /usr/include/hiredis'
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install || return 1
+}
+
+_package_extra() {
+	local extraname="${subpkgname#opensmtpd-}"
+
+	pkgdesc="OpenSMTPD $extraname addon"
+	depends="$(eval "echo \$_depends_${extraname//-/_}")"
+
+	mkdir -p "$subpkgdir"/usr/lib/opensmtpd
+	mv "$pkgdir"/usr/lib/opensmtpd/$extraname "$subpkgdir"/usr/lib/opensmtpd
+}
+
+md5sums="a6fd3238ca61d6f48dfd640e5ba9f816  opensmtpd-extras-201703132115.tar.gz
+d7be474d22719470a5e013710d8f32e1  remove-decls.patch"
+sha256sums="4672afdd756ef279c0adcfcbf8151d6d8a370d5a628a705967373a1c83ee0ef5  opensmtpd-extras-201703132115.tar.gz
+5305d2c2a2e26b7e104cece736e0834109743cc13e1d504adfa7865afdd576d5  remove-decls.patch"
+sha512sums="d841c63445ca674b368a5aa6012ae90e46b0c31b650067bdcea5badca3d818b1b732be880b2a18421fb39d07291dd413455944b178597bc13ae6ff5c75ac9aed  opensmtpd-extras-201703132115.tar.gz
+36efd3b6cf75728cc8b75b3d9d6bf464d1e949ccfbe6151ed53dbba0f9ee1e50eb61afcca05af302ab359bc9ea1136e7750a15e5f5b824899141298d3060782a  remove-decls.patch"

--- a/testing/opensmtpd-extras/remove-decls.patch
+++ b/testing/opensmtpd-extras/remove-decls.patch
@@ -1,0 +1,19 @@
+__BEGIN_DECLS / __END_DECLS are a glibc-only wrapper mechanism to make
+C declarations work in C++ code. As musl does not support these and the
+OpenSMTPD codebase is solely C anyway, simply remove them.
+
+--- a/extras/tables/table-ldap/ber.h
++++ b/extras/tables/table-ldap/ber.h
+@@ -75,7 +75,6 @@
+ 	size_t		bo_n;
+ };
+ 
+-__BEGIN_DECLS
+ struct ber_element	*ber_get_element(unsigned long);
+ void			 ber_set_header(struct ber_element *, int,
+ 			    unsigned long);
+@@ -123,4 +122,3 @@
+ void			 ber_set_application(struct ber *,
+ 			    unsigned long (*)(struct ber_element *));
+ void			 ber_free(struct ber *);
+-__END_DECLS


### PR DESCRIPTION
This aport packages the standard OpenSMTPD extras, providing it
with various filters, queues, schedulers, and tables.