### PR TITLE
community/modemmanager: update to 1.6.6 / remove libmm-glib-dev 

### DIFF
--- a/community/modemmanager/APKBUILD
+++ b/community/modemmanager/APKBUILD
@@ -7,6 +7,7 @@ pkgdesc="ModemManager library"
 url="http://www.freedesktop.org/wiki/Software/ModemManager"
 arch="all"
 license="GPL2, LGPL2.1"
+depends_dev="libmm-glib"
 makedepends="$depends_dev gobject-introspection-dev gtk-doc intltool vala
 	libgudev-dev polkit-dev libmbim-dev libqmi-dev linux-headers"
 checkdepends="glib-dev"

--- a/community/modemmanager/APKBUILD
+++ b/community/modemmanager/APKBUILD
@@ -1,15 +1,17 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=modemmanager
-pkgver=1.6.4
-pkgrel=3
+pkgver=1.6.6
+pkgrel=0
 pkgdesc="ModemManager library"
 url="http://www.freedesktop.org/wiki/Software/ModemManager"
 arch="all"
 license="GPL2, LGPL2.1"
 makedepends="$depends_dev gobject-introspection-dev gtk-doc intltool vala
 	libgudev-dev polkit-dev libmbim-dev libqmi-dev linux-headers"
-subpackages="$pkgname-lang $pkgname-doc libmm-glib:libmm libmm-glib-dev:libmmdev $pkgname-dev"
+checkdepends="glib-dev"
+options="!check" # https://bugs.freedesktop.org/show_bug.cgi?id=101197
+subpackages="$pkgname-lang $pkgname-doc libmm-glib:libmm $pkgname-dev"
 source="http://www.freedesktop.org/software/ModemManager/ModemManager-$pkgver.tar.xz
 	$pkgname.rules
 	"
@@ -29,43 +31,34 @@ build() {
 		--enable-more-warnings \
 		--with-newest-qmi-commands \
 		--with-dbus-sys-dir=/etc/dbus-1 \
-		--enable-vala=yes \
-		|| return 1
+		--enable-vala=yes
 	# https://bugzilla.gnome.org/show_bug.cgi?id=655517
 	sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
-	make || return 1
+	make
 }
 
 libmm() {
 	cd "$builddir"
 	mkdir -p "$subpkgdir"
-	make DESTDIR="$subpkgdir" -C libmm-glib install || return 1
-        make DESTDIR="$subpkgdir" -C vapi install || return 1
-}
-
-libmmdev() {
-	depends="libmm-glib modemmanager-dev"
-
-	mkdir -p "$subpkgdir/usr/lib/pkgconfig"
-	mv "${subpkgdir%*-dev}/usr/include" "$subpkgdir/usr/"
-	mv "${subpkgdir%*-dev}/usr/share" "$subpkgdir/usr/"
-	mv "${subpkgdir%*-dev}/usr/lib/libmm-glib.so" "$subpkgdir"/usr/lib/
-	mv "$pkgdir"/usr/lib/pkgconfig/mm-glib.pc "$subpkgdir"/usr/lib/pkgconfig/
+	make DESTDIR="$subpkgdir" -C libmm-glib install
+	# move dev files to modemmnager-dev
+	mv -f "$subpkgdir/usr/include/libmm-glib" "$pkgdir/usr/include/"
+	mv -f "$subpkgdir/usr/share/gir-1.0" "$pkgdir/usr/share/"
+	rmdir "$subpkgdir/usr/include" "$subpkgdir/usr/share"
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
-        make DESTDIR="$pkgdir" -C libmm-glib uninstall || return 1
-        make DESTDIR="$pkgdir" -C vapi uninstall || return 1
+	make DESTDIR="$pkgdir" install
+	make DESTDIR="$pkgdir" -C libmm-glib uninstall
 	rmdir "$pkgdir"/usr/lib/girepository-1.0 # in libmm-glib
 	rm -rf "$pkgdir"/usr/share/dbus-1/system-services #systemd-service
 	mkdir -p "$pkgdir/usr/share/polkit-1/rules.d"
 	install -m644 -D "$srcdir/$pkgname.rules" \
-                "$pkgdir/usr/share/polkit-1/rules.d/01-org.freedesktop.ModemManager.rules" || return 1
+		"$pkgdir/usr/share/polkit-1/rules.d/01-org.freedesktop.ModemManager.rules"
 	# post-install message
-        mkdir -p "$pkgdir/usr/share/doc/$pkgname"
-        cat > $pkgdir/usr/share/doc/$pkgname/README.alpine <<EOF
+	mkdir -p "$pkgdir/usr/share/doc/$pkgname"
+	cat > $pkgdir/usr/share/doc/$pkgname/README.alpine <<EOF
 If your USB modem shows up as a Flash drive when you plug it in:
 
 install 'usb-modeswitch' to automatically switch to USB modem mode whenever you plug it in.
@@ -73,9 +66,10 @@ To control your modem without the root password: add your user account to the 'p
 EOF
 }
 
-md5sums="06488186c7dd53f8104183b86f7a1568  ModemManager-1.6.4.tar.xz
-735e155a785554349906c09dd36d3866  modemmanager.rules"
-sha256sums="cdd5b4cb1e4d7643643a28ccbfc4bb354bfa9cb89a77ea160ebdf7926171c668  ModemManager-1.6.4.tar.xz
-577807e59b1e95757a4d94922c66f7f36487922c5092a6c148e7db6a4dc6afe8  modemmanager.rules"
-sha512sums="6b31ce186adce445cec8964df751b6146a86271e6c14d860740ae66cfe296ac2ac4df21079357775ac5f7a5837c80a7f8db21a2680bc6b45802f9928565f1c73  ModemManager-1.6.4.tar.xz
+check() {
+	cd "$builddir"
+	make check
+}
+
+sha512sums="9df55b38eefbb49ad8e4e24138de68ecfd36349944236cd4f5f84044c4412f31f9e48e422fbf620fa4d5d4e33d6f0476887c19415f07555a6ce120c77decbcc7  ModemManager-1.6.6.tar.xz
 3c76ee577334e25c836857f8e7fef6a249cdd9fcd8f889cb64d9c1667bc6a95c087267a153bddd1a13256c59f8cd578ccb448e6b9cb54b73bb74acb8a0ca1e3f  modemmanager.rules"

--- a/community/network-manager-applet/APKBUILD
+++ b/community/network-manager-applet/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=network-manager-applet
 pkgver=1.7.1
-pkgrel=0
+pkgrel=1
 pkgdesc="GTK network manager applet"
 url="https://wiki.gnome.org/Projects/NetworkManager"
 arch="all"
@@ -14,7 +14,6 @@ makedepends="$depends_dev
 	iso-codes-dev
 	jansson-dev
 	libgudev-dev
-	libmm-glib-dev
 	libnotify-dev
 	libsecret-dev
 	libsecret-dev

--- a/community/networkmanager/APKBUILD
+++ b/community/networkmanager/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=networkmanager
 pkgver=1.7.2
-pkgrel=1
+pkgrel=2
 pkgdesc="network management tool"
 url="http://projects.gnome.org/NetworkManager/"
 arch="all"
@@ -17,7 +17,6 @@ makedepends="$depends_dev
 	libgudev-dev
 	gobject-introspection-dev
 	intltool
-	libmm-glib-dev
 	libndp-dev
 	libnl3-dev
 	libsoup-dev


### PR DESCRIPTION
* libmm-glib-dev files moved into **modemmanager-dev**

networkmanager & network-manager-applet already have **modemmanager-dev** in `$makedepends`