### PR TITLE
main/gcc: fix cross-compile paths for gdb helper

### DIFF
--- a/main/gcc/APKBUILD
+++ b/main/gcc/APKBUILD
@@ -357,9 +357,10 @@ package() {
 	rm -f "$pkgdir"/usr/lib/libffi* "$pkgdir"/usr/share/man/man3/ffi*
 	find "$pkgdir" -name 'ffi*.h' | xargs rm -f
 
-	mkdir -p "$pkgdir"/usr/share/gdb/python/auto-load/usr/lib
-	mv "$pkgdir"/usr/lib/*-gdb.py \
-		"$pkgdir"/usr/share/gdb/python/auto-load/usr/lib/
+	local gdblib=${_target:+$CTARGET/}lib
+	mkdir -p "$pkgdir"/usr/share/gdb/python/auto-load/usr/$gdblib
+	mv "$pkgdir"/usr/$gdblib/*-gdb.py \
+		"$pkgdir"/usr/share/gdb/python/auto-load/usr/$gdblib/
 
 	paxmark -pmrs "$pkgdir"/$_gcclibexec/cc1
 


### PR DESCRIPTION
Cross-compile version fails to package GDB helper into the right path.