### PR TITLE
testing/icingaweb2-module-businessprocess: fix build and enable on ppc64le

### DIFF
--- a/testing/icingaweb2-module-businessprocess/APKBUILD
+++ b/testing/icingaweb2-module-businessprocess/APKBUILD
@@ -3,10 +3,10 @@
 pkgname=icingaweb2-module-businessprocess
 _module=${pkgname/*-/}
 pkgver=2.0.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Manage Business Processes in Icinga Web 2 "
 url="http://www.icinga.org"
-arch="noarch !armhf !ppc64le"
+arch="noarch !armhf"
 license="GPL2"
 _php=php5
 depends="icingaweb2-module-director"
@@ -22,6 +22,7 @@ build() {
 
 package() {
 	cd "$builddir"
+	mkdir -p "$pkgdir/etc/icingaweb2/modules/$_module"
 	mkdir -p "$pkgdir/usr/share/doc/$pkgname"
 	mkdir -p "$pkgdir/usr/share/webapps/icingaweb2/modules/$_module"
 	cp -a application library public \


### PR DESCRIPTION
The folder /etc/icingaweb2/modules/businessprocess was missing and chgrp command
was failing. Create the folder to fix build and also enable build on ppc64le as
icingaweb2-module-director package is enabled.