### PR TITLE
main/powerpc-utils: add missing dependencies

### DIFF
--- a/main/powerpc-utils/APKBUILD
+++ b/main/powerpc-utils/APKBUILD
@@ -1,12 +1,13 @@
-# Maintainer: Breno Leitao <breno.leitao@gmail.com>
+# Maintainer: Roberto Oliveira <robertoguimaraes8@gmail.com>
 pkgname=powerpc-utils
 pkgver=1.3.3
-pkgrel=0
+pkgrel=1
 pkgdesc="Utilities which are intended for maintenance of powerpc platforms"
 url="https://github.com/nfont/powerpc-utils"
 arch="ppc64le"
 license="GPL"
 makedepends="autoconf automake zlib-dev"
+depends="bash bc"
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/nfont/$pkgname/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
powerpc-utils needs bash and bc to work. I am adding both as depedency
and also assing me as this package maintainer.