### PR TITLE
testing/scala: new aport

### DIFF
--- a/testing/scala/APKBUILD
+++ b/testing/scala/APKBUILD
@@ -1,111 +1,141 @@
 # Contributor: norbjd
-# Maintainer:
+# Maintainer: norbjd <norbjd@users.noreply.github.com>
 pkgname=scala
 pkgver=2.12.2
 pkgrel=0
-pkgdesc="Scala 2.12.2"
+pkgdesc="The Scala Programming Language"
 url="http://scala-lang.org"
 arch="all"
 license="BSD3"
 
-# bash          : needed for scripts (e.g. scala)
 # openjdk8-jre  : needed for execution 
 depends="bash openjdk8-jre"
 
-# openjdk8      : needed for sbt + compilation
-# sbt           : needed for compilation
-# graphviz      : needed for diagrams generation in scaladoc
+# openjdk8  : needed for sbt + compilation
+# sbt       : needed for compilation
+# graphviz  : needed for diagrams generation in HTML scaladoc
 makedepends="openjdk8 sbt graphviz"
 
 # documentation is separated
-subpackages="${pkgname}-doc"
+subpackages="$pkgname-doc"
 
-source="${pkgname}-${pkgver}.tar.gz::https://github.com/scala/scala/archive/v2.12.2.tar.gz"
-builddir="${srcdir}/${pkgname}-${pkgver}"
+source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
 
 # important directories
-_scala_home="/usr/share/${pkgname}-${pkgver}"
-_scala_docs_home="/usr/share/doc/${pkgname}-${pkgver}"
-_scala_man_home="/usr/share/man/man1"
-_bin_home="/usr/bin"
+_scala_home="/usr/share/$pkgname-$pkgver"
+_scala_docs_home="/usr/share/doc/$pkgname-$pkgver"
 
