### PR TITLE
main/xen, main/binutils: Build and package Xen EFI binaries

### DIFF
--- a/main/binutils/APKBUILD
+++ b/main/binutils/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=binutils
 pkgver=2.28
-pkgrel=1
+pkgrel=2
 pkgdesc="Tools necessary to build programs"
 url="http://www.gnu.org/software/binutils/"
 depends=""
@@ -31,10 +31,15 @@ fi
 build() {
 	local _sysroot=/
 	local _cross_configure="--enable-install-libiberty"
+	local _arch_configure=""
 
 	if [ "$CHOST" != "$CTARGET" ]; then
 		_sysroot="$CBUILDROOT"
 		_cross_configure="--disable-install-libiberty"
+	fi
+
+	if [ "$CARCH" = "x86_64" ]; then
+		_arch_configure="--enable-targets=x86_64-pep"
 	fi
 
 	cd "$builddir"
@@ -56,6 +61,7 @@ build() {
 		--enable-relro \
 		--enable-deterministic-archives \
 		$_cross_configure \
+		$_arch_configure \
 		--disable-werror \
 		--disable-nls \
 		--with-system-zlib \

--- a/main/xen/APKBUILD
+++ b/main/xen/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=xen
 pkgver=4.8.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Xen hypervisor"
 url="http://www.xen.org/"
 arch="x86_64 armhf"
@@ -310,6 +310,12 @@ hypervisor() {
 	depends=
 	mkdir -p "$subpkgdir"
 	mv "$pkgdir"/boot "$subpkgdir"/
+
+	if [ "$CARCH" = "x86_64" ]; then
+		mv "$pkgdir"/usr/lib64/efi/* "$subpkgdir"/boot/
+		rm -r "$pkgdir"/usr/lib64/efi \
+			"$pkgdir"/usr/lib64
+	fi
 }
 
 sha512sums="9f535b4bb57d285dfb92c974d55513505cf485b2d7218fe8f6ed62768e2cee7f225b08adf6706590b2c0a04feca16e10915297c33b98e1b110f8ea7035f46c15  xen-4.8.1.tar.gz


### PR DESCRIPTION
These PR contains two commits with the goal to package Xen with its EFI binaries, in order to boot Xen on EFI systems.

First commit addresses the need to add x86_64-pep target to binutils, which Xen requires ld to have in order to build the EFI binaries. 
Some info from other distributions regarding this change:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=675364
https://bugs.archlinux.org/task/42540

Second commit is mostly bumping the revision to rebuild and get Xen binaries, but also placing the EFI binaries in /boot with the xen-hypervisor package.

Fixes #5909.