### PR TITLE
main/opensmtpd: fix sendmail crash through undefined declarations

### DIFF
--- a/main/opensmtpd/APKBUILD
+++ b/main/opensmtpd/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Jonathan Curran <jonathan@curran.in>
 pkgname=opensmtpd
 pkgver=5.9.2p1
-pkgrel=2
+pkgrel=3
 pkgdesc="secure, reliable, lean, and easy-to configure SMTP server"
 url="http://www.opensmtpd.org"
 arch="all"
@@ -17,7 +17,9 @@ subpackages="$pkgname-doc"
 source="https://www.opensmtpd.org/archives/${pkgname}-${pkgver}.tar.gz
 	smtpd.initd
 	aliases
-	opensmtpd-5.7.3p2-libressl-arc4random-circularity.patch"
+	opensmtpd-5.7.3p2-libressl-arc4random-circularity.patch
+	libressl-compat.patch
+	missing-decls.patch"
 options="suid"
 
 builddir="$srcdir"/$pkgname-$pkgver
@@ -57,12 +59,18 @@ package() {
 md5sums="d109374dcc4bc8be14f790b859f1dd31  opensmtpd-5.9.2p1.tar.gz
 a2f311a82c9a85f5c52975c4dbbdbd53  smtpd.initd
 561d2aead043a64a4ce5d66b4f78223e  aliases
-a4c72a6a5fe18b514571e4baac19756f  opensmtpd-5.7.3p2-libressl-arc4random-circularity.patch"
+a4c72a6a5fe18b514571e4baac19756f  opensmtpd-5.7.3p2-libressl-arc4random-circularity.patch
+53d2fd15020b736a13899ba56a3909a5  libressl-compat.patch
+85a813b6d90c0c7a76252304d68df8c3  missing-decls.patch"
 sha256sums="3522f273c1630c781facdb2b921228e338ed4e651909316735df775d6a70a71d  opensmtpd-5.9.2p1.tar.gz
 ab4b7f066a38dadd7a2dc6d7c3a06c3a8ac2367340d97e2a8b54f571ea0f8cf8  smtpd.initd
 7bef80f8d86aa5463c864681482a4908d22ff8b6f3e47d2a410ef2d59b316b53  aliases
-0dee9bb91e191bfe51e8609c9469cc141af1b1c049869db4eebbf0bbb55971f6  opensmtpd-5.7.3p2-libressl-arc4random-circularity.patch"
+0dee9bb91e191bfe51e8609c9469cc141af1b1c049869db4eebbf0bbb55971f6  opensmtpd-5.7.3p2-libressl-arc4random-circularity.patch
+db272f9e988e59c3b035f2579811b4603f662322fbb5dbb544666025d5610312  libressl-compat.patch
+fd7d7c89c97f8dc6104eb5ecf0dfe2f2a0e08fd57d60203390a9f9f9ab780099  missing-decls.patch"
 sha512sums="99ca15101557848aa6d642f0c0171b152d805192e6839a97410b19431c981a21a5c0dc011e2c8cd91f3e6f6acb37a77f0f4c8e68114bf9808240392fe2b5d375  opensmtpd-5.9.2p1.tar.gz
 8152fecadeb1d818b7865eae040123f855e81fafbb4b40d12a64336e09dc486c10e6828809182c8172bfd9f54dc7d050a154b61d5e6049df6ffd8a7b6e5e1277  smtpd.initd
 929ba0b8befca6cad558602f9793a9c653923924ee524902916b8ef4952d1ea8a391895e7450ed9768eb82a07bd307b49561f5d49ea4711bd87a1a73eb8d7dad  aliases
-f1958f86edbf558bac88f944196670b4d34b7367f8479ef13433981bcb174afd7aa0e42aa447eac4bd46b0be849e2cf97313cc1073782c86c4c0a4aa7326b456  opensmtpd-5.7.3p2-libressl-arc4random-circularity.patch"
+f1958f86edbf558bac88f944196670b4d34b7367f8479ef13433981bcb174afd7aa0e42aa447eac4bd46b0be849e2cf97313cc1073782c86c4c0a4aa7326b456  opensmtpd-5.7.3p2-libressl-arc4random-circularity.patch
+23553a534e71fc17a34955a4076ebf24d3def31dedc97f172bbc229005f37564eb92e7a0fc1d1719b1643dae2ab891a5643c265f591be78aa4d334e886e63b20  libressl-compat.patch
+217e7212345f4202bf7e136b2d5b347a9967ea10d15ef50a216bfcd8e4a522076e4ee2044d18a606baf670c0fe6a339951b6381cdb9047730e06987ab7796790  missing-decls.patch"

--- a/main/opensmtpd/libressl-compat.patch
+++ b/main/opensmtpd/libressl-compat.patch
@@ -1,0 +1,104 @@
+From f948b923873a93472dea9b786cf60a3472b0ddc8 Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Wed, 11 Jan 2017 17:35:29 -0600
+Subject: [PATCH] fix compatibility with libressl
+
+These functions are exported by libcrypto from libressl, due to its
+similar OpenBSD compatibility layer, but they are not present in any
+header files. Thus, while we can use the existing compiled function,
+and do not need to provide our own, we do need to provide the prototype
+for it.
+
+This avoids implicit function declarations and the resulting crashes due
+to pointer truncation.
+
+The patch is based on an equivalent patch for OpenSSH from
+https://bugzilla.mindrot.org/show_bug.cgi?id=2465
+Also see
+https://github.com/libressl-portable/portable/issues/109
+
+Fixes #691
+
+Backported-by: Shiz <hi@shiz.me>
+---
+ openbsd-compat/defines.h        |  9 ---------
+ openbsd-compat/openbsd-compat.h | 25 +++++++++++++++----------
+ 2 files changed, 15 insertions(+), 19 deletions(-)
+
+diff --git a/openbsd-compat/defines.h b/openbsd-compat/defines.h
+index 2cbfbca..3ffcc81 100644
+--- a/openbsd-compat/defines.h
++++ b/openbsd-compat/defines.h
+@@ -422,15 +422,6 @@ typedef uint16_t	in_port_t;
+ #define INET6_ADDRSTRLEN 46
+ #endif
+ 
+-/*
+- * Platforms that have arc4random_uniform() and not arc4random_stir()
+- * shouldn't need the latter.
+- */
+-#if defined(HAVE_ARC4RANDOM) && defined(HAVE_ARC4RANDOM_UNIFORM) && \
+-    !defined(HAVE_ARC4RANDOM_STIR)
+-# define arc4random_stir()
+-#endif
+-
+ #ifndef HAVE_VA_COPY
+ # ifdef HAVE___VA_COPY
+ #  define va_copy(dest, src) __va_copy(dest, src)
+diff --git a/openbsd-compat/openbsd-compat.h b/openbsd-compat/openbsd-compat.h
+index a51385b..51f33bb 100644
+--- a/openbsd-compat/openbsd-compat.h
++++ b/openbsd-compat/openbsd-compat.h
+@@ -119,21 +119,25 @@
+ int getpeereid(int , uid_t *, gid_t *);
+ #endif 
+ 
+-#ifdef HAVE_ARC4RANDOM
+-# ifndef HAVE_ARC4RANDOM_STIR
+-#  define arc4random_stir()
+-# endif
+-#else
++#if !defined(HAVE_ARC4RANDOM) || defined(LIBRESSL_VERSION_NUMBER)
+ unsigned int arc4random(void);
++#endif
++
++#if !defined(HAVE_ARC4RANDOM_STIR)
++# if defined(HAVE_ARC4RANDOM) || defined(LIBRESSL_VERSION_NUMBER)
++/* Recent system/libressl implementation; no need for explicit stir */
++#  define arc4random_stir()
++# else
+ void arc4random_stir(void);
+-#endif /* !HAVE_ARC4RANDOM */
++# endif
++#endif
+ 
+-#ifndef HAVE_ARC4RANDOM_BUF
++#if !defined(HAVE_ARC4RANDOM_BUF) || defined(LIBRESSL_VERSION_NUMBER)
+ void arc4random_buf(void *, size_t);
+ #endif
+ 
+-#ifndef HAVE_ARC4RANDOM_UNIFORM
+-u_int32_t arc4random_uniform(u_int32_t);
++#if !defined(HAVE_ARC4RANDOM_UNIFORM) || defined(LIBRESSL_VERSION_NUMBER)
++uint32_t arc4random_uniform(uint32_t);
+ #endif
+ 
+ #ifndef HAVE_ASPRINTF
+@@ -174,7 +178,7 @@
+ int vsnprintf(char *, size_t, const char *, va_list);
+ #endif
+ 
+-#ifndef HAVE_EXPLICIT_BZERO
++#if !defined(HAVE_EXPLICIT_BZERO) || defined(LIBRESSL_VERSION_NUMBER)
+ void explicit_bzero(void *p, size_t n);
+ #endif
+ 
+@@ -200,7 +204,7 @@
+ struct passwd *pw_dup(const struct passwd *);
+ #endif
+ 
+-#ifndef HAVE_REALLOCARRAY
++#if !defined(HAVE_REALLOCARRAY) || defined(LIBRESSL_VERSION_NUMBER)
+ void *reallocarray(void *, size_t, size_t);
+ #endif
+ 

--- a/main/opensmtpd/missing-decls.patch
+++ b/main/opensmtpd/missing-decls.patch
@@ -1,0 +1,51 @@
+From 2ab442623e689532910b34ff0dbbc2167da02330 Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Wed, 11 Jan 2017 17:39:07 -0600
+Subject: [PATCH] fix musl compatibility (missing function prototypes)
+
+inet_net_pton is already compiled, but no prototype is provided.
+res_hnok is provided by the compatibility layer in libasr.
+
+These fixes avoid warnings about implicit function declaration.
+
+Fixes #758
+---
+ configure.ac                    | 1 +
+ openbsd-compat/openbsd-compat.h | 8 ++++++++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 42e092f..e27c514 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -594,6 +594,7 @@ AC_CHECK_FUNCS([ \
+ 	pledge \
+ 	pw_dup \
+ 	reallocarray \
++	res_hnok \
+ 	setenv \
+ 	setlinebuf \
+ 	setproctitle \
+diff --git a/openbsd-compat/openbsd-compat.h b/openbsd-compat/openbsd-compat.h
+index a51385b..5d2e2c2 100644
+--- a/openbsd-compat/openbsd-compat.h
++++ b/openbsd-compat/openbsd-compat.h
+@@ -208,10 +208,18 @@ void *reallocarray(void *, size_t, size_t);
+ void errc(int, int, const char *, ...);
+ #endif
+ 
++#ifndef HAVE_INET_NET_PTON
++int inet_net_pton(int, const char *, void *, size_t);
++#endif
++
+ #ifndef HAVE_PLEDGE
+ #define pledge(promises, paths) 0
+ #endif
+ 
++#ifndef HAVE_RES_HNOK
++int res_hnok(const char *);
++#endif
++
+ #if !HAVE_DECL_AF_LOCAL
+ #define AF_LOCAL AF_UNIX
+ #endif


### PR DESCRIPTION
Backport from 36d195d7c2f7a01332478e5fbeda6c8ed7d2b3e3 in edge.