### PR TITLE
testing/ripgrep: new aport

### DIFF
--- a/testing/ripgrep/APKBUILD
+++ b/testing/ripgrep/APKBUILD
@@ -1,0 +1,61 @@
+# Contributor: André Klitzing <aklitzing@gmail.com>
+# Maintainer: André Klitzing <aklitzing@gmail.com>
+pkgname=ripgrep
+pkgver=0.10.0
+pkgrel=0
+pkgdesc="ripgrep combines the usability of The Silver Searcher with the raw speed of grep"
+url="https://github.com/BurntSushi/ripgrep"
+arch="x86_64" # limited by cargo pkg
+license="MIT public-domain"
+makedepends="cargo asciidoc pcre2-dev"
+subpackages="$pkgname-doc
+	$pkgname-bash-completion:bashcomp:noarch
+	$pkgname-zsh-completion:zshcomp:noarch
+	$pkgname-fish-completion:fishcomp:noarch"
+source="$pkgname-$pkgver.tar.gz::https://github.com/BurntSushi/$pkgname/archive/$pkgver.tar.gz"
+builddir="$srcdir/"$pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	cargo build --release --features 'pcre2'
+}
+
+check() {
+	cd "$builddir"
+	cargo test
+}
+
+package() {
+	cd "$builddir"
+	install -Dm755 "target/release/rg" "$pkgdir/usr/bin/rg"
+	install -Dm644 "target/release/build/ripgrep-"*/out/rg.1 "$pkgdir/usr/share/man/man1/rg.1"
+}
+
+bashcomp() {
+	depends=""
+	pkgdesc="Bash completions for $pkgname"
+	install_if="$pkgname=$pkgver-r$pkgrel bash-completion"
+
+	mkdir -p "$subpkgdir"/usr/share/bash-completion/completions/
+	install -Dm644 "$builddir/target/release/build/ripgrep-"*/out/rg.bash "$subpkgdir/usr/share/bash-completion/completions/rg"
+}
+
+zshcomp() {
+	depends=""
+	pkgdesc="Zsh completions for $pkgname"
+	install_if="$pkgname=$pkgver-r$pkgrel zsh"
+
+	mkdir -p "$subpkgdir"/usr/share/zsh/site-functions/
+	install -Dm644 "$builddir/complete/_rg" "$subpkgdir/usr/share/zsh/site-functions/_rg"
+}
+
+fishcomp() {
+	depends=""
+	pkgdesc="Fish completions for $pkgname"
+	install_if="$pkgname=$pkgver-r$pkgrel fish"
+
+	mkdir -p "$subpkgdir"/usr/share/fish/completions/
+	install -Dm644 "$builddir/target/release/build/ripgrep-"*/out/rg.fish "$subpkgdir/usr/share/fish/completions/rg.fish"
+}
+
+sha512sums="bc193d269131823076fdb857f69a95c165e88848896379039218139136028e3705e09f1b9be33903e060c8cc37ad5b992ea70a05f6f01c6210bef535a35570c0  ripgrep-0.10.0.tar.gz"


### PR DESCRIPTION
Unit test "regression_25" failed. I added an issue: https://github.com/BurntSushi/ripgrep/issues/448