### PR TITLE
Upgrade Hugo to 0.20.6

### DIFF
--- a/community/hugo/APKBUILD
+++ b/community/hugo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Thomas Boerger <thomas@webhippie.de>
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=hugo
-pkgver=0.19
+pkgver=0.20.6
 pkgrel=0
 pkgdesc="A Fast and Flexible Static Site Generator built with love in GoLang"
 url="http://gohugo.io/"
@@ -30,6 +30,6 @@ package() {
 	install -Dm755 "$builddir"/bin/$pkgname "$pkgdir"/usr/bin/$pkgname
 }
 
-md5sums="91844bf1b192941210d39f4aa8d47f0e  hugo-0.19.tar.gz"
-sha256sums="f2d1926b226b4a5d64c4880538eb1bb47c84dd886152660d72c69269f7c5cf6f  hugo-0.19.tar.gz"
-sha512sums="c1d5e206bc011e8ceb2fb4b515a02b56b2b619d768dd3b38456f50849651b0f16077ccf30a3a61e6b934b8a92bd71d45e24e1cc9d65b5d362f7c2f11e75c8a12  hugo-0.19.tar.gz"
+md5sums="4cea34e4683a5700a6c6b09dc089cb08  hugo-0.20.6.tar.gz"
+sha256sums="7edc370bd14f146af8079ecf785b38b9570f1d3d6f47b3312971abcb3c232bee  hugo-0.20.6.tar.gz"
+sha512sums="81515e92a10a2cce65ccd24dd4b70a5119af2e768fe86e3d0f5d4e60ec9247c64a729490136c83fd25cda5913c601d3e93b6366c632ca82f3fac2eb622ab7a9f  hugo-0.20.6.tar.gz"

--- a/community/hugo/APKBUILD
+++ b/community/hugo/APKBUILD
@@ -30,6 +30,6 @@ package() {
 	install -Dm755 "$builddir"/bin/$pkgname "$pkgdir"/usr/bin/$pkgname
 }
 
-md5sums="4cea34e4683a5700a6c6b09dc089cb08  hugo-0.20.6.tar.gz"
-sha256sums="7edc370bd14f146af8079ecf785b38b9570f1d3d6f47b3312971abcb3c232bee  hugo-0.20.6.tar.gz"
-sha512sums="81515e92a10a2cce65ccd24dd4b70a5119af2e768fe86e3d0f5d4e60ec9247c64a729490136c83fd25cda5913c601d3e93b6366c632ca82f3fac2eb622ab7a9f  hugo-0.20.6.tar.gz"
+md5sums="b8ae2dfd50f90edef6749226c3bf55bc  hugo-0.20.6.tar.gz"
+sha256sums="692e08b009430d27064821d498f1454152cbfd5f26d019c29002e6fbff8fc387  hugo-0.20.6.tar.gz"
+sha512sums="ffed313351b05be3b665121a27febe2b336d05e2ba6c43176a7e07a0e796736ec384ba6b6caf679faa2469e59ec7021303f1db034008abe08bd5444132ce6b01  hugo-0.20.6.tar.gz"


### PR DESCRIPTION
This PR updates Hugo package to latest `0.20.6` version.