### PR TITLE
main/openvpn: upgrade openvpn 2.4.3

### DIFF
--- a/main/openvpn/APKBUILD
+++ b/main/openvpn/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=openvpn
-pkgver=2.4.2
+pkgver=2.4.3
 pkgrel=0
 pkgdesc="A robust, and highly configurable VPN (Virtual Private Network)"
 url="http://openvpn.sourceforge.net/"
@@ -60,7 +60,7 @@ pam() {
 		"$subpkgdir"/usr/lib/openvpn/plugins/
 }
 
-sha512sums="9be3cef25f398c426087581d8bb2589ae2a3a1b3b812c73f7e9a4d3c35098421eea3099b33fc90606162d0429dcd7d9ae3449af89602e060e47cd4c053720e72  openvpn-2.4.2.tar.gz
+sha512sums="1d1f9afa6d0858fa32f73b2a51ed7652beac52ef974b104b51b521e6d8e872b8f5659c55ec1ef442fed3b6c6b058627b0af73e765a1261871b1cd96c8acd657e  openvpn-2.4.3.tar.gz
 8a4080b7784faa156aa0775f7b73fe5c054707270af2a3139150629450ad0f1f5954dce5fc850f1bfd7b93bcc47ed4bc9b22159c536874698c78d81ba99338a7  openvpn.initd
 982ade883afbe2e656a9cbbe36c31c0e8b4f7bbbe5b63df9f7b834f02a9153032fb7445c85d3e91f62c68a7ddd13c3afbf420fb71cdd13d9c4b69f867bdd9f37  openvpn.confd
 f904d6125ed1ddb48ea632c3b290a7a4a7a7436be0d46b323fc8c92f919f9d076fdc78ff7bed0dd65675f0bc3559e531e372b805fc11ef287efeeb4d54fe52f4  openvpn.up


### PR DESCRIPTION
Not sure if this is sufficient for a PR, but there seem to be some significant security fixes in 2.4.3 (https://guidovranken.wordpress.com/2017/06/21/the-openvpn-post-audit-bug-bonanza/)