-# sbt command with JVM options (memory)
+# sbt command with JVM options (memory, to avoid OOM errors)
 _sbt() {
-        sbt -Xms2G -Xmx4G -XX:MaxMetaspaceSize=1G "$@"
+    sbt -Xms2G -Xmx4G -XX:MaxMetaspaceSize=1G "$@"
 }
 
 build() {
-        cd "$builddir"
+    cd "$builddir"
 
-        # use sbt to compile, package, and create doc
-	_sbt ';dist/mkPack;doc;compile:managedResources;packageDoc' || return 1
+    # use sbt to compile, package, and create doc
+    _sbt ';dist/mkPack;doc;compile:managedResources;packageDoc'
 }
 
 check() {
-        cd "$builddir"
+    cd "$builddir"
 
-        # check if all scripts have been created and work
-	./build/pack/bin/scala -version
-	./build/pack/bin/scalac -version
-	./build/pack/bin/scaladoc -version
-	./build/pack/bin/scalap -version
-	./build/pack/bin/fsc -version
+    # check if all scripts have been created and work
+    ./build/pack/bin/scala -version
+    ./build/pack/bin/scalac -version
+    ./build/pack/bin/scaladoc -version
+    ./build/pack/bin/scalap -version
+    ./build/pack/bin/fsc -version
 }
 
 package() {
-        cd "$builddir"
+    cd "$builddir"
 
-        # copy scripts
-	mkdir -p "$pkgdir"/"$_scala_home" || return 1
-	cp -R build/pack/* "$pkgdir"/"$_scala_home"/ || return 1
+    # copy scripts
+    mkdir -p "$pkgdir/$_scala_home"
+    cp -R build/pack/* "$pkgdir/$_scala_home"
 
-        # remove useless specific Windows scripts
-	rm "$pkgdir"/"$_scala_home"/bin/*.bat || return 1
+    # remove useless specific Windows scripts
+    rm "$pkgdir/$_scala_home"/bin/*.bat
 
-        # create symbolic links
-	mkdir -p "$pkgdir"/"$_bin_home" || return 1
-	for _bin in `ls "$pkgdir"/"$_scala_home"/bin/`
-	do
-		ln -sf "$_scala_home"/bin/"$_bin" "$pkgdir"/"$_bin_home"/"$_bin" || return 1
-	done
+    # create symbolic links
+    mkdir -p "$pkgdir"/usr/bin
+
+#    local _bin
+#    for _bin in "$pkgdir/$_scala_home"/bin/*
+#    do
+#        local _bin_basename=$(basename "$_bin")
+#        ln -sf "$_scala_home"/bin/"$_bin_basename" "$pkgdir"/usr/bin/"$_bin_basename"
+#    done
+    
+    ls "$pkgdir/$_scala_home"/bin/ | \
+    xargs -I_bin \
+        ln -sf "$_scala_home"/bin/_bin "$pkgdir"/usr/bin/_bin
+}
+
+man_doc() {
+    cd "$builddir"
+
+    mkdir -p "$subpkgdir"/usr/share/man/man1
+
+    # copy manpages for scripts
+#    local _manfile
+#    for _manfile in $(find "$builddir"/target/scala-dist/resource_managed/main/man/man1/ -type f)
+#    do
+#        gzip "$_manfile"
+#        cp "$_manfile".gz "$subpkgdir"/usr/share/man/man1
+#    done
+
+    find "$builddir"/target/scala-dist/resource_managed/main/man/man1/ -type f \
+        -exec gzip {} \; \
+        -exec cp {}.gz "$subpkgdir"/usr/share/man/man1 \;
+}
+
+html_doc() {
+    cd "$builddir"
+
+    mkdir -p "$subpkgdir/$_scala_docs_home"
+    mkdir -p "$subpkgdir/$_scala_docs_home"/api
+    mkdir -p "$subpkgdir/$_scala_docs_home"/api/jars
+    mkdir -p "$subpkgdir/$_scala_docs_home"/tools
+
+    # copy default doc resources (licenses, README)
+    cp -R "$builddir"/doc/* "$subpkgdir/$_scala_docs_home"/
+    
+    # copy HTML scaladoc for default API
+    cp -R "$builddir"/build/scaladoc/compiler   "$subpkgdir/$_scala_docs_home"/api/compiler
+    cp -R "$builddir"/build/scaladoc/library    "$subpkgdir/$_scala_docs_home"/api/library
+    cp -R "$builddir"/build/scaladoc/reflect    "$subpkgdir/$_scala_docs_home"/api/reflect
+    cp -R "$builddir"/build/scaladoc/scalap     "$subpkgdir/$_scala_docs_home"/api/scalap
+
+    # copy HTML doc for tools (scripts)
+    cp -R "$builddir"/src/manual/scala/tools/docutil/resources/* "$subpkgdir/$_scala_docs_home"/tools/
+    cp "$builddir"/target/scala-dist/resource_managed/main/doc/tools/* "$subpkgdir/$_scala_docs_home"/tools/
+}
+
+jar_doc() {
+    cd "$builddir"
+
+    # copy javadoc JARs
+#    local _javadoc_jar
+#    for _javadoc_jar in $(find "$builddir"/target/ -type f -name '*-javadoc.jar')
+#    do
+#        cp "$_javadoc_jar" "$subpkgdir"/$_scala_docs_home/api/jars/
+#    done
+
+    find "$builddir"/target/ -type f -name '*-javadoc.jar' \
+        -exec cp {} "$subpkgdir"/$_scala_docs_home/api/jars \;
 }
 
 doc() {
-	cd "$builddir"
+    cd "$builddir"
 
-    	default_doc || return 1
+    default_doc
+    man_doc
 
-    	mkdir -p "$subpkgdir"/"$_scala_docs_home"
-    	mkdir -p "$subpkgdir"/"$_scala_docs_home"/api
-    	mkdir -p "$subpkgdir"/"$_scala_docs_home"/api/jars
-    	mkdir -p "$subpkgdir"/"$_scala_docs_home"/tools
-    	mkdir -p "$subpkgdir"/"$_scala_man_home"
-
-        # copy default doc resources (licenses, README)
-  	cp -R "$builddir"/doc/* "$subpkgdir"/"$_scala_docs_home"/ || return 1
-
-        # copy HTML scaladoc for default API
-        cp -R "$builddir"/build/scaladoc/compiler       "$subpkgdir"/"$_scala_docs_home"/api/compiler || return 1
-        cp -R "$builddir"/build/scaladoc/library        "$subpkgdir"/"$_scala_docs_home"/api/library || return 1
-        cp -R "$builddir"/build/scaladoc/reflect        "$subpkgdir"/"$_scala_docs_home"/api/reflect || return 1
-        cp -R "$builddir"/build/scaladoc/scalap         "$subpkgdir"/"$_scala_docs_home"/api/scalap || return 1
-
-        # copy HTML doc for tools (scripts)
-        cp -R "$builddir"/src/manual/scala/tools/docutil/resources/* "$subpkgdir"/"$_scala_docs_home"/tools/ || return 1
-    	cp "$builddir"/target/scala-dist/resource_managed/main/doc/tools/* "$subpkgdir"/"$_scala_docs_home"/tools/ || return 1
-
-        # copy manpages for scripts
-	for _manfile in `find "$builddir"/target/scala-dist/resource_managed/main/man/man1/ -type f`
-	do
-		gzip "$_manfile"
-		cp "$_manfile".gz "$subpkgdir"/$_scala_man_home/ || return 1
-	done
-
-        # copy javadoc JARs
-	for _javadoc_jar in `find "$builddir"/target/ -type f -name '*-javadoc.jar'`
-	do
-		cp "$_javadoc_jar" "$subpkgdir"/$_scala_docs_home/api/jars/ || return 1
-	done
+    html_doc
+    jar_doc
 }
 
 sha512sums="ab450e94fa79a9a0af238567b17537b12f23627eb066b84cd996a88422ec34ee8d26e09eca0416d49daccadaeb016ad6419d8022d471065389a26b024f2049b1  scala-2.12.2.tar.gz"

--- a/testing/scala/APKBUILD
+++ b/testing/scala/APKBUILD
@@ -61,13 +61,6 @@ package() {
 
     # create symbolic links
     mkdir -p "$pkgdir"/usr/bin
-
-#    local _bin
-#    for _bin in "$pkgdir/$_scala_home"/bin/*
-#    do
-#        local _bin_basename=$(basename "$_bin")
-#        ln -sf "$_scala_home"/bin/"$_bin_basename" "$pkgdir"/usr/bin/"$_bin_basename"
-#    done
     
     ls "$pkgdir/$_scala_home"/bin/ | \
     xargs -I_bin \
@@ -80,13 +73,6 @@ man_doc() {
     mkdir -p "$subpkgdir"/usr/share/man/man1
 
     # copy manpages for scripts
-#    local _manfile
-#    for _manfile in $(find "$builddir"/target/scala-dist/resource_managed/main/man/man1/ -type f)
-#    do
-#        gzip "$_manfile"
-#        cp "$_manfile".gz "$subpkgdir"/usr/share/man/man1
-#    done
-
     find "$builddir"/target/scala-dist/resource_managed/main/man/man1/ -type f \
         -exec gzip {} \; \
         -exec cp {}.gz "$subpkgdir"/usr/share/man/man1 \;
@@ -118,12 +104,6 @@ jar_doc() {
     cd "$builddir"
 
     # copy javadoc JARs
-#    local _javadoc_jar
-#    for _javadoc_jar in $(find "$builddir"/target/ -type f -name '*-javadoc.jar')
-#    do
-#        cp "$_javadoc_jar" "$subpkgdir"/$_scala_docs_home/api/jars/
-#    done
-
     find "$builddir"/target/ -type f -name '*-javadoc.jar' \
         -exec cp {} "$subpkgdir"/$_scala_docs_home/api/jars \;
 }

--- a/testing/scala/APKBUILD
+++ b/testing/scala/APKBUILD
@@ -1,0 +1,111 @@
+# Contributor: norbjd
+# Maintainer:
+pkgname=scala
+pkgver=2.12.2
+pkgrel=0
+pkgdesc="Scala 2.12.2"
+url="http://scala-lang.org"
+arch="all"
+license="BSD3"
+
+# bash          : needed for scripts (e.g. scala)
+# openjdk8-jre  : needed for execution 
+depends="bash openjdk8-jre"
+
+# openjdk8      : needed for sbt + compilation
+# sbt           : needed for compilation
+# graphviz      : needed for diagrams generation in scaladoc
+makedepends="openjdk8 sbt graphviz"
+
+# documentation is separated
+subpackages="${pkgname}-doc"
+
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/scala/scala/archive/v2.12.2.tar.gz"
+builddir="${srcdir}/${pkgname}-${pkgver}"
+
+# important directories
+_scala_home="/usr/share/${pkgname}-${pkgver}"
+_scala_docs_home="/usr/share/doc/${pkgname}-${pkgver}"
+_scala_man_home="/usr/share/man/man1"
+_bin_home="/usr/bin"
+
+# sbt command with JVM options (memory)
+_sbt() {
+        sbt -Xms2G -Xmx4G -XX:MaxMetaspaceSize=1G "$@"
+}
+
+build() {
+        cd "$builddir"
+
+        # use sbt to compile, package, and create doc
+	_sbt ';dist/mkPack;doc;compile:managedResources;packageDoc' || return 1
+}
+
+check() {
+        cd "$builddir"
+
+        # check if all scripts have been created and work
+	./build/pack/bin/scala -version
+	./build/pack/bin/scalac -version
+	./build/pack/bin/scaladoc -version
+	./build/pack/bin/scalap -version
+	./build/pack/bin/fsc -version
+}
+
+package() {
+        cd "$builddir"
+
+        # copy scripts
+	mkdir -p "$pkgdir"/"$_scala_home" || return 1
+	cp -R build/pack/* "$pkgdir"/"$_scala_home"/ || return 1
+
+        # remove useless specific Windows scripts
+	rm "$pkgdir"/"$_scala_home"/bin/*.bat || return 1
+
+        # create symbolic links
+	mkdir -p "$pkgdir"/"$_bin_home" || return 1
+	for _bin in `ls "$pkgdir"/"$_scala_home"/bin/`
+	do
+		ln -sf "$_scala_home"/bin/"$_bin" "$pkgdir"/"$_bin_home"/"$_bin" || return 1
+	done
+}
+
+doc() {
+	cd "$builddir"
+
+    	default_doc || return 1
+
+    	mkdir -p "$subpkgdir"/"$_scala_docs_home"
+    	mkdir -p "$subpkgdir"/"$_scala_docs_home"/api
+    	mkdir -p "$subpkgdir"/"$_scala_docs_home"/api/jars
+    	mkdir -p "$subpkgdir"/"$_scala_docs_home"/tools
+    	mkdir -p "$subpkgdir"/"$_scala_man_home"
+
+        # copy default doc resources (licenses, README)
+  	cp -R "$builddir"/doc/* "$subpkgdir"/"$_scala_docs_home"/ || return 1
+
+        # copy HTML scaladoc for default API
+        cp -R "$builddir"/build/scaladoc/compiler       "$subpkgdir"/"$_scala_docs_home"/api/compiler || return 1
+        cp -R "$builddir"/build/scaladoc/library        "$subpkgdir"/"$_scala_docs_home"/api/library || return 1
+        cp -R "$builddir"/build/scaladoc/reflect        "$subpkgdir"/"$_scala_docs_home"/api/reflect || return 1
+        cp -R "$builddir"/build/scaladoc/scalap         "$subpkgdir"/"$_scala_docs_home"/api/scalap || return 1
+
+        # copy HTML doc for tools (scripts)
+        cp -R "$builddir"/src/manual/scala/tools/docutil/resources/* "$subpkgdir"/"$_scala_docs_home"/tools/ || return 1
+    	cp "$builddir"/target/scala-dist/resource_managed/main/doc/tools/* "$subpkgdir"/"$_scala_docs_home"/tools/ || return 1
+
+        # copy manpages for scripts
+	for _manfile in `find "$builddir"/target/scala-dist/resource_managed/main/man/man1/ -type f`
+	do
+		gzip "$_manfile"
+		cp "$_manfile".gz "$subpkgdir"/$_scala_man_home/ || return 1
+	done
+
+        # copy javadoc JARs
+	for _javadoc_jar in `find "$builddir"/target/ -type f -name '*-javadoc.jar'`
+	do
+		cp "$_javadoc_jar" "$subpkgdir"/$_scala_docs_home/api/jars/ || return 1
+	done
+}
+
+sha512sums="ab450e94fa79a9a0af238567b17537b12f23627eb066b84cd996a88422ec34ee8d26e09eca0416d49daccadaeb016ad6419d8022d471065389a26b024f2049b1  scala-2.12.2.tar.gz"


### PR DESCRIPTION
Hello,                                                                                              
                                                                                                    
I have just created a new aport for `scala` (version 2.12.2).                                       
                                                                                                    
This is my first contribution, I followed the guidelines, but I may have done a few mistakes in the `APKBUILD` (at least, some bad practices). I'll be grateful if someone can review it and make constructive criticisms to progress.
                                                                                                    
I have separated `scala-doc` from `scala`, since the documentation is quite heavy (~ 600 MB) because it contains :
- HTML scaladoc for default API + scripts                                                           
- Man pages for scripts                                                                             
- Javadoc JARs                                                                                      
                                                                                                    
For `scala-doc`, I took the `.deb` package as an example.                                           
                                                                                                    
The build can take some time (~ 30 minutes on my laptop). The longest task is documentation generation.