### PR TITLE
testing/libkeyfinder: fix build on ppc64le

### DIFF
--- a/testing/libkeyfinder/APKBUILD
+++ b/testing/libkeyfinder/APKBUILD
@@ -5,13 +5,14 @@ pkgver=2.2.1
 pkgrel=2
 pkgdesc="Musical key detection for digital audio"
 url="http://www.ibrahimshaath.co.uk/keyfinder/"
-arch="all !ppc64le" #does not build on ppc64le yet
+arch="all"
 license="GPL"
 # Its just using qmake
 makedepends="qt-dev fftw-dev"
 subpackages="$pkgname-dev $pkgname-doc"
 source="libkeyfinder-$pkgver.tar.gz::https://github.com/ibsh/libKeyFinder/archive/v$pkgver.tar.gz
-	alpine-settings-to-pro.patch"
+	alpine-settings-to-pro.patch
+	add-missing-include-for-ppc64le.patch"
 builddir="$srcdir/libKeyFinder-$pkgver"
 
 build() {
@@ -35,9 +36,6 @@ check() {
 	LD_LIBRARY_PATH="$builddir" ./tests
 }
 
-md5sums="4d29fb42f1ec55766652eb3f8296d8a2  libkeyfinder-2.2.1.tar.gz
-2650ed076d43872cc474099021bd84cd  alpine-settings-to-pro.patch"
-sha256sums="f168247012da2467af846d5a1301ca3eff23eb48938fb9b2dbbfa8dd0e5ccf10  libkeyfinder-2.2.1.tar.gz
-bc2dd2f8948d6565dd90b75074d7f2e61802d9e2f67e315ba92464958e5dc0ea  alpine-settings-to-pro.patch"
 sha512sums="62790681e34e8513ac185396c9f76981238da3136a9bd646b197a1e7032d6d612e90157be9dd13700bbeb98085ee3d628ae847716e0091490cd6c3839bf2c25d  libkeyfinder-2.2.1.tar.gz
-580c968da0d24126d92b09cc4a970bb898fe020f2b9a9232d80ef63be8d3f90e618ea0b2f66ccde174a51dcf7160dfd62ab3b9428bf0ae6b11608b7dd7aede23  alpine-settings-to-pro.patch"
+580c968da0d24126d92b09cc4a970bb898fe020f2b9a9232d80ef63be8d3f90e618ea0b2f66ccde174a51dcf7160dfd62ab3b9428bf0ae6b11608b7dd7aede23  alpine-settings-to-pro.patch
+6292619361970bb85bb41a9ea94f12b2d70ca2b6d1957d9e27c56dbc3eaf55c49eb3616c0cbcd9b5855197f66c67064a8461c693e90a037e1019f0cd5da90587  add-missing-include-for-ppc64le.patch"

--- a/testing/libkeyfinder/add-missing-include-for-ppc64le.patch
+++ b/testing/libkeyfinder/add-missing-include-for-ppc64le.patch
@@ -1,0 +1,13 @@
+--- libKeyFinder-2.2.1/fftadapter.cpp
++++ libKeyFinder-2.2.1/fftadapter.cpp
+@@ -25,6 +25,10 @@
+ #include <cmath>
+ #include <fftw3.h>
+ 
++#ifdef __powerpc64__
++#include <string.h>
++#endif
++
+ namespace KeyFinder {
+ 
+   std::mutex fftwPlanMutex;


### PR DESCRIPTION
add missing include for string.h, that was not been included for ppc64le.