### PR TITLE
testing/upx: enable build on ppc64le

### DIFF
--- a/testing/upx/APKBUILD
+++ b/testing/upx/APKBUILD
@@ -5,7 +5,7 @@ pkgver=3.94
 pkgrel=0
 pkgdesc="The Ultimate Packer for eXecutables"
 url="https://upx.github.io"
-arch="all !ppc64le"
+arch="all"
 license="GPL2 public-domain"
 # perl-dev is used to generate man pages
 makedepends="bash perl-dev ucl-dev zlib-dev"


### PR DESCRIPTION
upx has support for ppc64le and is allow to compress/decompress the
following ppc64le formats:

powerpc64le-darwin.macho             macho/ppc64le
powerpc64le-linux.elf                linux/ppc64le
powerpc64le-linux.kernel.vmlinux     vmlinux/ppc64le