### PR TITLE
main/imagemagick: upgrade to 7.0.5.9

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
-pkgver=7.0.5.5
+pkgver=7.0.5.9
 _abiver=7
 _pkgver=${pkgver%.*}-${pkgver##*.}
 pkgrel=0
@@ -66,4 +66,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="56ac34cde0dace2e6dcd6968efd6b1f814cd1ec6c27ed9f10d441610a540028df8cde354c662f7b37dc0bd2e6005374eef0a26ea4e432a0ab39acf6e2bf5a4a6  ImageMagick-7.0.5-5.tar.xz"
+sha512sums="ac815562ba8632ad0ee82deaa8339ea9b482c0a0219193ca7aaa10c36b2ddd3173d639a0965b9a75bb48d72633d4015ff79d41dc71a817acf0160160783514be  ImageMagick-7.0.5-9.tar.xz"


### PR DESCRIPTION
7.0.5.9 contains an important fix that resolves segfault in php imagick extensions https://github.com/ImageMagick/ImageMagick/issues/497