### PR TITLE
community/psmisc: Fix FTBFS on ppc64le

### DIFF
--- a/community/psmisc/APKBUILD
+++ b/community/psmisc/APKBUILD
@@ -6,10 +6,13 @@ pkgdesc="A set of some small useful utilities that use the proc filesystem"
 url="http://psmisc.sourceforge.net/"
 arch="all"
 license="BSD GPL"
-depends=""
-makedepends="ncurses-dev"
+depends="libintl gettext"
+makedepends="gettext-dev ncurses-dev"
 subpackages="$pkgname-doc"
-source="http://downloads.sourceforge.net/psmisc/$pkgname-$pkgver.tar.gz"
+source="http://downloads.sourceforge.net/psmisc/$pkgname-$pkgver.tar.gz
+	peekfd_lintl.patch
+	include_limits.patch"
+
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -27,6 +30,6 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-md5sums="935c0fd6eb208288262b385fa656f1bf  psmisc-22.21.tar.gz"
-sha256sums="97323cad619210845b696d7d722c383852b2acb5c49b5b0852c4f29c77a8145a  psmisc-22.21.tar.gz"
-sha512sums="766aeb45687090b88b17176c5117a603e83fe92a13c013aea72c8ee80048adf02e18c7daa52ddfb8b2135f7c9a1bcae38896cdfb8d0158728d85a446c5e0d5ae  psmisc-22.21.tar.gz"
+sha512sums="766aeb45687090b88b17176c5117a603e83fe92a13c013aea72c8ee80048adf02e18c7daa52ddfb8b2135f7c9a1bcae38896cdfb8d0158728d85a446c5e0d5ae  psmisc-22.21.tar.gz
+ec84b84a02e48aed9f47a9efdd7ee4a4d409373751e9872e32c06912b506d9102a0526f244dcaff172598cd77e61344d38449a60181c2bbb010a674662e8f439  peekfd_lintl.patch
+63dea6a65c4cabcfa06d225950bc78fd6ac42f7445b8d10bde5e86dd8d96eb89823e486d7635b78562da058642f87289356c416225563a8e1ccfc2e32d81e884  include_limits.patch"

--- a/community/psmisc/include_limits.patch
+++ b/community/psmisc/include_limits.patch
@@ -1,0 +1,45 @@
+Author: Breno Leitao <brenohl@br.ibm.com>
+Date:   Thu Apr 6 13:59:57 2017 -0300
+
+    peekfd: Include headers for ppc64
+    
+    Currently peekfd fails to build on ppc64le architecture with musl
+    because it does not find reference for __WORDSIZE.
+    
+    This patch just includes reference for this macro if it was not
+    previously defined.
+
+Index: psmisc-22.21/src/peekfd.c
+===================================================================
+--- psmisc-22.21.orig/src/peekfd.c
++++ psmisc-22.21/src/peekfd.c
+@@ -37,6 +37,14 @@
+ 
+ #include "i18n.h"
+ 
++#if !defined(PATH_MAX)
++#include <limits.h>
++#endif
++
++#if !defined(__WORDSIZE)
++#include <bits/reg.h>
++#endif
++
+ #ifdef I386
+ 	#define REG_ORIG_ACCUM orig_eax
+ 	#define REG_ACCUM eax
+Index: psmisc-22.21/src/pstree.c
+===================================================================
+--- psmisc-22.21.orig/src/pstree.c
++++ psmisc-22.21/src/pstree.c
+@@ -45,6 +45,10 @@
+ #include "i18n.h"
+ #include "comm.h"
+ 
++#if !defined(PATH_MAX)
++#include <limits.h>
++#endif
++
+ #ifdef WITH_SELINUX
+ #include <selinux/selinux.h>
+ #else

--- a/community/psmisc/peekfd_lintl.patch
+++ b/community/psmisc/peekfd_lintl.patch
@@ -1,0 +1,30 @@
+Author: Breno Leitao <brenohl@br.ibm.com>
+Date:   Thu Apr 6 14:03:00 2017 -0300
+
+    pstree: Linking with libintl.
+    
+    Curently pstree does built, at least on ppc64le, because it does
+    not have a explicit link against gettext, causing the following error:
+    
+      peekfd.o: In function `print_version':
+      peekfd.c:(.text+0x160): undefined reference to `libintl_gettext'
+      peekfd.c:(.text+0x18c): undefined reference to `libintl_gettext'
+      peekfd.c:(.text+0x1ac): undefined reference to `libintl_gettext'
+    
+    peekfd depends on libint because of the following macro:
+    
+      #define _(String) gettext (String)
+
+Index: psmisc-22.21/src/Makefile.in
+===================================================================
+--- psmisc-22.21.orig/src/Makefile.in
++++ psmisc-22.21/src/Makefile.in
+@@ -131,7 +131,7 @@ killall_OBJECTS = $(am_killall_OBJECTS)
+ killall_DEPENDENCIES =
+ am_peekfd_OBJECTS = peekfd.$(OBJEXT)
+ peekfd_OBJECTS = $(am_peekfd_OBJECTS)
+-peekfd_LDADD = $(LDADD)
++peekfd_LDADD = $(LDADD) -lintl
+ am_prtstat_OBJECTS = prtstat.$(OBJEXT)
+ prtstat_OBJECTS = $(am_prtstat_OBJECTS)
+ prtstat_DEPENDENCIES =


### PR DESCRIPTION
Currently psmisc fails to build on ppc64le because there are some
issues with the package:

 * Usage of macros not included in the header
 * Using lintl (gettext) functions without passing -lintl
 * Not explicilty adding gettext dependencies.