### PR TITLE
community/ioping: fix bug s390x builder

### DIFF
--- a/community/ioping/APKBUILD
+++ b/community/ioping/APKBUILD
@@ -5,7 +5,7 @@ pkgver=1.0
 pkgrel=1
 pkgdesc="A simple disk i/o latency measurement tool"
 url="https://github.com/koct9i/ioping"
-arch="all !s390x"
+arch="all"
 license="GPL3+"
 depends=""
 depends_dev=""
@@ -18,6 +18,7 @@ _builddir="$srcdir"/$pkgname-$pkgver
 prepare() {
 	local i
 	cd "$_builddir"
+	[ "$CARCH" = "s390x" ] && sed -i -e 's@./$(BINARY)@./$(BINARY) -C@g' Makefile
 	for i in $source; do
 		case $i in
 		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;


### PR DESCRIPTION
since s390x builder is lxc, the host kernel returns EINVAL when
fadvice() is called with POSIX_FADV_DONTNEED which gives advice to the kernel to free the test file after running ioping.
Using POSIX_FADV_NORMAL gives no advice about the test file for future
usage. Temp fix for 3.6.