### PR TITLE
community/asciinema: upgrade to 1.4.0 and enable on ppc64le

### DIFF
--- a/community/asciinema/APKBUILD
+++ b/community/asciinema/APKBUILD
@@ -1,32 +1,25 @@
 # Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=asciinema
-pkgver=1.2.0
+pkgver=1.4.0
 pkgrel=0
 pkgdesc="A Command line recorder for asciinema.org service"
 url="https://github.com/asciinema/asciinema/"
-arch="all !aarch64 !ppc64le !s390x"
+arch="all !aarch64 !s390x"
 license="GPLv3"
-depends="curl"
-depends_dev=""
-makedepends="go python2"
-subpackages="$pkgname-doc"
-options="!strip"
+depends="ncurses"
+makedepends="python3-dev"
 source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$pkgver.tar.gz"
-
 builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
 	cd "$builddir"
-	export GOPATH="$builddir"
-	mkdir -p src/github.com/asciinema
-	ln -s "$builddir" src/github.com/asciinema/asciinema
-	make build
+	python3 setup.py build
 }
 
 package() {
 	cd "$builddir"
-	PREFIX="$pkgdir"/usr make install
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
 }
 
-sha512sums="b172fa2c122ce6d4191d898292f70b462f18c9436a7a95b56a3d4405f66a4003d52877b5d632a829f94704f7d8a07c1202f1d3059e1eec6b583b63daf90a9006  asciinema-1.2.0.tar.gz"
+sha512sums="23c67a462acdbbbed495e6cc3e0e22ed028effcc945af30b5925854e216c6f74bb1b416d9b0001726732ae8be510796e996bbca69b225c20422143e5ed1aca5c  asciinema-1.4.0.tar.gz"


### PR DESCRIPTION
The upgrade from version 1.2.0 to 1.3.0 brings back the original Python implementation
of asciinema[1] and it supports only Python 3.

This patch changes the build to reflect the changes and also enable build on ppc64le.

[1] http://blog.asciinema.org/post/and-now-for-something-completely-different/