### PR TITLE
community/xpra: enable build on ppc64le

### DIFF
--- a/community/xpra/APKBUILD
+++ b/community/xpra/APKBUILD
@@ -5,7 +5,7 @@ pkgver=2.0.2
 pkgrel=1
 pkgdesc="Xpra is 'screen for X' & allows you to run X programs, usually on a remote host over SSH or encrypted tcp."
 url="http://xpra.org"
-arch="all !ppc64le !s390x"
+arch="all !s390x"
 license="GPLv2+"
 depends="py-gobject py-gtk py-imaging xf86-video-dummy xvfb setxkbmap xorg-server
 	py2-numpy py2-pillow py-gtkglext py2-lz4 py-rencode py-opencl py2-xxhash


### PR DESCRIPTION
xpra was disabled because py-opencl was not building in ppc64le, but now
we have the py-opencl, so enabling it.