### PR TITLE
community/php7 / community/php5 Add php virtual packages

### DIFF
--- a/community/php5/APKBUILD
+++ b/community/php5/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
 pkgver=5.6.35
-pkgrel=0
+pkgrel=1
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
 arch="all"
@@ -12,7 +12,7 @@ license="PHP-3.0"
 depends="$pkgname-cli"
 depends_dev="$pkgname-cli pcre-dev"
 install="$pkgname.post-upgrade"
-provides="php"
+provides="$pkgname-cli php-cli php"
 makedepends="
 	$depends_dev
 	apache2-dev
@@ -339,7 +339,7 @@ doc() {
 
 common() {
 	pkgdesc="PHP Common Files"
-	provides="$pkgname-zlib"  # for backward compatibility
+	provides="php-common $pkgname-zlib php-zlib"  # for backward compatibility
 	depends=""
 
 	cd "$srcdir"/php-$pkgver
@@ -354,6 +354,7 @@ common() {
 cgi() {
 	pkgdesc="PHP Common Gateway Interface (CGI)"
 	depends="$pkgname-common"
+	provides="php-cgi"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/php-cgi* "$subpkgdir"/usr/bin/
 }
@@ -370,6 +371,7 @@ cli() {
 fpm() {
 	pkgdesc="PHP FastCGI Process Manager (FPM)"
 	depends="$pkgname-common"
+	provides="php-fpm"
 	mkdir -p "$subpkgdir"$_confdir/fpm.d
 	install -D -m755 "$srcdir"/build-fpm/sapi/fpm/php-fpm \
 		"$subpkgdir"/usr/bin/php-fpm5 || return 1
@@ -388,6 +390,7 @@ fpm() {
 apache2() {
 	pkgdesc="PHP Module for Apache2"
 	depends="$pkgname-common apache2"
+	provides="php-apache2"
 	install -D -m755 "$srcdir"/build-apache2/libs/libphp5.so \
 		"$subpkgdir"/usr/lib/apache2/libphp5.so || return 1
 	install -D -m644 "$srcdir"/php5-module.conf \
@@ -397,6 +400,7 @@ apache2() {
 embed() {
 	pkgdesc="PHP Embed Library"
 	depends="$pkgname-common"
+	provides="php-embed"
 	mkdir -p "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/lib/libphp5.so "$subpkgdir"/usr/lib/
 }
@@ -404,6 +408,7 @@ embed() {
 pear() {
 	pkgdesc="PHP Extension and Application Repository (PEAR)"
 	depends="$pkgname-cli $pkgname-xml"
+	provides="php-pear"
 	mkdir -p "$subpkgdir"/usr/share "$subpkgdir"$_confdir \
 		"$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/pecl \
@@ -418,6 +423,7 @@ pear() {
 
 phpdbg() {
 	pkgdesc="Interactive PHP debugger"
+	provides="php-phpdbg"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/phpdbg* "$subpkgdir"/usr/bin/
 }
@@ -426,6 +432,7 @@ _mv_ext() {
 	local ext=$1
 	local ini=$ext.ini
 	pkgdesc="${ext} extension for PHP"
+	provides="php-$extname"
 
 	# extension dependencies
 	if [ -n "${2-}" ]; then

--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -26,7 +26,7 @@
 pkgname=php7
 _pkgreal=php
 pkgver=7.2.4
-pkgrel=0
+pkgrel=1
 _apiver=20170718
 _suffix=${pkgname#php}
 # Is this package the default (latest) PHP version?
@@ -83,7 +83,8 @@ makedepends="
 	unixodbc-dev
 	zlib-dev
 	"
-provides="$pkgname-cli"  # for backward compatibility
+provides="$pkgname-cli php-cli php"  # for backward compatibility
+provider_priority=100
 subpackages="$pkgname-dev $pkgname-doc $pkgname-apache2 $pkgname-phpdbg
 	$pkgname-embed $pkgname-litespeed $pkgname-cgi $pkgname-fpm
 	$pkgname-pear::noarch
@@ -442,6 +443,7 @@ doc() {
 apache2() {
 	pkgdesc="PHP$_suffix Module for Apache2"
 	depends="$depends apache2"
+	provides="php-apache2"
 
 	install -D -m 755 "$builddir"/sapi/apache2handler/mod_php$_suffix.so \
 		"$subpkgdir"/usr/lib/apache2/mod_php$_suffix.so
@@ -452,6 +454,7 @@ apache2() {
 
 phpdbg() {
 	pkgdesc="Interactive PHP$_suffix debugger"
+	provides="php-phpdbg"
 
 	install -Dm755 "$builddir"/sapi/phpdbg/phpdbg \
 		"$subpkgdir"/usr/bin/phpdbg$_suffix
@@ -463,12 +466,14 @@ phpdbg() {
 
 embed() {
 	pkgdesc="PHP$_suffix Embedded Library"
+	provides="php-embed"
 
 	_mv "$pkgdir"/usr/lib/libphp*.so "$subpkgdir"/usr/lib/
 }
 
 litespeed() {
 	pkgdesc="PHP$_suffix LiteSpeed SAPI"
+	provides="php-lightspeed"
 
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/lsphp$_suffix "$subpkgdir"/usr/bin
@@ -480,6 +485,7 @@ litespeed() {
 
 cgi() {
 	pkgdesc="PHP$_suffix Common Gateway Interface"
+	provides="php-cgi"
 
 	_mv "$pkgdir"/usr/bin/php-cgi$_suffix "$subpkgdir"/usr/bin/
 
@@ -490,6 +496,7 @@ cgi() {
 
 fpm() {
 	pkgdesc="PHP$_suffix FastCGI Process Manager"
+	provides="php-fpm"
 
 	cd "$pkgdir"
 
@@ -515,6 +522,7 @@ fpm() {
 pear() {
 	pkgdesc="PHP$_suffix Extension and Application Repository"
 	depends="$pkgname $pkgname-xml"
+	provides="php-pear"
 
 	cd "$pkgdir"
 
@@ -536,7 +544,7 @@ pear() {
 
 common() {
 	pkgdesc="$pkgdesc (common config)"
-	provides="$pkgname-zlib"  # for backward compatibility
+	provides="php-common $pkgname-zlib php-zlib"  # for backward compatibility
 	depends=""
 
 	cd "$pkgdir"
@@ -568,6 +576,7 @@ _extension() {
 	local extdepends="$(eval "echo \$_depends_$extname")"
 	local extdesc="$(head -n1 "$builddir"/ext/$extname/CREDITS 2>/dev/null ||:)"
 	pkgdesc="PHP$_suffix extension: ${extdesc:-$extname}"
+	provides="php-$extname"
 
 	: ${extdepends:=$(_resolve_extension_deps "$extname")}
 	depends="$depends $extdepends"


### PR DESCRIPTION
This allows other packages to depend on php5 or php7 via the php or php-[extension] virtual packages. A good example of this is the composer package. It will run with PHP 5.6 or 7.x. This virtual package will allow me to define either as the dependency via the `php`, `php-json` dependencies instead of hardcoding `php5` and `php5-json` packages.