### PR TITLE
main/libressl: fix curl error 77

### DIFF
--- a/main/libressl/APKBUILD
+++ b/main/libressl/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Orion <systmkor@gmail.com>
 # Maintainer: Orion <systmkor@gmail.com>
 pkgname=libressl
-pkgver=2.5.3
+pkgver=2.5.4
 _namever=${pkgname}${pkgver%.*}
 pkgrel=0
 pkgdesc="Version of the TLS/crypto stack forked from OpenSSL"
@@ -29,19 +29,21 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
+	# fix for programs that expect the Debian default location:
+	mkdir -p "$pkgdir"/etc/ssl/certs
+	ln -s ../cert.pem "$pkgdir"/etc/ssl/certs/ca-certificates.crt
 }
 
 dev() {
-	default_dev || return 1
+	default_dev
 	replaces="openssl-dev"
 }
 
@@ -57,4 +59,4 @@ _libs() {
 	done
 }
 
-sha512sums="e5ba2abb8a0835a025d2777d9c0e8e95813777af8167e322d8e5ae20485c32b628ced77141b156fd3619b65a5afae1a5bc90a7252166a9a54f7e3d23388b3bd0  libressl-2.5.3.tar.gz"
+sha512sums="8ca86c14af0020c90bef4651892799864938dab9d898172269cb78bad5963314e064f2b4c46e6a04e0b85d1eddbd1840b734803c11ceec8fd6bb1290e0fe204c  libressl-2.5.4.tar.gz"


### PR DESCRIPTION
fixes:
```
	curl: (77) error setting certificate verify locations:
	  CAfile: /etc/ssl/certs/ca-certificates.crt
	  CApath: none
```