### PR TITLE
main/python3: upgrade to 3.6.2, optimize build, cleanup

### DIFF
--- a/main/python3/APKBUILD
+++ b/main/python3/APKBUILD
@@ -12,33 +12,30 @@ license="custom"
 provides="py3-pip"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-tests::noarch
 	$pkgname-tkinter:tkinter"
-depends=""
 makedepends="expat-dev libressl-dev zlib-dev ncurses-dev bzip2-dev xz-dev
 	sqlite-dev libffi-dev tcl-dev linux-headers gdbm-dev readline-dev
 	tk tk-dev"
 source="http://www.python.org/ftp/python/$pkgver/Python-$pkgver.tar.xz
 	musl-find_library.patch
-	fix-xattrs-glibc.patch
-	"
+	fix-xattrs-glibc.patch"
 builddir="$srcdir/Python-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	# force system libs
 	rm -r Modules/expat \
 		Modules/zlib \
 		Modules/_ctypes/darwin* \
-		Modules/_ctypes/libffi* \
-		|| return 1
+		Modules/_ctypes/libffi*
 }
 
 build() {
 	cd "$builddir"
 
 	./configure \
-		--prefix=/usr
+		--prefix=/usr \
 		--disable-rpath \
 		--enable-ipv6 \
 		--enable-loadable-sqlite-extensions \
@@ -50,26 +47,23 @@ build() {
 		--with-system-expat \
 		--with-system-ffi \
 		--with-threads \
-		|| return 1
 
-	make EXTRA_CFLAGS="$CFLAGS" || return 1
+	make EXTRA_CFLAGS="$CFLAGS"
 }
 
 package() {
 	cd "$builddir"
-	make -j1 DESTDIR="$pkgdir" EXTRA_CFLAGS="$CFLAGS" install maninstall \
-		|| return 1
+	make -j1 DESTDIR="$pkgdir" EXTRA_CFLAGS="$CFLAGS" install maninstall
 	install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
-
 }
 
 dev() {
-	default_dev || return 1
+	default_dev
 
 	# pyconfig.h is needed runtime so we move it back
 	mkdir -p "$pkgdir"/usr/include/python${_basever}m
 	mv "$subpkgdir"/usr/include/python${_basever}m/pyconfig.h \
-		"$pkgdir"/usr/include/python${_basever}m/
+	    "$pkgdir"/usr/include/python${_basever}m/
 }
 
 tests() {
@@ -93,6 +87,6 @@ tkinter() {
 	mv "$pkgdir"/$libdir/_tkinter.*.so "$subpkgdir"/$libdir/
 }
 
-sha512sums="8605fb7019386fec227d4b06d06f00ae500a8a89df289bfe6141bb56196c75483a60cc0ee553930742b31cefce68add5ccf226e0f27b7b915f5026d597e1ac29  Python-3.6.1.tar.xz
+sha512sums="a8270a09a9e9b39f69ece6cdade2fa964665d2107b5acbad4453f1b921107b329c697c137185928fb4a576fc0f2ae2a98dbf26a8b7ea17219e990ddbc216db8b  Python-3.6.2.tar.xz
 ab8eaa2858d5109049b1f9f553198d40e0ef8d78211ad6455f7b491af525bffb16738fed60fc84e960c4889568d25753b9e4a1494834fea48291b33f07000ec2  musl-find_library.patch
 37b6ee5d0d5de43799316aa111423ba5a666c17dc7f81b04c330f59c1d1565540eac4c585abe2199bbed52ebe7426001edb1c53bd0a17486a2a8e052d0f494ad  fix-xattrs-glibc.patch"

--- a/main/python3/APKBUILD
+++ b/main/python3/APKBUILD
@@ -2,9 +2,9 @@
 # Contributor: Kiyoshi Aman <kiyoshi.aman@gmail.com>
 
 pkgname=python3
-pkgver=3.6.1
+pkgver=3.6.2
 _basever="${pkgver%.*}"
-pkgrel=4
+pkgrel=0
 pkgdesc="A high-level scripting language"
 url="http://www.python.org"
 arch="all"
@@ -38,13 +38,13 @@ build() {
 	cd "$builddir"
 
 	./configure \
-		--prefix=/usr \
+		--prefix=/usr
 		--disable-rpath \
 		--enable-ipv6 \
 		--enable-loadable-sqlite-extensions \
 		--enable-shared \
-		--enable-optimize \
-		--enable-lto \
+		--enable-optimizations \
+		--with-lto \
 		--with-computed-gotos \
 		--with-dbmliborder=gdbm:ndbm \
 		--with-system-expat \


### PR DESCRIPTION
Spitted into two commits since https://github.com/scadu/aports/commit/dcf6247dc0426b59bcbce8deefcd852dc7e02820 which fixes issue reported by @awilfox on IRC:

> I am building packages in a chroot.  the host system is 64-bit Debian, the chroot is 32-bit Alpine, but it says: checking host system type... powerpc64-unknown-linux-gnu
this is definitely not desireable.  it should be using --build --host like any other

The second commit https://github.com/scadu/aports/commit/6c482bda93672107fa892d2a1ed213da31ce2b39 actually enables optimization options somehow missed during previous builds. 

Travis test will fail here. Unfortunately it requires more time, however the boost is noticeably: 30% speed boost in some parts of the stdlib -- I think it's worth it.