### PR TITLE
testing/nginx-naxsi: update to 1.13.8

### DIFF
--- a/testing/nginx-naxsi/APKBUILD
+++ b/testing/nginx-naxsi/APKBUILD
@@ -5,8 +5,8 @@
 
 pkgname=nginx-naxsi
 _pkgname=nginx
-pkgver=1.11.10
-pkgrel=2
+pkgver=1.13.8
+pkgrel=0
 pkgdesc="Lightweight HTTP and reverse proxy server with Naxsi WAF support, see also 'nxapi'"
 url="http://www.nginx.org | https://github.com/nbs-system/naxsi"
 arch="all"
@@ -22,7 +22,7 @@ _ngx_cache_purge_ver=2.3.0.1
 _ngx_cache_purge_dir="$srcdir/$_ngx_cache_purge_name-$_ngx_cache_purge_ver"
 
 _ngx_upstream_fair_name=nginx-upstream-fair
-_ngx_upstream_fair_ver=0.1.1
+_ngx_upstream_fair_ver=0.1.2
 _ngx_upstream_fair_dir="$srcdir/$_ngx_upstream_fair_name-$_ngx_upstream_fair_ver"
 
 _ngx_http_sysguard_name=tengine-http-sysguard
@@ -53,6 +53,7 @@ source="http://nginx.org/download/$_pkgname-$pkgver.tar.gz
 	nginx.logrotate
 	nginx.conf
 	default.conf
+	sysguard.conf
 	"
 builddir="$srcdir"/$_pkgname-$pkgver
 
