### PR TITLE
community/syncthing13: enable build on ppc64le

### DIFF
--- a/community/syncthing13/APKBUILD
+++ b/community/syncthing13/APKBUILD
@@ -8,7 +8,7 @@ pkgver=0.13.10
 pkgrel=1
 pkgdesc="Open Source Continuous File Synchronization"
 url="http://syncthing.net/"
-arch="all !ppc64le"
+arch="all"
 license="MPLv2"
 pkgusers="$_realname"
 pkggroups="$_realname"
@@ -31,6 +31,7 @@ prepare() {
 	# fix IPv6 definition errors on s390x, remove when upstream
 	# updates vendor manifest!
 	rm -r "$builddir"/$_realname/vendor/golang.org/x/net
+	rm "$srcdir"/net-*.tar.gz
 	ln -s "$srcdir"/net-* "$builddir"/$_realname/vendor/golang.org/x/net
 }
 


### PR DESCRIPTION
enabling syncthing13 package on ppc64le as go is available.
Also had to remove a tar.gz before using ln command, otherwise it
was failing the build in ppc64le.