### PR TITLE
main/awstats: fix default include path

### DIFF
--- a/main/awstats/APKBUILD
+++ b/main/awstats/APKBUILD
@@ -20,6 +20,11 @@ prepare() {
 		sed -e "s:/usr/local/$pkgname/wwwroot:/usr/lib/$pkgname:g" \
 			-i "$file"
 	done
+	for file in wwwroot/cgi-bin/*; do
+		[ -f "${file}" ] || continue
+		sed -e "s:/usr/share/$pkgname:/usr/lib/$pkgname/cgi-bin:g" \
+			-i "$file"
+	done
 }
 
 package() {


### PR DESCRIPTION
```
If awstats is called as /usr/bin/awstats.pl, @PossibleLibDir
(see e.g. line 2236 in awstats.pl) will be
( "/usr/bin/lib", "/usr/share/awstats/lib" ), neither
of which exist on alpine. Add sed to change /usr/share/awstats
to /usr/lib/awstats/cgi-bin in order to properly find the /lang,
/lib, and /plugins directories in /cgi-bin when called from /usr/bin.
```