### PR TITLE
testing/console-setup: new Aport

### DIFF
--- a/testing/console-setup/APKBUILD
+++ b/testing/console-setup/APKBUILD
@@ -1,0 +1,27 @@
+# Contributor: Roberto Oliveira <robertoguimaraes8@gmail.com>
+# Maintainer: Roberto Oliveira <robertoguimaraes8@gmail.com>
+pkgname=console-setup
+pkgver=1.164
+pkgrel=0
+pkgdesc="Tools for configuring the console using X Window System key maps"
+url="https://packages.debian.org/cs/sid/console-setup"
+arch="ppc64le"
+license="GPL"
+depends="perl"
+makedepends=""
+install=""
+subpackages="$pkgname-doc"
+source="http://http.debian.net/debian/pool/main/c/$pkgname/${pkgname}_${pkgver}.tar.xz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	make build-linux
+}
+
+package() {
+	cd "$builddir"
+	make prefix="$pkgdir"/usr/ install-linux
+}
+
+sha512sums="89f69d97014ff3023ff28020bc214be8746bad8e1d59369d3fc5333e357dc3f2c486336507f5480a5ad22a4ad8c541b895782b60151f78ad43aa0732f2cee8c5  console-setup_1.164.tar.xz"


### PR DESCRIPTION
Adding console-setup package, that will be required for grub2 works
correctly.

Adding this package only for for ppc64le at this moment.