### PR TITLE
main/alpine-base: add layouts for mail and web servers

### DIFF
--- a/main/alpine-base/APKBUILD
+++ b/main/alpine-base/APKBUILD
@@ -2,18 +2,21 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=alpine-base
 pkgver=3.5.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Meta package for minimal alpine base"
 url="http://alpinelinux.org"
 arch="noarch"
+pkgusers="mail"
+pkggroups="mail www-data"
 license="MIT"
+options="!check"
 depends="alpine-baselayout alpine-conf apk-tools busybox busybox-suid busybox-initscripts
 	openrc libc-utils alpine-keys"
 makedepends=""
-install=""
-subpackages=""
+install="$pkgname-mail.pre-install $pkgname-www.pre-install"
+subpackages="$pkgname-mail:_mail $pkgname-www:_www"
 replaces="alpine-baselayout"
-source=""
+source="$pkgname-mail.aliases"
 
 build() {
 	return 0
@@ -42,3 +45,17 @@ HOME_URL="http://alpinelinux.org"
 BUG_REPORT_URL="http://bugs.alpinelinux.org"
 EOF
 }
+
+_mail() {
+	depends=$pkgname
+	pkgdesc="Base layout for smtp servers"
+	install -Dm750 -g mail -d "$subpkgdir"/var/spool/mail || return 1
+	install -Dm644 "$srcdir"/$subpkgname.aliases "$subpkgdir"/etc/mail/aliases
+}
+
+_www() {
+	depends=$pkgname
+	pkgdesc="Base layout for http servers and webapps"
+	install -Dm755 -g www-data -d "$subpkgdir"/var/www/localhost/htdocs
+}
+sha512sums="a9a0cceee81ff80915484707ce206c13df50fc629a43c20187103716e12779f7e0c044a1aab0fe24f72b7eb9b47cd824de2258e1b5021f29535fa6b6c0f34b01  alpine-base-mail.aliases"

--- a/main/alpine-base/alpine-base-mail.aliases
+++ b/main/alpine-base/alpine-base-mail.aliases
@@ -1,0 +1,55 @@
+# Well-known aliases -- this should be filled in!
+# root: your-every-day-user
+
+# Basic system aliases -- these MUST be present
+MAILER-DAEMON: postmaster
+postmaster: root
+operator: root
+
+# General redirections for important pseudo accounts
+daemon:	root
+uucp: root
+
+# Redirections for pseudo accounts that should not receive mail
+bin: /dev/null
+adm: /dev/null
+lp: /dev/null
+sync: /dev/null
+shutdown: /dev/null
+halt: /dev/null
+mail: /dev/null
+news: /dev/null
+man: /dev/null
+cron: /dev/null
+ftp: /dev/null
+sshd: /dev/null
+at: /dev/null
+squid: /dev/null
+gdm: /dev/null
+xfs: /dev/null
+games: /dev/null
+named: /dev/null
+mysql: /dev/null
+postgres: /dev/null
+apache: /dev/null
+nut: /dev/null
+cyrus: /dev/null
+vpopmail: /dev/null
+ntp: /dev/null
+postfix: /dev/null
+smmsp: /dev/null
+distcc: /dev/null
+guest: /dev/null
+nobody: /dev/null
+
+# RFC 2142: NETWORK OPERATIONS MAILBOX NAMES
+abuse:		root
+# noc:		root
+security:	root
+
+# RFC 2142: SUPPORT MAILBOX NAMES FOR SPECIFIC INTERNET SERVICES
+# hostmaster:	root
+# usenet:	root
+# news:		usenet
+# webmaster:	root
+# ftp:		root

--- a/main/alpine-base/alpine-base-mail.pre-install
+++ b/main/alpine-base/alpine-base-mail.pre-install
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+addgroup -S -g 12 mail 2>/dev/null
+adduser -S -u 8 -D -H -h /var/spool/mail -s /sbin/nologin -G mail -g mail mail 2>/dev/null

--- a/main/alpine-base/alpine-base-www.pre-install
+++ b/main/alpine-base/alpine-base-www.pre-install
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+addgroup -S -g 82 www-data 2>/dev/null
+
+exit 0


### PR DESCRIPTION
I want to introduse a kind of common layout for mail and web servers.

Beacuse:
- every mail server uses 'aliases' file and /var/spool/mail as a default storage for local mail.
- every web server creates /var/www/localhost/htdocs directory and create www-data group. Many of webapps does the same.

I think it's a good idea to unify these things for all of them.