### PR TITLE
testing/jsonnet: new aport

### DIFF
--- a/testing/jsonnet/APKBUILD
+++ b/testing/jsonnet/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Benjamin Staffin <benley@gmail.com>
+# Maintainer: Benjamin Staffin <benley@gmail.com>
+pkgname=jsonnet
+pkgver=0.9.3
+pkgrel=0
+pkgdesc="The data templating language"
+url="https://jsonnet.org"
+arch="all"
+license="ASL 2.0"
+depends=""
+makedepends=""
+install=""
+subpackages=""
+source="jsonnet-$pkgver.tar.gz::https://github.com/google/jsonnet/archive/v$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+  cd "$builddir"
+  CXXFLAGS="$CXXFLAGS -g -O3 -Wall -Wextra -Woverloaded-virtual -pedantic -std=c++0x -fPIC -Iinclude -Ithird_party/md5"
+  CFLAGS="$CFLAGS -g -O3 -Wall -Wextra -pedantic -std=c99 -fPIC -Iinclude"
+  make jsonnet
+}
+
+package() {
+  cd "$builddir"
+  mkdir -p "$pkgdir"
+  cp jsonnet "$pkgdir"
+}
+
+md5sums="6715f8f08c4de0b65401a5f0b017f55a  jsonnet-0.9.3.tar.gz"
+sha256sums="25f21410acb3e1a9c8ced2a9d416cc39af70a0e4e12fb52c48f4eb4ac25bc938  jsonnet-0.9.3.tar.gz"
+sha512sums="f5a77bc07d5034244d02d1b5b7b68c2365d6f7891bb32250349a68b4c585f72f9e9dae4d11af770e97cf7f7533c2efc8d5052d4fcb70a2d3acb49b41f269e4c4  jsonnet-0.9.3.tar.gz"


### PR DESCRIPTION
This package uses a simple makefile build, but not autotools; there is no configure script and no install target.