### PR TITLE
main/libressl: update to 2.5.3 / fix curl error 77 / add check()

### DIFF
--- a/main/libressl/APKBUILD
+++ b/main/libressl/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Orion <systmkor@gmail.com>
 # Maintainer: Orion <systmkor@gmail.com>
 pkgname=libressl
-pkgver=2.4.5
+pkgver=2.5.3
 _namever=${pkgname}${pkgver%.*}
 pkgrel=0
 pkgdesc="Version of the TLS/crypto stack forked from OpenSSL"
@@ -36,12 +36,15 @@ build() {
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
+	# fix curl: (77) error setting certificate verify locations:
+	mkdir -p "$pkgdir"/etc/ssl/certs
+	ln -s /etc/ssl/cert.pem "$pkgdir"/etc/ssl/certs/ca-certificates.crt
 }
 
 dev() {
-	default_dev || return 1
+	default_dev
 	replaces="openssl-dev"
 }
 
@@ -57,6 +60,9 @@ _libs() {
 	done
 }
 
-md5sums="c4bd1779a79929bbeb59121449d142c3  libressl-2.4.5.tar.gz"
-sha256sums="d300c4e358aee951af6dfd1684ef0c034758b47171544230f3ccf6ce24fe4347  libressl-2.4.5.tar.gz"
-sha512sums="bdbd0fcb868e77e5fba26da7653fe6e7f7b5017455e1beb13e11b42b8db0742b9ca6442f0949adc91ddc1f53fb93549a6c0529795cd34db2bf887cbca2d33070  libressl-2.4.5.tar.gz"
+check() {
+	cd "$builddir"
+	make check
+}
+
+sha512sums="e5ba2abb8a0835a025d2777d9c0e8e95813777af8167e322d8e5ae20485c32b628ced77141b156fd3619b65a5afae1a5bc90a7252166a9a54f7e3d23388b3bd0  libressl-2.5.3.tar.gz"


### PR DESCRIPTION
fixes:

```
	curl: (77) error setting certificate verify locations:
	  CAfile: /etc/ssl/certs/ca-certificates.crt
	  CApath: none
```