### PR TITLE
main/luajit: fix a segfault in ppc64le

### DIFF
--- a/main/luajit/APKBUILD
+++ b/main/luajit/APKBUILD
@@ -18,6 +18,9 @@ builddir=$srcdir/LuaJIT-$_realver
 
 build() {
 	cd "$builddir"
+	if [ "$CARCH" = "ppc64le" ]; then
+		local LDFLAGS="-no-pie"
+	fi
 	make amalg PREFIX=/usr || return 1
 }
 


### PR DESCRIPTION
Add -no-pie linker flag to fix a segfault in ppc64le. The segfault was happening
because -pie was adding a prologue and corrupting the toc pointer.

This is a temporary workaround to fix this issue for now but I will investigate
latter why it is happening.