### PR TITLE
community/go: enable build on ppc64le.

### DIFF
--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -7,7 +7,7 @@ _toolsver="26c35b4dcf6dfcb924e26828ed9f4d028c5ce05a"
 pkgrel=2
 pkgdesc="Go programming language compiler"
 url="http://www.golang.org/"
-arch="all !ppc64le"
+arch="all"
 license="BSD"
 depends="binutils gcc"
 depends_dev=""
@@ -56,6 +56,7 @@ build() {
 	s390x)  export GOARCH="s390x" ;;
 	x86)    export GOARCH="386" GO386=387 ;;
 	x86_64) export GOARCH="amd64" ;;
+	ppc64le) export GOARCH="ppc64le" ;;
 	*)      die "Unsupported arch" ;;
 	esac
 


### PR DESCRIPTION
Go package build was disabled on ppc64le because it was missing go-bootstrap dependency.
As the last version of go-bootstrap (1.4) is not available for ppc64le, I cross-compiled
it and uploaded it to: ftp://ftp.unicamp.br/pub/ppc64el/alpine/go-bootstrap/

The go-bootstrap is now installed in build-edge-ppc64le and can compile the go package.