### PR TITLE
testing/pass: update to 1.7.1

### DIFF
--- a/testing/pass/APKBUILD
+++ b/testing/pass/APKBUILD
@@ -2,36 +2,37 @@
 # Contributor: Johannes Matheis <jomat+alpinebuild@jmt.gr>
 # Maintainer: Johannes Matheis <jomat+alpinebuild@jmt.gr>
 pkgname=pass
-pkgver=1.6.5
-pkgrel=3
+pkgver=1.7.1
+pkgrel=0
 pkgdesc="Stores, retrieves, generates, and synchronizes passwords securely"
 url="http://zx2c4.com/projects/password-store/"
 arch="noarch"
 license="GPL2"
-depends="bash"
+depends="bash tree"
 depends_dev=""
 makedepends="$depends_dev"
-install=""
+options="!check"
 subpackages="$pkgname-doc
 	$pkgname-contrib
 	$pkgname-bash-completion:bashcomp
 	$pkgname-fish-completion:fishcomp
 	$pkgname-zsh-completion:zshcomp"
-source="http://git.zx2c4.com/password-store/snapshot/password-store-${pkgver}.tar.xz"
+source="http://git.zx2c4.com/password-store/snapshot/password-store-${pkgver}.tar.xz
+	README.alpine
+	"
+builddir="$srcdir/password-store-$pkgver"
 
-_builddir="$srcdir/password-store-$pkgver"
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	make DESTDIR="$pkgdir" \
-		FORCE_BASHCOMP=1 \
-		FORCE_ZSHCOMP=1 \
-		FORCE_FISHCOMP=1 install
+		WITH_ALLCOMP=yes install
+	install -Dm 644 "$srcdir"/README.alpine "$pkgdir"/usr/share/doc/pass/README.alpine
 }
 
 contrib() {
 	pkgdesc="contrib files for pass"
 	mkdir -p "$subpkgdir"/usr/share
-	cp -a "$_builddir"/contrib "$subpkgdir"/usr/share/$pkgname
+	cp -a "$builddir"/contrib "$subpkgdir"/usr/share/$pkgname
 }
 
 bashcomp() {
@@ -42,7 +43,7 @@ bashcomp() {
 
 	mkdir -p "$subpkgdir"/usr/share/bash-completion/completions
 	mv "$pkgdir"/usr/share/bash-completion/completions/* \
-		"$subpkgdir"/usr/share/bash-completion/completions/ || return 1
+		"$subpkgdir"/usr/share/bash-completion/completions/
 }
 
 fishcomp() {
@@ -53,7 +54,7 @@ fishcomp() {
 
 	mkdir -p "$subpkgdir"/usr/share/fish/completions/
 	mv "$pkgdir"/usr/share/fish/vendor_completions.d/* \
-		"$subpkgdir"/usr/share/fish/completions/ || return 1
+		"$subpkgdir"/usr/share/fish/completions/
 }
 
 zshcomp() {
@@ -64,9 +65,8 @@ zshcomp() {
 
 	mkdir -p "$subpkgdir/usr/share/zsh/site-functions"
 	mv "$pkgdir"/usr/share/zsh/site-functions/* \
-		"$subpkgdir"/usr/share/zsh/site-functions || return 1
+		"$subpkgdir"/usr/share/zsh/site-functions
 }
 
-md5sums="2c4468360c678184051e76f03c2f6b04  password-store-1.6.5.tar.xz"
-sha256sums="337a39767e6a8e69b2bcc549f27ff3915efacea57e5334c6068fcb72331d7315  password-store-1.6.5.tar.xz"
-sha512sums="e28503b63c6d18a2f45f4a732fdec0380c2ac15e1778136ec5e7ac568662b09183d3ad4fd36ca7e87cfe74540f916cb6365695bdf665a39da4cbe86c4bde7a78  password-store-1.6.5.tar.xz"
+sha512sums="2ba2ebc80c90454bbab1da3c43c2cfc87135f838f381e2616eef7c36b0c1de01e491cf587a666bb052d6dfd475fa429bc8fd82b0269325bd2b70afbb897b923e  password-store-1.7.1.tar.xz
+f3122c1b3d31d54427073ffcf15a42d5f0a3d19c61d32673f8bbf35642a790ef89a4db4c2a2708443b8a93e567dfa1259987ad16a33179418db64e3ce9beb3bb  README.alpine"

--- a/testing/pass/README.alpine
+++ b/testing/pass/README.alpine
@@ -1,0 +1,28 @@
+# Alpine Linux README: Password Store #
+---------------------------------------
+
+Notes for making the clipboard work for root over ssh:
+------------------------------------------------------
+
+(1) apk add xauth xclip
+
+(2) On your LOCAL machine add to ~/.ssh/config:
+
+host xxxxxxx
+  ForwardX11 yes
+  ForwardX11Trusted yes
+
+(3) In the REMOTE USER ~/.profile add:
+
+  echo "$DISPLAY" > ~/.display
+
+(4) In the REMOTE ROOT ~/.profile add:
+
+  export DISPLAY=$(cat /home/login-user/.display)
+
+(5) file=/home/login-user/.Xauthority
+    touch $file
+    chmod 0600 $file
+    chown user:user $file
+    ln -s $file /root/.Xauthority
+


### PR DESCRIPTION
* also adds a `README.alpine` with instructions to make the clipboard work for `root` over `ssh`.