### PR TITLE
community/go: fix external linker for ppc64le

### DIFF
--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -4,7 +4,7 @@ pkgname=go
 pkgver=1.8.1
 # This should be the latest commit on the corresponding release branch
 _toolsver="5682db0e919ed9cfc6f52ac32e170511a106eb3b"
-pkgrel=0
+pkgrel=1
 pkgdesc="Go programming language compiler"
 url="http://www.golang.org/"
 arch="all"
@@ -170,4 +170,4 @@ _crosspkg() {
 sha512sums="f01fe7b35ac23101610f6fc169b88dafe2edc49b3b044d5d0aff771b05dcb2c8d2e7a5090ed6dbe67f861e78e792ace32e209ed464399ca02dcd186b13ec8037  go1.8.1.src.tar.gz
 343fca47f250278b22df1c1cd92cce91e01009043d05d8ccce095e4386fa0f5ca8ccaa58232635332c7288ceca9d2a240f774f8bb3b08129a681a582cba60248  go-tools-1.8.1.tar.gz
 13cd386c38875b951da4057586007f3c67503dc79ddf57befbf763af85ec2cd2a2e6b00614450c179c93f1f8747ee7456ee412adccd08a5f115b33812598a148  default-buildmode-pie.patch
-ab06554c1c37fda2bf0112d7343f253111911e07cdd77805e9811aaabe298980a0fac60f6294e68b95df017ab40d73655874e3d1d230c54181d6ffc7639e3ed6  set-external-linker.patch"
+6b36f3780ab10e5c4902473a8ab5c0417220ece584b537517e9e60979bdc5a548ed14dd2546605392c89ec5ea6691769d337d34e2e19b92eba5bbca1898f4ada  set-external-linker.patch"

--- a/community/go/set-external-linker.patch
+++ b/community/go/set-external-linker.patch
@@ -72,7 +72,7 @@ index 6eff2f4..1f3c0be 100644
  
  	// TODO(austin): ABI v1 uses /usr/lib/ld.so.1
 -	ld.Thearch.Linuxdynld = "/lib64/ld64.so.1"
-+	ld.Thearch.Linuxdynld = "/lib64/ld-musl-ppc64le.so.1"
++	ld.Thearch.Linuxdynld = "/lib/ld-musl-powerpc64le.so.1"
  
  	ld.Thearch.Freebsddynld = "XXX"
  	ld.Thearch.Openbsddynld = "XXX"


### PR DESCRIPTION
The external linker for ppc64le was pointing to /lib64/ld-musl-ppc64le.so.1
but the valid path for alpine ppc64le is /lib/ld-musl-powerpc64le.so.1.

This issue was found by Lynn Boger from IBM go compiler team.