### PR TITLE
main/protobuf: upgrade to 3.3.2 and add subpackage ruby-google-protobuf

### DIFF
--- a/community/bitcoin/APKBUILD
+++ b/community/bitcoin/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=bitcoin
 pkgver=0.14.2
 _ver=${pkgver/_/}
-pkgrel=1
+pkgrel=2
 pkgdesc="decentralized P2P electronic cash system"
 url="http://www.bitcoin.org/"
 arch="all !armhf"

--- a/community/mumble/APKBUILD
+++ b/community/mumble/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Johannes Matheis <jomat+alpinebuild@jmt.gr>
 pkgname=mumble
 pkgver=1.2.19
-pkgrel=1
+pkgrel=2
 pkgdesc="A low-latency, high quality voice chat software"
 url="http://wiki.mumble.info"
 arch="all"

--- a/community/namecoin/APKBUILD
+++ b/community/namecoin/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=namecoin
 pkgver=0.13.0_rc1
 _ver=${pkgver/_/}
-pkgrel=4
+pkgrel=5
 pkgdesc="Namecoin is a peer to peer DNS based on bitcoin"
 url="http://www.namecoin.org/"
 arch="all"

--- a/community/rethinkdb/APKBUILD
+++ b/community/rethinkdb/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Daniel Treadwell <daniel@djt.id.au>
 pkgname=rethinkdb
-pkgver=2.3.5
-pkgrel=9
+pkgver=2.3.6
+pkgrel=0
 pkgdesc="Distributed powerful and scalable NoSQL database"
 url="http://www.rethinkdb.com"
 arch="x86_64"
