### PR TITLE
main/openvpn: security update to 2.4.2

### DIFF
--- a/main/openvpn/APKBUILD
+++ b/main/openvpn/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=openvpn
-pkgver=2.4.1
-pkgrel=1
+pkgver=2.4.2
+pkgrel=0
 pkgdesc="A robust, and highly configurable VPN (Virtual Private Network)"
 url="http://openvpn.sourceforge.net/"
 arch="all"
@@ -60,7 +60,7 @@ pam() {
 		"$subpkgdir"/usr/lib/openvpn/plugins/
 }
 
-sha512sums="bfb6a3c4d17af0461763d8a8e15d83a6fde88382a9b92739dd78d1f8ef85bfa246db14ba1504249ad05479f316df692120cfc3ddfd13b070a21dc6956242acd3  openvpn-2.4.1.tar.gz
+sha512sums="9be3cef25f398c426087581d8bb2589ae2a3a1b3b812c73f7e9a4d3c35098421eea3099b33fc90606162d0429dcd7d9ae3449af89602e060e47cd4c053720e72  openvpn-2.4.2.tar.gz
 8a4080b7784faa156aa0775f7b73fe5c054707270af2a3139150629450ad0f1f5954dce5fc850f1bfd7b93bcc47ed4bc9b22159c536874698c78d81ba99338a7  openvpn.initd
 982ade883afbe2e656a9cbbe36c31c0e8b4f7bbbe5b63df9f7b834f02a9153032fb7445c85d3e91f62c68a7ddd13c3afbf420fb71cdd13d9c4b69f867bdd9f37  openvpn.confd
 f904d6125ed1ddb48ea632c3b290a7a4a7a7436be0d46b323fc8c92f919f9d076fdc78ff7bed0dd65675f0bc3559e531e372b805fc11ef287efeeb4d54fe52f4  openvpn.up


### PR DESCRIPTION
Update due to [security audit](https://ostif.org/the-openvpn-2-4-0-audit-by-ostif-and-quarkslab-results/) done by OSTIF and QuarksLab