### PR TITLE
testing/py-flake8-class: $source URL returning 404

### DIFF
--- a/testing/py-flake8-class/APKBUILD
+++ b/testing/py-flake8-class/APKBUILD
@@ -10,7 +10,7 @@ arch="noarch"
 license="MIT"
 depends="flake8"
 makedepends="python3-dev"
-source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+source="$_pkgname-$pkgver.tar.gz::https://github.com/hellysmile/$_pkgname/archive/$pkgver.tar.gz"
 builddir="$srcdir"/$_pkgname-$pkgver
 
 build() {
@@ -23,6 +23,4 @@ package() {
 	python3 setup.py install --prefix=/usr --root="$pkgdir" || return 1
 }
 
-md5sums="2985f994e54d1fe5a96f9e7362e7dac7  flake8-class-0.0.6.tar.gz"
-sha256sums="945bdb688ef892a2eff2a148c5a271342f85d2ea7ac30e5f52ccaeaf38262260  flake8-class-0.0.6.tar.gz"
-sha512sums="453c994bdb98921dc384ead1373fc455ac664273c3a9fb6c05485f40abb44e9120597e7f54541a72c3a1cca4a634188771379def722dd20b7f28bf95cbf85636  flake8-class-0.0.6.tar.gz"
+sha512sums="598a7a29500ec85fa9eb81b378d1271d888508246ba63cac6df8473922c009c5d6fb514884b9c57686652e90eedede3c41f16b291737b9b5cf6b21a42cba2356  flake8-class-0.0.6.tar.gz"


### PR DESCRIPTION
The current $source URL does not seem to exist anymore. Grabbing the
source from the github project.

The checksum package changed!