### PR TITLE
community/suitesparse: build at -O3

### DIFF
--- a/community/suitesparse/APKBUILD
+++ b/community/suitesparse/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=suitesparse
 _pkgname=SuiteSparse
 pkgver=4.5.5
-pkgrel=0
+pkgrel=1
 pkgdesc="A collection of sparse matrix libraries"
 url="http://faculty.cse.tamu.edu/davis/suitesparse.html"
 arch="all !s390x"
@@ -22,9 +22,6 @@ prepare() {
 
 	# OpenBLAS provides also LAPACK.
 	export LAPACK="-lopenblas"
-
-	# gcc fails on internal error when using default -O3.
-	export OPTIMIZATION="-O2"
 
 	# Do not include the Partition module and METIS (it's optional and
 	# Julia doesn't need it).


### PR DESCRIPTION
The bug that prevented this has been fixed upstream.
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71505