@@ -69,7 +69,7 @@ doc() {
 	mv "$pkgdir"/etc/$pkgname/*.sample "$subpkgdir"/usr/share/doc/$pkgname
 }
 
-sha512sums="ac71656fd2451fd36432fa0f7d2c16c2be53888f748d88f0bfc2fb9ad7cd3c704b56551bc35eda72eb08fffdd799727a3cbe83830337cf71e17c159588d33c94  rethinkdb-2.3.5.tgz
+sha512sums="653177750f7439fa1d61a121e488d578be1eab90f87c7d17ad52b9793d8543f22bbe98f8d501c2ab2d7048c65118096430fe7bde945d87c7a3228905af801af2  rethinkdb-2.3.6.tgz
 9ff727feedc7a9f58e7bf8554dc26e32ebca259b2d5d75ff0d064f5aea7a54c9c94fab16b83a3bc4039d4ae6d6d805d7b129ab9d5f762186d0388adeeff6e67c  libressl.patch
 c27e21073048bd5e8e2ec91303b43ce873748573e2b44ba28ee57ca1b3080afb67e56880b6a6da7a0abf4f2967dce45aa27fe8d6dd44b70d874d776e876ef132  rethinkdb.initd
 3a07f9c78ef96b2ca37fca508ee14a644d3c08612f662ba5260182fbfcceba064d20253f1261f56dc0a2c28d1a4d5e2320872c3c4e7595cb7ab4e202eb28ad42  rethinkdb.confd"

--- a/community/rethinkdb/APKBUILD
+++ b/community/rethinkdb/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Daniel Treadwell <daniel@djt.id.au>
 pkgname=rethinkdb
 pkgver=2.3.5
-pkgrel=8
+pkgrel=9
 pkgdesc="Distributed powerful and scalable NoSQL database"
 url="http://www.rethinkdb.com"
 arch="x86_64"

--- a/main/mosh/APKBUILD
+++ b/main/mosh/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=mosh
 pkgver=1.3.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Mobile shell surviving disconnects with local echo and line editing"
 url="https://mosh.org"
 arch="all"

--- a/main/protobuf/APKBUILD
+++ b/main/protobuf/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=protobuf
 _gemname=google-protobuf
 pkgver=3.3.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Library for extensible, efficient structure packing"
 url="https://github.com/google/protobuf"
 arch="all"

--- a/main/protobuf/APKBUILD
+++ b/main/protobuf/APKBUILD
@@ -7,7 +7,6 @@ pkgdesc="Library for extensible, efficient structure packing"
 url="https://github.com/google/protobuf"
 arch="all"
 license="BSD"
-depends=""
 depends_dev="zlib-dev"
 makedepends="$depends_dev autoconf automake libtool"
 subpackages="$pkgname-dev $pkgname-vim::noarch"
@@ -17,7 +16,7 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/google/$pkgname/archive/v$pk
 builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	./autogen.sh
@@ -31,15 +30,18 @@ build() {
 			--sysconfdir=/etc \
 			--mandir=/usr/share/man \
 			--infodir=/usr/share/info \
-			--localstatedir=/var \
-		|| return 1
-	make || return 1
-	make check || return 1
+			--localstatedir=/var
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
 vim() {

--- a/main/protobuf/APKBUILD
+++ b/main/protobuf/APKBUILD
@@ -1,6 +1,7 @@
 # Contributor: Kiyoshi Aman <kiyoshi.aman@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=protobuf
+_gemname=google-protobuf
 pkgver=3.3.2
 pkgrel=0
 pkgdesc="Library for extensible, efficient structure packing"
@@ -8,10 +9,11 @@ url="https://github.com/google/protobuf"
 arch="all"
 license="BSD"
 depends_dev="zlib-dev"
-makedepends="$depends_dev autoconf automake libtool"
-subpackages="$pkgname-dev $pkgname-vim::noarch"
+makedepends="$depends_dev autoconf automake libtool ruby ruby-dev ruby-rake"
+subpackages="ruby-$_gemname:_ruby $pkgname-dev $pkgname-vim::noarch"
 source="$pkgname-$pkgver.tar.gz::https://github.com/google/$pkgname/archive/v$pkgver.tar.gz
 	musl-fix.patch
+	trim-rakefile.patch
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -32,8 +34,22 @@ build() {
 			--infodir=/usr/share/info \
 			--localstatedir=/var
 	make
+
+	cd "$builddir"/ruby
+
+	# Generate proto files for built-in protocols.
+	rake genproto
+
+	gem build $_gemname.gemspec
+	gem install --local \
+		--install-dir dist \
+		--ignore-dependencies \
+		--no-document \
+		--verbose \
+		$_gemname
 }
 
+# TODO: Run tests for ruby gem.
 check() {
 	cd "$builddir"
 	make check
@@ -42,6 +58,23 @@ check() {
 package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install
+}
+
+_ruby() {
+	pkgdesc="Ruby bindings to Google's data interchange format"
+
+	local gemdir="$subpkgdir/$(ruby -rubygems -e 'puts Gem.default_dir')"
+	cd "$builddir"/ruby/dist
+
+	mkdir -p "$gemdir"
+	cp -r extensions gems specifications "$gemdir"/
+
+	# Remove duplicated .so libs (should be only in extensions directory).
+	find "$gemdir"/gems/ -name "*.so" -delete
+
+	# Remove unnecessary files.
+	cd "$gemdir"/gems/$_gemname-$pkgver
+	rm -r ext/ tests/
 }
 
 vim() {
@@ -54,4 +87,5 @@ vim() {
 }
 
 sha512sums="795b2b438e6c3628f574bdb2929b7a3771a8105af2d320ca0f9b144b93d9be4f713fb389f5a08c1c771ce93585b7aefc9b272c9cb57299d9ee6827e06e7ff557  protobuf-3.3.2.tar.gz
-66b430c81f34f49a86dfca50edbb517e4ad1a5ea922625b6266410c5feacfb621fe583c2998ac8994c6de45470652d2408c6c731d9746b74891a627564ca01f0  musl-fix.patch"
+66b430c81f34f49a86dfca50edbb517e4ad1a5ea922625b6266410c5feacfb621fe583c2998ac8994c6de45470652d2408c6c731d9746b74891a627564ca01f0  musl-fix.patch
+e1f6483b7e8d38b07cd01883bda439b2017fa0a87626fa49628f1d2042b5097ba8a68bdf1a03cd385e3e9a7c0bd2af6fbccec25e1c061617c3cceccabd17dce4  trim-rakefile.patch"

--- a/main/protobuf/APKBUILD
+++ b/main/protobuf/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Kiyoshi Aman <kiyoshi.aman@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=protobuf
-pkgver=3.1.0
-pkgrel=1
+pkgver=3.3.2
+pkgrel=0
 pkgdesc="Library for extensible, efficient structure packing"
 url="https://github.com/google/protobuf"
 arch="all"
@@ -53,9 +53,5 @@ vim() {
 		"$subpkgdir"/usr/share/vim/vimfiles/syntax/proto.vim
 }
 
-md5sums="14a532a7538551d5def317bfca41dace  protobuf-3.1.0.tar.gz
-c5dc07b41fc2423352f37d03d1b32484  musl-fix.patch"
-sha256sums="0a0ae63cbffc274efb573bdde9a253e3f32e458c41261df51c5dbc5ad541e8f7  protobuf-3.1.0.tar.gz
-88b62bfdd8f81825b06e71a27aff887f79db7a7c12f36fe2c11d96ac4cdd8dbf  musl-fix.patch"
-sha512sums="8d3289a16944c255bd1cceab696e515e52467f2bfe1cc10f6b32fabdf082d5acdc248ec9cadc572223a24d04d431f75921076153109cea2f90ee533f502ab47a  protobuf-3.1.0.tar.gz
+sha512sums="795b2b438e6c3628f574bdb2929b7a3771a8105af2d320ca0f9b144b93d9be4f713fb389f5a08c1c771ce93585b7aefc9b272c9cb57299d9ee6827e06e7ff557  protobuf-3.3.2.tar.gz
 66b430c81f34f49a86dfca50edbb517e4ad1a5ea922625b6266410c5feacfb621fe583c2998ac8994c6de45470652d2408c6c731d9746b74891a627564ca01f0  musl-fix.patch"

--- a/main/protobuf/trim-rakefile.patch
+++ b/main/protobuf/trim-rakefile.patch
@@ -1,0 +1,66 @@
+Remove code that we don't use to avoid installing additional dependencies.
+--- a/ruby/Rakefile
++++ b/ruby/Rakefile
+@@ -1,6 +1,4 @@
+ require "rubygems"
+-require "rubygems/package_task"
+-require "rake/extensiontask" unless RUBY_PLATFORM == "java"
+ require "rake/testtask"
+ 
+ spec = Gem::Specification.load("google-protobuf.gemspec")
+@@ -39,45 +37,6 @@
+   end
+ end
+ 
+-if RUBY_PLATFORM == "java"
+-  if `which mvn` == ''
+-    raise ArgumentError, "maven needs to be installed"
+-  end
+-  task :clean do
+-    system("mvn --batch-mode clean")
+-  end
+-
+-  task :compile do
+-    system("mvn --batch-mode package")
+-  end
+-else
+-  Rake::ExtensionTask.new("protobuf_c", spec) do |ext|
+-    ext.ext_dir = "ext/google/protobuf_c"
+-    ext.lib_dir = "lib/google"
+-    ext.cross_compile = true
+-    ext.cross_platform = [
+-      'x86-mingw32', 'x64-mingw32',
+-      'x86_64-linux', 'x86-linux',
+-      'universal-darwin'
+-    ]
+-  end
+-
+-  task 'gem:windows' do
+-    require 'rake_compiler_dock'
+-    RakeCompilerDock.sh "bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION=2.4.0:2.3.0:2.2.2:2.1.5:2.0.0"
+-  end
+-
+-  if RUBY_PLATFORM =~ /darwin/
+-    task 'gem:native' do
+-      system "rake genproto"
+-      system "rake cross native gem RUBY_CC_VERSION=2.4.0:2.3.0:2.2.2:2.1.5:2.0.0"
+-    end
+-  else
+-    task 'gem:native' => [:genproto, 'gem:windows']
+-  end
+-end
+-
+-
+ # Proto for tests.
+ genproto_output << "tests/generated_code.rb"
+ genproto_output << "tests/test_import.rb"
+@@ -93,9 +52,6 @@
+ 
+ task :clean do
+   sh "rm -f #{genproto_output.join(' ')}"
+-end
+-
+-Gem::PackageTask.new(spec) do |pkg|
+ end
+ 
+ Rake::TestTask.new(:test => :build) do |t|

--- a/main/umurmur/APKBUILD
+++ b/main/umurmur/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=umurmur
 pkgver=0.2.16a
-pkgrel=5
+pkgrel=6
 pkgdesc="Minimalistic Mumble server primarily targeted to run on routers"
 url="http://umurmur.net/"
 arch="all"

--- a/testing/criu/APKBUILD
+++ b/testing/criu/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=criu
 pkgver=2.9
-pkgrel=1
+pkgrel=2
 pkgdesc="A Checkpoint/Restore utility for Linux in Userspace"
 url="http://criu.org"
 arch="x86_64"

--- a/testing/ostinato/APKBUILD
+++ b/testing/ostinato/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Corentin Henry <corentinhenry@gmail.com>
 pkgname=ostinato
 pkgver=0.7.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Packet/Traffic Generator and Analyzer"
 url="https://www.ostinato.org/"
 arch="all"

--- a/testing/pulseaudio/APKBUILD
+++ b/testing/pulseaudio/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer:
 pkgname=pulseaudio
 pkgver=9.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A featureful, general-purpose sound server"
 url="http://www.freedesktop.org/wiki/Software/PulseAudio"
 arch="all"


### PR DESCRIPTION
Depending packages needs to be rebuild!

**Problems with depending packages:**

- [x] community/bitcoin: fails to build due to incorrect source checksum (what happened?!) [UPDATE: works now]
- [ ] community/namecoin: fails to build due to incorrect source checksum (what happened?!)
- [x] community/rethinkdb: fails to build: [UPDATE: works with protobuf 3.3.2]
    ```
        [12/423] CP ./build/drivers/ruby/lib
    [libprotobuf WARNING google/protobuf/compiler/parser.cc:546] No syntax specified for the proto file: rdb_protocol/ql2.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
        [14/423] BUILD re2_20140111
        [13/423] CC build/release_system/obj/web_assets/web_assets.o
        [15/423] CC build/release_system/obj/rdb_protocol/ql2.pb.o
    build/proto/rdb_protocol/ql2.pb.cc: In member function 'virtual google::protobuf::uint8* VersionDummy::InternalSerializeWithCachedSizesToArray(bool, google::protobuf::uint8*) const':
    build/proto/rdb_protocol/ql2.pb.cc:1123:10: error: unused parameter 'deterministic' [-Werror=unused-parameter]
         bool deterministic, ::google::protobuf::uint8* target) const {
              ^~~~~~~~~~~~~
    build/proto/rdb_protocol/ql2.pb.cc: In member function 'virtual google::protobuf::uint8* Frame::InternalSerializeWithCachedSizesToArray(bool, google::protobuf::uint8*) const':
    build/proto/rdb_protocol/ql2.pb.cc:2470:10: error: unused parameter 'deterministic' [-Werror=unused-parameter]
         bool deterministic, ::google::protobuf::uint8* target) const {
              ^~~~~~~~~~~~~
    cc1plus: all warnings being treated as errors
    make[1]: *** [src/build.mk:387: build/release_system/obj/rdb_protocol/ql2.pb.o] Error 1
    ```
- [ ] testing/ostinato: fails to build:
    ```
    g++ -c -pipe -O2 -fPIC -D_REENTRANT -Wall -W -DQT_NO_DEBUG -DQT_SCRIPT_LIB -DQT_XML_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/linux-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtXml -I/usr/include/QtScript -I/usr/include -I../extra/qhexedit2/src -I. -I. -o moc_ipv6addressdelegate.o moc_ipv6addressdelegate.cpp
    fileformat.pb.cc: In member function 'virtual google::protobuf::uint8* OstProto::FileMetaData::InternalSerializeWithCachedSizesToArray(bool, google::protobuf::uint8*) const':
    fileformat.pb.cc:600:10: warning: unused parameter 'deterministic' [-Wunused-parameter]
         bool deterministic, ::google::protobuf::uint8* target) const {
              ^~~~~~~~~~~~~
    fileformat.pb.cc: In member function 'virtual google::protobuf::uint8* OstProto::FileMagic::InternalSerializeWithCachedSizesToArray(bool, google::protobuf::uint8*) const':
    fileformat.pb.cc:2198:10: warning: unused parameter 'deterministic' [-Wunused-parameter]
         bool deterministic, ::google::protobuf::uint8* target) const {
              ^~~~~~~~~~~~~
    g++ -c -pipe -O2 -fPIC -D_REENTRANT -Wall -W -DQT_NO_DEBUG -DQT_SCRIPT_LIB -DQT_XML_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/linux-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtGui -I/usr/include/QtXml -I/usr/include/QtScript -I/usr/include -I../extra/qhexedit2/src -I. -I. -o moc_pdmlreader.o moc_pdmlreader.cpp
    fileformat.pb.cc: In member function 'virtual google::protobuf::uint8* OstProto::FileChecksum::InternalSerializeWithCachedSizesToArray(bool, google::protobuf::uint8*) const':
    fileformat.pb.cc:3105:10: warning: unused parameter 'deterministic' [-Wunused-parameter]
         bool deterministic, ::google::protobuf::uint8* target) const {
              ^~~~~~~~~~~~~
    ...
    g++ -c -pipe -O2 -D_REENTRANT -Wall -W -DHAVE_REMOTE -DWPCAP -DHAVE_IFLA_STATS64 -DQT_NO_DEBUG -DQT_SCRIPT_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/linux-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtScript -I/usr/include -I../rpc -I. -o pcapextra.o pcapextra.cpp
    echo "const char *version = \"0.7.1\"; const char *revision = \"da551b378f72@\";" > version.cpp
    /usr/bin/moc -DHAVE_REMOTE -DWPCAP -DHAVE_IFLA_STATS64 -DQT_NO_DEBUG -DQT_SCRIPT_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/linux-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtScript -I/usr/include -I../rpc -I. drone.h -o moc_drone.cpp
    /usr/bin/moc -DHAVE_REMOTE -DWPCAP -DHAVE_IFLA_STATS64 -DQT_NO_DEBUG -DQT_SCRIPT_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt/mkspecs/linux-g++ -I. -I/usr/include/QtCore -I/usr/include/QtNetwork -I/usr/include/QtScript -I/usr/include -I../rpc -I. myservice.h -o moc_myservice.cpp
    In file included from /usr/include/pcap.h:43:0,
                     from pcapextra.h:23,
                     from pcapextra.cpp:20:
    /usr/include/pcap/pcap.h:531:26: fatal error: remote-ext.h: No such file or directory
       #include <remote-ext.h>
                              ^
    compilation terminated.
    make[1]: *** [Makefile.drone:309: pcapextra.o] Error 1
    make[1]: *** Waiting for unfinished jobs....
    In file included from /usr/include/pcap.h:43:0,
                     from pcapport.h:25,
                     from pcapport.cpp:20:
    /usr/include/pcap/pcap.h:531:26: fatal error: remote-ext.h: No such file or directory
       #include <remote-ext.h>
                              ^
    compilation terminated.
    make[1]: *** [Makefile.drone:278: pcapport.o] Error 1
    In file included from /usr/include/pcap.h:43:0,
                     from pcapport.h:25,
                     from linuxport.h:27,
                     from linuxport.cpp:20:
    /usr/include/pcap/pcap.h:531:26: fatal error: remote-ext.h: No such file or directory
       #include <remote-ext.h>
                              ^
    compilation terminated.
    make[1]: *** [Makefile.drone:290: linuxport.o] Error 1
    In file included from /usr/include/pcap.h:43:0,
                     from pcapport.h:25,
                     from linuxport.h:27,
                     from portmanager.cpp:23:
    /usr/include/pcap/pcap.h:531:26: fatal error: remote-ext.h: No such file or directory
       #include <remote-ext.h>
                              ^
    compilation terminated.
    make[1]: *** [Makefile.drone:268: portmanager.o] Error 1
    abstractport.cpp: In member function 'void AbstractPort::updatePacketListSequential()':
    abstractport.cpp:245:43: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
                 qDebug("ibg1 = %" PRIu64, ibg1);
                                               ^
    abstractport.cpp:246:42: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
                 qDebug("nb1  = %" PRIu64, nb1);
                                              ^
    abstractport.cpp:247:43: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
                 qDebug("ibg2 = %" PRIu64, ibg2);
                                               ^
    abstractport.cpp:248:47: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
                 qDebug("nb2  = %" PRIu64 "\n", nb2);
                                                   ^
    abstractport.cpp:251:43: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
                 qDebug("ipg1 = %" PRIu64, ipg1);
                                               ^
    abstractport.cpp:252:43: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
                 qDebug("npx1 = %" PRIu64, npx1);
                                               ^
    abstractport.cpp:253:43: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
                 qDebug("npy1 = %" PRIu64, npy1);
                                               ^
    abstractport.cpp:254:43: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
                 qDebug("ipg2 = %" PRIu64, ipg2);
                                               ^
    abstractport.cpp:255:43: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
                 qDebug("npx2 = %" PRIu64, npx2);
                                               ^
    abstractport.cpp:256:48: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
                 qDebug("npy2 = %" PRIu64 "\n", npy2);
                                                    ^
    abstractport.cpp: In member function 'void AbstractPort::updatePacketListInterleaved()':
    abstractport.cpp:415:40: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
             qDebug("ibg1 = %" PRIu64, _ibg1);
                                            ^
    abstractport.cpp:416:39: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
             qDebug("nb1  = %" PRIu64, _nb1);
                                           ^
    abstractport.cpp:417:40: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
             qDebug("ibg2 = %" PRIu64, _ibg2);
                                            ^
    abstractport.cpp:418:44: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
             qDebug("nb2  = %" PRIu64 "\n", _nb2);
                                                ^
    abstractport.cpp:421:40: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
             qDebug("ipg1 = %" PRIu64, _ipg1);
                                            ^
    abstractport.cpp:422:39: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
             qDebug("np1  = %" PRIu64, _np1);
                                           ^
    abstractport.cpp:423:40: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
             qDebug("ipg2 = %" PRIu64, _ipg2);
                                            ^
    abstractport.cpp:424:44: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
             qDebug("np2  = %" PRIu64 "\n", _np2);
                                                ^
    abstractport.cpp:485:41: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
         qDebug("minGap   = %" PRIu64, minGap);
                                             ^
    abstractport.cpp:486:43: warning: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
         qDebug("duration = %" PRIu64, duration);
                                               ^
    abstractport.cpp:521:79: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
                     qDebug("q(%d) sec = %" PRIu64 " nsec = %" PRIu64, i, sec, nsec);
                                                                                   ^
    abstractport.cpp:521:79: warning: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'quint64 {aka long long unsigned int}' [-Wformat=]
    abstractport.cpp:561:68: warning: format '%ld' expects argument of type 'long int', but argument 2 has type 'qint64 {aka long long int}' [-Wformat=]
         qDebug("loop Delay = %" PRId64 "/%" PRId64, delaySec, delayNsec);
                                                                        ^
    abstractport.cpp:561:68: warning: format '%ld' expects argument of type 'long int', but argument 3 has type 'qint64 {aka long long int}' [-Wformat=]
    make[1]: Leaving directory '/home/jirutjak/aports/testing/ostinato/src/ostinato-0.7.1/server'
    make: *** [Makefile:189: sub-server-drone-pro-make_default-ordered] Error 2
    ```