### PR TITLE
testing/grub: fix build on ppc64le

### DIFF
--- a/testing/grub/APKBUILD
+++ b/testing/grub/APKBUILD
@@ -11,30 +11,33 @@ license="GPLv3+"
 depends=""
 depends_dev=""
 makedepends="$depends_dev bison flex linux-headers xz-dev lvm2-dev
-	automake autoconf libtool python2"
+	automake autoconf libtool python2 freetype-dev"
 install=""
 # strip handled by grub Makefiles, abuild strip breaks xen pv-grub
 options="!strip"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-efi"
-if [ "$CARCH" == "x86_64" ]; then
-	subpackages="$subpackages $pkgname-xenhost"
-fi
+subpackages="$pkgname-dev $pkgname-doc"
+
+# currently grub only builds on x86*, aarch64 and ppc64le systems
+case "$CARCH" in
+x86)	 subpackages="$subpackages $pkgname-efi $pkgname-bios" ;;
+x86_64)  subpackages="$subpackages $pkgname-efi $pkgname-bios $pkgname-xenhost" ;;
+aarch64) subpackages="$subpackages $pkgname-efi" ;;
+ppc64le) subpackages="$subpackages $pkgname-ieee1275" ;;
+esac
+
 source="ftp://alpha.gnu.org/gnu/grub/grub-$_ver.tar.xz
 	2.02_beta3-gcc6-ld-no-pie.patch
 	fix-gcc-no-pie-specs.patch
 	grub2-accept-empty-module.patch
 	grub-xen-host_grub.cfg
 	2.02_beta3-mkconfig-alpine.patch
+	do-not-require-unifont-on-powerpc-ieee1275.patch
 	"
 builddir="$srcdir/grub-$_ver"
 
-# currently grub only builds on x86* and aarch64 systems
-# aarch64 is not supported on pc/bios platform.
-if [ ! "$CARCH" = aarch64 ]; then
-	subpackages="$subpackages $pkgname-bios"
-fi
 
 _build_bios() {
+	msg "Building grub for platform BIOS"
 	cd $builddir/bios
 	./configure \
 		--build=$CBUILD \
@@ -51,6 +54,7 @@ _build_bios() {
 }
 
 _build_efi() {
+	msg "Building grub for platform EFI"
 	cd $builddir/efi
 	./configure \
 		--build=$CBUILD \
@@ -68,23 +72,38 @@ _build_efi() {
 }
 
 _build_xen() {
-	#Xen is supported only x86_64
-	if [ "$CARCH" == "x86_64" ]; then
-		cd $builddir/xen
-		./configure \
-			--build=$CBUILD \
-			--host=$CHOST \
-			--prefix=/usr \
-			--sysconfdir=/etc \
-			--mandir=/usr/share/man \
-			--localstatedir=/var \
-			--disable-nls \
-			--disable-werror \
-			--with-platform=xen \
-				--target=$CARCH \
-		|| return 1
-		make || return 1
-	fi
+	msg "Building grub for platform XEN"
+	cd $builddir/xen
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var \
+		--disable-nls \
+		--disable-werror \
+		--with-platform=xen \
+		--target=$CARCH \
+	|| return 1
+	make || return 1
+}
+
+_build_ieee1275() {
+	msg "Building grub for platform IEEE1275"
+	cd $builddir/ieee1275
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var \
+		--disable-nls \
+		--disable-werror \
+		--with-platform=ieee1275 \
+	|| return 1
+	make || return 1
 }
 
 build() {
@@ -98,38 +117,35 @@ build() {
 	mkdir "$builddir"
 	cp -r "$tmpdir" "$builddir"/bios
 	cp -r "$tmpdir" "$builddir"/efi
-	mv    "$tmpdir" "$builddir"/xen
+	cp -r "$tmpdir" "$builddir"/xen
+	mv    "$tmpdir" "$builddir"/ieee1275
 
-	# BIOS build
-	if [ ! "$CARCH" = aarch64 ]; then
-		msg "Building grub for platform BIOS"
+	case "$CARCH" in
+	x86)
 		_build_bios || return 1
-	fi
-	
-	# EFI build
-	msg "Building grub for platform EFI"
-	_build_efi || return 1
-
-	# xenhost build
-	msg "Building grub for platform XEN"
-	_build_xen || return 1
+		_build_efi  || return 1 ;;
+	x86_64)
+		_build_bios || return 1
+		_build_efi  || return 1
+		_build_xen  || return 1	;;
+	aarch64)
+		_build_efi || return 1 ;;
+	ppc64le)
+		_build_ieee1275 || return 1 ;;
+	esac
 }
 
