### PR TITLE
testing/neofetch: new aport

### DIFF
--- a/testing/neofetch/APKBUILD
+++ b/testing/neofetch/APKBUILD
@@ -1,0 +1,23 @@
+# Contributor: Dawid Dziurla <dawidd0811@gmail.com>
+# Maintainer: Dawid Dziurla <dawidd0811@gmail.com>
+pkgname=neofetch
+pkgver=3.2.0
+pkgrel=0
+pkgdesc="A CLI system information tool written in BASH that supports displaying images."
+url="https://github.com/dylanaraps/neofetch"
+arch="noarch"
+license="MIT"
+makedepends="make"
+depends="bash"
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz"
+options="!check"
+builddir="$srcdir/$pkgname-$pkgver"
+
+package()
+{
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install || return 1
+}
+
+sha512sums="790dd282b99437a416f25a895d5a3359be31d162447e2f59863c635c144045a6b81672e4469ca9b6eeba56fc927e787a67f0a317309bbc0f52500b0f9e072764  neofetch-3.2.0.tar.gz"


### PR DESCRIPTION
Neofetch is a CLI system information tool written in BASH. Neofetch displays information about your system next to an image, your OS logo, or any ASCII file of your choice. The main purpose of Neofetch is to be used in screenshots to show other users what OS/Distro you're running, what Theme/Icons you're using etc.