### PR TITLE
testing/mylg: fix build and enable on ppc64le

### DIFF
--- a/testing/mylg/APKBUILD
+++ b/testing/mylg/APKBUILD
@@ -2,10 +2,10 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=mylg
 pkgver=0.2.6
-pkgrel=0
+pkgrel=1
 pkgdesc="Network Diagnostic Tool"
 url="http://mylg.io"
-arch="all !ppc64le"
+arch="all"
 license="MIT"
 makedepends="go libpcap-dev"
 subpackages=""
@@ -15,13 +15,13 @@ builddir="$srcdir/$pkgname-$pkgver"
 build() {
 	cd "$builddir"
 	export GOPATH="$srcdir"
-	go get -v
+	go get -v -d
 	go build mylg.go
 }
 
 package() {
 	cd "$builddir"
-    install -Dm0755 "$builddir"/mylg "$pkgdir"/usr/bin/$pkgname
+	install -Dm0755 "$builddir"/mylg "$pkgdir"/usr/bin/$pkgname
 }
 
 md5sums="82f0377f3d3edc9b85ff2da4e4120687  mylg-0.2.6.tar.gz"


### PR DESCRIPTION
Added -d flag in 'go get' command, otherwise it was trying to install
the package and build was failing.