### PR TITLE
Upgrade Hugo package to 0.20.6

### DIFF
--- a/community/hugo/APKBUILD
+++ b/community/hugo/APKBUILD
@@ -1,11 +1,11 @@
 # Contributor: Thomas Boerger <thomas@webhippie.de>
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=hugo
-pkgver=0.18
+pkgver=0.20.6
 pkgrel=0
 pkgdesc="A Fast and Flexible Static Site Generator built with love in GoLang"
 url="http://gohugo.io/"
-arch="all"
+arch="all !ppc64le"
 license="Apache 2.0"
 depends=""
 makedepends="go govendor"
@@ -30,6 +30,6 @@ package() {
 	install -Dm755 "$builddir"/bin/$pkgname "$pkgdir"/usr/bin/$pkgname
 }
 
-md5sums="f8b829b348ab7ea85c467631c6552fb0  hugo-0.18.tar.gz"
-sha256sums="9d432f53018d642526a44f9182b6584a4be83810dcd6ebc13e7a44c015ae35a0  hugo-0.18.tar.gz"
-sha512sums="b55a9e75a9d71fab2882d1eb923861dad0f504b219bcd9c6d5dd8a81fdb7509355cbb2ce692a488dc8b7439166772cd40563742234182e5e66c320906145583f  hugo-0.18.tar.gz"
+md5sums="b8ae2dfd50f90edef6749226c3bf55bc  hugo-0.20.6.tar.gz"
+sha256sums="692e08b009430d27064821d498f1454152cbfd5f26d019c29002e6fbff8fc387  hugo-0.20.6.tar.gz"
+sha512sums="ffed313351b05be3b665121a27febe2b336d05e2ba6c43176a7e07a0e796736ec384ba6b6caf679faa2469e59ec7021303f1db034008abe08bd5444132ce6b01


### PR DESCRIPTION
This PR upgrades Hugo package to `0.20.6` version for 3.5 branch.