### PR TITLE
main/alpine-conf: add lvm2 dependency

### DIFF
--- a/main/alpine-conf/APKBUILD
+++ b/main/alpine-conf/APKBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=alpine-conf
 pkgver=3.6.0_rc1
-pkgrel=2
+pkgrel=3
 pkgdesc="Alpine configuration management scripts"
 url=http://git.alpinelinux.org/cgit/$pkgname
 arch="all"
 license="MIT"
-depends="openrc>0.13 busybox>=1.26.1-r3"
+depends="openrc>0.13 busybox>=1.26.1-r3 lvm2"
 source="http://dev.alpinelinux.org/archive/alpine-conf/alpine-conf-$pkgver.tar.xz
 	0001-setup-keymap-allow-specify-the-variant-together-with.patch
 	0001-setup-disk-add-xfs-support-as-boot_fs.patch


### PR DESCRIPTION
alpine-conf package provides 'setup-disk' script which uses
'vgchange' command. This command is provided by lvm2 package,
and it was missing as dependency.