### PR TITLE
testing/php7-mustache: new aport

### DIFF
--- a/testing/libmustache/APKBUILD
+++ b/testing/libmustache/APKBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Renoir Boulanger <hello@renoirboulanger.com>
+
+pkgname=libmustache
+_mustachespec_gitrev=b96be9fd4c6d6984828d93169fe7e86d8a8aec2f
+pkgver=0.4.3
+pkgrel=0
+pkgdesc="C++ implementation of Mustache intended mainly for use as a PHP extension"
+url="https://github.com/jbboehr/libmustache"
+arch=all
+license=MIT
+makedepends="autoconf automake libtool yaml-dev"
+source="$pkgname-$pkgver.tar.gz::https://github.com/jbboehr/${pkgname}/archive/v${pkgver}.tar.gz
+		mustache-spec-${_mustachespec_gitrev}.tar.gz::https://github.com/jbboehr/mustache-spec/archive/${_mustachespec_gitrev}.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+prepare() {
+	rm -rf "$builddir"/spec
+	ln -s "$srcdir"/mustache-spec-$_mustachespec_gitrev "$builddir"/spec
+	cd "$builddir"
+	autoreconf -fiv
+}
+
+build() {
+	cd "$builddir"
+	./configure \
+		--prefix=/usr
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="864a6205bb128d95ecbb82806f526bbdb611d169f74e8cb25fae4e6ba3c36d52587316817ea092f494f140f41d1e70d9485bd10107847881ac56ad37b52fff05  libmustache-0.4.3.tar.gz
+9031df8459426bcc91dceb149b19c7e4397bdb08d80dbf175b536effe16ba1808f0a87be1a1f27997ef0b31d87d9c209dec167732e21abc8bd7f3e9982e6d262  mustache-spec-b96be9fd4c6d6984828d93169fe7e86d8a8aec2f.tar.gz"

--- a/testing/php7-mustache/APKBUILD
+++ b/testing/php7-mustache/APKBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Renoir Boulanger <hello@renoirboulanger.com>
+
+pkgname=php7-mustache
+_phpext=mustache
+pkgver=0.7.3
+pkgrel=0
+pkgdesc="PHP 7 PECL extension: C++ implementation of Mustache"
+giturl="https://github.com/jbboehr/php-mustache.git"
+url="https://github.com/jbboehr/php-mustache"
+arch=all
+license=MIT
+depends=libmustache
+makedepends="php7-dev autoconf"
+# Look at commit ref for spec/ folder at https://github.com/jbboehr/mustache-spec
+_mustachespec_gitrev=72233f3ffda9e33915fd3022d0a9ebbcce265acd
+_pkg_filename=php-mustache-$pkgver
+source="php-mustache-$pkgver.tar.gz::https://github.com/jbboehr/php-mustache/archive/v$pkgver.tar.gz
+		mustache-spec-$_mustachespec_gitrev.tar.gz::https://github.com/jbboehr/mustache-spec/archive/$_mustachespec_gitrev.tar.gz"
+builddir="$srcdir/$_pkg_filename/"
+
+prepare() {
+	rm -rf "$builddir"/spec
+	ln -s "$srcdir"/mustache-spec-$_mustachespec_gitrev "$builddir"/spec
+	cd "$builddir"
+	default_prepare
+}
+
+build() {
+	cd "$builddir"
+	phpize7
+	./configure \
+		--prefix=/usr \
+		--with-php-config=php-config7 \
+		--enable-mustache
+	make
+}
+
+package() {
+	cd "$builddir"
+	make INSTALL_ROOT="$pkgdir" install
+	install -d "$pkgdir"/etc/php7/conf.d
+	echo "extension=$_phpext.so" > "$pkgdir"/etc/php7/conf.d/70_$_phpext.ini
+}
+
+sha512sums="672d8e64aea0c843a85e8ec1501d2453f8cff5237ce160185ecc3fc421e31000f806aec8d4055b558d32d4a1017b80ca05868b36ebf81892a2b7f910a09da235  php-mustache-0.7.3.tar.gz
+d63ca7c3016190e101b2db153a33e4e523e0199e3fb3778733d791e4853bab20925046d0cb34bbde0985a4b6b78b1ec6003db1e2384693352d03f7d67799ed10  mustache-spec-72233f3ffda9e33915fd3022d0a9ebbcce265acd.tar.gz"


### PR DESCRIPTION
Add Mustache C++ bindings to PHP. This PR has two separate commits, one per new package build.

See also #1530