### PR TITLE
testing/mailutils: new aport

### DIFF
--- a/testing/gpg-remailer/APKBUILD
+++ b/testing/gpg-remailer/APKBUILD
@@ -2,11 +2,12 @@
 # Maintainer: Shiz <hi@shiz.me>
 pkgname=gpg-remailer
 pkgver=3.02.01
-pkgrel=0
+pkgrel=1
 pkgdesc="Decrypt GPG messages and re-encrypt them to a well-defined group"
 url="https://fbb-git.github.io/gpg-remailer/"
 arch="all"
 license="GPL3+"
+depends="gnupg mailutils"
 makedepends="icmake bash yodl bobcat-dev"
 subpackages="$pkgname-doc"
 source="gpg-remailer-$pkgver.tar.gz::https://github.com/fbb-git/gpg-remailer/archive/$pkgver.tar.gz

--- a/testing/mailutils/APKBUILD
+++ b/testing/mailutils/APKBUILD
@@ -1,0 +1,75 @@
+# Contributor: Shiz <hi@shiz.me>
+# Maintainer: Shiz <hi@shiz.me>
+pkgname=mailutils
+pkgver=3.2
+pkgrel=0
+pkgdesc="GNU swiss army knife of electronic mail handling"
+url="https://mailutils.org/"
+arch="all"
+license="GPL3+"
+provides="mailx=$pkgver-r$pkgrel"
+replace="mailx"
+depends_dev="$pkgname-libs=$pkgver-r$pkgrel"
+makedepends="readline-dev libtool"
+checkdepends="autoconf"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-libs $pkgname-servers $pkgname-mh"
+source="https://ftp.gnu.org/gnu/mailutils/mailutils-$pkgver.tar.gz
+	disable-koi8-r-test.patch"
+builddir="$srcdir/mailutils-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr
+	make
+}
+
+check() {
+	cd "$builddir"
+	# exclude imap4d tests as they require chdir("/root") which won't work
+	sed -i 's/$(IMAP4D_DIR)/# $(IMAP4D_DIR)/g' Makefile
+	make check
+}
+
+package() {
+	cd "$builddir"
+	# re-enable imap4d subdirectory for install
+	sed -i 's/# $(IMAP4D_DIR)/$(IMAP4D_DIR)/g' Makefile
+	make DESTDIR="$pkgdir" install
+
+	cd "$pkgdir"
+	rm usr/lib/charset.alias
+	# no need for these to be suid/sgid root.
+	chmod u-s usr/sbin/maidag
+	chmod g-s usr/bin/dotlock
+}
+
+servers() {
+	pkgdesc="$pkgdesc (servers)"
+	mkdir -p "$subpkgdir"/usr/sbin
+
+	local server; for server in pop3d imap4d comsatd; do
+		mv "$pkgdir"/usr/sbin/$server "$subpkgdir"/usr/sbin
+	done
+}
+
+libs() {
+	pkgdesc="$pkgdesc (libraries)"
+	mkdir -p "$subpkgdir"/usr
+
+	mv "$pkgdir"/usr/lib "$subpkgdir"/usr
+}
+
+mh() {
+	pkgdesc="$pkgdesc (MH compatibility)"
+	mkdir -p "$subpkgdir"/usr/bin "$subpkgdir"/usr/share/$pkgname
+
+	mv "$pkgdir"/usr/bin/mu-mh "$subpkgdir"/usr/bin
+	mv "$pkgdir"/usr/share/$pkgname/mh "$subpkgdir"/usr/share/$pkgname
+	rmdir -p "$pkgdir"/usr/share/$pkgname || true
+}
+
+sha512sums="5528799ba1bf7b8eaf3c0e2fe436aeb0be03ccb85788eff7ab6f860da9a03d00f86a4ebcf6839c0a164c6c6d1a0cfe38ec8c848db45376d958325dadba13549e  mailutils-3.2.tar.gz
+d0d78bba10d3ce039bb00657a570fb9411fabf448548994860285701939ae52afd15c007daa85bb18662a67153dda86069afe240b430fbe1b28a45755108f477  disable-koi8-r-test.patch"

--- a/testing/mailutils/disable-koi8-r-test.patch
+++ b/testing/mailutils/disable-koi8-r-test.patch
@@ -1,0 +1,16 @@
+musl does not support this charset.
+--- a/libmailutils/tests/decode2047.at
++++ b/libmailutils/tests/decode2047.at
+@@ -49,12 +49,6 @@
+ [If you can read this yo ... u understand the example.
+ ])
+ 
+-# Malformed input string: lacks trailing =. MU 0.6.90 hanged on it.
+-TESTDEC2047([malformed input],[decode05],
+-[=?koi8-r?B?RndkOiDSxcfJ09TSwcPJ0SDEz83FzsE?=],
+-[Fwd: \322\305\307\311\323\324\322\301\303\311\321 \304\317\315\305
+-])
+-
+ m4_popdef([TESTDEC2047])
+ 
+ 


### PR DESCRIPTION
Also add the new aport as a requirement for `gpg-remailer`.