### PR TITLE
testing/ed: New aport

### DIFF
--- a/testing/ed/APKBUILD
+++ b/testing/ed/APKBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Breno Leitao <breno.leitao@gmail.com>
+pkgname=ed
+pkgver=1.14.2
+pkgrel=0
+pkgdesc="GNU ed is a line-oriented text editor. It is used to create, display, modify and otherwise manipulate text files"
+url="https://www.gnu.org/software/ed/"
+arch="all"
+license="GPL"
+depends=""
+makedepends=""
+subpackages="$pkgname-doc"
+source="https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.lz"
+
+builddir=$srcdir/$pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--mandir=/usr/share/man
+	make all
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="653bcb89788b2d18c726336fb6f17678ac031fe6ea03a93ff248886a075c867ba5423d5471401e44cbdcce3b4cb766b621ca7b70d76881f5044ec3412767b11f  ed-1.14.2.tar.lz"


### PR DESCRIPTION
GNU ed is a line-oriented text editor. It is used to create, display,
modify and otherwise manipulate text files, both interactively and via
shell scripts. A restricted version of ed, red, can only edit files in
the current directory and cannot execute shell commands. Ed is the
"standard" text editor in the sense that it is the original editor for
Unix, and thus widely available. For most purposes, however, it is
superseded by full-screen editors such as GNU Emacs or GNU Moe.

This aport depends on an abuild change to understands .tar.lz files.