### PR TITLE
testing/ejson: new aport

### DIFF
--- a/testing/ejson/10-patch1.patch
+++ b/testing/ejson/10-patch1.patch
@@ -1,0 +1,36 @@
+--- ejson/cmd/ejson/main.go.orig	2017-04-06 19:25:23.711948831 +0000
++++ ejson/cmd/ejson/main.go	2017-04-06 19:25:41.585791634 +0000
+@@ -4,33 +4,15 @@ import (
+ 	"fmt"
+ 	"os"
+ 	"runtime"
+-	"syscall"
+ 
+ 	"github.com/codegangsta/cli"
+ )
+ 
+-func execManpage(sec, page string) {
+-	if err := syscall.Exec("/usr/bin/env", []string{"/usr/bin/env", "man", sec, page}, os.Environ()); err != nil {
+-		fmt.Println("Exec error:", err)
+-	}
+-	os.Exit(1)
+-}
+ 
+ func main() {
+ 	// Encryption is expensive. We'd rather burn cycles on many cores than wait.
+ 	runtime.GOMAXPROCS(runtime.NumCPU())
+ 
+-	// Rather than using the built-in help printer, display the bundled manpages.
+-	cli.HelpPrinter = func(templ string, data interface{}) {
+-		if cmd, ok := data.(cli.Command); ok {
+-			switch cmd.Name {
+-			case "encrypt", "decrypt", "keygen":
+-				execManpage("1", "ejson-"+cmd.Name)
+-			}
+-		}
+-		execManpage("1", "ejson")
+-	}
+-
+ 	app := cli.NewApp()
+ 	app.Flags = []cli.Flag{
+ 		cli.StringFlag{

--- a/testing/ejson/APKBUILD
+++ b/testing/ejson/APKBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Andy McLeod <andy@amcleod.ca>
+pkgname=ejson
+pkgver=1.0.2
+pkgrel=1
+pkgdesc="EJSON is a small library to manage encrypted secrets using asymmetric encryption."
+url="https://github.com/Shopify/ejson"
+arch="all"
+license="MIT"
+depends=""
+depends_dev=""
+makedepends="$depends_dev go"
+subpackages=""
+source="$pkgname-$pkgver.tar.gz::https://github.com/Shopify/$pkgname/archive/$pkgver.tar.gz
+        10-patch1.patch
+	"
+
+_gourl=github.com/Shopify/ejson
+builddir="$srcdir"/src/$_gourl
+
+prepare() {
+        mkdir -p "${builddir%/*}"
+        mv "$srcdir"/$pkgname-$pkgver "$builddir" || return 1
+	mv $builddir/Godeps/_workspace/src/github.com/* $srcdir/src/github.com
+	mv $builddir/Godeps/_workspace/src/golang.org $srcdir/src
+
+        default_prepare
+}
+
+build() {
+	cd "$builddir" || return 1
+	export GOPATH="$srcdir"
+	CGO_ENABLED=0 go build -v -o e${pkgname} github.com/Shopify/ejson/cmd/ejson || return 1
+}
+
+package() {
+	cd "$builddir"
+	install -Dm755 e${pkgname} \
+		"$pkgdir"/usr/bin/ejson || return 1
+}
+md5sums="67d4c48df5e946e03d20bfc5577b9c54  ejson-1.0.2.tar.gz
+cae100de618a9d26e75de943787d8a56  10-patch1.patch"
+sha256sums="61700af931b88912c3e529f1ca4b8ac2eeb31167d993831e62f872d2a3af7999  ejson-1.0.2.tar.gz
+ff25b5efd162606e27a6ffb7d83be5f3c6cf64126e6597881f2bae2f2903f6ac  10-patch1.patch"
+sha512sums="c1d5c568ff1cb23af1968d52c331612e07cd8fc100d1eb9f00dc6c0f3a42cb20bd575c89900c61bb6ebb432913976c6271836d8b9fedeff9da1e1aeafe361521  ejson-1.0.2.tar.gz
+53aab34fceb0b546b7eb5296b668da592bf7c44d76e95aa10962a8dfd649f0090b8097d31f09055598e5c0f281a5dd90a87efe13c46f306921b2fa7fca01e4a1  10-patch1.patch"


### PR DESCRIPTION
Adds a new piece of software to aports. EJSON is a small library to
manage encrypted secrets using asymmetric encryption.

This aport includes only the binary cli program. It omits the man pages
and ruby gem.