### PR TITLE
testing/vips: upgrade to 8.5.6

### DIFF
--- a/testing/vips/APKBUILD
+++ b/testing/vips/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Will Jordan <will.jordan@gmail.com>
 # Maintainer: Will Jordan <will.jordan@gmail.com>
 pkgname=vips
-pkgver=8.4.5
+pkgver=8.5.6
 pkgrel=1
 pkgdesc="A fast image processing library with low memory needs"
 url="http://www.vips.ecs.soton.ac.uk/"
@@ -13,7 +13,7 @@ makedepends="$depends_dev fftw-dev giflib-dev glib-dev libpng-dev libwebp-dev
 	libxml2-dev orc-dev tiff-dev"
 install=""
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang $pkgname-tools"
-source="http://www.vips.ecs.soton.ac.uk/supported/current/vips-$pkgver.tar.gz"
+source="https://github.com/jcupitt/libvips/releases/download/v$pkgver/vips-$pkgver.tar.gz"
 
 builddir="$srcdir"/vips-$pkgver
 build() {
@@ -44,6 +44,6 @@ tools() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-md5sums="38347ebab211722e436e124ea067da16  vips-8.4.5.tar.gz"
-sha256sums="0af73a51f53250ca240a683ba0d652003744382b78d8a10152c8f1bd019897fd  vips-8.4.5.tar.gz"
-sha512sums="7c925f81a03773ce417b25c1866a35d1cc29f1bf9705916ecc9d6b9ccbd0cda841e8411c345b1aa9949cdb4c1079ed6d7aaa3c861f002e2dfe50891be960cdfe  vips-8.4.5.tar.gz"
+md5sums="4dd710633746346f7c894daf4304b814  vips-8.5.6.tar.gz"
+sha256sums="19a77ab200eb0ddfcd8babab130fe43c7730880d1f1fdfbdd8def519af32c4b8  vips-8.5.6.tar.gz"
+sha512sums="44f4b1a99f75a6abe594a0fee497ac8e03f9810a4e84d3cec7518b589eef80795800968d799acdb82ff296f23a1077bc6759c838730ba2257dd7867bbd5468c3  vips-8.5.6.tar.gz"

--- a/testing/vips/APKBUILD
+++ b/testing/vips/APKBUILD
@@ -10,7 +10,7 @@ license="LGPL 2.1+"
 depends=""
 depends_dev="libjpeg-turbo-dev libexif-dev lcms2-dev"
 makedepends="$depends_dev fftw-dev giflib-dev glib-dev libpng-dev libwebp-dev
-	libxml2-dev orc-dev tiff-dev"
+	expat-dev orc-dev tiff-dev"
 install=""
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang $pkgname-tools"
 source="https://github.com/jcupitt/libvips/releases/download/v$pkgver/vips-$pkgver.tar.gz"


### PR DESCRIPTION
libvips moved to https://github.com/jcupitt/libvips, APKBUILD now uses releases from there