### PR TITLE
testing/libmustache: new aport

### DIFF
--- a/testing/libmustache/APKBUILD
+++ b/testing/libmustache/APKBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Renoir Boulanger <hello@renoirboulanger.com>
+
+pkgname=libmustache
+_mustachespec_gitrev=b96be9fd4c6d6984828d93169fe7e86d8a8aec2f
+pkgver=0.4.3
+pkgrel=0
+pkgdesc="C++ implementation of Mustache intended mainly for use as a PHP extension"
+url="https://github.com/jbboehr/libmustache"
+arch=all
+license=MIT
+makedepends="autoconf automake libtool yaml-dev"
+source="$pkgname-$pkgver.tar.gz::https://github.com/jbboehr/${pkgname}/archive/v${pkgver}.tar.gz
+		mustache-spec-${_mustachespec_gitrev}.tar.gz::https://github.com/jbboehr/mustache-spec/archive/${_mustachespec_gitrev}.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+prepare() {
+	rm -rf "$builddir"/spec
+	ln -s "$srcdir"/mustache-spec-$_mustachespec_gitrev "$builddir"/spec
+	cd "$builddir"
+	autoreconf -fiv
+}
+
+build() {
+	cd "$builddir"
+	./configure \
+		--prefix=/usr
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="864a6205bb128d95ecbb82806f526bbdb611d169f74e8cb25fae4e6ba3c36d52587316817ea092f494f140f41d1e70d9485bd10107847881ac56ad37b52fff05  libmustache-0.4.3.tar.gz
+9031df8459426bcc91dceb149b19c7e4397bdb08d80dbf175b536effe16ba1808f0a87be1a1f27997ef0b31d87d9c209dec167732e21abc8bd7f3e9982e6d262  mustache-spec-b96be9fd4c6d6984828d93169fe7e86d8a8aec2f.tar.gz"


### PR DESCRIPTION
https://github.com/jbboehr/libmustache
C++ implementation of Mustache intended mainly for use as a PHP extension

Related to PR alpinelinux/aports #1382 