### PR TITLE
[llvm packages]: add tests and cleanup dependencies

### DIFF
--- a/community/lld/APKBUILD
+++ b/community/lld/APKBUILD
@@ -2,20 +2,23 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=lld
 pkgver=4.0.0
-pkgrel=0
-_vermajor=${pkgver%%.*}
+pkgrel=1
+_llvmver=${pkgver%%.*}
 pkgdesc="The LLVM Linker"
 url="http://llvm.org"
 arch="all"
 license="UOI-NCSA"
 makedepends="
 	cmake
-	llvm-dev>=$_vermajor
-	llvm-static>=$_vermajor
+	llvm-dev>=$_llvmver
+	llvm-static>=$_llvmver
 	zlib-dev"
+checkdepends="llvm-utils>=$_llvmver gtest gtest-dev"
 subpackages="$pkgname-dev"
 source="http://llvm.org/releases/$pkgver/$pkgname-$pkgver.src.tar.xz
-	cmake-fix-pthread-handling-for-out-of-tree-builds.patch"
+	cmake-fix-pthread-handling-for-out-of-tree-builds.patch
+	cmake-support-running-tests-in-stand-alone-builds.patch
+	fix-standalone-test-suite.patch"
 builddir="$srcdir/$pkgname-$pkgver.src"
 
 build() {
@@ -24,19 +27,19 @@ build() {
 
 	cmake .. \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_VERBOSE_MAKEFILE=OFF \
 		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
 		-DCMAKE_C_FLAGS="$CFLAGS" \
+		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
 		-DCMAKE_SKIP_INSTALL_RPATH=ON \
+		-DLLVM_INCLUDE_TESTS=ON \
 		-DLLVM_LINK_LLVM_DYLIB=ON
 	make
 }
 
 check() {
-	cd "$builddir"
+	cd "$builddir"/build
 
-	./build/bin/ld.lld --version
+	make check-lld
 }
 
 package() {
@@ -46,4 +49,6 @@ package() {
 }
 
 sha512sums="66b2c9cc57f5e94ad7e7da1b1bcc08cbbaee1b55c6efa64b2424b9d8776c70b842c2a31c188a99b447be6a8621ad1b1e70573bbfcf5d6b1aa986b03b3b3350f3  lld-4.0.0.src.tar.xz
-2aa44973dd86aaddbd5b21789bb5e2a611d00558c41ebd078c2b7d1a3eb5c303db69084f50517b14e77674c46148ecae6bde1b037d8ba5269a342fba84116a9b  cmake-fix-pthread-handling-for-out-of-tree-builds.patch"
+2aa44973dd86aaddbd5b21789bb5e2a611d00558c41ebd078c2b7d1a3eb5c303db69084f50517b14e77674c46148ecae6bde1b037d8ba5269a342fba84116a9b  cmake-fix-pthread-handling-for-out-of-tree-builds.patch
+5871cd12512494a8914b0079ef2deceb37396ad9eafedd21969bf74e8889f5252dcfde1d1d3d06ac447e5317287faa678b74bed6102d20ada5dfda56bfa33e7c  cmake-support-running-tests-in-stand-alone-builds.patch
+03f9cab3efff93a077dd98a7d80feaf974dbde6f07c5604a5a3b7dab9fc5f225e7bb0a13e9a7b781dacf14d1e659546a535e353dba496b570e235311dba0bb5a  fix-standalone-test-suite.patch"

--- a/community/lld/cmake-support-running-tests-in-stand-alone-builds.patch
+++ b/community/lld/cmake-support-running-tests-in-stand-alone-builds.patch
@@ -1,0 +1,157 @@
+From 187040013836066b5fbf91cd037caec655a797c9 Mon Sep 17 00:00:00 2001
+From: Michal Gorny <mgorny@gentoo.org>
+Date: Tue, 31 Jan 2017 14:10:20 +0000
+Subject: [PATCH] [cmake] Support running tests in stand-alone builds
+
+Add the CMake bits necessary to run lld tests (and unittests) when
+building stand-alone. The code is based on the equivalent code in clang,
+and includes:
+
+1. checking for Python, searching for lit and necessary LLVM test tools
+(FileCount and not),
+
+2. building LLVM test tools (FileCount and not) from LLVM sources if
+they are not installed,
+
+3. building gtest libraries from LLVM sources,
+
+4. adjusting dependencies so that test targets depend only on those LLVM
+targets that are available for a particular variant of stand-alone
+build.
+
+With this patch, I am able to successfully run 1002 (+10 unsupported)
+lit tests on Gentoo using installed LLVM.
+
+Differential Revision: https://reviews.llvm.org/D28750
+
+git-svn-id: https://llvm.org/svn/llvm-project/lld/trunk@293630 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ CMakeLists.txt      | 68 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
+ test/CMakeLists.txt | 16 ++++++++-----
+ 2 files changed, 77 insertions(+), 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index be424efbb..7fcb1a748 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,8 +11,11 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+     message(FATAL_ERROR "llvm-config not found: specify LLVM_CONFIG_PATH")
+   endif()
+ 
+-  execute_process(COMMAND "${LLVM_CONFIG_PATH}" "--obj-root" "--includedir"
++  execute_process(COMMAND "${LLVM_CONFIG_PATH}"
++                          "--obj-root"
++                          "--includedir"
+                           "--cmakedir"
++                          "--src-root"
+                   RESULT_VARIABLE HAD_ERROR
+                   OUTPUT_VARIABLE LLVM_CONFIG_OUTPUT
+                   OUTPUT_STRIP_TRAILING_WHITESPACE)
+@@ -25,9 +28,11 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+   list(GET LLVM_CONFIG_OUTPUT 0 OBJ_ROOT)
+   list(GET LLVM_CONFIG_OUTPUT 1 MAIN_INCLUDE_DIR)
+   list(GET LLVM_CONFIG_OUTPUT 2 LLVM_CMAKE_PATH)
++  list(GET LLVM_CONFIG_OUTPUT 3 MAIN_SRC_DIR)
+ 
+   set(LLVM_OBJ_ROOT ${OBJ_ROOT} CACHE PATH "path to LLVM build tree")
+   set(LLVM_MAIN_INCLUDE_DIR ${MAIN_INCLUDE_DIR} CACHE PATH "path to llvm/include")
++  set(LLVM_MAIN_SRC_DIR ${MAIN_SRC_DIR} CACHE PATH "Path to LLVM source tree")
+ 
+   file(TO_CMAKE_PATH ${LLVM_OBJ_ROOT} LLVM_BINARY_DIR)
+ 
+@@ -49,6 +54,67 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+   include(AddLLVM)
+   include(TableGen)
+   include(HandleLLVMOptions)
++
++  if(LLVM_INCLUDE_TESTS)
++    set(Python_ADDITIONAL_VERSIONS 2.7)
++    include(FindPythonInterp)
++    if(NOT PYTHONINTERP_FOUND)
++      message(FATAL_ERROR
++"Unable to find Python interpreter, required for testing.
++
++Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
++    endif()
++
++    if(${PYTHON_VERSION_STRING} VERSION_LESS 2.7)
++      message(FATAL_ERROR "Python 2.7 or newer is required")
++    endif()
++
++    # Check prebuilt llvm/utils.
++    if(EXISTS ${LLVM_TOOLS_BINARY_DIR}/FileCheck${CMAKE_EXECUTABLE_SUFFIX}
++        AND EXISTS ${LLVM_TOOLS_BINARY_DIR}/not${CMAKE_EXECUTABLE_SUFFIX})
++      set(LLVM_UTILS_PROVIDED ON)
++    endif()
++
++    if(EXISTS ${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py)
++      # Note: path not really used, except for checking if lit was found
++      set(LLVM_LIT ${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py)
++      if(NOT LLVM_UTILS_PROVIDED)
++        add_subdirectory(${LLVM_MAIN_SRC_DIR}/utils/FileCheck utils/FileCheck)
++        add_subdirectory(${LLVM_MAIN_SRC_DIR}/utils/not utils/not)
++        set(LLVM_UTILS_PROVIDED ON)
++        set(LLD_TEST_DEPS FileCheck not)
++      endif()
++      set(UNITTEST_DIR ${LLVM_MAIN_SRC_DIR}/utils/unittest)
++      if(EXISTS ${UNITTEST_DIR}/googletest/include/gtest/gtest.h
++          AND NOT EXISTS ${LLVM_LIBRARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}
++          AND EXISTS ${UNITTEST_DIR}/CMakeLists.txt)
++        add_subdirectory(${UNITTEST_DIR} utils/unittest)
++      endif()
++    else()
++      # Seek installed Lit.
++      find_program(LLVM_LIT
++                   NAMES llvm-lit lit.py lit
++                   PATHS "${LLVM_MAIN_SRC_DIR}/utils/lit"
++                   DOC "Path to lit.py")
++    endif()
++
++    if(LLVM_LIT)
++      # Define the default arguments to use with 'lit', and an option for the user
++      # to override.
++      set(LIT_ARGS_DEFAULT "-sv")
++      if (MSVC OR XCODE)
++        set(LIT_ARGS_DEFAULT "${LIT_ARGS_DEFAULT} --no-progress-bar")
++      endif()
++      set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
++
++      # On Win32 hosts, provide an option to specify the path to the GnuWin32 tools.
++      if(WIN32 AND NOT CYGWIN)
++        set(LLVM_LIT_TOOLS_DIR "" CACHE PATH "Path to GnuWin32 tools")
++      endif()
++    else()
++      set(LLVM_INCLUDE_TESTS OFF)
++    endif()
++  endif()
+ endif()
+ 
+ set(LLD_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 678880b7f..ede92c13d 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -19,13 +19,17 @@ configure_lit_site_cfg(
+   ${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg
+   )
+ 
+-set(LLD_TEST_DEPS
+-  FileCheck not llvm-ar llvm-as llvm-dis llvm-dwarfdump llvm-nm
+-  llc lld llvm-config llvm-objdump llvm-readobj yaml2obj obj2yaml
+-  llvm-mc llvm-lib llvm-pdbdump opt
+-  )
++set(LLD_TEST_DEPS lld)
++if (NOT LLD_BUILT_STANDALONE)
++  list(APPEND LLD_TEST_DEPS
++    FileCheck not llvm-ar llvm-as llvm-dis llvm-dwarfdump llvm-nm
++    llc llvm-config llvm-objdump llvm-readobj yaml2obj obj2yaml
++    llvm-mc llvm-lib llvm-pdbdump opt
++    )
++endif()
++
+ if (LLVM_INCLUDE_TESTS)
+-  set(LLD_TEST_DEPS ${LLD_TEST_DEPS} LLDUnitTests)
++  list(APPEND LLD_TEST_DEPS LLDUnitTests)
+ endif()
+ 
+ set(LLD_TEST_PARAMS

--- a/community/lld/fix-standalone-test-suite.patch
+++ b/community/lld/fix-standalone-test-suite.patch
@@ -1,0 +1,11 @@
+--- a/test/lit.cfg
++++ b/test/lit.cfg
+@@ -174,7 +174,7 @@
+                           pattern)
+     tool_pipe = tool_match.group(2)
+     tool_name = tool_match.group(4)
+-    tool_path = lit.util.which(tool_name, llvm_tools_dir)
++    tool_path = lit.util.which(tool_name, os.pathsep.join([lld_obj_root + '/bin', llvm_tools_dir]))
+     if not tool_path:
+         # Warn, but still provide a substitution.
+         lit_config.note('Did not find ' + tool_name + ' in ' + llvm_tools_dir)

--- a/community/llvm-libunwind/APKBUILD
+++ b/community/llvm-libunwind/APKBUILD
@@ -4,18 +4,18 @@ pkgname=llvm-libunwind
 _pkgname=libunwind
 pkgver=4.0.0
 _llvmver=${pkgver%%.*}
-pkgrel=0
+pkgrel=1
 pkgdesc="LLVM version of libunwind library"
 url="http://llvm.org/"
 arch="all !ppc64le !s390x"
 license="BSD"
 depends_dev="!libunwind-dev"
-makedepends="cmake llvm$_llvmver-dev"
+makedepends="cmake llvm-dev>=$_llvmver"
 subpackages="$pkgname-dev"
 source="http://www.llvm.org/releases/$pkgver/$_pkgname-$pkgver.src.tar.xz
 	no-exec-stack.patch"
 builddir="$srcdir/$_pkgname-$pkgver.src"
-options="!check"
+options="!check"  # no working testsuite provided
 
 build() {
 	cd "$builddir"
@@ -23,9 +23,8 @@ build() {
 	cmake \
 		-DCMAKE_BUILD_TYPE=MinSizeRel \
 		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
 		-DCMAKE_C_FLAGS="$CFLAGS" \
-		-DLLVM_CONFIG_PATH="/usr/lib/llvm$_llvmver/bin/llvm-config" \
+		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
 		-DLIBUNWIND_HAS_NODEFAULTLIBS_FLAG=OFF
 	make
 }

--- a/main/clang/APKBUILD
+++ b/main/clang/APKBUILD
@@ -3,8 +3,8 @@
 pkgname=clang
 # Note: Update together with llvm.
 pkgver=4.0.0
-pkgrel=0
-_vermajor=${pkgver%%.*}
+pkgrel=1
+_llvmver=${pkgver%%.*}
 pkgdesc="A C language family front-end for LLVM"
 arch="all"
 url="http://llvm.org/"
@@ -14,11 +14,12 @@ makedepends="
 	isl-dev
 	libxml2-dev
 	libxml2-utils
-	llvm-dev>=$_vermajor
-	llvm-static>=$_vermajor
+	llvm-dev>=$_llvmver
+	llvm-static>=$_llvmver
 	paxmark
 	python2
 	"
+checkdepends="llvm-utils>=$_llvmver"
 depends_dev="$pkgname=$pkgver-r$pkgrel"
 subpackages="$pkgname-static $pkgname-dev $pkgname-doc $pkgname-libs
 	$pkgname-analyzer::noarch"
@@ -37,35 +38,34 @@ build() {
 	mkdir -p "$builddir"/build
 	cd "$builddir"/build
 
-	cmake .. -G "Unix Makefiles" -Wno-dev \
+	cmake .. -Wno-dev \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DCMAKE_VERBOSE_MAKEFILE=OFF \
+		-DCMAKE_C_FLAGS="$CFLAGS" \
+		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+		-DLLVM_ENABLE_EH=ON \
+		-DLLVM_ENABLE_RTTI=ON \
+		-DLIBCLANG_BUILD_STATIC=ON \
+		-DCLANG_VENDOR=Alpine \
 		-DCLANG_BUILD_EXAMPLES=OFF \
 		-DCLANG_INCLUDE_DOCS=ON \
 		-DCLANG_INCLUDE_TESTS=ON \
-		-DCLANG_PLUGIN_SUPPORT=ON \
-		-DLIBCLANG_BUILD_STATIC=ON \
-		-DLLVM_ENABLE_EH=ON \
-		-DLLVM_ENABLE_RTTI=ON \
-		|| return 1
+		-DCLANG_PLUGIN_SUPPORT=ON
 
-	make clang-tblgen || return 1
+	make clang-tblgen
 	make
 }
 
 check() {
 	cd "$builddir"/build
 
-	./bin/clang --version
-	./bin/clang-check --version
-	./bin/clang-format --version
+	make check-clang
 }
 
 package() {
 	cd "$builddir"/build
 
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -m 644 lib/libclang.a "$pkgdir"/usr/lib
 }
 

--- a/main/compiler-rt/APKBUILD
+++ b/main/compiler-rt/APKBUILD
@@ -3,8 +3,8 @@
 pkgname=compiler-rt
 # Note: Update together with llvm.
 pkgver=4.0.0
-pkgrel=0
-_vermajor=${pkgver%%.*}
+pkgrel=1
+_llvmver=${pkgver%%.*}
 pkgdesc="LLVM compiler-rt runtime libraries"
 arch="all"
 url="http://llvm.org/"
@@ -12,11 +12,13 @@ license="UOI-NCSA"
 makedepends="
 	cmake
 	linux-headers
-	llvm-dev>=$_vermajor
-	llvm-static>=$_vermajor
+	llvm-dev>=$_llvmver
+	llvm-static>=$_llvmver
 	python2
 	"
-source="http://llvm.org/releases/$pkgver/$pkgname-$pkgver.src.tar.xz"
+checkdepends="llvm-utils>=$_llvmver"
+source="http://llvm.org/releases/$pkgver/$pkgname-$pkgver.src.tar.xz
+	dont-test-unbuilt-sanitizers.patch"
 builddir="$srcdir/$pkgname-$pkgver.src"
 
 build() {
@@ -25,17 +27,24 @@ build() {
 
 	cmake .. \
 		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_C_FLAGS="$CFLAGS" \
+		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCOMPILER_RT_BUILD_SANITIZERS=OFF \
 		-DCOMPILER_RT_BUILD_XRAY=OFF \
-		|| return 1
-	make || return 1
+		-DCOMPILER_RT_INCLUDE_TESTS=ON
+	make
+}
+
+check() {
+	cd "$builddir"/build
+	make check-compiler-rt
 }
 
 package() {
 	cd "$builddir"/build
 
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 
 	cd "$pkgdir"
 
@@ -46,4 +55,5 @@ package() {
 	esac
 }
 
-sha512sums="ed52436a2399ca82c1af46a523e89e88c23367f74cd110f0267af49a72aa4912ae8f48c6093e6b01c9ea68c48354a12201d26baf721d254fb017ddb98af2e3dd  compiler-rt-4.0.0.src.tar.xz"
+sha512sums="ed52436a2399ca82c1af46a523e89e88c23367f74cd110f0267af49a72aa4912ae8f48c6093e6b01c9ea68c48354a12201d26baf721d254fb017ddb98af2e3dd  compiler-rt-4.0.0.src.tar.xz
+b0c3dac34820e8b95f461c5b9025e154f2244237e38ed3fa482baea8233686e0c40c7ae8f572513161856313029db40566bf4d21f102a554e556b45d8d0ef794  dont-test-unbuilt-sanitizers.patch"

--- a/main/compiler-rt/dont-test-unbuilt-sanitizers.patch
+++ b/main/compiler-rt/dont-test-unbuilt-sanitizers.patch
@@ -1,0 +1,25 @@
+--- a/cmake/config-ix.cmake
++++ b/cmake/config-ix.cmake
+@@ -434,7 +434,8 @@
+     "sanitizers to build if supported on the target (all;${ALL_SANITIZERS})")
+ list_replace(COMPILER_RT_SANITIZERS_TO_BUILD all "${ALL_SANITIZERS}")
+ 
+-if (SANITIZER_COMMON_SUPPORTED_ARCH AND NOT LLVM_USE_SANITIZER AND
++if (SANITIZER_COMMON_SUPPORTED_ARCH AND COMPILER_RT_BUILD_SANITIZERS AND
++    NOT LLVM_USE_SANITIZER AND
+     (OS_NAME MATCHES "Android|Darwin|Linux|FreeBSD" OR
+     (OS_NAME MATCHES "Windows" AND (NOT MINGW AND NOT CYGWIN))))
+   set(COMPILER_RT_HAS_SANITIZER_COMMON TRUE)
+--- a/cmake/config-ix.cmake
++++ b/cmake/config-ix.cmake
+@@ -484,8 +484,8 @@
+   set(COMPILER_RT_HAS_MSAN FALSE)
+ endif()
+ 
+-if (PROFILE_SUPPORTED_ARCH AND NOT LLVM_USE_SANITIZER AND
+-    OS_NAME MATCHES "Darwin|Linux|FreeBSD|Windows")
++if (PROFILE_SUPPORTED_ARCH AND COMPILER_RT_BUILD_SANITIZERS AND
++    NOT LLVM_USE_SANITIZER AND OS_NAME MATCHES "Darwin|Linux|FreeBSD|Windows")
+   set(COMPILER_RT_HAS_PROFILE TRUE)
+ else()
+   set(COMPILER_RT_HAS_PROFILE FALSE)

--- a/main/llvm4/APKBUILD
+++ b/main/llvm4/APKBUILD
@@ -6,14 +6,14 @@ _pkgname=llvm
 pkgver=4.0.0
 _majorver=${pkgver%%.*}
 pkgname=$_pkgname$_majorver
-pkgrel=5
+pkgrel=6
 pkgdesc="Low Level Virtual Machine compiler system, version $_majorver"
 arch="all"
 url="http://llvm.org/"
 license="UOI-NCSA"
 depends_dev="$pkgname=$pkgver-r$pkgrel"
 makedepends="binutils-dev chrpath cmake file libffi-dev paxmark python2 py-setuptools zlib-dev"
-subpackages="$pkgname-static $pkgname-libs $pkgname-dev $pkgname-test-utils:_test_utils"
+subpackages="$pkgname-static $pkgname-libs $pkgname-dev $pkgname-utils:_utils"
 source="http://llvm.org/releases/$pkgver/llvm-$pkgver.src.tar.xz
 	llvm-fix-build-with-musl-libc.patch
 	llvm-fix-DynamicLibrary-to-build-with-musl-libc.patch
@@ -32,6 +32,11 @@ esac
 
 # Whether is this package the default (latest) LLVM version.
 _default_llvm="yes"
+# List of utilities. Keep up-to-date with CMakeLists.txt's LLVM_INCLUDE_UTILS!
+# Exceptions:
+# * llvm-lit (only for running local LLVM tests)
+# * unittest (no binaries)
+_utils="FileCheck llvm-PerfectShuffle count not yaml-bench"
 
 if [ "$_default_llvm" = yes ]; then
 	provides="llvm=$pkgver-r$pkgrel"
@@ -74,10 +79,9 @@ build() {
 	# Auto-detect it by guessing either.
 	local ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
 
-	cmake -G "Unix Makefiles" -Wno-dev \
+	cmake .. -Wno-dev \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_INSTALL_PREFIX=/$_prefix \
-		-DCMAKE_VERBOSE_MAKEFILE=NO \
+		-DCMAKE_INSTALL_PREFIX="/$_prefix" \
 		-DFFI_INCLUDE_DIR="$ffi_include_dir" \
 		-DLLVM_BINUTILS_INCDIR=/usr/include \
 		-DLLVM_BUILD_DOCS=OFF \
@@ -86,7 +90,6 @@ build() {
 		-DLLVM_BUILD_LLVM_DYLIB=ON \
 		-DLLVM_BUILD_TESTS=ON \
 		-DLLVM_DEFAULT_TARGET_TRIPLE="$CBUILD" \
-		-DLLVM_DYLIB_EXPORT_ALL=ON \
 		-DLLVM_ENABLE_ASSERTIONS=OFF \
 		-DLLVM_ENABLE_CXX1Y=ON \
 		-DLLVM_ENABLE_FFI=ON \
@@ -98,9 +101,9 @@ build() {
 		-DLLVM_ENABLE_ZLIB=ON \
 		-DLLVM_HOST_TRIPLE="$CHOST" \
 		-DLLVM_INCLUDE_EXAMPLES=OFF \
+		-DLLVM_INSTALL_UTILS=ON \
 		-DLLVM_LINK_LLVM_DYLIB=ON \
-		-DLLVM_TARGETS_TO_BUILD='X86;ARM;AArch64;PowerPC;SystemZ;AMDGPU;NVPTX;Mips;BPF' \
-		"$builddir"
+		-DLLVM_TARGETS_TO_BUILD='X86;ARM;AArch64;PowerPC;SystemZ;AMDGPU;NVPTX;Mips;BPF'
 
 	make llvm-tblgen
 	make
@@ -155,9 +158,10 @@ package() {
 			newname=$name
 		fi
 		case "$name" in
-			FileCheck | obj2yaml | yaml2obj) continue;;
+			ll*) ;;
+			*) continue;;
 		esac
-		ln -s ../lib/llvm$_majorver/bin/$name "$pkgdir"/usr/bin/$newname
+		ln -s ../${_prefix#*/}/bin/$name "$pkgdir"/usr/bin/$newname
 	done
 
 	# Move /usr/lib/$pkgname/include/ into /usr/include/$pkgname/
@@ -211,11 +215,11 @@ dev() {
 	_mv "$pkgdir"/$_prefix/bin/llvm-config $_prefix/bin/
 }
 
-_test_utils() {
+_utils() {
 	pkgdesc="LLVM $_majorver utilities for executing LLVM and Clang style test suites"
 	depends="python2 py-setuptools"
 	_common_subpkg
-	replaces=""
+	replaces="$pkgname-test-utils"
 
 	local litver=$(python2 "$builddir"/utils/lit/setup.py --version 2>/dev/null \
 		| sed 's/\.dev.*$//')
@@ -224,8 +228,10 @@ _test_utils() {
 
 	cd "$builddir"/build
 
-	install -D -m 755 bin/FileCheck "$subpkgdir"/$_prefix/bin/FileCheck
-	install -D -m 755 bin/not "$subpkgdir"/$_prefix/bin/not
+	local util; for util in $_utils; do
+		_mv "$pkgdir"/$_prefix/bin/$util "$subpkgdir"/$_prefix/bin
+		rm -f "$pkgdir"/usr/bin/$util
+	done
 
 	python2 ../utils/lit/setup.py install --prefix=/usr --root="$subpkgdir"
 	ln -s ../../../bin/lit "$subpkgdir"/$_prefix/bin/lit

--- a/testing/libc++/APKBUILD
+++ b/testing/libc++/APKBUILD
@@ -14,7 +14,7 @@ makedepends="cmake
 	llvm-dev>=$_llvmver
 	llvm-libunwind-dev>=$_llvmver
 	llvm-static>=$_llvmver"
-checkdepends="lit"
+checkdepends="llvm-utils>=$_llvmver"
 subpackages="$pkgname-dev"
 source="http://releases.llvm.org/$pkgver/libcxx-$pkgver.src.tar.xz
 	http://releases.llvm.org/$pkgver/libcxxabi-$pkgver.src.tar.xz


### PR DESCRIPTION
This PR adds tests to the the LLVM packages and cleans up their dependencies.
It also moves the `llvm-test-utils` package to `llvm-utils` to reflect its more general usage and upstream terminology.