### PR TITLE
main/xen: build EFI binaries

### DIFF
--- a/main/xen/APKBUILD
+++ b/main/xen/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=xen
 pkgver=4.8.1
-pkgrel=4
+pkgrel=5
 pkgdesc="Xen hypervisor"
 url="http://www.xen.org/"
 arch="x86_64 armhf"
@@ -319,6 +319,11 @@ hypervisor() {
 	depends=
 	mkdir -p "$subpkgdir"
 	mv "$pkgdir"/boot "$subpkgdir"/
+
+	if [ "$CARCH" = "x86_64" ]; then
+		mkdir -p "$subpkgdir"/usr/lib
+		mv "$pkgdir"/usr/lib64/efi "$subpkgdir"/usr/lib/efi
+	fi
 }
 
 bridge() {


### PR DESCRIPTION
New binutils 2.28-r2 provides the x86_64-pep target which makes Xen
build its EFI bootloader.

The EFI binaries are placed in /boot and provided by xen-hypervisor:
 /boot/xen-4.8.1.efi
 /boot/xen-4.8.efi
 /boot/xen-4.efi
 /boot/xen.efi