### PR TITLE
testing/harminv: enable build on ppc64le

### DIFF
--- a/testing/harminv/APKBUILD
+++ b/testing/harminv/APKBUILD
@@ -5,8 +5,7 @@ pkgver=1.4
 pkgrel=1
 pkgdesc="Free program to solve the problem of harmonic inversion"
 url="http://ab-initio.mit.edu/wiki/index.php/Harminv"
-# openblas not avail on ppc64le yet
-arch="all !ppc64le"
+arch="all"
 license="GPL"
 depends=""
 depends_dev="openblas-dev"


### PR DESCRIPTION
enabling build on ppc64le as openblass is enabled.