### PR TITLE
main/linux-pam: allow password-less su for root

### DIFF
--- a/main/linux-pam/APKBUILD
+++ b/main/linux-pam/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=linux-pam
 pkgver=1.2.1
-pkgrel=0
+pkgrel=1
 pkgdesc="pluggable authentication modules for linux"
 url="http://www.kernel.org/pub/linux/libs/pam"
 arch="all"
@@ -25,6 +25,7 @@ source="http://linux-pam.org/library/Linux-PAM-$pkgver.tar.bz2
 	base-session.pamd
 	base-session-noninteractive.pamd
 	other.pamd
+	su.pamd
 	"
 
 _builddir="$srcdir"/Linux-PAM-$pkgver
@@ -84,28 +85,6 @@ package() {
 		&& chmod g+s "$pkgdir"/sbin/unix_chkpwd || return 1
 }
 
-md5sums="9dc53067556d2dd567808fd509519dd6  Linux-PAM-1.2.1.tar.bz2
-c309401e103cc86e8b25557ff3eb0b53  linux-pam-innetgr.patch
-283a399db933a7598fc63ada5d3eb38c  fix-compat.patch
-23320dadf8e36846b6bbd7903f95ece5  libpam-fix-build-with-eglibc-2.16.patch
-9ade1e4582b34e138368664ff145fd94  musl-fix-pam_exec.patch
-aa5bb7c9d8e4687aea1ae69b7447254a  base-auth.pamd
-fafcf29cb9bab788cb4933106be31883  base-account.pamd
-117535e4938f478efced1398b408cf96  base-password.pamd
-baec6808544bf6cebc59e07467f8c213  base-session.pamd
-afbdd8eb4db5c31dfd8e8da35c698b90  base-session-noninteractive.pamd
-b8e839ece64df173f16d28520eb8d66c  other.pamd"
-sha256sums="342b1211c0d3b203a7df2540a5b03a428a087bd8a48c17e49ae268f992b334d9  Linux-PAM-1.2.1.tar.bz2
-fb609212837c67da7da033a0daa01d1c2e34166867530e6924102b655e00ebde  linux-pam-innetgr.patch
-4e1f855779a73960f48e570ce507884325a3aef374721e3973e1e22a60b9bec0  fix-compat.patch
-01c9216a2a833d10c2b42e1182b161b125d869e8620e60989636feb721d466c5  libpam-fix-build-with-eglibc-2.16.patch
-c0e51d82de9271d38217209d8a55b444b743a226ac9d7a3220b433d49236bd11  musl-fix-pam_exec.patch
-daedb66d2b6c324f62100657383f3da6af196ad516837f36a3142da5318b8874  base-auth.pamd
-51dba5c32d8cfa0c1795b2ed72af7aa5871f7943a20f89d2e4ad00b9053bc9c8  base-account.pamd
-16c2d6f750f8bb320d64537554c48e3474f13623e7f6e231135d2cd2362745a3  base-password.pamd
-5bf97347375ffc626fd3ed2e8d39abde566c2eca3f5e06a737ccffd48aede5de  base-session.pamd
-a65802b72a44b0c2083bce7e7d0cd1b04782272a6281a65c5b0075b8f9bccd5f  base-session-noninteractive.pamd
-2e4850ba8db3aee3fe97eaf76286ada585d821cd8affc97c845eb58b2bf68bb6  other.pamd"
 sha512sums="4572aa1eaf5a1312410c74b5ed055b2592c5efe2bb82f59981da4e9e93555ad40aee3a89f446d9dc6c6af79efc04c33f739f66db9edc07e02479475a14e426da  Linux-PAM-1.2.1.tar.bz2
 ca32ecdacfc5b8f1482031203b616932b646a008b02080315ea2589af5962180d4ff4339c27fe9f6a878a89f47fb69429f4ac75d67b0e70ad7765a4db1dc74d9  linux-pam-innetgr.patch
 52b97e23084f7b835ce1fa441663f91a50ea797cb38ba2c6662bcdaf0d25ba487118442674ac347fb17353af126dd6b3b696612faa56cac428dd842d14e1c90d  fix-compat.patch
@@ -116,4 +95,5 @@ bc443d2a9b1d90b81959ce6fa154042365d5e7840f8696f847a145bbaaeffcbe1e9cd2b8ba76131a
 8223b815148c3b9b874d2c283840f6428c266e56c7cf49ce8fc508c4945ae31c837bef96dab17f64a60812d1c9cd0055cf0a50d7951d23070b69bd2e5bb9666d  base-password.pamd
 b0138f662715974bd865d755c5e7d403faf5b9ad1b7e2b1d1598ad7eb5764a9ff407f1a5e6ce7f16db9fc10f8d643323b494563416fd6a654032529b52213c5b  base-session.pamd
 444e20046843057b17c0aac14d2b71a68923b989b3d8b478bbf684698673683186e928e5ca2e6cb9a1c76abc4248044a0e10ef6b06b3f51857106796ecce250d  base-session-noninteractive.pamd
-d103ba06b2c4929171e09c845f9866539220cd20d8d56a03d25850342ef5eabe281e958dfe1eaefd550c00f9440e8700c1d74c88c3001f933134ca6fd7cb9b7b  other.pamd"
+d103ba06b2c4929171e09c845f9866539220cd20d8d56a03d25850342ef5eabe281e958dfe1eaefd550c00f9440e8700c1d74c88c3001f933134ca6fd7cb9b7b  other.pamd
+b512d691f2a6b11fc329bf91dd05ca9c589bbd444308b27d3c87c75262dedf6afc68a9739229249a4bd3d0c43cb1f871eecbb93c4fe559e0f38bdabbffd06ad7  su.pamd"

--- a/main/linux-pam/su.pamd
+++ b/main/linux-pam/su.pamd
@@ -1,0 +1,6 @@
+# basic PAM configuration for Alpine.
+auth		sufficient	pam_rootok.so
+auth		include		base-auth
+account		include		base-account
+password	include		base-password
+session		include		base-session-noninteractive


### PR DESCRIPTION
This allows su(1) to be used without additional authentication by root, just like busybox su does.