### PR TITLE
main/opensmtpd: clean up APKBUILD and disambiguate config/initd location

### DIFF
--- a/main/opensmtpd/APKBUILD
+++ b/main/opensmtpd/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Jonathan Curran <jonathan@curran.in>
 pkgname=opensmtpd
 pkgver=6.0.2p1
-pkgrel=0
+pkgrel=1
 pkgdesc="secure, reliable, lean, and easy-to configure SMTP server"
 url="http://www.opensmtpd.org"
 arch="all"
@@ -15,7 +15,7 @@ makedepends="automake autoconf libtool mdocml db-dev libasr-dev libevent-dev
 install="$pkgname.pre-install $pkgname.post-install"
 subpackages="$pkgname-doc"
 source="https://www.opensmtpd.org/archives/${pkgname}-${pkgver}.tar.gz
-	smtpd.initd
+	opensmtpd.initd
 	aliases
 	autoconf-decl-checks.patch"
 options="suid"
@@ -26,28 +26,24 @@ build() {
 	cd "$builddir"
 	./configure \
 		--prefix=/usr \
-		--sysconfdir=/etc/smtpd \
-		--with-libssl=/usr/include/openssl \
-		--mandir=/usr/share/man \
-		--libexecdir=/usr/lib/$pkgname \
+		--sysconfdir=/etc/opensmtpd \
+		--libexecdir=/usr/lib \
 		--with-table-db \
 		--with-user-queue=smtpq \
 		--with-group-queue=smtpq \
 		--with-user-smtpd=smtpd \
 		--with-path-socket=/run \
-		--with-libs="-lfts" \
-		--with-pie \
 		--with-path-CAfile=/etc/ssl/certs/ca-certificates.crt \
-		--with-mantype=man || return 1
-        make || return 1
+		--with-mantype=man
+	make
 }
 
 package() {
-	make DESTDIR="${pkgdir}" -C "$builddir" install || return 1
-	sed -i 's#/etc/mail#/etc/smtpd#g' "$pkgdir"/etc/smtpd/smtpd.conf
+	make DESTDIR="${pkgdir}" -C "$builddir" install
+	sed -i 's#/etc/mail#/etc/opensmtpd#g' "$pkgdir"/etc/opensmtpd/smtpd.conf
 
-	install -Dm755 "$srcdir"/smtpd.initd "$pkgdir"/etc/init.d/smtpd || return 1
-	install -Dm644 "$srcdir"/aliases "$pkgdir"/etc/smtpd/aliases || return 1
+	install -Dm755 "$srcdir"/opensmtpd.initd "$pkgdir"/etc/init.d/opensmtpd
+	install -Dm644 "$srcdir"/aliases "$pkgdir"/etc/opensmtpd/aliases
 
 	# Create compatibility symlinks for mailq, newaliases, makemap and sendmail.
 	for binary in mailq newaliases makemap sendmail; do
@@ -56,6 +52,6 @@ package() {
 }
 
 sha512sums="1e4275795dd2c43174ffa268398a0d9864ce4cb7d370330f7b8c55a9b40e757616bbd280919a409ebde403769e3dea62047857dc2ff98d7ecce660b459c7ff1c  opensmtpd-6.0.2p1.tar.gz
-6cbcca9fc74cc0bb007164442dea87d039b06668da1b43da5e1fac2160a96da95d6644437c79a92480a3ab1fc252686bd10eceed38a19971344b0a8fca65a3d6  smtpd.initd
+28aeec6f6f88b63f442973dbe6a1efb4641a23be643932ab88885eff91e8a879432041a95fb0e8341b0a8f1939c5a713b921712018e62f6053caffa56b9074b1  opensmtpd.initd
 929ba0b8befca6cad558602f9793a9c653923924ee524902916b8ef4952d1ea8a391895e7450ed9768eb82a07bd307b49561f5d49ea4711bd87a1a73eb8d7dad  aliases
 e61b7b0ab98acca9c092469d3ed756161225af5126e2fc0611b2676b8e1df05db7037549febe85b860fa48e47536a01fa3bfa37976f42e47666065ba4198e903  autoconf-decl-checks.patch"

--- a/main/opensmtpd/opensmtpd.initd
+++ b/main/opensmtpd/opensmtpd.initd
@@ -1,7 +1,7 @@
 #!/sbin/openrc-run
 
-name="$RC_SVCNAME"
-command="/usr/sbin/$RC_SVCNAME"
+name="OpenSMTPD"
+command="/usr/sbin/smtpd"
 command_args="-F $SMTPD_OPTS"
 command_background=yes
 pidfile="/run/$RC_SVCNAME.pid"


### PR DESCRIPTION
As /etc/smtpd and /etc/init.d/smtpd are rather generic, follow other distros
and rename them /etc/opensmtpd and /etc/init.d/opensmtpd.

We furthermore clean out some ./configure options that were never used or had
no effect, and remove redundant || return 1 statements.

Is there a viable upgrade path we want to offer existing `/etc/smtpd` users?