### PR TITLE
testing/ostree: upgrade to 2017.4

### DIFF
--- a/testing/ostree/APKBUILD
+++ b/testing/ostree/APKBUILD
@@ -1,14 +1,14 @@
 # Contributor: André Klitzing <aklitzing@gmail.com>
 # Maintainer: André Klitzing <aklitzing@gmail.com>
 pkgname=ostree
-pkgver=2017.3
+pkgver=2017.4
 pkgrel=0
 pkgdesc="Operating system and container binary deployment and upgrades"
 url="https://github.com/ostreedev/ostree"
 arch="all"
 license="GPL"
 makedepends="bison glib-dev xz-dev libarchive-dev e2fsprogs-dev
-             libsoup-dev gpgme-dev fuse-dev"
+             libsoup-dev gpgme-dev fuse-dev linux-headers"
 subpackages="$pkgname-dev $pkgname-doc"
 source="https://github.com/ostreedev/ostree/releases/download/v$pkgver/libostree-$pkgver.tar.xz
 		musl-fixes.patch
@@ -40,5 +40,5 @@ package() {
 	install -D -m644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 
-sha512sums="eabb89b2c66395867feb516c07fdd71645570b9f145a535a6b3bb0d5612d300d4f22aede8332276023fb7439f14537a353722537c2e5a6a3c973bab72b8b87af  libostree-2017.3.tar.xz
-24cf6d3d4681f95c84a76b77eb99d08dc56275142e4bb475708b2c74e8ad9633c26bf1ba73995cbf30d88c4c754bbbd1cb65e8f454359e2f6b2e6e53b6b48739  musl-fixes.patch"
+sha512sums="550c3c6d29c62e5af87bd8af2761decde7c2586c1b4f04aea46aea49e3ba880c7bac370bfdb5395629e9a8d0f4c47c286bdcc47c84e5abfefcab4c5258439471  libostree-2017.4.tar.xz
+539f5020f3380e841372f80c60c71c803ccfeffb719f1b83361b75557022c61d9cd29d9cd36929426420644def9de91fd92f5dd6923352f2ae6e1dd4b676de8c  musl-fixes.patch"

--- a/testing/ostree/musl-fixes.patch
+++ b/testing/ostree/musl-fixes.patch
@@ -1,24 +1,3 @@
---- a/src/libostree/ostree-repo.c
-+++ b/src/libostree/ostree-repo.c
-@@ -43,6 +43,8 @@
- #include <locale.h>
- #include <glib/gstdio.h>
- 
-+#include <sys/file.h>
-+
- /**
-  * SECTION:ostree-repo
-  * @title: Content-addressed object store
---- a/src/libostree/ostree-sysroot.c
-+++ b/src/libostree/ostree-sysroot.c
-@@ -21,6 +21,7 @@
- #include "config.h"
- 
- #include "otutil.h"
-+#include <sys/file.h>
- #include <sys/mount.h>
- #include <sys/wait.h>
- 
 --- a/config.h.in
 +++ b/config.h.in
 @@ -148,3 +148,15 @@


### PR DESCRIPTION
Remove merged musl fixes