### PR TITLE
testing/tsung: new aport

### DIFF
--- a/testing/tsung/0005-Do-not-install-manpages-in-main-install.patch
+++ b/testing/tsung/0005-Do-not-install-manpages-in-main-install.patch
@@ -1,0 +1,36 @@
+--- tsung-445d78213bb4360d78df3753b3e23e6a28d701f0/Makefile.in
++++ tsung-445d78213bb4360d78df3753b3e23e6a28d701f0/Makefile.in
+@@ -211,6 +211,12 @@
+ 	-rm -f $(EBIN)/*.beam tsung.sh tsung.spec tsung.xml tsung.sh tsung-recorder.sh
+ 	-rm -f *.xml config.log src/test/*.xml src/test/usersdb.csv
+ 
++install_doc: tsung doc install_recorder install_controller $(CONFFILE)
++	install -d $(DESTDIR)$(MAN_DIR)
++	install -pm 0644 $(MANPAGES) $(DESTDIR)$(MAN_DIR)
++	install -d $(DESTDIR)$(CONFDIR)
++	install -pm 0644 $(CONFFILE) $(DESTDIR)$(CONFDIR)/
++
+ install: tsung doc install_recorder install_controller $(CONFFILE)
+ 	-rm -f $(TMP)
+ 
+@@ -230,10 +236,6 @@
+ 
+ 	install -pm 0644 $(SRC) $(DESTDIR)$(TARGETDIR)/src/
+ 
+-# install the man page
+-	install -d $(DESTDIR)$(MAN_DIR)
+-	install -pm 0644 $(MANPAGES) $(DESTDIR)$(MAN_DIR)
+-
+ # create startup script
+ 	install -pm 0755 tsung.sh $(DESTDIR)$(SCRIPT)
+ 	install -pm 0755 tsung-recorder.sh $(DESTDIR)$(REC_SCRIPT)
+@@ -244,9 +246,6 @@
+ 	install -d $(DESTDIR)$(SHARE_DIR)/tsung_plotter
+ 	install -pm 0644 $(TSUNG_PLOTTER_LIB) $(DESTDIR)$(LIBDIR)/tsung_plotter
+ 	install -pm 0644 $(TSUNG_PLOTTER_CONF) $(DESTDIR)$(SHARE_DIR)/tsung_plotter
+-
+-	install -d $(DESTDIR)$(CONFDIR)
+-	install -pm 0644 $(CONFFILE) $(DESTDIR)$(CONFDIR)/
+ 
+ 	install -d $(DESTDIR)$(TEMPLATES_DIR)
+ 	install -d $(DESTDIR)$(TEMPLATES_DIR)/style

--- a/testing/tsung/APKBUILD
+++ b/testing/tsung/APKBUILD
@@ -1,0 +1,60 @@
+# Contributor: Michael Truog <mjtruog@gmail.com>
+# Maintainer: Michael Truog <mjtruog@gmail.com>
+
+pkgname=tsung
+pkgver=1.6.0.1
+_srcver=445d78213bb4360d78df3753b3e23e6a28d701f0
+pkgrel=0
+pkgdesc="Tsung is a high-performance benchmark framework for various protocols including HTTP,XMPP,LDAP,etc."
+url="http://www.process-one.net/en/tsung/"
+license="GPL2"
+arch="noarch"
+depends="bash
+         erlang
+         gnuplot
+         perl-template-toolkit
+         python2
+         py-matplotlib
+         "
+makedepends="erlang
+             erlang-asn1
+             erlang-crypto
+             erlang-dev
+             erlang-eunit
+             erlang-inets
+             erlang-os-mon
+             erlang-snmp
+             erlang-ssl
+             erlang-tools
+             erlang-xmerl
+             perl
+             "
+subpackages=""
+source="https://github.com/processone/$pkgname/archive/$_srcver.tar.gz
+        0005-Do-not-install-manpages-in-main-install.patch"
+
+builddir="$srcdir/tsung-$_srcver"
+
+build() {
+	cd "$builddir"
+	./configure --prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--host="$CHOST" \
+		--build="$CBUILD"
+	make -j1
+}
+
+check() {
+	cd "$builddir"
+	make -j1 test
+}
+
+package() {
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
+}
+
+sha512sums="53a16363d30c2b593d4b3cda789457cd00f009c4163924a01d6a1b08f725cde2be35d02902a3c8436ddc5db7fb6215384444609c354c171ca4cf0088418f7934  445d78213bb4360d78df3753b3e23e6a28d701f0.tar.gz
+ee80c21fe6a66c96b1aa68afd96209516a5a3fe1d51a1ee01a1f465d164c332bbe30f03de1cc20f3d6e0651770fa7e579d64f52d282b64d6ca02d098852f2a93  0005-Do-not-install-manpages-in-main-install.patch"


### PR DESCRIPTION
http://www.process-one.net/en/tsung/
Tsung is a high-performance benchmark framework for various protocols including HTTP, XMPP, LDAP, etc.

This package is using the latest git commit which is considered "stable" pre-release (without the version officially incremented).  A ".1" suffix was added to the (last) version to signify this, since "rc1" was not accepted by abuild.