### PR TITLE
[3.5-stable] main/git: upgrade to 2.11.2

### DIFF
--- a/main/git/APKBUILD
+++ b/main/git/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=git
-pkgver=2.11.1
+pkgver=2.11.2
 pkgrel=0
 pkgdesc="A distributed version control system"
 url="https://www.git-scm.com/"
@@ -215,15 +215,15 @@ _git_perl() {
 }
 
 
-md5sums="2970ae6cd234b2fca4f2d14ba4226f35  git-2.11.1.tar.xz
+md5sums="f865d2e48e8619d20a93e7dcdc3b824a  git-2.11.2.tar.xz
 0549894076c2081d886fa5ee44c20e23  bb-tar.patch
 8bb51e7742a171891a51967b84c8088e  git-daemon.initd
 33427921f86acc26d1578d8b308e5baa  git-daemon.confd"
-sha256sums="c0a779cae325d48a1d5ba08b6ee1febcc31d0657a6da01fd1dec1c6e10976415  git-2.11.1.tar.xz
+sha256sums="0bc9b669229ef32ca8af2bdaf0e42247a1f1b7842f34a4bf54c2208c2da1d228  git-2.11.2.tar.xz
 968e996a306dab643970c5ce1ac40926146b01b9c38a8fe81c74340a0302dbc7  bb-tar.patch
 ff9b5beefbe55ba6340f1c4acced195515002d0ccb431a8fcd5b1078eacd2e59  git-daemon.initd
 4703ba2372c661fb674a29fea7f64983f8b1b3136d971663509249655bca6e21  git-daemon.confd"
-sha512sums="c9d4196ad9c4f656b5a25fe688c06248bfce4fadac38e9bc835e5e9063ab95e3d4b3db4174acea0b3b64c5455adc93d39870f2b6009d2dd6aa0edb5a5f5bda40  git-2.11.1.tar.xz
+sha512sums="73ab86643433c485b66787abc568f364e1a8be63fbfc5c1a33efb085734d9f609356e9597ed1a4c53306704dc0e9da1a3ff522457cc31add6f8b1739915ee714  git-2.11.2.tar.xz
 85767b5e03137008d6a96199e769e3979f75d83603ac8cb13a3481a915005637409a4fd94e0720da2ec6cd1124f35eba7cf20109a94816c4b4898a81fbc46bd2  bb-tar.patch
 89528cdd14c51fd568aa61cf6c5eae08ea0844e59f9af9292da5fc6c268261f4166017d002d494400945e248df6b844e2f9f9cd2d9345d516983f5a110e4c42a  git-daemon.initd
 fbf1f425206a76e2a8f82342537ed939ff7e623d644c086ca2ced5f69b36734695f9f80ebda1728f75a94d6cd2fcb71bf845b64239368caab418e4d368c141ec  git-daemon.confd"


### PR DESCRIPTION
https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.11.2.txt

Git v2.11.2 Release Notes
=========================

Fixes since v2.11.1
-------------------

 * "git-shell" rejects a request to serve a repository whose name
   begins with a dash, which makes it no longer possible to get it
   confused into spawning service programs like "git-upload-pack" with
   an option like "--help", which in turn would spawn an interactive
   pager, instead of working with the repository user asked to access
   (i.e. the one whose name is "--help").