### PR TITLE
main/libbsd: enable build on ppc64le

### DIFF
--- a/main/libbsd/APKBUILD
+++ b/main/libbsd/APKBUILD
@@ -6,14 +6,15 @@ pkgver=0.8.3
 pkgrel=1
 pkgdesc="commonly-used BSD functions not implemented by all libcs"
 url="http://libbsd.freedesktop.org/"
-arch="all !armhf !aarch64 !ppc64le"
+arch="all !armhf !aarch64"
 license="BSD"
 depends=""
 depends_dev="bsd-compat-headers linux-headers"
 makedepends="$depends_dev autoconf automake libtool"
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://libbsd.freedesktop.org/releases/$pkgname-$pkgver.tar.xz
-	musl-fixes.patch"
+	musl-fixes.patch
+	fix-build-with-musl-on-ppc64le.patch"
 
 builddir="$srcdir/$pkgname-$pkgver"
 prepare() {
@@ -42,9 +43,6 @@ package() {
 		install || return 1
 }
 
-md5sums="e935c1bb6cc98a4a43cb1da22795493a  libbsd-0.8.3.tar.xz
-21a350d9723d667b5ed8a8b610528843  musl-fixes.patch"
-sha256sums="934b634f4dfd865b6482650b8f522c70ae65c463529de8be907b53c89c3a34a8  libbsd-0.8.3.tar.xz
-cc7d2f2dfe2cc5d823e6ea5f7c1efea236f688c7ee53ec925471264e54c72359  musl-fixes.patch"
 sha512sums="155b895d6bd62b180718d65a2cda7484946c492d52735a57b51005705dfe4528b6a72e8745acea47b01fe68e3bbbe3c036c5e9998a8d06fc79efe2b96a04767f  libbsd-0.8.3.tar.xz
-032b8de7abfe6ffec80957db05fcb02b2cec74f26ecc99ef20d2a314efd0dfd88486e31bd33dd7460ac85b48acdab3ba849cd96bdd0884cd5667e7a43ab30c3a  musl-fixes.patch"
+032b8de7abfe6ffec80957db05fcb02b2cec74f26ecc99ef20d2a314efd0dfd88486e31bd33dd7460ac85b48acdab3ba849cd96bdd0884cd5667e7a43ab30c3a  musl-fixes.patch
+6e9e182bc45acde46aedd7696783636a6f9901e01436d26ee22104d39adae13b6bb0231b02be0db1a461faa3bc611c16296f37f5ab5f365dd3719daaebb9863a  fix-build-with-musl-on-ppc64le.patch"

--- a/main/libbsd/fix-build-with-musl-on-ppc64le.patch
+++ b/main/libbsd/fix-build-with-musl-on-ppc64le.patch
@@ -1,0 +1,60 @@
+Libbsd includes a.out.h header to get some definitions like struct nlist, struct exec.
+
+In Alpine x86_64 this header is provided by linux-headers package (linux/a.out.h),
+in Ubuntu ppc64le it is provided by glibc (a.out.h), but in Alpine ppc64le it is not
+available.
+
+A workaround for this problem is to define the types that are being used
+by libbsd instead of including the invalid header for ppc64le.
+===
+--- libbsd-0.8.3.orig/src/nlist.c
++++ libbsd-0.8.3/src/nlist.c
+@@ -40,7 +40,48 @@
+
+ #include <errno.h>
+ #include <fcntl.h>
++
++#ifndef __powerpc64__
+ #include <linux/a.out.h>
++#else
++// Copied from a.out.h, because it is not available on ppc64le with musl
++struct nlist
++{
++  union
++     {
++	char *n_name;
++	struct nlist *n_next;
++	long n_strx;
++     } n_un;
++    unsigned char n_type;
++    char n_other;
++    short n_desc;
++    unsigned long n_value;
++};
++
++struct exec
++{
++  unsigned long a_info; /* Use macros N_MAGIC, etc for access.  */
++  unsigned int a_text;  /* Length of text, in bytes.  */
++  unsigned int a_data;  /* Length of data, in bytes.  */
++  unsigned int a_bss;   /* Length of uninitialized data area for file, in bytes.  */
++  unsigned int a_syms;  /* Length of symbol table data in file, in bytes.  */
++  unsigned int a_entry; /* Start address.  */
++  unsigned int a_trsize;/* Length of relocation info for text, in bytes.  */
++  unsigned int a_drsize;/* Length of relocation info for data, in bytes.  */
++};
++
++#define N_UNDF  0
++#define N_ABS   2
++#define N_TEXT  4
++#define N_DATA  6
++#define N_BSS   8
++#define N_FN    15
++#define N_EXT   1
++#define N_STAB  0340
++
++#endif
++
+ #include <stdio.h>
+ #include <string.h>
+ #include <unistd.h>


### PR DESCRIPTION
Libbsd includes a.out.h header to get some definitions, like struct nlist,
struct exec.
In Alpine x86_64 this header is provided by linux-headers package (linux/a.out.h),
in Ubuntu ppc64le it is provided by glibc (a.out.h), but in Alpine ppc64le it is not
available.

A workaround for this problem is to define the types that are being used
by libbsd instead of including the invalid header for ppc64le.