### PR TITLE
community/php7: fix _php_default checks

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -386,8 +386,9 @@ package() {
 	find "$pkgdir" -name '.*' | xargs rm -rf
 	rmdir "$pkgdir"/var/run
 
-	[ "$_default_php" = yes ] \
-		&& ln -s php$_suffix "$pkgdir"/usr/bin/php
+	if [ "$_default_php" = yes ]; then
+		ln -s php$_suffix "$pkgdir"/usr/bin/php
+	fi
 }
 
 dev() {
@@ -436,8 +437,9 @@ phpdbg() {
 	install -Dm755 "$builddir"/sapi/phpdbg/phpdbg \
 		"$subpkgdir"/usr/bin/phpdbg$_suffix
 
-	[ "$_default_php" = yes ] \
-		&& ln -s phpdbg$_suffix "$subpkgdir"/usr/bin/phpdbg
+	if [ "$_default_php" = yes ]; then
+		ln -s phpdbg$_suffix "$subpkgdir"/usr/bin/phpdbg
+	fi
 }
 
 embed() {
@@ -452,8 +454,9 @@ litespeed() {
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/lsphp "$subpkgdir"/usr/bin/lsphp$_suffix
 
-	[ "$_default_php" = yes ] \
-		&& ln -s lsphp$_suffix "$subpkgdir"/usr/bin/lsphp
+	if [ "$_default_php" = yes ]; then
+		ln -s lsphp$_suffix "$subpkgdir"/usr/bin/lsphp
+	fi
 }
 
 cgi() {
@@ -461,8 +464,9 @@ cgi() {
 
 	_mv "$pkgdir"/usr/bin/php-cgi$_suffix "$subpkgdir"/usr/bin/
 
-	[ "$_default_php" = yes ] \
-		&& ln -s php-cgi$_suffix "$subpkgdir"/usr/bin/php-cgi
+	if [ "$_default_php" = yes ]; then
+		ln -s php-cgi$_suffix "$subpkgdir"/usr/bin/php-cgi
+	fi
 }
 
 fpm() {
@@ -502,8 +506,9 @@ pear() {
 	mkdir -p "$subpkgdir"/usr/bin
 	local file; for file in pecl pear peardev; do
 		mv usr/bin/$file "$subpkgdir"/usr/bin/$file$_suffix
-		[ "$_default_php" = yes ] \
-			&& ln -s $file$_suffix "$subpkgdir"/usr/bin/$file
+		if [ "$_default_php" = yes ]; then
+			ln -s $file$_suffix "$subpkgdir"/usr/bin/$file
+		fi
 	done
 
 	_mv etc/$pkgname/pear.conf "$subpkgdir"/etc/$pkgname/


### PR DESCRIPTION
remaded all **_php_default** checks to **if...then...fi**, because packaging fails if **_default_php** is not **"yes"**

there is no need to bump up pkgrel.