### PR TITLE
community/arpack: disable check() in ppc64le for now

### DIFF
--- a/community/arpack/APKBUILD
+++ b/community/arpack/APKBUILD
@@ -11,6 +11,9 @@ license="BSD"
 depends=""
 depends_dev="openblas-dev"
 makedepends="$depends_dev autoconf automake gfortran libtool"
+if [ "$CARCH" = "ppc64le" ]; then
+	options="!check"
+fi
 subpackages="$pkgname-dev $pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/opencollab/$_pkgname/archive/$pkgver.tar.gz"
 builddir="$srcdir/$_pkgname-$pkgver"


### PR DESCRIPTION
Tests from arpack are hanging on ppc64le with abuild but tests work when
running manually (make check) and all tests pass. It can be an issue in
fakeroot. Disabling ppc64le tests for now.