### PR TITLE
scripts/mkimg.base.sh: add console=hvc0 for ppc64le grub config

### DIFF
--- a/scripts/mkimg.base.sh
+++ b/scripts/mkimg.base.sh
@@ -193,6 +193,7 @@ build_grubefi_img() {
 section_grubieee1275() {
 	[ "$ARCH" = ppc64le ] || return 0
 	[ "$output_format" = "iso" ] || return 0
+	kernel_cmdline="$kernel_cmdline console=hvc0"
 
 	build_section grub_cfg boot/grub/grub.cfg $(grub_gen_config | checksum)
 }


### PR DESCRIPTION
set console=hvc0 via boot option. This configuration make init to add
hvc0 to /etc/inittab and /etc/securetty. This is needed to allow login
with 'root' user.