### PR TITLE
community/duo_unix: security upgrade to 1.9.21 (DUO-PSA-2017-002)

### DIFF
--- a/community/duo_unix/APKBUILD
+++ b/community/duo_unix/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Alan Lacerda <alacerda@alpinelinux.org>
 # Maintainer: Paul Morgan <jumanjiman@gmail.com>
 pkgname=duo_unix
-pkgver=1.9.19
-pkgrel=3
+pkgver=1.9.21
+pkgrel=0
 pkgdesc="duosecurity.com two-factor authentication"
 url="https://duo.com/support/documentation/duounix"
 arch="all"
@@ -13,7 +13,8 @@ makedepends="$depends_dev"
 install=""
 options="suid"
 subpackages="$pkgname-dev $pkgname-doc"
-source="https://dl.duosecurity.com/$pkgname-$pkgver.tar.gz"
+source="https://dl.duosecurity.com/$pkgname-$pkgver.tar.gz
+	libressl.patch"
 
 _builddir="$srcdir"/$pkgname-$pkgver
 prepare() {
@@ -44,6 +45,5 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-md5sums="2df21908cb1f8b58823291b4673289cd  duo_unix-1.9.19.tar.gz"
-sha256sums="2d23f9700f091da1c9113b45919203b37fac6392a9e24a666c7b0269a7571b0a  duo_unix-1.9.19.tar.gz"
-sha512sums="daefc3bddf685c90fc42ca91fc961dcdc0f48c296dfb393e0baccc083874d7214914c0faa840d3c9b6a9f454e4e2122ebd312c33319c56c19e30374a89bd03cf  duo_unix-1.9.19.tar.gz"
+sha512sums="8caf1b9dea266662d2e221fa120be1989622828ba346f874f77090ed0f91431e250da2cfe335bc9ff0b8a6336a20458851e715342c5f90151cf4514e76b04fa9  duo_unix-1.9.21.tar.gz
+4e078c876baaedeffb4b8790f713e4bd486a71ef8a8cccade9262ea56dc7ada4ec65f467850d6d2311899b4d93afc95e21d0b585a446a3ca0a36498ada37ec67  libressl.patch"

--- a/community/duo_unix/libressl.patch
+++ b/community/duo_unix/libressl.patch
@@ -1,0 +1,7 @@
+diff --git a/lib/https.c b/lib/https.c
+index b64e03a..b900924 100644
+--- a/lib/https.c
++++ b/lib/https.c
+@@ -356 +356 @@ _establish_connection(struct https_request * const req,
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)


### PR DESCRIPTION
Duo Product Security Advisory
=============================

Advisory ID: DUO-PSA-2017-002
Publication Date: 2017-05-31
Revision Date: 2017-05-31
Status: Confirmed, Fixed
Document Revision: 1

Overview
--------

Duo Security has identified an issue in duo_unix, which, under
certain uncommon configurations, could enable attackers to bypass
second-factor user authentication. Duo has no evidence that this
vulnerability has actively been exploited and we believe this
specific configuration is extraordinarily uncommon.

This issue was resolved in version 1.9.21 of duo_unix. Customers
using an affected configuration should update to the latest
version as soon as possible (see "Solution" section below).

Description
-----------

Prior to version 1.9.21, duo_unix (which includes both login_duo
and pam_duo), supported setting an HTTP proxy configuration
through the standard 'http_proxy' environment variable. Under some
uncommon configurations (examples listed below), however, it is
possible for an untrusted user to set a value for the 'http_proxy'
variable prior to initiating a Duo authentication attempt.

If an invalid proxy host (e.g. '0.0.0.0') is selected, then
login_duo/pam_duo will ultimately fail to connect to Duo's API,
and as a result, trigger the configured "failmode" behavior. If
"failmode" is set to "safe" (which is the default), then this
could result in a bypass of second-factor authentication.

Duo has identified two specific configuration scenarios in which an
untrusted user may be able to control the value of the 'http_proxy'
environment variable.

1. login_duo with nonstandard sshd "AcceptEnv" configurations:

OpenSSH can permit clients to forward environment variables
to servers. By default, OpenSSH server distributions generally
allow only a whitelisted set of variables (which does not include
'http_proxy') to be forwarded in this way. It is possible, however,
for an administrator to configure a less-restrictive policy using
the AcceptEnv keyword in sshd_config.

If a server has been configured with a non-default AcceptEnv
policy that permits clients to send an 'http_proxy' environment
variable, and is using login_duo to add Duo 2FA to ssh logins,
then this configuration could result in a bypass of Duo 2FA.

This scenario only applies to login_duo; when used with OpenSSH,
pam_duo is unaffected by this issue.

2. pam_duo with local authentication (e.g. su / sudo):

While pam_duo is not affected by this issue when used with OpenSSH,
when pam_duo is being used to perform 2FA in other contexts -
particularly, to authenticate system-local actions performed
by untrusted users - it may be possible for untrusted users to
control the value of the 'http_proxy' environment variable prior
to initiating an authentication attempt.

In particular, Duo has confirmed that configurations which use
pam_duo to add Duo 2FA to the "su" and "sudo" commands are impacted
by this issue.

Version 1.9.21 of duo_unix has been released to resolve this
issue. It removes support for configuring an HTTP Proxy via an
environment variable.

Impact
------

Attackers may be able to bypass second-factor authentication
on impacted configurations which accept attacker-controlled
environment variables.

Affected Product(s)
-------------------

All versions of duo_unix prior to 1.9.21 are impacted when used
in one of the following configuration scenarios:

* login_duo is performing 2FA for SSH logins, and
  sshd has been configured with a permissive (non-default) AcceptEnv policy
* pam_duo is performing 2FA for scenarios other than SSH logins

Workaround
----------

Customers using login_duo in an affected configuration may work
around this issue by ensuring that their AcceptEnv configuration
for sshd (e.g. in /etc/ssh/sshd_config) does not permit clients
to send an 'http_proxy' variable.

Customers using pam_duo in an affected configuration must upgrade
to the latest version of duo_unix.

Solution
--------

Customers should upgrade to the latest version of the duo_unix
client as discussed above. Clone the latest version from:

* https://github.com/duosecurity/duo_unix

For more information on upgrading duo_unix,
see https://duo.com/docs/duounix

Vulnerability Metrics
---------------------

Vulnerability Class: CWE-454: External Initialization of Trusted Variables or Data Stores
https://cwe.mitre.org/data/definitions/454.html
Remotely Exploitable: [No]
Authentication Required: [Partial]
Severity: [High]
CVSSv2 Overall Score: 5.0
CVSSv2 Group Scores: Base: 6.0, Temporal: 5.0
CVSSv2 Vector: AV:L/AC:M/Au:S/C:P/I:P/A:N/E:F/RL:OF/RC:C

References
----------

* CWE-454: External Initialization of Trusted Variables or Data Stores - https://cwe.mitre.org/data/definitions/454.html
* Duo Unix Reference - https://duo.com/docs/duounix

Timeline
--------

2017-05-19
* Duo privately receives report of a security vulnerability in Duo Unix
* Duo acknowledges receipt of report and begins investigation

2017-05-22
* Duo confirms vulnerability exists in related case to original report

2017-05-30
* Duo completes development and testing of fixes

2017-05-31
* Advisory released to all Duo customers using duo_unix

Credits/Contact
---------------

Technical questions regarding this issue should be sent to
support@duosecurity.com and reference "DUO-PSA-2017-002" in the
subject, or to your Customer Success Manager, if appropriate.

Duo Security would like to thank Fred Emmott for reporting this issue.