### PR TITLE
testing/cloudi: new aport

### DIFF
--- a/testing/cloudi/0005-Disable-pgsql-mysql-tests-for-aports-travis-build.patch
+++ b/testing/cloudi/0005-Disable-pgsql-mysql-tests-for-aports-travis-build.patch
@@ -1,0 +1,19 @@
+--- src/rebar_src_test.config.in
++++ src/rebar_src_test.config.in
+@@ -8,8 +8,6 @@
+ {sub_dirs,
+  ["lib/cloudi_core",
+   "lib/cloudi_service_api_requests",
+-  "lib/cloudi_service_db_mysql",
+-  "lib/cloudi_service_db_pgsql",
+   "lib/cloudi_service_filesystem",
+   "lib/cloudi_service_http_client",
+   "lib/cloudi_service_http_cowboy",
+@@ -17,7 +15,6 @@
+   "lib/cloudi_service_http_rest",
+   "lib/cloudi_service_map_reduce",
+   "lib/cloudi_service_monitoring",
+-  "lib/cloudi_service_oauth1",
+   "lib/cloudi_service_queue",
+   "lib/cloudi_service_quorum",
+   "lib/cloudi_service_router",

--- a/testing/cloudi/APKBUILD
+++ b/testing/cloudi/APKBUILD
@@ -1,0 +1,84 @@
+# Contributor: Michael Truog <mjtruog@gmail.com>
+# Maintainer: Michael Truog <mjtruog@gmail.com>
+
+pkgname=cloudi
+pkgver=1.7.1
+pkgrel=0
+pkgdesc="CloudI is an open-source private cloud computing framework for efficient, scalable, and stable soft-realtime event processing."
+url="http://cloudi.org/"
+license="MIT"
+arch="all"
+depends="g++"
+makedepends="autoconf
+             automake
+             binutils-dev
+             boost-dev
+             boost-system
+             boost-thread
+             erlang
+             erlang-asn1
+             erlang-common-test
+             erlang-crypto
+             erlang-dev
+             erlang-erl-interface
+             erlang-eunit
+             erlang-inets
+             erlang-jinterface
+             erlang-public-key
+             erlang-reltool
+             erlang-sasl
+             erlang-snmp
+             erlang-ssl
+             erlang-syntax-tools
+             erlang-tools
+             erlang-xmerl
+             gmp-dev
+             libexecinfo-dev
+             libtool
+             nodejs
+             openjdk8
+             perl
+             php7
+             python2
+             python2-dev
+             ruby
+             "
+install=""
+subpackages=""
+source="http://downloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.gz
+        0005-Disable-pgsql-mysql-tests-for-aports-travis-build.patch
+        $pkgname.initd"
+
+builddir="$srcdir/$pkgname-$pkgver/src"
+
+build() {
+	cd "$builddir"
+	./autogen.sh
+	export PATH="/usr/lib/jvm/java-1.8-openjdk/bin:$PATH"
+	LIBS="-lexecinfo" ./configure \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--localstatedir=/var \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--host="$CHOST" \
+		--build="$CBUILD" \
+		--with-cxx-backtrace
+	make -j1
+}
+
+check() {
+	cd "$builddir"
+	make -j1 ct
+}
+
+package() {
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
+	install -m755 -D "$srcdir"/$pkgname.initd \
+		"$pkgdir"/etc/init.d/$pkgname
+}
+
+sha512sums="6a9260b3d1e81f54e5d765804d43ee04d976239b6eb9d9785ba3762f1822a998a57f58fecab79b10b26b682b169f660bf3d99742debaefd010e171ecc309db35  cloudi-1.7.1.tar.gz
+7134271bb9a183c16aed2de8d3e0909654fa7b2c805abf1b496842f10dc4baf8d49236dd448bc8ba4408013beb350fea69b669751c6f4860e955acbdae63f29a  0005-Disable-pgsql-mysql-tests-for-aports-travis-build.patch
+3eebc8c38a16522df91ea86ae8dae21137e752db6f1dd1d6531319dcd051e9977dc649ccb27d582ca0e82140426f931168721d187cafc2646559932eef475887  cloudi.initd"

--- a/testing/cloudi/cloudi.initd
+++ b/testing/cloudi/cloudi.initd
@@ -1,0 +1,29 @@
+#!/sbin/openrc-run
+
+name=cloudi
+command="/usr/bin/$name"
+command_args=""
+command_background="false"
+
+description="CloudI is an open-source private cloud computing framework for efficient, scalable, and stable soft-realtime event processing."
+
+extra_started_commands="attach"
+description_attach="Attach to the running CloudI Erlang shell"
+
+depend() {
+	need localmount
+	need net
+	after firewall
+}
+start() {
+	$command start
+}
+stop() {
+	$command stop
+}
+restart() {
+	$command restart
+}
+attach() {
+	$command attach
+}


### PR DESCRIPTION
http://cloudi.org/
CloudI is an open-source private cloud computing framework for efficient, scalable, and stable soft-realtime event processing.

The configuration is all done within files that live in the directory `/etc/cloudi/` (so a `cloudi.confd` file wouldn't have anything to configure, since command line options aren't used with the `cloudi` executable).  The logging (including a pid file) is put into `/var/log/cloudi/`.  The `cloudi` executable is a start/stop script that needs to function synchronously to wait for other OS processes to terminate (external services) while enforcing its own timeout (a max of 60 seconds) and it needs to start the Erlang release in the background in a way where the pidfile is valid, which is why the `cloudi.initd` file is not using `start-stop-daemon`.  Some of the `makedepends` get dynamically linked and become runtime dependencies, but my understanding is that `apk` understands those packages need to exist on the installation as a dependency, even if they don't exist in the `depends` variable.