### PR TITLE
{main,testing}/{llvm,llvm3.9,llvm4}: Additional musl related fixes

### DIFF
--- a/main/llvm/llvm-0002-Fix-build-with-musl-libc.patch
+++ b/main/llvm/llvm-0002-Fix-build-with-musl-libc.patch
@@ -14,7 +14,7 @@ diff --git a/include/llvm/Analysis/TargetLibraryInfo.h b/include/llvm/Analysis/T
 index 7becdf0..7f14427 100644
 --- a/include/llvm/Analysis/TargetLibraryInfo.h
 +++ b/include/llvm/Analysis/TargetLibraryInfo.h
-@@ -18,6 +18,15 @@
+@@ -18,6 +18,26 @@
  #include "llvm/IR/Module.h"
  #include "llvm/Pass.h"
  
@@ -26,6 +26,17 @@ index 7becdf0..7f14427 100644
 +#undef lstat64
 +#undef stat64
 +#undef tmpfile64
++#undef F_GETLK64
++#undef F_SETLK64
++#undef F_SETLKW64
++#undef flock64
++#undef open64
++#undef openat64
++#undef creat64
++#undef lockf64
++#undef posix_fadvise64
++#undef posix_fallocate64
++#undef off64_t
 +
  namespace llvm {
  /// VecDesc - Describes a possible vectorization of a function.

--- a/testing/llvm3.9/llvm-fix-build-with-musl-libc.patch
+++ b/testing/llvm3.9/llvm-fix-build-with-musl-libc.patch
@@ -14,7 +14,7 @@ diff --git a/include/llvm/Analysis/TargetLibraryInfo.h b/include/llvm/Analysis/T
 index 7becdf0..7f14427 100644
 --- a/include/llvm/Analysis/TargetLibraryInfo.h
 +++ b/include/llvm/Analysis/TargetLibraryInfo.h
-@@ -18,6 +18,15 @@
+@@ -18,6 +18,26 @@
  #include "llvm/IR/Module.h"
  #include "llvm/Pass.h"
  
@@ -26,6 +26,17 @@ index 7becdf0..7f14427 100644
 +#undef lstat64
 +#undef stat64
 +#undef tmpfile64
++#undef F_GETLK64
++#undef F_SETLK64
++#undef F_SETLKW64
++#undef flock64
++#undef open64
++#undef openat64
++#undef creat64
++#undef lockf64
++#undef posix_fadvise64
++#undef posix_fallocate64
++#undef off64_t
 +
  namespace llvm {
  /// VecDesc - Describes a possible vectorization of a function.

--- a/testing/llvm4/llvm-fix-build-with-musl-libc.patch
+++ b/testing/llvm4/llvm-fix-build-with-musl-libc.patch
@@ -14,7 +14,7 @@ diff --git a/include/llvm/Analysis/TargetLibraryInfo.h b/include/llvm/Analysis/T
 index 7becdf0..7f14427 100644
 --- a/include/llvm/Analysis/TargetLibraryInfo.h
 +++ b/include/llvm/Analysis/TargetLibraryInfo.h
-@@ -18,6 +18,15 @@
+@@ -18,6 +18,26 @@
  #include "llvm/IR/Module.h"
  #include "llvm/Pass.h"
  
@@ -26,6 +26,17 @@ index 7becdf0..7f14427 100644
 +#undef lstat64
 +#undef stat64
 +#undef tmpfile64
++#undef F_GETLK64
++#undef F_SETLK64
++#undef F_SETLKW64
++#undef flock64
++#undef open64
++#undef openat64
++#undef creat64
++#undef lockf64
++#undef posix_fadvise64
++#undef posix_fallocate64
++#undef off64_t
 +
  namespace llvm {
  /// VecDesc - Describes a possible vectorization of a function.


### PR DESCRIPTION
Additional musl libc defines for compatibility need to be undef'd.
The list included in this PR (F_GETLK64, F_SETLK64, F_SETLKW64,
flock64, open64, openat64, creat64, lockf64, posix_fadvise64,
posix_fallocate64, off64_t) is from the defines in:
https://git.musl-libc.org/cgit/musl/tree/include/fcntl.h#n169

----------------

I tried following https://github.com/alpinelinux/aports/blob/master/.github/CONTRIBUTING.md but please let me know if I've made any mistakes along the way.