### PR TITLE
gearmand: fix system user name

### DIFF
--- a/testing/gearmand/APKBUILD
+++ b/testing/gearmand/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Aaron Hurt <ahurt@ena.com>
 pkgname=gearmand
 pkgver=1.1.15
-pkgrel=0
+pkgrel=1
 pkgdesc="A distributed job queue"
 url="http://gearman.org"
 arch="all"
@@ -72,4 +72,4 @@ sha512sums="c405f5bbecd198d852ccc1a082522a00d1a31dcf8b92f39dc1af78c12926e9d6f13c
 8d7c7473d8bcc06a6dfcb1975dd5b4992457661c6c2fab5e160f6252222af603003466c26de0c2d241d247ac33bc68f8fae853b7401691f36b2e6c57ff9b65ba  libtest-cmdline.cc.patch
 08a1ce2ef071a33efc5c93de5812f83ee2b96ae604eaedb1d40a998ccb4e88a0f588d846d19623de9b8f98df18639168521763d27f1fb3ca046b4c679d61468b  libhashkit-common.h.patch
 d97dbee95c0b96f0a81e42b730afdb9d129eb83e09be101e1bc2b2cd06a95fe1259265b912bf3850a51c6404e2c5883532a008946dfd46992cb488e1221dae97  gearmand.initd
-94373ff94862bcd9432f17ff55c94a99a9ad0432b9e863b2c710ba05a0b705378bb4d8ea821adf9859c0242d1b708050b3867faba085e7f776fab5ac1a8b013d  gearmand.confd"
+d27a6acbce663aad91055f96e374ddf12d00a1ccded318693be441b7c4dfde43db73c755002ecfc683a3c1e95139cf378f26e3ab39b5ab6584a40e3991efe245  gearmand.confd"

--- a/testing/gearmand/gearmand.confd
+++ b/testing/gearmand/gearmand.confd
@@ -1,5 +1,5 @@
 # Gearman server
 
-gearmand_user="gearmand"
-gearmand_group="gearmand"
+gearmand_user="gearman"
+gearmand_group="gearman"
 gearmand_opts=""

--- a/testing/gearmand/gearmand.post-deinstall
+++ b/testing/gearmand/gearmand.post-deinstall
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-echo "Please manually remove the 'gearmand' user and group if no longer needed" >&2
+echo "Please manually remove the 'gearman' user and group if no longer needed" >&2

--- a/testing/gearmand/gearmand.pre-install
+++ b/testing/gearmand/gearmand.pre-install
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-addgroup -S gearmand 2>/dev/null
-adduser -S -D -H -s /bin/false -G gearmand \
+addgroup -S gearman 2>/dev/null
+adduser -S -D -H -s /bin/false -G gearman \
 	-g "Gearman Server" gearman 2>/dev/null
 
 exit 0


### PR DESCRIPTION
As it stands now the configuration file expects the system user to be named `gearmand`, while the pre-install script names it `gearman`, therefore the daemon cannot start.

```
alpinada:~# /etc/init.d/gearmand start
 * Starting gearmand ...
 * start-stop-daemon: user `gearmand' not found
 * Failed to start gearmand                                                [ !! ]
 * ERROR: gearmand failed to start

alpinada:~# tail /var/log/messages | grep gearm
May 16 14:45:43 alpinada daemon.err /etc/init.d/gearmand[1918]: start-stop-daemon: user `gearmand' not found
May 16 14:45:43 alpinada daemon.err /etc/init.d/gearmand[1902]: ERROR: gearmand failed to start
```