### PR TITLE
community/php7-xdebug: rebuild for php 7.1

### DIFF
--- a/community/php7-xdebug/APKBUILD
+++ b/community/php7-xdebug/APKBUILD
@@ -5,7 +5,7 @@
 pkgname=php7-xdebug
 _pkgname=xdebug
 pkgver=2.5.3
-pkgrel=0
+pkgrel=1
 _phpver=${pkgname#php}
 _phpver=${_phpver%%-*}
 pkgdesc="PHP$_phpver extension that provides functions for function traces and profiling"


### PR DESCRIPTION
php7 got upgrade to 7.1 so release 0 should stay for 7.0 but 1 for 7.1