### PR TITLE
testing/refpolicy: inital import

### DIFF
--- a/testing/refpolicy/APKBUILD
+++ b/testing/refpolicy/APKBUILD
@@ -11,48 +11,52 @@ depends_dev=""
 makedepends="$depends_dev checkpolicy python gawk"
 install=""
 subpackages="$pkgname-doc"
-source="https://raw.githubusercontent.com/wiki/TresysTechnology/refpolicy/files/refpolicy-2.$pkgver.tar.bz2"
+source="https://raw.githubusercontent.com/wiki/TresysTechnology/refpolicy/files/refpolicy-2.$pkgver.tar.bz2
+	Makefile.devel"
 builddir="$srcdir/refpolicy"
 
 # refpolicy config
 monolithic=n
-# This causes various distro-specific policies to be built. Since most SELinux
-# policies are written against redhat-based distros, we set that here.
-distro=redhat
+distro=gentoo
+# unknown perms here means what to do with perms that are unknown to the
+# current userspace, because the kernel version is newer. By default, we deny.
 unknown_perms=deny
 
 # These are somewhat related to what is in the CentOS spec file, although they
 # are slightly differnet in what they install.
-makeCmds() {
+#
+# https://selinuxproject.org/page/NB_RefPolicy#Reference_Policy_Build_Options_-_build.conf
+# are the build options: M{L,C}S_CATS are the number of categories for m{l,c}s policies.
+make_cmds() {
 	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=1024 bare || return 1
 	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=1024 conf || return 1
 }
 
-installCmds() {
-	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=0124 SEMOD_EXP="/usr/bin/semodule_expand -a" base.pp
+install_cmds() {
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=1024 SEMOD_EXP="/usr/bin/semodule_expand -a" base.pp
 	make validate UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=1024 SEMOD_EXP="/usr/bin/semodule_expand -a" modules
-	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=0124 DESTDIR="$pkgdir" install
-	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=0124 DESTDIR="$pkgdir" install-appconfig
-	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=0124 DESTDIR="$pkgdir" install-docs
-	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=0124 DESTDIR="$pkgdir" install-headers
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=1024 DESTDIR="$pkgdir" install
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=1024 DESTDIR="$pkgdir" install-appconfig
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=1024 DESTDIR="$pkgdir" install-docs
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=1024 DESTDIR="$pkgdir" install-headers
 }
 
 build() {
 	cd "$builddir"
-	makeCmds targeted mcs $unknown_perms || return 1
+	make_cmds targeted mcs $unknown_perms || return 1
 }
 
 package() {
 	cd "$builddir"
-	echo packaging now
-	installCmds targeted mcs $unknown_perms || return 1
+	install_cmds targeted mcs $unknown_perms || return 1
 	mkdir -p $pkgdir/usr/share/selinux/devel || return 1
-	mv "$pkgdir/usr/share/selinux/targeted/include" "$pkgdir/usr/share/selinux/devel/include"
-	cp $startdir/Makefile.devel "$pkgdir/usr/share/selinux/devel/Makefile" || return 1
+	cp -r "$pkgdir/usr/share/selinux/targeted/include" "$pkgdir/usr/share/selinux/devel/include"
+	cp $srcdir/Makefile.devel "$pkgdir/usr/share/selinux/devel/Makefile" || return 1
 	install -m 644 doc/example.* "$pkgdir/usr/share/selinux/devel" || return 1
 	install -m 644 doc/policy.* "$pkgdir/usr/share/selinux/devel" || return 1
 	# TODO: libselinux needs to build the python bindings for this to work
 	# sepolicy manpage -a -p "$pkgdir/usr/share/man/man8/" -w -r "$pkgdir" || return 1
 }
 
-sha512sums="30deabb02a5bde51c463e3e89988d850cff51596c2e72733a064245dec152ea46317eea79550dbe82a7a0d327ec0bcfbd9474ff8a902507392df0da00df6397f  refpolicy-2.20170204.tar.bz2"
+sha512sums="30deabb02a5bde51c463e3e89988d850cff51596c2e72733a064245dec152ea46317eea79550dbe82a7a0d327ec0bcfbd9474ff8a902507392df0da00df6397f  refpolicy-2.20170204.tar.bz2
+01bd5f58e05feba2f318f6b80fb4c6cbe405691f947fee48566ad75c935d6e824ccfda5de88c5dad74b531ed28c18615d8ef4e2c2371d71c776b78767eb33740  Makefile.devel"

--- a/testing/refpolicy/APKBUILD
+++ b/testing/refpolicy/APKBUILD
@@ -1,0 +1,58 @@
+# Maintainer: Tycho Andersen <tycho@docker.com>
+pkgname=refpolicy
+pkgver=20170204
+pkgrel=0
+pkgdesc="SELinux policy reference"
+url="https://github.com/TresysTechnology/refpolicy/wiki"
+arch="noarch"
+license="GPLv2"
+depends=""
+depends_dev=""
+makedepends="$depends_dev checkpolicy python gawk"
+install=""
+subpackages="$pkgname-doc"
+source="https://raw.githubusercontent.com/wiki/TresysTechnology/refpolicy/files/refpolicy-2.$pkgver.tar.bz2"
+builddir="$srcdir/refpolicy"
+
+# refpolicy config
+monolithic=n
+# This causes various distro-specific policies to be built. Since most SELinux
+# policies are written against redhat-based distros, we set that here.
+distro=redhat
+unknown_perms=deny
+
+# These are somewhat related to what is in the CentOS spec file, although they
+# are slightly differnet in what they install.
+makeCmds() {
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=1024 bare || return 1
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=1024 conf || return 1
+}
+
+installCmds() {
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=0124 SEMOD_EXP="/usr/bin/semodule_expand -a" base.pp
+	make validate UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=1024 SEMOD_EXP="/usr/bin/semodule_expand -a" modules
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=0124 DESTDIR="$pkgdir" install
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=0124 DESTDIR="$pkgdir" install-appconfig
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=0124 DESTDIR="$pkgdir" install-docs
+	make UNK_PERMS=$3 NAME=$1 TYPE=$2 DISTRO=$distro UBAC=n DIRECT_INITRC=y MONOLITHIC=$monolithic MLS_CATS=1024 MCS_CATS=0124 DESTDIR="$pkgdir" install-headers
+}
+
+build() {
+	cd "$builddir"
+	makeCmds targeted mcs $unknown_perms || return 1
+}
+
+package() {
+	cd "$builddir"
+	echo packaging now
+	installCmds targeted mcs $unknown_perms || return 1
+	mkdir -p $pkgdir/usr/share/selinux/devel || return 1
+	mv "$pkgdir/usr/share/selinux/targeted/include" "$pkgdir/usr/share/selinux/devel/include"
+	cp $startdir/Makefile.devel "$pkgdir/usr/share/selinux/devel/Makefile" || return 1
+	install -m 644 doc/example.* "$pkgdir/usr/share/selinux/devel" || return 1
+	install -m 644 doc/policy.* "$pkgdir/usr/share/selinux/devel" || return 1
+	# TODO: libselinux needs to build the python bindings for this to work
+	# sepolicy manpage -a -p "$pkgdir/usr/share/man/man8/" -w -r "$pkgdir" || return 1
+}
+
+sha512sums="30deabb02a5bde51c463e3e89988d850cff51596c2e72733a064245dec152ea46317eea79550dbe82a7a0d327ec0bcfbd9474ff8a902507392df0da00df6397f  refpolicy-2.20170204.tar.bz2"

--- a/testing/refpolicy/Makefile.devel
+++ b/testing/refpolicy/Makefile.devel
@@ -1,0 +1,22 @@
+# installation paths
+SHAREDIR := /usr/share/selinux
+
+AWK ?= gawk
+NAME ?= $(strip $(shell $(AWK) -F= '/^SELINUXTYPE/{ print $$2 }' /etc/selinux/config))
+
+ifeq ($(MLSENABLED),)
+	MLSENABLED := 1
+endif
+
+ifeq ($(MLSENABLED),1)
+	NTYPE = mcs
+endif
+
+ifeq ($(NAME),mls)
+	NTYPE = mls
+endif
+
+TYPE ?= $(NTYPE)
+
+HEADERDIR := $(SHAREDIR)/devel/include
+include $(HEADERDIR)/Makefile


### PR DESCRIPTION
This is the SELinux policy library, which contains a large number of
interface (and other) definitions for use in SELinux policies.

Signed-off-by: Tycho Andersen <tycho@docker.com>