### PR TITLE
main/binutils: enable x86_64-pep target

### DIFF
--- a/main/binutils/APKBUILD
+++ b/main/binutils/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=binutils
 pkgver=2.28
-pkgrel=1
+pkgrel=2
 pkgdesc="Tools necessary to build programs"
 url="http://www.gnu.org/software/binutils/"
 depends=""
@@ -31,10 +31,15 @@ fi
 build() {
 	local _sysroot=/
 	local _cross_configure="--enable-install-libiberty"
+	local _arch_configure=""
 
 	if [ "$CHOST" != "$CTARGET" ]; then
 		_sysroot="$CBUILDROOT"
 		_cross_configure="--disable-install-libiberty"
+	fi
+
+	if [ "$CARCH" = "x86_64" ]; then
+		_arch_configure="--enable-targets=x86_64-pep"
 	fi
 
 	cd "$builddir"
@@ -56,6 +61,7 @@ build() {
 		--enable-relro \
 		--enable-deterministic-archives \
 		$_cross_configure \
+		$_arch_configure \
 		--disable-werror \
 		--disable-nls \
 		--with-system-zlib \


### PR DESCRIPTION
On x86_64, enable the additional target x86_64-pep. This will allow Xen
to build it's EFI bootloader.

Some info from other distributions regarding this change:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=675364
https://bugs.archlinux.org/task/42540

Will send up PR for Xen after this is merged.

ping @kaniini 