### PR TITLE
community/firefox-esr: enable build on s390x

### DIFF
--- a/community/firefox-esr/APKBUILD
+++ b/community/firefox-esr/APKBUILD
@@ -104,6 +104,7 @@ build() {
 
 	# set rpath so linker finds the libs
 	export LDFLAGS="$LDFLAGS -Wl,-rpath,${_mozappdir}"
+	[ "$CARCH" = "s390x" ] && _s390x_flags="--disable-startupcache"
 
 	../configure \
 		--prefix=/usr \
@@ -141,7 +142,7 @@ build() {
 		--with-system-pixman \
 		--with-system-png \
 		--with-system-zlib \
-		|| return 1
+		$_s390x_flags
 	make || return 1
 
 	# paxmark outside fakeroot


### PR DESCRIPTION
('Error while running startup cache precompilation') at
resource://gre/modules/addons/XPIProviderUtils.js

Previously this error was mitigated by lowering optimization level to
-O1 on s390x but no more with new esr release.