### PR TITLE
testing/nginx-ultimate-bad-bot-blocker: new aport

### DIFF
--- a/testing/nginx-ultimate-bad-bot-blocker/APKBUILD
+++ b/testing/nginx-ultimate-bad-bot-blocker/APKBUILD
@@ -1,0 +1,41 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+pkgname=nginx-ultimate-bad-bot-blocker
+pkgver=3.2018.01.1039
+pkgrel=0
+pkgdesc="Nginx Bad Bot and User-Agent Blocker"
+url="https://github.com/mitchellkrogza/nginx-ultimate-bad-bot-blocker"
+arch="noarch"
+license="MIT"
+install=""
+options="!check"
+subpackages="$pkgname-doc"
+source="nginx-ubbb-$pkgver.tar.gz::https://github.com/mitchellkrogza/$pkgname/archive/V$pkgver.tar.gz"
+builddir="$srcdir/"$pkgname-$pkgver
+
+build() {
+	return 0
+}
+
+package() {
+	cd "$builddir"
+	mkdir -p "$pkgdir"/etc/nginx
+	mkdir -p "$pkgdir"/usr/share/nginx-ultimate-bad-bot-blocker/google
+	mkdir -p "$pkgdir"/usr/share/nginx-ultimate-bad-bot-blocker/fail2ban
+	mkdir -p "$pkgdir"/usr/share/nginx-ultimate-bad-bot-blocker/examples
+	mkdir -p "$pkgdir"/usr/share/nginx-ultimate-bad-bot-blocker/generator-lists
+	cp -rf conf.d "$pkgdir"/etc/nginx
+	cp -rf bots.d "$pkgdir"/etc/nginx
+	cp -rf man "$pkgdir"/usr/share
+	cp -rf _fail2ban_addon "$pkgdir"/usr/share/nginx-ultimate-bad-bot-blocker/fail2ban
+	cp -rf _sample_config_files "$pkgdir"/usr/share/nginx-ultimate-bad-bot-blocker/examples
+	install -Dm700 update-ngxblocker "$pkgdir"/usr/sbin/update-ngxblocker
+	install -Dm700 install-ngxblocker "$pkgdir"/usr/sbin/install-ngxblocker
+	install -Dm700 setup-ngxblocker "$pkgdir"/sbin/setup-ngxblocker
+	install -m644 _google_analytics_ghost_spam/* "$pkgdir"/usr/share/nginx-ultimate-bad-bot-blocker/google/
+	install -m644 _google_webmaster_disavow_links/*.txt "$pkgdir"/usr/share/nginx-ultimate-bad-bot-blocker/google/
+	install -m644 _generator_lists/* "$pkgdir"/usr/share/nginx-ultimate-bad-bot-blocker/generator-lists/
+	install -Dm644 LICENSE.md "$pkgdir"/usr/share/licenses/nginx-ultimate-bad-bot-blocker/LICENSE
+}
+
+sha512sums="ef72343722ef6c6ae902cbcd1a3770580cc40fd890e11ca166b34781950656f6761fdd10a71fd611d55c35e5f30696ad77847b97b53ba2725dbfb0bc8832a3c0  nginx-ubbb-3.2018.01.1039.tar.gz"


### PR DESCRIPTION
includes:

* `/sbin/setup-ngxblocker` - to see options run `setup-ngxblocker -h` or `--help`
 
by default it does nothing & just prints to `stdout` the configuration changes it would make. 
to actually make the changes run with `setup-ngxblocker -x`

* `/usr/sbin/update-ngxblocker` to update `globalblacklist.conf`