-package() {
-	# install BIOS & EFI version into the same directory
-	# and overwrite similar files.
-	
-	# BIOS install
-	if [ ! "$CARCH" = aarch64 ]; then
-		cd "$builddir"/bios
-		make DESTDIR="$pkgdir" install-strip || return 1
-	fi
+_install_bios() {
+	cd "$builddir"/bios
+	make DESTDIR="$pkgdir" install-strip || return 1
+}
 
-	# EFI install
+_install_efi() {
 	cd "$builddir"/efi
 	make DESTDIR="$pkgdir" install-strip || return 1
+}
 
-	# xenhost install
+_install_xen() {
 	cd "$builddir"/xen
 
 	grub_dir=`mktemp -d`
@@ -153,6 +169,30 @@ package() {
 	rm -r "$grub_dir"
 	rm "$cfg"
 	rm "$grub_memdisk"
+}
+
+_install_ieee1275() {
+	cd "$builddir"/ieee1275
+	make DESTDIR="$pkgdir" install-strip || return 1
+}
+
+package() {
+	# install BIOS & EFI version into the same directory
+	# and overwrite similar files.
+
+	case "$CARCH" in
+	x86)
+		_install_bios
+		_install_efi ;;
+	x86_64)
+		_install_bios
+		_install_efi
+		_install_xen ;;
+	aarch64)
+		_install_efi ;;
+	ppc64le)
+		_install_ieee1275 ;;
+	esac
 
 	rm -f "$pkgdir"/usr/lib/charset.alias
 }
@@ -177,9 +217,17 @@ xenhost() {
 	mv $pkgdir/*-xen.bin $subpkgdir/usr/lib/grub-xen/
 }
 
+ieee1275() {
+	pkgdesc="$pkgdesc (IEEE1275 version)"
+	depends="$pkgname"
+	mkdir -p $subpkgdir/usr/lib/grub
+	mv $pkgdir/usr/lib/grub/*-ieee1275 $subpkgdir/usr/lib/grub/
+}
+
 sha512sums="4a530efef4dae45f4046cf3550563f14acb24d25cb88d5e06c93953ca5b1eec115118c6860233a9f627edcddae2571e5d6b867b70ff9dd5c184c9fef83ef7e11  grub-2.02~beta3.tar.xz
 fc15c95bf26b28eee3b5a0d8e5fac538445179cea19a8657cd360e37dd5a95010ea2b899d1e4f3692b778a71f79526539ad1c741f028186f0daf135ee1678da0  2.02_beta3-gcc6-ld-no-pie.patch
 b9eab870006ab7842e0af27171d3b66fea10835d3fd4e606f241a9898aa28bfc4c1cdf59cece8ad50d2e284a44cba74eb0f390ac29627518f86257a8d586976e  fix-gcc-no-pie-specs.patch
 098a1742aef131c85d63b934a9815879b991f2e73030cb90ac4b5dcd07d249fa0dd0a281e52ada0e10f05d59223493bd416eb47543242bf0ba336a0ebc9b2a1a  grub2-accept-empty-module.patch
 4e7394e0fff6772c89683039ccf81099ebbfe4f498e6df408977a1488fd59389b6e19afdbf0860ec271e2b2aea0df7216243dcc8235d1ca3af0e7f4d0a9d60a4  grub-xen-host_grub.cfg
-5de7c1cc11640a3892447f0daa1e3fd1f67b0c474c8aec555e4e6315b5e6c00491ba02c88b420cec221da0640c6961d639f148746df14a0b2c15bda7989cd25c  2.02_beta3-mkconfig-alpine.patch"
+5de7c1cc11640a3892447f0daa1e3fd1f67b0c474c8aec555e4e6315b5e6c00491ba02c88b420cec221da0640c6961d639f148746df14a0b2c15bda7989cd25c  2.02_beta3-mkconfig-alpine.patch
+dde35771d15d85b1fde29454c24772f65acf4d7c1786e8bc05e159f7e9ef3437a5b6fa04e0d87342cdb90d4521fd88888a7853bb88bb0d659df5fb297e27c8a7  do-not-require-unifont-on-powerpc-ieee1275.patch"

--- a/testing/grub/do-not-require-unifont-on-powerpc-ieee1275.patch
+++ b/testing/grub/do-not-require-unifont-on-powerpc-ieee1275.patch
@@ -1,0 +1,23 @@
+Remove the unifont dependency from build time with powerpc-ieee1275
+
+This patch is applied in grub project. For more information:
+commit: 0af7539bd297fb03da8166ba0c0c143cd2143fd2
+author: Aaro Koskinen
+====
+--- a/configure.ac
++++ b/configure.ac
+@@ -1633,11 +1633,11 @@
+   FONT_SOURCE=
+ fi
+ 
+-if test "x$FONT_SOURCE" = x && ( test "x$platform" = xqemu || test "x$platform" = xloongson || test "x$platform" = xqemu_mips || test "x$target_cpu"-"$platform" = xpowerpc-ieee1275 || test "x$platform" = xcoreboot ); then
++if test "x$FONT_SOURCE" = x && ( test "x$platform" = xqemu || test "x$platform" = xloongson || test "x$platform" = xqemu_mips || test "x$platform" = xcoreboot ); then
+   if test x"$grub_build_mkfont_excuse" = x ; then
+-    AC_MSG_ERROR([qemu, powerpc-ieee1275, coreboot and loongson ports need unifont])
++    AC_MSG_ERROR([qemu, coreboot and loongson ports need unifont])
+   else
+-    AC_MSG_ERROR([qemu, powerpc-ieee1275, coreboot and loongson ports need unifont ($grub_build_mkfont_excuse)])
++    AC_MSG_ERROR([qemu, coreboot and loongson ports need unifont ($grub_build_mkfont_excuse)])
+   fi
+ fi
+ 


### PR DESCRIPTION
grub was not building on ppc64le. This patch adds the correct 'platform'
value in configure and make necessary adjusts to make grub build.