### PR TITLE
community/elasticsearch: update to 5.4.2 / add bash depends

### DIFF
--- a/community/elasticsearch/APKBUILD
+++ b/community/elasticsearch/APKBUILD
@@ -1,14 +1,15 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=elasticsearch
-pkgver=5.2.1
+pkgver=5.4.2
 pkgrel=0
 pkgdesc="Open Source, Distributed, RESTful Search Engine"
 url="https://www.elastic.co/products/elasticsearch"
 arch="x86 x86_64"
 license="ASL-2.0"
-depends="java-jna-native>=4.1 openjdk8-jre"
+depends="java-jna-native>=4.1 openjdk8-jre bash"
 makedepends=""
+options="!check"
 install="$pkgname.pre-install"
 subpackages="$pkgname-doc"
 source="https://artifacts.elastic.co/downloads/$pkgname/$pkgname-$pkgver.tar.gz
@@ -20,14 +21,14 @@ builddir="$srcdir/$pkgname-$pkgver"
 
 default_module=transport-netty4
 _modules="lang-mustache
-	  reindex
-	  ingest-common
-	  lang-expression
-	  lang-groovy
-	  percolator
-	  aggs-matrix-stats
-	  lang-painless
-	  transport-netty3"
+	reindex
+	ingest-common
+	lang-expression
+	lang-groovy
+	percolator
+	aggs-matrix-stats
+	lang-painless
+	transport-netty3"
 for _mod in $_modules; do
 	subpackages="$subpackages $pkgname-$_mod:_${_mod//-/_}"
 	eval "_${_mod//-/_}() { _builtin_module $_mod; }"
@@ -48,22 +49,22 @@ package() {
 	cd "$builddir"
 
 	install -dm755 "$destdir"/lib "$destdir"/modules "$destdir"/bin
-	install -m644 -t "$destdir"/lib lib/* || return 1
+	install -m644 -t "$destdir"/lib lib/*
 
 	install -dm755 "$docdir"
 	install -dm755 "$confdir"
-	install -m644 -t "$confdir" config/* || return 1
+	install -m644 -t "$confdir" config/*
 
 	# remove windows files
 	find bin -type f -name *.bat -exec rm -f {} \;
 	find bin -type f -name *.exe -exec rm -f {} \;
 
 	# ES bin script parses the new jvm.options file
-	install -m755 -t "$destdir"/bin bin/* || return 1
+	install -m755 -t "$destdir"/bin bin/*
 
 	# ES does not run without a transport module
 	install -dm755 "$destdir/modules/$default_module"
-	install -m644 -t "$destdir/modules/$default_module" modules/"$default_module"/* || return 1
+	install -m644 -t "$destdir/modules/$default_module" modules/"$default_module"/*
 
 	# reduce heap sizes
 	sed -i \
@@ -72,13 +73,13 @@ package() {
 	$confdir/jvm.options
 
 	install -m755 -D "$srcdir"/$pkgname.initd \
-		"$pkgdir"/etc/init.d/$pkgname || return 1
+		"$pkgdir"/etc/init.d/$pkgname
 
 	install -m644 -D "$srcdir"/$pkgname.confd \
-		"$pkgdir"/etc/conf.d/$pkgname || return 1
+		"$pkgdir"/etc/conf.d/$pkgname
 
 	install -m644 -D "$srcdir"/README.alpine \
-		"$docdir" || return 1
+		"$docdir"
 }
 
 _builtin_module() {
@@ -89,7 +90,7 @@ _builtin_module() {
 	install -m644 -t "$destdir" "$builddir"/modules/$name/*
 }
 
-sha512sums="aa8734c1e1111987d45e8dd64b5f8a0473955c48e09e6f1875e877090c21070fc18768b413e7b0c20652cec9ebd9bb6836a2c014cf8159b041f0d22b28ad5a08  elasticsearch-5.2.1.tar.gz
-dc916861497d4a589d6b3ab70d90ff9970e4d57003ed82d08c5f90dec337f995dcabf2556b7a27ade926e846ad435392f7845acfe9280dce17b4c172d85328ae  elasticsearch.initd
+sha512sums="cbeacdc9f6b391cea753a656f190f37db8130bcce3210356b63a0e27964aff6c079a3650f94242c6b98b0a87f58f6748fed02eb1f3a70495e9d6ccd09d138b7d  elasticsearch-5.4.2.tar.gz
+503d7093326f5f69aab66b3eb0e834bbdf1b898986155b131e9d226dad2801885c5aa60640c56e5fead5fecb177c53dee3fb3c634b97891ac8383a253cb4a36e  elasticsearch.initd
 2ab1baf1b5c8782f3f371ba221aadd3e841abc62175f0b1ddcfc68d711e2370465124e076f8cc2e549c25a1da9db8c90172b2f410bd6bbe4153f0e831620b6ba  elasticsearch.confd
 6de81485cdc059afef58382862e4155482463fde0b604aaa8dbe904c778b841467c4a383a5e54acd09e3436f1fb7be9923e001fb77bd3d7894e113a5e0f4036b  README.alpine"

--- a/community/elasticsearch/elasticsearch.initd
+++ b/community/elasticsearch/elasticsearch.initd
@@ -15,7 +15,8 @@ name="Elasticsearch"
 : ${conf_dir:="/etc/elasticsearch/${instance_name#_default}"}
 : ${home_dir:="/var/lib/elasticsearch/$instance_name"}
 : ${default_data_dir:="$home_dir/data"}
-: ${default_plugins_dir:="$home_dir/plugins"}
+  # ES expects plugins to be found with the libs
+: ${default_plugins_dir:="/usr/share/java/elasticsearch/plugins"}
 : ${default_logs_dir:="/var/log/elasticsearch/${instance_name#_default}"}
 : ${default_script_dir:="$conf_dir/scripts"}
 : ${default_work_dir:="/var/tmp/elasticsearch/$instance_name"}


### PR DESCRIPTION
* also fixes plugin path:

`ES` expects to find plugins in the same path as the libs. Looking at
the java command line in htop `ES` sets `path.home` a 2nd time for the
libs & expects the plugins to also be in this path (which is why
there is no configuration for the plugin path in `elasticsearch.yml`).