### PR TITLE
main/libnl: clean up APKBUILD and add tests

### DIFF
--- a/main/libnl/APKBUILD
+++ b/main/libnl/APKBUILD
@@ -3,56 +3,38 @@ pkgname=libnl
 pkgver=1.1.4
 pkgrel=0
 pkgdesc="Library for applications dealing with netlink sockets"
-url="http://people.suug.ch/~tgr/libnl"
+url="https://www.infradead.org/~tgr/libnl/"
 arch="all"
-license="GPL"
-depends=
+license="LGPL2.1"
 makedepends="linux-headers"
 subpackages="$pkgname-dev"
-source="http://www.carisma.slowglass.com/~tgr/libnl/files/$pkgname-$pkgver.tar.gz
+source="https://www.infradead.org/~tgr/libnl/files/$pkgname-$pkgver.tar.gz
 	libnl-1.1-flags.patch
 	libnl-1.1-vlan-header.patch
 	fix-strerror_r.patch
-	fix-includes.patch
-	"
+	fix-includes.patch"
+builddir="$srcdir"/$pkgname-$pkgver
 
-_builddir="$srcdir"/libnl-$pkgver
-
-prepare () { 
-	cd "$_builddir"
-	for i in "$srcdir"/*.patch; do
-		[ -r "$i" ] || continue
-		msg "Applying $i"
-		patch -s -p1 -i $i || return 1
-	done
-}
-
-build () { 
-	cd "$_builddir"
+build() {
+	cd "$builddir"
 	export CFLAGS="$CFLAGS -D_GNU_SOURCE"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
+}
+
+check() {
+	cd "$builddir"/tests
+	LD_LIBRARY_PATH=$(pwd)/../lib ./test-genl
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 
-md5sums="580cb878be536804daca87fb75ae46cc  libnl-1.1.4.tar.gz
-9c9072ac8b74135798e0ebcf2d90290d  libnl-1.1-flags.patch
-d757127e7af3bd3c82cdb51b1b09d2e0  libnl-1.1-vlan-header.patch
-08714767527cb9579c0b918f3433eb4d  fix-strerror_r.patch
-eebc5ce0956034b3526de410a814442b  fix-includes.patch"
-sha256sums="4f80c21fe5bbcdde6e72b59b4f98306063a41421f909887c34e58d93e746d063  libnl-1.1.4.tar.gz
-1b89c83789c695c7622318496c6cb6de338c76a61844c2bbaa200a5a1d6a8c9b  libnl-1.1-flags.patch
-c9c7d8bf94ab06884f91ecd98977433be952530555aff37befc335f1f6312619  libnl-1.1-vlan-header.patch
-93d5dbb813cf5f6424c6110a05bc39bf2e9a942b2eecc150d3e5e0cbf13066b8  fix-strerror_r.patch
-1429f078e58372a7bfbd94e02f8be13d302731013673d14fbeb5f685125e9a92  fix-includes.patch"
 sha512sums="25e26ddcc16540346ea34815ab6ac094177e5cee2eb3d843c4f8b30cd9d83390a3e87cb46046dc3bd9ae4d21f77e57bb3827c2cfc588eb18afe049921f2030b4  libnl-1.1.4.tar.gz
 7ef2b3a7fb79227644c897a8cd59d6fc1e94a37211ea59684fe11ec4e34fe95cdc8c3df72134128326c2db10cbada9641290994253a4a80875971d95a73a74c0  libnl-1.1-flags.patch
 ea45d780b16e6045735aaf2e3febf19ddccab4ca0e03710aebfe51655adc50177aefa3bd4d06e0ccce0160f4c6db73cfa4eb7cebe53b3e15c1807c3b00dc1c9c  libnl-1.1-vlan-header.patch


### PR DESCRIPTION
Considering its lack of usage by anything in main, it may warrant a move to community.
I didn't bump `$pkgrel` because nothing changes in the resulting package.