@@ -157,6 +158,9 @@ package() {
 	rm -rf ./run ./etc/$_pkgname/*.default
 	# scgi & uwsgi servers are disabled
 	rm ./etc/$_pkgname/scgi_params ./etc/$_pkgname/uwsgi_params
+
+	# add module configuration
+	_mod_conf sysguard.conf nginx-naxsi-mod-http-sysguard
 }
 
 _module() {
@@ -176,15 +180,20 @@ _module() {
 	echo "load_module \"modules/$soname\";" > ./etc/nginx/modules/$name.conf
 }
 
-sha512sums="b6437d8305547a834a0f3ad076ac591b90189eb922f48759094efaa9618e39fc249600ab13650113fe841fc9af0b736acc61a9b9baba7bacd35224c34df1bbc9  nginx-1.11.10.tar.gz
+_mod_conf() {
+	local conf=$1 module=$2
+	install -Dm644 "$srcdir"/$conf ${pkgdir%/*}/$module/etc/nginx/conf.d/$conf
+}
+sha512sums="f2a4d41941ec223afcb57a6deb6523e0d4f54f96c7362835d366fa04a4b4578f6c4f27aa7774c1ecd40a42087df83e5c03d024e72caba83c558ec7e580c756a1  nginx-1.13.8.tar.gz
 9e8f41a5cd1342cc9b8aa334a603842d14a256aab1f4a21205bb1278aecbb0c49e39c889d8113a5b41aad2efeaa2ed9f11cba6929173f50add91f54c4c59c8a0  naxsi-0.55.3.tar.gz
 c49c81dbdb8bd507fccf31295e603cea8f0a964867c27eff0436dcea3b4a547c8ae2f11ecf49c4d82c693cf8138c17ebbed395738539d0d61254951e5f0db7e3  ngx_cache_purge-2.3.0.1.tar.gz
-fd305b859c868ef55171b05f64071a2836c12073bcd89d6197af4946a3d1177f77c6708d4d589d460c84967273dee87ca9de97ab0f0d47e6d65f86b465d70316  upstream-fair-0.1.1.tar.gz
+4da7734301d21cd696fcc3aed1a496a93be15af373307487622c0a5920e79d9b580fd5836de7f9c0b60c01485021ba85afae1abb471e703c2d6e23c60ffe7d0a  upstream-fair-0.1.2.tar.gz
 2743d9aea60bd4984b650213e571cf27e6ff5b3db708242ccb53b8fc669d1cc82ee224ba79aee2f6969b6e13821cfdd3df7b412541e1fdbb867ecc95326e07e1  sysguard-2.2.0.tar.gz
 1117ca5887822e002d9995c041435fda53890614fd7309ea011a59bfb0df3261fc7ba8670e93aaee9116cda16b9806921a85f52c9959b093f2e5ac5df4d9b0fb  anonymise.patch
 cae9f842c3d1188730d4355440476ad2338b19c027c4b329efe88d4487e90d96bf60dea6feb4be6a6f96d4b356fc154345e32c2bb643d70f68e428df26330a49  ipv6.patch
 2dca2ac74fb92e330fde7b6b6120b2fd2565c377a629c9536cf77beebe41aa4b092d4229d5b487b0fb02be4f2cc5b897c429c87bbbbc7b0d31e1cbb94231ddce  sysguard.patch
-e0784764d509589a9626e20bd800787583573314293caf0ebc135bbfc50346f86847d4a93b91cb01d7b8f6e1b00285569ae8088e35ed9bc3ae8278cad3ba320e  nginx.initd
+72888c43cec3203cafe1c5e018be464129a220913c21e0abe5ca57ad0649b7120d419ede9b37181def3daad7f08b1c1afdacb33a20aa148ce1d1b9ce3b5b2a33  nginx.initd
 01b77cff16f6e8bfd7fa1d4d20f625bbcddd08f0509173452d060c342c93dc315a7b0560f4734323a5d29ea294de0491f2e3f32e5337574e1a28ebc005eceea8  nginx.logrotate
 a1a1d9dbd65955b458d17918138fc65bf8990c46909ef43940b1633458c8f119eb485939179b6a9a3dac0c3b58c1eb0c5aec44e7b25ea7a34969c4a0807d4788  nginx.conf
-9bd5145762a5040a6b5494d31f216d1db7c52921142275f26eed67aff746270526caad8e34eae65ec6390975ce603b35f6add05eb857f1670bf28ab5049b97d8  default.conf"
+ed1257ca2c0f687e24ebfd5446c472a592a9f7abea022bd04b3dd519631cc235f448027aabf699a89cb7aa4d5761031d44dffcd33d02fd17db0c93da0d5e8689  default.conf
+8067c78b00e9fd89141b7a70fdc39ab1095a89c97abc8c9a37df26bef40785715dabdae19bce596ec3c3baff00f9022e2f24c7f5d884590857773e87aae75734  sysguard.conf"

--- a/testing/nginx-naxsi/default.conf
+++ b/testing/nginx-naxsi/default.conf
@@ -5,6 +5,8 @@ server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
 
+	server_tokens off;
+
 	# Everything is a 404
 	location / {
 		return 404;

--- a/testing/nginx-naxsi/nginx.initd
+++ b/testing/nginx-naxsi/nginx.initd
@@ -24,13 +24,13 @@ start_pre() {
 }
 
 reload() {
-	ebegin "Reloading ${SVCNAME} configuration"
+	ebegin "Reloading ${RC_SVCNAME} configuration"
 	start_pre && $command -s reload
 	eend $?
 }
 
 reopen() {
-	ebegin "Reopening ${SVCNAME} log files"
+	ebegin "Reopening ${RC_SVCNAME} log files"
 	$command -s reopen
 	eend $?
 }
@@ -45,4 +45,3 @@ restart() {
 	sleep 0.05
 	start
 }
-

--- a/testing/nginx-naxsi/sysguard.conf
+++ b/testing/nginx-naxsi/sysguard.conf
@@ -1,0 +1,25 @@
+# http://tengine.taobao.org/document/http_sysguard
+
+sysguard on;
+
+sysguard_load load=10.5 action=/loadlimit;
+sysguard_mem swapratio=20% action=/swaplimit;
+sysguard_mem free=20M action=/freelimit;
+sysguard_rt  rt=2.5 period=5s action=/rtlimit;
+    
+location /loadlimit {
+	return 503;
+}
+    
+location /swaplimit {
+	return 503;
+}
+    
+location /freelimit {
+	return 503;
+}
+    
+location /rtlimit {
+	return 503;
+}
+


### PR DESCRIPTION
* add `sysguard.conf` to the sysguard module
* fixes `${SVCNAME}` => `${RC_SVCNAME}` in `initd`
* add `server_tokens off;` to `default.conf`

https://nginx.org/en/CHANGES