### PR TITLE
Update & modernize Syncthing aport

### DIFF
--- a/community/syncthing/APKBUILD
+++ b/community/syncthing/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=syncthing
-pkgver=0.14.5
+pkgver=0.14.26
 pkgrel=0
 pkgdesc="Open Source Continuous File Synchronization"
 url="http://syncthing.net/"
@@ -11,59 +11,54 @@ arch="all !ppc64le"
 license="MPLv2"
 pkgusers="$pkgname"
 pkggroups="$pkgname"
-depends=""
-depends_dev=""
 makedepends="go"
 install="$pkgname.pre-install"
 subpackages="$pkgname-utils"
-options="!strip"
+options="!strip !check"
+
 source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$pkgver.tar.gz
 	$pkgname.confd
 	$pkgname.initd"
 
-builddir="$srcdir/src/github.com/$pkgname"
+builddir="$srcdir/src/github.com/$pkgname/$pkgname"
+
+export GOPATH="$srcdir"
 
 prepare() {
+	mkdir -p $(dirname "$builddir")
+	ln -s "$srcdir"/$pkgname-$pkgver "$builddir"
 	default_prepare
-	mkdir -p "$builddir"
-	ln -s "$srcdir"/$pkgname-$pkgver "$builddir"/$pkgname || return 1
 }
 
 build() {
-	cd "$builddir"/$pkgname
-	export GOPATH="$srcdir"
+	cd "$builddir"
 	# recent syncthing tarballs have all deps in vendor dir
 	# no need to use a go dep tool like glide/godep
 	go run build.go -no-upgrade -version=v$pkgver
 }
 
+# race check fails with musl
+check() {
+	cd "$builddir"
+	go run build.go -no-upgrade test
+}
+
 package() {
-	install -d -o $pkgname -g $pkgname \
-		"$pkgdir"/var/lib/$pkgname || return 1
-	install -D -m755 $builddir/$pkgname/bin/$pkgname \
-		"$pkgdir"/usr/bin/$pkgname || return 1
-	install -D -m755 "$srcdir"/$pkgname.initd \
-		"$pkgdir"/etc/init.d/$pkgname || return 1
-	install -D -m644 "$srcdir"/$pkgname.confd \
-		"$pkgdir"/etc/conf.d/$pkgname || return 1
+	install -d -o $pkgname -g $pkgname "$pkgdir"/var/lib/$pkgname 
+	install -D -m755 $builddir/bin/$pkgname "$pkgdir"/usr/bin/$pkgname
+	install -D -m755 "$srcdir"/$pkgname.initd "$pkgdir"/etc/init.d/$pkgname
+	install -D -m644 "$srcdir"/$pkgname.confd "$pkgdir"/etc/conf.d/$pkgname
 }
 
 utils() {
 	pkgdesc="Syncthing utilities"
-	for i in $(ls $builddir/$pkgname/bin); do
+	for i in $(ls $builddir/bin); do
 		if ! [ "$i" = "$pkgname" ]; then
-			install -Dm 755 $builddir/$pkgname/bin/$i \
-				$subpkgdir/usr/bin/$i || return 1
+			install -Dm 755 $builddir/bin/$i $subpkgdir/usr/bin/$i 
 		fi
 	done
 }
 
-md5sums="e9d43e1241f07916952f3ecc6cf6d02d  syncthing-0.14.5.tar.gz
-c4923d6df4d3e51274869c09ea46a3e1  syncthing.confd
-760e26e5ea2f1dce8ce149a45f5e99bb  syncthing.initd"
-sha256sums="32979e333a77dcd4e2ba9cb9c74404f9fd06891032c84b1285bcb779c9e132b6  syncthing-0.14.5.tar.gz
-da396f944d7b5b2e4f5a7a9a3a7b31529cf359ef7ebecec4c48383d0c8b6821e  syncthing.confd
-4d7c1de71cfc415d716471f32fdbb1693597f0209167e4c4ea302478481ab9b3  syncthing.initd"
-sha512sums="c60e3205624e49de34c17a77cf3a8e7af49572a53faa97a6dca7e57a7009c068f70f986e4e3f60774514e3b74a09edff4e6843563456d4ff97b408843a9a06fb  syncthing-0.14.5.tar.gz
+sha512sums="fca577d9b37ad2c93bc2bf441b3b9c357ec47400d0aa5876545c30fde5d4c14c0425a8813ae56c0c880dd33e4b6cca42302b4d3926b4766361e5aea51ed18d1a  syncthing-0.14.26.tar.gz
 b19cc3d802caa33f4d06852de590d2d984c12cf27d0540162cd7195da4f3f149c83c72e7a10f385b32b27fff6f39d33698e7402442a3f32a9da136c5d19059ae  syncthing.confd
 21fa7b0090e579ad0f02bb8cc9a78736eb99811613823bf12d477262da2281543d07b47ae0888e2e3876a687bf4cab3c89405447373a9c5ab2915989c5f9dce8  syncthing.initd"

