### PR TITLE
community/glances: add py-setuptools as missing dependency

### DIFF
--- a/community/glances/APKBUILD
+++ b/community/glances/APKBUILD
@@ -29,6 +29,11 @@ package() {
 		"$pkgdir"/usr/share/doc/$pkgname/images
 }
 
+check() {
+    cd "$builddir"
+    python2 unitest.py
+}
+
 md5sums="312a6488549abfa9ec870c95dc8b7f1b  glances-2.7.1.tar.gz"
 sha256sums="0f747423e4dee049b1113fc6db2d76af73ef75b1c3445af00cada103bcbbeb69  glances-2.7.1.tar.gz"
 sha512sums="7ac20ca8da774ee13696e9f3246b7dd9739ae81b65168a81265c3b3483d4e561fa1df639fd7debe790a5c2145a976db5ad19925ef30c978f65441b9f8fd91c9b  glances-2.7.1.tar.gz"

--- a/community/glances/APKBUILD
+++ b/community/glances/APKBUILD
@@ -4,12 +4,12 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=glances
 pkgver=2.7.1
-pkgrel=0
+pkgrel=1
 pkgdesc="A CLI curses based monitoring tool"
 url="http://nicolargo.github.com/glances/"
 arch="noarch"
 license="LGPL3+"
-depends="py2-psutil py2-bottle py2-snmp py2-batinfo docker-py"
+depends="py2-psutil py2-bottle py2-snmp py2-batinfo docker-py py-setuptools" 
 makedepends="python2-dev py-setuptools"
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/nicolargo/$pkgname/archive/v$pkgver.tar.gz"
@@ -17,16 +17,16 @@ builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
-	python2 setup.py build || return 1
+	python2 setup.py build
 }
 
 package() {
 	cd "$builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	python2 setup.py install --prefix=/usr --root="$pkgdir"
 
 	# Remove images and HTML doc depending on those
 	rm -rf "$pkgdir"/usr/share/doc/$pkgname/$pkgname-doc.html \
-		"$pkgdir"/usr/share/doc/$pkgname/images || return 1
+		"$pkgdir"/usr/share/doc/$pkgname/images
 }
 
 md5sums="312a6488549abfa9ec870c95dc8b7f1b  glances-2.7.1.tar.gz"


### PR DESCRIPTION
Currently glances does not even start due to missing pkg_resources