### PR TITLE
testing/etckeeper: fix store-metadata

### DIFF
--- a/testing/etckeeper/0001-30store-metadata-fix-bug-when-listfile-is-empty.patch
+++ b/testing/etckeeper/0001-30store-metadata-fix-bug-when-listfile-is-empty.patch
@@ -1,0 +1,30 @@
+From 4ba839ff1898331f55947dcbee4b132a6bc96f18 Mon Sep 17 00:00:00 2001
+From: Henrik Riomar <henrik.riomar@gmail.com>
+Date: Wed, 15 Mar 2017 18:26:32 +0100
+Subject: [PATCH] 30store-metadata: fix bug when $listfile is empty
+
+(cherry picked from commit fad539b0ed762a7f6bc1bd94e64351ef56a25f2a)
+---
+ pre-commit.d/30store-metadata | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/pre-commit.d/30store-metadata b/pre-commit.d/30store-metadata
+index 6d7d4b1..1e624dc 100755
+--- a/pre-commit.d/30store-metadata
++++ b/pre-commit.d/30store-metadata
+@@ -20,7 +20,11 @@ filter_ignore() {
+ 				;;
+ 			git)
+ 				(git ls-files -oi --exclude-standard; git ls-files -oi --exclude-standard --directory) | sort | uniq > "$listfile" || true
+-				sed 's/^\.\///' | grep -xFvf "$listfile"
++				if [ -s "$listfile" ]; then
++					sed 's/^\.\///' | grep -xFvf "$listfile"
++				else
++					cat -
++				fi
+ 				;;
+ 		esac
+ 		rm -f "$listfile"
+-- 
+2.1.4
+

--- a/testing/etckeeper/APKBUILD
+++ b/testing/etckeeper/APKBUILD
@@ -3,16 +3,18 @@
 
 pkgname=etckeeper
 pkgver=1.18.6
-pkgrel=2
+pkgrel=3
 pkgdesc="Store /etc in git."
 url="http://etckeeper.branchable.com"
 arch="noarch"
 license="GPL2"
 depends="findutils git perl"
 subpackages="$pkgname-doc"
+options="!check"
 install="$pkgname.post-install $pkgname.pre-deinstall"
 source="$pkgname-$pkgver.tar.gz::https://git.joeyh.name/index.cgi/$pkgname.git/snapshot/$pkgname-$pkgver.tar.gz
 	apk-commit_hook
+	0001-30store-metadata-fix-bug-when-listfile-is-empty.patch
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -37,4 +39,5 @@ package() {
 }
 
 sha512sums="a5a3a4677f31cf1d010ab40ed37ce602c71c2e8ebf2273bf8be6dc8209f603ae0fc6a2c0d5d60d9a9d9aa4f3e7b7c0037534890cbc67b38132e5f654abcda04c  etckeeper-1.18.6.tar.gz
-2b1a29d31b6e7cf4ddb05de9b5e088b5747c2abfb2d63f9bddd25f4b7dc8503d457df7fd644afe5bd6fea6a5285a111a47c0489d24378b483c1e026cc11c6bf7  apk-commit_hook"
+2b1a29d31b6e7cf4ddb05de9b5e088b5747c2abfb2d63f9bddd25f4b7dc8503d457df7fd644afe5bd6fea6a5285a111a47c0489d24378b483c1e026cc11c6bf7  apk-commit_hook
+5db81313cf103c63560726c88ff68575206fb9df3b60050c93b9c4be6033630fac60626a36dbd6ae15eb458e967d07b83b21b3b891149081ff82f62d13c86063  0001-30store-metadata-fix-bug-when-listfile-is-empty.patch"


### PR DESCRIPTION
Fix from upstream master

Disable check for now, test is planned for upstream 1.18.7