### PR TITLE
main/gnutls: upgrade to 3.5.13

### DIFF
--- a/main/gnutls/APKBUILD
+++ b/main/gnutls/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Michael Mason <ms13sp@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gnutls
-pkgver=3.5.12
+pkgver=3.5.13
 pkgrel=0
 pkgdesc="A TLS protocol implementation"
 url="http://www.gnutls.org/"
@@ -54,4 +54,4 @@ xx() {
 	mv "$pkgdir"/usr/lib/lib*xx.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="8fec23e7e494a2e15e0f938115cae1ba3fee952d634db387f983b01096f68ca4313b23bc4c439d3c7fdd07c861eac4913a7c2343c8704961588ae195886ec90c  gnutls-3.5.12.tar.xz"
+sha512sums="e98f23a589042f879936c3f8b474535e695fb7dd68a9e81323668c013241f765c2d3af6c6a072ecf867acc1e551ec46e15bb842144d3a06bdd5d2f4fc3d828a7  gnutls-3.5.13.tar.xz"


### PR DESCRIPTION
Maybe backport to v3.6? http://gnutls.org/security.html#GNUTLS-SA-2017-4