### PR TITLE
testing/wmi-client: enable build on ppc64le

### DIFF
--- a/testing/wmi-client/APKBUILD
+++ b/testing/wmi-client/APKBUILD
@@ -6,7 +6,7 @@ pkgver=1.3.16
 pkgrel=1
 pkgdesc="DCOM/WMI client implementation"
 url="https://www.orvant.com/packages"
-arch="all !aarch64 !ppc64le"
+arch="all !aarch64"
 license="GPL3"
 subpackages="libwmiclient-dev:libdev libwmiclient:lib"
 makedepends="autoconf python-dev perl-datetime"
@@ -21,6 +21,10 @@ source="https://launchpad.net/~cybersec/+archive/ubuntu/chaos-ppa-v2/+files/${_p
 
 builddir="$srcdir/$_pkgname-$pkgver"
 
+prepare() {
+	default_prepare
+	update_config_guess
+}
 build() {
 	cd "$builddir"
 	make build "CPP=gcc -E -ffreestanding"


### PR DESCRIPTION
update config guess and enable build on ppc64le.