### PR TITLE
scripts: add support for ppc64le in vanilla configuration

### DIFF
--- a/scripts/mkimg.standard.sh
+++ b/scripts/mkimg.standard.sh
@@ -10,6 +10,7 @@ profile_standard() {
 profile_vanilla() {
 	profile_standard
 	#arch="$arch aarch64"
+	arch="$arch ppc64le"
 	kernel_flavors="vanilla"
 	kernel_addons=
 }


### PR DESCRIPTION
To boot ppc64le we need to use grub with ieee1275 platform. Said that,
a new section to support grub ieee1275 was created.
Also needed to change xorrisofs command by grub-mkrescue, that is the one
used to create a bootable image for power and it is also a wrapper to xorriso.