### PR TITLE
testing/fontforge: new Aport

### DIFF
--- a/testing/fontforge/APKBUILD
+++ b/testing/fontforge/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Roberto Oliveira <robertoguimaraes8@gmail.com>
+# Maintainer: Roberto Oliveira <robertoguimaraes8@gmail.com>
+pkgname=fontforge
+pkgver=20161012
+pkgrel=0
+pkgdesc="FontForge is a free (libre) font editor for Windows, Mac OS X and GNU+Linux"
+url="http://fontforge.org"
+arch="ppc64le"
+license="GPL"
+depends="desktop-file-utils giflib gtk-update-icon-cache hicolor-icon-theme libtool libxi libxkbui libxml2 pango python3 zeromq"
+makedepends=""
+install=""
+subpackages="$pkgname-dev $pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+prepare() {
+	cd "$builddir"
+	default_prepare
+	./bootstrap
+}
+
+build() {
+	cd "$builddir"
+	./configure --prefix=/usr
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="7ce8b7b6350ffbf03ddfdbc81f12798ea7c02e326fa163b1b1a06ff1f97ce508c725d1c0084f2a0befebbf8edda75ea0151a37b7d51e4578858a0df854a3090d  fontforge-20161012.tar.gz"
+


### PR DESCRIPTION
Adding fontforge package, that will be required for grub2 works
correctly.

Adding this package only for for ppc64le at this moment.