### PR TITLE
community/docker: ulimit -u to -p

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=docker
 pkgver=17.03.1
 _ver=${pkgver/_/-}-ce
-pkgrel=1
+pkgrel=2
 _gitcommit=v$_ver
 pkgdesc="Pack, ship and run any application as a lightweight container"
 url="http://www.docker.io/"
@@ -43,6 +43,7 @@ source="
 	tini-$_tini_ver.tar.gz::https://github.com/krallin/tini/archive/$_tini_ver.tar.gz
 	docker-openrc-fixes.patch
 	tini-cmake-fixes.patch
+	docker-openrc-busybox-ash.patch
 	"
 
 builddir="$srcdir"/$pkgname-$_ver
@@ -218,4 +219,5 @@ f17c7ff09578573a161f14616446e74d92d66039c1462bce23ea507b151eb66ede12d2ca583d3dac
 754cf6489968f3a83392c52b9445f71e8d5faca96e23ffc3ee2c6e8644bf065b64c7497395cf8fac9cc083ce9c7668260e319d01a8f10613e67db2d8254f6b06  libnetwork-0f534354b813003a754606689722fe253101bc4e.tar.gz
 b6c1454f734662adf2fdedcb75cb7cdc82f4cf5b4c41fadf6891a670fa26d49b789034f4af8bf920b9e1ff1c3536123637ade9471f4ae2c1ef6c534e839b9f27  tini-949e6facb77383876aeff8a6944dde66b3089574.tar.gz
 8296b1bc88ef3dec4f9038c4e0bf83120ac5870860f6662eac9f9f8850ea8b7596bcd2b47932551e804ae8b6f6f26ad3bc4ce6d49600cc8eaf0a3016c15a9ccf  docker-openrc-fixes.patch
-29a343848d0aa14864c6bfc87c2a6fd408f546f0114e12f7035fb4678ee769fe728872a5d283803177990a61d7e02c4916017d5e45380ad3b0a2dffa3e746857  tini-cmake-fixes.patch"
+29a343848d0aa14864c6bfc87c2a6fd408f546f0114e12f7035fb4678ee769fe728872a5d283803177990a61d7e02c4916017d5e45380ad3b0a2dffa3e746857  tini-cmake-fixes.patch
+9b24dc0c50904c3d12bb04c1a7df169651043ddbc258018647010a5aa01d8a19ad54d10ca79dce6d6283c81f4fa0cc8de417f6180dd824c5a588b22b23546cb5  docker-openrc-busybox-ash.patch"

--- a/community/docker/docker-openrc-busybox-ash.patch
+++ b/community/docker/docker-openrc-busybox-ash.patch
@@ -1,0 +1,11 @@
+--- a/contrib/init/openrc/docker.initd
++++ b/contrib/init/openrc/docker.initd
+@@ -16,7 +16,7 @@
+ 
+ 	# Having non-zero limits causes performance problems due to accounting overhead
+ 	# in the kernel. We recommend using cgroups to do container-local accounting.
+-	ulimit -u unlimited
++	ulimit -p unlimited
+ 
+ 	return 0
+ }


### PR DESCRIPTION
There is no -u flag to ulimit provided by Busybox ash, change
to -p in docker.init

bash ulimit:
-n     The maximum number of open file descriptors
-u     The maximum number of processes available to a single user

ash ulimit (from Busybox):
    { RLIMIT_NOFILE,    0,  'n',    "file descriptors" },
    { RLIMIT_NPROC,     0,  'p',    "processes" },

References:
 https://github.com/docker/docker/commit/428d7337e808ec5f4dba1b0aceda002f295cc320
 https://github.com/docker/docker/commit/8db61095a3d0bcb0733580734ba5d54bc27a614d