### PR TITLE
testing/cloudi: new aport

### DIFF
--- a/testing/cloudi/0005-Disable-tests-for-aports-buildservers.patch
+++ b/testing/cloudi/0005-Disable-tests-for-aports-buildservers.patch
@@ -1,0 +1,19 @@
+--- src/rebar_src_test.config.in
++++ src/rebar_src_test.config.in
+@@ -8,8 +8,6 @@
+ {sub_dirs,
+  ["lib/cloudi_core",
+   "lib/cloudi_service_api_requests",
+-  "lib/cloudi_service_db_mysql",
+-  "lib/cloudi_service_db_pgsql",
+   "lib/cloudi_service_filesystem",
+   "lib/cloudi_service_http_client",
+   "lib/cloudi_service_http_cowboy",
+@@ -17,7 +15,6 @@
+   "lib/cloudi_service_http_rest",
+   "lib/cloudi_service_map_reduce",
+   "lib/cloudi_service_monitoring",
+-  "lib/cloudi_service_oauth1",
+   "lib/cloudi_service_queue",
+   "lib/cloudi_service_quorum",
+   "lib/cloudi_service_router",

--- a/testing/cloudi/APKBUILD
+++ b/testing/cloudi/APKBUILD
@@ -1,0 +1,118 @@
+# Contributor: Michael Truog <mjtruog@gmail.com>
+# Maintainer: Michael Truog <mjtruog@gmail.com>
+#
+# INFO
+#
+# Why is the cloudi.initd file not using the openrc default start-stop-daemon?
+#
+#   With the Erlang VM it is possible to use the -heart erl command line
+#   argument (which is possible with cloudi configuration of the
+#   /etc/cloudi/vm.args file).  To allow the use of the heartbeat monitoring
+#   of the Erlang runtime system, it is necessary to rely upon the cloudi
+#   script for handling the cloudi pid and not utilize openrc for pidfile
+#   creation or signal-based termination.
+#
+#   With a typical Erlang VM release, it is normally expected to provide
+#   the ability to attach to the Erlang VM shell of the running node using
+#   pipes.  The setup of the Erlang VM shell pipes needs to be handled with
+#   Erlang VM execution that also handles detaching the daemon process.
+#   If the openrc default start-stop-daemon execution was used instead,
+#   it would not be possible to easily setup the Erlang VM shell pipes.
+#
+#   The termination of cloudi utilizes a 65000 millisecond timeout, allowing
+#   all services a maximum of 60000 milliseconds for termination with
+#   5000 millisecond for internal Erlang VM delays.  The cloudi script does
+#   block for this termination to complete.
+#
+#   The pid file path is set during the configuration step
+#   (shown below with the assignment of CLOUDI_PID_FILE).
+
+pkgname=cloudi
+pkgver=1.7.2_rc1
+_srcver=70addfda7133ac209157d48e38be70be7597ce8a
+pkgrel=0
+pkgdesc="Cloud computing framework for efficient, scalable, and stable soft-realtime event processing."
+url="http://cloudi.org/"
+license="MIT"
+arch="all"
+depends="g++"
+makedepends="autoconf
+             automake
+             binutils-dev
+             boost-dev
+             boost-system
+             boost-thread
+             erlang
+             erlang-asn1
+             erlang-common-test
+             erlang-crypto
+             erlang-dev
+             erlang-erl-interface
+             erlang-eunit
+             erlang-inets
+             erlang-jinterface
+             erlang-public-key
+             erlang-reltool
+             erlang-sasl
+             erlang-snmp
+             erlang-ssl
+             erlang-syntax-tools
+             erlang-tools
+             erlang-xmerl
+             gmp-dev
+             libexecinfo-dev
+             libtool
+             nodejs
+             openjdk8
+             perl
+             php7
+             python2
+             python2-dev
+             ruby
+             "
+install=""
+subpackages=""
+source="https://github.com/$pkgname/$pkgname/archive/$_srcver.tar.gz
+        0005-Disable-tests-for-aports-buildservers.patch
+        $pkgname.initd"
+builddir="$srcdir/CloudI-$_srcver/src"
+
+prepare() {
+	cd "$builddir"
+	default_prepare
+	./autogen.sh
+}
+
+build() {
+	cd "$builddir"
+	export PATH="/usr/lib/jvm/java-1.8-openjdk/bin:$PATH"
+	LIBS="-lexecinfo" CLOUDI_PID_FILE="/run/cloudi.pid" ./configure \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--localstatedir=/var \
+		--bindir=/usr/sbin \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--host="$CHOST" \
+		--build="$CBUILD" \
+		--with-cxx-backtrace
+	# -j1 is currently required due to automake usage for java and erlang
+	#     which will be fixed in the future
+	make -j1
+}
+
+check() {
+	cd "$builddir"
+	make -j1 ct
+}
+
+package() {
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
+	install -m755 -D "$srcdir"/$pkgname.initd \
+		"$pkgdir"/etc/init.d/$pkgname
+}
+
+sha512sums="c47d3016002c5cf76782eb45a8c9da8aafa27d2046c82d6339dd59b88fb84e7c17f7df67071d9c3ca4fc8e87cd45980494664cd4ba5fb8900a67e47e909a0e7c  70addfda7133ac209157d48e38be70be7597ce8a.tar.gz
+7134271bb9a183c16aed2de8d3e0909654fa7b2c805abf1b496842f10dc4baf8d49236dd448bc8ba4408013beb350fea69b669751c6f4860e955acbdae63f29a  0005-Disable-tests-for-aports-buildservers.patch
+08e930424d4b7f4bbb7888fc9c16f6007a215886ebd0bdf4a296d4870d8d4e48bcc9df11ab79362aae238c3ae30a05dc47d9fbbc54fe07306dd06e8336576ad8  cloudi.initd"

--- a/testing/cloudi/cloudi.initd
+++ b/testing/cloudi/cloudi.initd
@@ -1,0 +1,35 @@
+#!/sbin/openrc-run
+
+# Justification for the script use here exists in the port's APKBUILD file.
+
+name=cloudi
+command=/usr/sbin/cloudi
+command_args=""
+command_background="false"
+
+description="CloudI is an open-source private cloud computing framework for efficient, scalable, and stable soft-realtime event processing."
+
+depend() {
+	need localmount
+	need net
+	after firewall
+}
+start() {
+	$command start
+}
+stop() {
+	$command stop
+}
+restart() {
+	$command restart
+}
+status() {
+	$command test
+	if [ $? -eq 0 ]; then
+		einfo "status: started"
+		return 0
+	else
+		einfo "status: stopped"
+		return 3
+	fi
+}


### PR DESCRIPTION
http://cloudi.org/
CloudI is an open-source private cloud computing framework for efficient, scalable, and stable soft-realtime event processing.

This pull-request is a continuation of https://github.com/alpinelinux/aports/pull/1741 .  The tests that use postgresql and mysql are disabled to avoid them failing when they attempt to test these databases (Travis has the databases running, but they require a database be created for the tests to pass).  The cloudi_service_filesystem test is disabled due to the x86_64 and x86 buildservers not wanting /tmp to be used for temporary files during testing.  These changes are applied within the `0005-Disable-tests-for-aports-buildservers.patch` patch.