### PR TITLE
testing/netdata: update config guess

### DIFF
--- a/testing/netdata/APKBUILD
+++ b/testing/netdata/APKBUILD
@@ -17,6 +17,11 @@ source="https://github.com/firehol/netdata/releases/download/v$pkgver/netdata-$p
 	$pkgname.initd"
 builddir="$srcdir"/$pkgname-$pkgver
 
+prepare() {
+	default_prepare
+	update_config_guess
+}
+
 build() {
 	cd "$builddir"
 	./configure \


### PR DESCRIPTION
Run configure guess before build to fix build failure on ppc64le.