### PR TITLE
main/librsync: backport fix for segfault

### DIFF
--- a/main/librsync/0001-Handle-searched-checksum-is-bigger-than-any-existing.patch
+++ b/main/librsync/0001-Handle-searched-checksum-is-bigger-than-any-existing.patch
@@ -1,0 +1,26 @@
+From e4f891a2bf923ce1a6b0867670db1dfc8e552981 Mon Sep 17 00:00:00 2001
+From: Victor Denisov <vdenisov@mirantis.com>
+Date: Mon, 18 Jan 2016 23:00:58 -0800
+Subject: [PATCH] Handle searched checksum is bigger than any existing
+
+Fix for issue #50
+---
+ src/search.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/search.c b/src/search.c
+index 75433b4..fce3831 100644
+--- a/src/search.c
++++ b/src/search.c
+@@ -218,7 +218,7 @@ rs_search_for_block(rs_weak_sum_t weak_sum,
+ 	    r = m;
+     }
+ 
+-    if (l == r) {
++    if ((l == r) && (l <= bucket->r)) {
+ 	int i = sig->targets[l].i;
+ 	rs_block_sig_t *b = &(sig->block_sigs[i]);
+ 	if (weak_sum != b->weak_sum)
+-- 
+2.13.0
+

--- a/main/librsync/APKBUILD
+++ b/main/librsync/APKBUILD
@@ -2,14 +2,15 @@
 # Maintainer: Jeremy Thomerson <jeremy@thomersonfamily.com>
 pkgname=librsync
 pkgver=2.0.0
-pkgrel=0
+pkgrel=1
 pkgdesc="librsync implements the rolling-checksum algorithm of rsync"
 url="https://github.com/librsync/librsync"
 arch="all"
 license="LGPL 2.1"
 makedepends="cmake popt-dev bzip2-dev zlib-dev perl"
 subpackages="$pkgname-dev $pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/librsync/librsync/archive/v$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/librsync/librsync/archive/v$pkgver.tar.gz
+	0001-Handle-searched-checksum-is-bigger-than-any-existing.patch"
 builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
@@ -25,4 +26,5 @@ package() {
 	install -D -m644 doc/librsync.3 "$pkgdir/usr/share/man/man3/librsync.3" || return 1
 }
 
-sha512sums="1a88dcc3aa60949e058c57eb0df3e0086823c493de40fed927246f5aada6274db57202074456a0ce5d9aa8b81b41836b0d6221ded6a75d43829572584177e8c0  librsync-2.0.0.tar.gz"
+sha512sums="1a88dcc3aa60949e058c57eb0df3e0086823c493de40fed927246f5aada6274db57202074456a0ce5d9aa8b81b41836b0d6221ded6a75d43829572584177e8c0  librsync-2.0.0.tar.gz
+ca34d1b6d0c227d582926e4342711a17604ece50b99bc5657758b50b405bc6df216c3c47d5ddb055f47d45b67ef056aefbd9d58317921202b68fc4c31433bcc4  0001-Handle-searched-checksum-is-bigger-than-any-existing.patch"


### PR DESCRIPTION
When running rdiff-backup we get a segfault in librsync.so.2.0.0,
backport upstream fix.