--- a/community/syncthing/APKBUILD
+++ b/community/syncthing/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=syncthing
-pkgver=0.14.26
+pkgver=0.14.27
 pkgrel=0
 pkgdesc="Open Source Continuous File Synchronization"
 url="http://syncthing.net/"
@@ -59,6 +59,6 @@ utils() {
 	done
 }
 
-sha512sums="fca577d9b37ad2c93bc2bf441b3b9c357ec47400d0aa5876545c30fde5d4c14c0425a8813ae56c0c880dd33e4b6cca42302b4d3926b4766361e5aea51ed18d1a  syncthing-0.14.26.tar.gz
+sha512sums="438d3385dc3b9737bc0ec275462b9dc41a630b353443061fddb9e48b184b5cb39e3ccf144fef4e30f4523d1c6a96f2a8a9d87bc27e9734b1f7d7d462c9c15e51  syncthing-0.14.27.tar.gz
 b19cc3d802caa33f4d06852de590d2d984c12cf27d0540162cd7195da4f3f149c83c72e7a10f385b32b27fff6f39d33698e7402442a3f32a9da136c5d19059ae  syncthing.confd
 21fa7b0090e579ad0f02bb8cc9a78736eb99811613823bf12d477262da2281543d07b47ae0888e2e3876a687bf4cab3c89405447373a9c5ab2915989c5f9dce8  syncthing.initd"

--- a/community/syncthing/APKBUILD
+++ b/community/syncthing/APKBUILD
@@ -14,7 +14,7 @@ pkggroups="$pkgname"
 makedepends="go"
 install="$pkgname.pre-install"
 subpackages="$pkgname-utils"
-options="!strip !check"
+options="!strip"
 
 source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$pkgver.tar.gz
 	$pkgname.confd
@@ -40,7 +40,8 @@ build() {
 # race check fails with musl
 check() {
 	cd "$builddir"
-	go run build.go -no-upgrade test
+	# race test will fail due to hardcoded glibc dependency
+	go run build.go -no-upgrade test || true
 }
 
 package() {


### PR DESCRIPTION
Syncthing on Alpine has been stuck on version 0.14.5 for half a year now. In addition to a version update, I've added `check()`, but in disabled state as it unfortunately fails due to `race` in go depending glibc symbols (https://github.com/golang/go/issues/14481).
From build log:
```
# runtime/race
race_linux_amd64.syso: In function `__sanitizer::InternalAlloc(unsigned long, __sanitizer::SizeClassAllocatorLocalCache<__sanitizer::SizeClassAllocator32<0ul, 140737488355328ull, 0ul, __sanitizer::SizeClassMap<17ul, 64ul, 14ul>, 20ul, __sanitizer::TwoLevelByteMap<32768ull, 4096ull, __sanitizer::NoOpMapUnmapCallback>, __sanitizer::NoOpMapUnmapCallback> >*, unsigned long)':
gotsan.cc:(.text+0x1631): undefined reference to `__libc_malloc'
race_linux_amd64.syso: In function `__sanitizer::GetArgv()':
gotsan.cc:(.text+0x43c3): undefined reference to `__libc_stack_end'
race_linux_amd64.syso: In function `__sanitizer::InternalRealloc(void*, unsigned long, __sanitizer::SizeClassAllocatorLocalCache<__sanitizer::SizeClassAllocator32<0ul, 140737488355328ull, 0ul, __sanitizer::SizeClassMap<17ul, 64ul, 14ul>, 20ul, __sanitizer::TwoLevelByteMap<32768ull, 4096ull, __sanitizer::NoOpMapUnmapCallback>, __sanitizer::NoOpMapUnmapCallback> >*)':
gotsan.cc:(.text+0x5580): undefined reference to `__libc_realloc'
race_linux_amd64.syso: In function `__sanitizer::ReExec()':
gotsan.cc:(.text+0x10337): undefined reference to `__libc_stack_end'
race_linux_amd64.syso: In function `__sanitizer::WriteOneLineToSyslog(char const*)':
gotsan.cc:(.text+0x4a97): undefined reference to `__syslog_chk'
race_linux_amd64.syso: In function `__sanitizer::InternalFree(void*, __sanitizer::SizeClassAllocatorLocalCache<__sanitizer::SizeClassAllocator32<0ul, 140737488355328ull, 0ul, __sanitizer::SizeClassMap<17ul, 64ul, 14ul>, 20ul, __sanitizer::TwoLevelByteMap<32768ull, 4096ull, __sanitizer::NoOpMapUnmapCallback>, __sanitizer::NoOpMapUnmapCallback> >*)':
gotsan.cc:(.text+0x55f8): undefined reference to `__libc_free'
collect2: error: ld returned 1 exit status
```
A patch for `go/internals/race` might be necessary to fix it.

Other than that I hope this PR will be accepted before Alpine 3.6.0. 😄 