### PR TITLE
testing/steghide: fix build and enable on ppc64e

### DIFF
--- a/testing/steghide/APKBUILD
+++ b/testing/steghide/APKBUILD
@@ -2,10 +2,10 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=steghide
 pkgver=0.5.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Steganography program that is able to hide data in various kinds of image- and audio-files"
 url="http://steghide.sourceforge.net/index.php"
-arch="all !ppc64le"
+arch="all"
 license="GPL"
 makedepends="libmcrypt-dev jpeg-dev zlib-dev libmhash-dev 
 bash libtool automake autoconf"
@@ -13,7 +13,8 @@ install=""
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::http://prdownloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.gz
 steghide-0.5.1-am.patch
-build-fixes-new-gcc.patch"
+build-fixes-new-gcc.patch
+missing-files-configure-in.patch"
 builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
@@ -32,12 +33,7 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-md5sums="5be490e24807d921045780fd8cc446b3  steghide-0.5.1.tar.gz
-3b66fbf01bd02306f02f2fe392af6c36  steghide-0.5.1-am.patch
-a76c32c0718de1ba27c0c5792f16a3b0  build-fixes-new-gcc.patch"
-sha256sums="78069b7cfe9d1f5348ae43f918f06f91d783c2b3ff25af021e6a312cf541b47b  steghide-0.5.1.tar.gz
-54a7743990743711614073b7245712bdc887b85cefc66d1199a6542badcb5612  steghide-0.5.1-am.patch
-668d2038bb94b1d4a0c7c5ec924f96a63bf3a412788ebcc1536076f267f701d2  build-fixes-new-gcc.patch"
 sha512sums="6cda3e33e91123fbc5caa112efcacf09180505abd4f6f229878cd443817c60a04498aead02509c7532fd6924225c6b752820c51e452a83c520f228273d610a57  steghide-0.5.1.tar.gz
 b41652a1cfcd5313cb79c220cebc308c5491de4b56433ca5c6099c0b23c532c565cb67b553c32d24398c0e26cec3d1749acd8890e45596464ed499a83fd04fb3  steghide-0.5.1-am.patch
-66443a0ca340969d568e0343fafcef6623f429f6a718b5ea55afcceb444f907521db22702c213d9b72a82e6b353c138f2703afcb4a6d573fe37f70891bc69334  build-fixes-new-gcc.patch"
+66443a0ca340969d568e0343fafcef6623f429f6a718b5ea55afcceb444f907521db22702c213d9b72a82e6b353c138f2703afcb4a6d573fe37f70891bc69334  build-fixes-new-gcc.patch
+27dbae3ef3ab4373ddd046bad07a4d3d0df014717b3a1a4b178c761f39f9b3c74aef7aeeb037c93e083445026e96cf46a64a1351074938af9b87ab9bd9e95bbe  missing-files-configure-in.patch"

--- a/testing/steghide/missing-files-configure-in.patch
+++ b/testing/steghide/missing-files-configure-in.patch
@@ -1,0 +1,18 @@
+autoreconf fails because steghide do not provide AUTHORS,
+NEWS and ChangeLog files
+
+Use 'foreign' keyword to allow automake runs whithout these files.
+
+--- steghide-0.5.1/configure.in
++++ steghide-0.5.1/configure.in
+@@ -1,7 +1,8 @@
+ dnl Process this file with autoconf to produce a configure script.
+-AC_INIT(src/main.cc)
++AC_INIT([steghide], [0.5.1])
++AC_CONFIG_SRCDIR([src/main.cc])
+ AC_CANONICAL_SYSTEM
+-AM_INIT_AUTOMAKE(steghide, 0.5.1)
++AM_INIT_AUTOMAKE([foreign])
+ AM_CONFIG_HEADER(config.h)
+ 
+ dnl checks for programs.


### PR DESCRIPTION
autoreconf was failing because steghide did not provide AUTHORS,
NEWS and ChangeLog files

Use 'foreign' keyword to allow automake runs whithout these files.