### PR TITLE
community/whois: bump to 5.2.16 / create mkpasswd subpkg

### DIFF
--- a/community/whois/APKBUILD
+++ b/community/whois/APKBUILD
@@ -1,31 +1,42 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=whois
-pkgver=5.2.15
+pkgver=5.2.16
 pkgrel=0
 pkgdesc="Intelligent WHOIS client by Marco d'Itri"
 url="http://www.linux.it/~md/software/"
 arch="all"
 license="GPL2"
 makedepends="perl libidn-dev gettext-dev"
-subpackages="$pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/rfc1036/$pkgname/archive/v$pkgver.tar.gz
+options="!check"
+subpackages="$pkgname-doc mkpasswd:_mkpasswd mkpasswd-doc"
+source="$pkgname-$pkgver.tar.xz::http://ftp.de.debian.org/debian/pool/main/w/$pkgname/${pkgname}_$pkgver.tar.xz
 	undefined-libintl.patch
+	enable-sha256-sha512-mkpasswd.patch
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
 	make CONFIG_FILE="/etc/whois.conf" \
-		HAVE_LIBIDN=1 HAVE_ICONV=1 \
-		|| return 1
+		HAVE_LIBIDN=1 HAVE_ICONV=1
+}
+
+_mkpasswd() {
+	depends="!expect"
+	pkgdesc="mkpasswd with configurable number of rounds"
+	cd "$builddir"
+	make BASEDIR="$subpkgdir" install-mkpasswd
+	mkdir -p  "$subpkgdir"-doc/usr
+	mv "$subpkgdir"/usr/share "$subpkgdir"-doc/usr
 }
 
 package() {
 	cd "$builddir"
-	make BASEDIR="$pkgdir" install-whois || return 1
+	make BASEDIR="$pkgdir" install-whois
 	install -D -m644 whois.conf "$pkgdir/etc/whois.conf"
 }
 
-sha512sums="3dcf7767cc4bf96dd86489d531a110d9b596de2b307caa228c143c155a9ffc71b72e10628cadda5b85e61041ab61b3551b30de504bbad02fc7815b27c92836d8  whois-5.2.15.tar.gz
-efa32ec848e3d3e61481567815e8c02757eab32712eb5a431adb13b59fd359f735eb684fbdf8a5b8334410d17052dc93d65bdda27a328617e2b6772b23717487  undefined-libintl.patch"
+sha512sums="08e75edbdab2c094150b92570e04de0fc10d42a18643e404262bef4366338bd67a4f23cef248660a4c2a435825cf5ebcc396c71d5702905ca97746686a5c8f06  whois-5.2.16.tar.xz
+efa32ec848e3d3e61481567815e8c02757eab32712eb5a431adb13b59fd359f735eb684fbdf8a5b8334410d17052dc93d65bdda27a328617e2b6772b23717487  undefined-libintl.patch
+ef455fd21403995524a3de6039db41261b6549181f3dd234c6a28a10a65d09a6e86c71b6ddb752aa15f0e4ff2232887ff65bd72ed9a977b8da2ed40ea11519f1  enable-sha256-sha512-mkpasswd.patch"

--- a/community/whois/enable-sha256-sha512-mkpasswd.patch
+++ b/community/whois/enable-sha256-sha512-mkpasswd.patch
@@ -1,0 +1,14 @@
+--- whois-5.2.15/mkpasswd.c
++++ whois-5.2.15/mkpasswd.c.new
+@@ -104,11 +104,9 @@
+ #if defined FreeBSD
+     { "nt",		"$3$",  0,	0,	0, "NT-Hash" },
+ #endif
+-#if defined HAVE_SHA_CRYPT
+     /* http://people.redhat.com/drepper/SHA-crypt.txt */
+     { "sha-256",	"$5$",	8,	16,	1, "SHA-256" },
+     { "sha-512",	"$6$",	8,	16,	1, "SHA-512" },
+-#endif
+     /* http://www.crypticide.com/dropsafe/article/1389 */
+     /*
+      * Actually the maximum salt length is arbitrary, but Solaris by default


### PR DESCRIPTION
the Debian version of `mkpasswd` allows you to specify up to `999,999` rounds
when generating the password hash (Busybox's does not have this option)

tested with a `512`bit passwd authenticating to `exim`.