### PR TITLE
community/firefox-esr: upgrade to 52.1.2

### DIFF
--- a/community/firefox-esr/APKBUILD
+++ b/community/firefox-esr/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: William Pitcock <nenolod@dereferenced.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox-esr
-pkgver=52.1.0
+pkgver=52.1.2
 _pkgver=$pkgver
 _xulver=$pkgver
 pkgrel=0
@@ -229,7 +229,7 @@ dev() {
 	default_dev
 }
 
-sha512sums="ba833904654eda347f83df77e04c8e81572772e8555f187b796ecc30e498b93fb729b6f60935731d9584169adc9d61329155364fddf635cbd11abebe4a600247  firefox-52.1.0esr.source.tar.xz
+sha512sums="76362738f6db82a41ff6af4e12a15a302068a5ce10d23739f29375f3279573d0ea43ecee9d2e46fce833a029e437efcfcceab9442c288560f476e0cff2ea9e1d  firefox-52.1.2esr.source.tar.xz
 0b3f1e4b9fdc868e4738b5c81fd6c6128ce8885b260affcb9a65ff9d164d7232626ce1291aaea70132b3e3124f5e13fef4d39326b8e7173e362a823722a85127  stab.h
 7e123144bc2b1efed149dfb41b255c447d43ea93a63ebe114d01945e6a6d69edc2f2a3c36980a93279106c1842355851b8b6c1d96679ee6be7b9b30513e0b1a8  0002-Use-C99-math-isfinite.patch
 09bc32cf9ee81b9cc6bb58ddbc66e6cc5c344badff8de3435cde5848e5a451e0172153231db85c2385ff05b5d9c20760cb18e4138dfc99060a9e960de2befbd5  fix-fortify-inline.patch


### PR DESCRIPTION
CVE-2017-5031: Use after free in ANGLE, fixed in 52.1.1