### PR TITLE
testing/wireguard-*: bump to 0.0.20170613

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=1
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20170531
-_mypkgrel=0
+_ver=0.0.20170613
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -60,4 +60,4 @@ package() {
 	done
 }
 
-sha512sums="82ad68e61ccd2844837f817065f7576839cb19e278d28c140d168620fe257f41f201de069105f3b4e2a104d9390460409e831581f2dc02a1bfda18c13c410bed  WireGuard-0.0.20170531.tar.xz"
+sha512sums="71b31900f8064415b54a023042a199f77ba212466ffa4f6fb13428f8acc592873e6f8d75063d6777464c6b13bfa86949be2036ff62179aaae2f63c0a99937987  WireGuard-0.0.20170613.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20170531
+pkgver=0.0.20170613
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="82ad68e61ccd2844837f817065f7576839cb19e278d28c140d168620fe257f41f201de069105f3b4e2a104d9390460409e831581f2dc02a1bfda18c13c410bed  WireGuard-0.0.20170531.tar.xz"
+sha512sums="71b31900f8064415b54a023042a199f77ba212466ffa4f6fb13428f8acc592873e6f8d75063d6777464c6b13bfa86949be2036ff62179aaae2f63c0a99937987  WireGuard-0.0.20170613.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=1
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20170531
-_mypkgrel=0
+_ver=0.0.20170613
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -60,4 +60,4 @@ package() {
 	done
 }
 
-sha512sums="82ad68e61ccd2844837f817065f7576839cb19e278d28c140d168620fe257f41f201de069105f3b4e2a104d9390460409e831581f2dc02a1bfda18c13c410bed  WireGuard-0.0.20170531.tar.xz"
+sha512sums="71b31900f8064415b54a023042a199f77ba212466ffa4f6fb13428f8acc592873e6f8d75063d6777464c6b13bfa86949be2036ff62179aaae2f63c0a99937987  WireGuard-0.0.20170613.tar.xz"


### PR DESCRIPTION
Simple version bump, should be uncontroversial.