### PR TITLE
community/phpmyadmin: Upgrade to 4.7.0

### DIFF
--- a/community/phpmyadmin/APKBUILD
+++ b/community/phpmyadmin/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Matt Smith <mcs@darkregion.net>
 _php=php5
 pkgname=phpmyadmin
-pkgver=4.6.6
+pkgver=4.7.0
 pkgrel=0
 pkgdesc="A Web-based PHP tool for administering MySQL"
 url="http://www.phpmyadmin.net/"
@@ -98,9 +98,5 @@ doc() {
 	done
 }
 
-md5sums="474af1974cadf7f0300d80a63acc14d2  phpMyAdmin-4.6.6-all-languages.tar.xz
-2d144825122042b4a2536ad789d66e8e  phpmyadmin.apache2.conf"
-sha256sums="b7b9e0f88ca740fcba249e7e3e7d51d1923b038b7742cde72de193a2b0a2654f  phpMyAdmin-4.6.6-all-languages.tar.xz
-4fbc1d0338ed7234a3d74f71910a24e467c8a0ec1dad31324e954741f93bd2d3  phpmyadmin.apache2.conf"
-sha512sums="7bd18b83f205604dc653ef2daffb22d0bf99a4e2a7960958fb1687daf2a800a76e34477748c6239394e99ab060e789971b73cf8e66adb3182f1b17002345c054  phpMyAdmin-4.6.6-all-languages.tar.xz
+sha512sums="03f3b56d3fed846e8e27e38a1bf32175b267a3cc2784ee499b64a48b6a37f0352302a9c150e1db1c99f633aabd8a373a834ad7ab2b694146b0ac13dd05bd27e3  phpMyAdmin-4.7.0-all-languages.tar.xz
 c6af2960b95924c31cc05d90e7282ba9be6cb6eabb134b8bb627230a4253c017eca75132420a356acd6aecdce146e29666ed90fc90749820060a64478d3e2105  phpmyadmin.apache2.conf"


### PR DESCRIPTION
Release notes https://www.phpmyadmin.net/news/2017/3/29/phpmyadmin-470-released/