### PR TITLE
testing/openscenegraph: fix build with ffmpeg 3.2.5

### DIFF
--- a/testing/openscenegraph/APKBUILD
+++ b/testing/openscenegraph/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=openscenegraph
 pkgver=3.4.0
-pkgrel=4
+pkgrel=5
 pkgdesc="High performance 3D graphics toolkit"
 url="https://openscenegraph.org"
 arch="all !ppc64le"
@@ -14,6 +14,7 @@ install=
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-$pkgver.zip
 	musl-fixes.patch
+	replace-deprecated-FFmpeg-API-to-fix-build-with-ffmp.patch
 	"
 builddir="$srcdir"/OpenSceneGraph-$pkgver
 
@@ -38,9 +39,6 @@ package() {
 	[ -d "$pkgdir/usr/lib64" ] && mv "$pkgdir/usr/lib64" "$pkgdir/usr/lib" || true
 }
 
-md5sums="a5e762c64373a46932e444f6f7332496  OpenSceneGraph-3.4.0.zip
-4340415e1e29eb1fea48165626625045  musl-fixes.patch"
-sha256sums="5c727d84755da276adf8c4a4a3a8ba9c9570fc4b4969f06f1d2e9f89b1e3040e  OpenSceneGraph-3.4.0.zip
-ced73f54f03f7ed5204824d7ed4a164dcc8c3f6ffd8ca829af3c5dd158caad2b  musl-fixes.patch"
 sha512sums="b598a7d68c9e5bf840d7b0a59a334037c3b6efe4d2dce333280b63a8ccef1b9a37cd5ff32b98f18e110ff9cbc48226f588e143cb1d68405edda3c60ab2f3f73a  OpenSceneGraph-3.4.0.zip
-016b09874bd6ca14cf1dba9274df4fc0413d2d97c3438135ecf6c5726029963f1ff279eb4986afe86173739512799e1e8ee5f7443e30fe1131524405a9d002be  musl-fixes.patch"
+016b09874bd6ca14cf1dba9274df4fc0413d2d97c3438135ecf6c5726029963f1ff279eb4986afe86173739512799e1e8ee5f7443e30fe1131524405a9d002be  musl-fixes.patch
+8fa606d29ff7f45b9ada05482f61f99541d6b7803ba2fcb1d82c2b4c4045db7706334075a90a100cad5b9c1e25d290c4be6899fb12b36593e004b830cf1bdb64  replace-deprecated-FFmpeg-API-to-fix-build-with-ffmp.patch"

--- a/testing/openscenegraph/replace-deprecated-FFmpeg-API-to-fix-build-with-ffmp.patch
+++ b/testing/openscenegraph/replace-deprecated-FFmpeg-API-to-fix-build-with-ffmp.patch
@@ -1,0 +1,176 @@
+From e85d5743341585c6e6eb1ac693884f80e1fa06ce Mon Sep 17 00:00:00 2001
+From: Andreas Cadhalpun <Andreas.Cadhalpun@googlemail.com>
+Date: Wed, 1 Jun 2016 10:32:35 +0100
+Subject: [PATCH] Replace deprecated FFmpeg API to fix build with ffmpeg-3.0.x
+
+---
+ src/osgPlugins/ffmpeg/FFmpegDecoderAudio.cpp |  3 +-
+ src/osgPlugins/ffmpeg/FFmpegDecoderVideo.cpp | 48 +++++++++++++---------------
+ src/osgPlugins/ffmpeg/FFmpegDecoderVideo.hpp |  4 +--
+ src/osgPlugins/ffmpeg/FFmpegParameters.cpp   |  2 +-
+ 4 files changed, 26 insertions(+), 31 deletions(-)
+
+diff --git a/src/osgPlugins/ffmpeg/FFmpegDecoderAudio.cpp b/src/osgPlugins/ffmpeg/FFmpegDecoderAudio.cpp
+index 665c68f5f..636bddd25 100644
+--- a/src/osgPlugins/ffmpeg/FFmpegDecoderAudio.cpp
++++ b/src/osgPlugins/ffmpeg/FFmpegDecoderAudio.cpp
+@@ -227,8 +227,7 @@ printf("### CONVERTING from sample format %s TO %s\n\t\tFROM %d TO %d channels\n
+         if (avcodec_open2(m_context, p_codec, NULL) < 0)
+             throw std::runtime_error("avcodec_open() failed");
+ 
+-        m_context->get_buffer = avcodec_default_get_buffer;
+-        m_context->release_buffer = avcodec_default_release_buffer;
++        m_context->get_buffer2 = avcodec_default_get_buffer2;
+ 
+     }
+ 
+diff --git a/src/osgPlugins/ffmpeg/FFmpegDecoderVideo.cpp b/src/osgPlugins/ffmpeg/FFmpegDecoderVideo.cpp
+index 9375657aa..083d3dbf5 100644
+--- a/src/osgPlugins/ffmpeg/FFmpegDecoderVideo.cpp
++++ b/src/osgPlugins/ffmpeg/FFmpegDecoderVideo.cpp
+@@ -71,7 +71,7 @@ void FFmpegDecoderVideo::open(AVStream * const stream)
+     findAspectRatio();
+ 
+     // Find out whether we support Alpha channel
+-    m_alpha_channel = (m_context->pix_fmt == PIX_FMT_YUVA420P);
++    m_alpha_channel = (m_context->pix_fmt == AV_PIX_FMT_YUVA420P);
+ 
+     // Find out the framerate
+     #if LIBAVCODEC_VERSION_MAJOR >= 56
+@@ -95,20 +95,19 @@ void FFmpegDecoderVideo::open(AVStream * const stream)
+         throw std::runtime_error("avcodec_open() failed");
+ 
+     // Allocate video frame
+-    m_frame.reset(avcodec_alloc_frame());
++    m_frame.reset(av_frame_alloc());
+ 
+     // Allocate converted RGB frame
+-    m_frame_rgba.reset(avcodec_alloc_frame());
+-    m_buffer_rgba[0].resize(avpicture_get_size(PIX_FMT_RGB24, width(), height()));
++    m_frame_rgba.reset(av_frame_alloc());
++    m_buffer_rgba[0].resize(avpicture_get_size(AV_PIX_FMT_RGB24, width(), height()));
+     m_buffer_rgba[1].resize(m_buffer_rgba[0].size());
+ 
+     // Assign appropriate parts of the buffer to image planes in m_frame_rgba
+-    avpicture_fill((AVPicture *) (m_frame_rgba).get(), &(m_buffer_rgba[0])[0], PIX_FMT_RGB24, width(), height());
++    avpicture_fill((AVPicture *) (m_frame_rgba).get(), &(m_buffer_rgba[0])[0], AV_PIX_FMT_RGB24, width(), height());
+ 
+     // Override get_buffer()/release_buffer() from codec context in order to retrieve the PTS of each frame.
+     m_context->opaque = this;
+-    m_context->get_buffer = getBuffer;
+-    m_context->release_buffer = releaseBuffer;
++    m_context->get_buffer2 = getBuffer;
+ }
+ 
+ 
+@@ -267,8 +266,8 @@ int FFmpegDecoderVideo::convert(AVPicture *dst, int dst_pix_fmt, AVPicture *src,
+ #ifdef USE_SWSCALE
+     if (m_swscale_ctx==0)
+     {
+-        m_swscale_ctx = sws_getContext(src_width, src_height, (PixelFormat) src_pix_fmt,
+-                                      src_width, src_height, (PixelFormat) dst_pix_fmt,
++        m_swscale_ctx = sws_getContext(src_width, src_height, (AVPixelFormat) src_pix_fmt,
++                                      src_width, src_height, (AVPixelFormat) dst_pix_fmt,
+                                       /*SWS_BILINEAR*/ SWS_BICUBIC, NULL, NULL, NULL);
+     }
+ 
+@@ -315,14 +314,14 @@ void FFmpegDecoderVideo::publishFrame(const double delay, bool audio_disabled)
+     AVPicture * const dst = (AVPicture *) m_frame_rgba.get();
+ 
+     // Assign appropriate parts of the buffer to image planes in m_frame_rgba
+-    avpicture_fill((AVPicture *) (m_frame_rgba).get(), &(m_buffer_rgba[m_writeBuffer])[0], PIX_FMT_RGB24, width(), height());
++    avpicture_fill((AVPicture *) (m_frame_rgba).get(), &(m_buffer_rgba[m_writeBuffer])[0], AV_PIX_FMT_RGB24, width(), height());
+ 
+     // Convert YUVA420p (i.e. YUV420p plus alpha channel) using our own routine
+ 
+-    if (m_context->pix_fmt == PIX_FMT_YUVA420P)
++    if (m_context->pix_fmt == AV_PIX_FMT_YUVA420P)
+         yuva420pToRgba(dst, src, width(), height());
+     else
+-        convert(dst, PIX_FMT_RGB24, src, m_context->pix_fmt, width(), height());
++        convert(dst, AV_PIX_FMT_RGB24, src, m_context->pix_fmt, width(), height());
+ 
+     // Wait 'delay' seconds before publishing the picture.
+     int i_delay = static_cast<int>(delay * 1000000 + 0.5);
+@@ -349,7 +348,7 @@ void FFmpegDecoderVideo::publishFrame(const double delay, bool audio_disabled)
+ 
+ void FFmpegDecoderVideo::yuva420pToRgba(AVPicture * const dst, AVPicture * const src, int width, int height)
+ {
+-    convert(dst, PIX_FMT_RGB24, src, m_context->pix_fmt, width, height);
++    convert(dst, AV_PIX_FMT_RGB24, src, m_context->pix_fmt, width, height);
+ 
+     const size_t bpp = 4;
+ 
+@@ -367,31 +366,28 @@ void FFmpegDecoderVideo::yuva420pToRgba(AVPicture * const dst, AVPicture * const
+     }
+ }
+ 
+-
+-
+-int FFmpegDecoderVideo::getBuffer(AVCodecContext * const context, AVFrame * const picture)
++int FFmpegDecoderVideo::getBuffer(AVCodecContext * const context, AVFrame * const picture, int flags)
+ {
++    AVBufferRef *ref;
+     const FFmpegDecoderVideo * const this_ = reinterpret_cast<const FFmpegDecoderVideo*>(context->opaque);
+ 
+-    const int result = avcodec_default_get_buffer(context, picture);
++    const int result = avcodec_default_get_buffer2(context, picture, flags);
+     int64_t * p_pts = reinterpret_cast<int64_t*>( av_malloc(sizeof(int64_t)) );
+ 
+     *p_pts = this_->m_packet_pts;
+     picture->opaque = p_pts;
+ 
++    ref = av_buffer_create((uint8_t *)picture->opaque, sizeof(int64_t), FFmpegDecoderVideo::freeBuffer, picture->buf[0], flags);
++    picture->buf[0] = ref;
++
+     return result;
+ }
+ 
+-
+-
+-void FFmpegDecoderVideo::releaseBuffer(AVCodecContext * const context, AVFrame * const picture)
++void FFmpegDecoderVideo::freeBuffer(void *opaque, uint8_t *data)
+ {
+-    if (picture != 0)
+-        av_freep(&picture->opaque);
+-
+-    avcodec_default_release_buffer(context, picture);
++    AVBufferRef *ref = (AVBufferRef *)opaque;
++    av_buffer_unref(&ref);
++    av_free(data);
+ }
+ 
+-
+-
+ } // namespace osgFFmpeg
+diff --git a/src/osgPlugins/ffmpeg/FFmpegDecoderVideo.hpp b/src/osgPlugins/ffmpeg/FFmpegDecoderVideo.hpp
+index 7883b177c..778c1a9b8 100644
+--- a/src/osgPlugins/ffmpeg/FFmpegDecoderVideo.hpp
++++ b/src/osgPlugins/ffmpeg/FFmpegDecoderVideo.hpp
+@@ -94,8 +94,8 @@ private:
+                 int src_pix_fmt, int src_width, int src_height);
+ 
+ 
+-    static int getBuffer(AVCodecContext * context, AVFrame * picture);
+-    static void releaseBuffer(AVCodecContext * context, AVFrame * picture);
++    static int getBuffer(AVCodecContext * context, AVFrame * picture, int flags);
++    static void freeBuffer(void * opaque, uint8_t *data);
+ 
+     PacketQueue &           m_packets;
+     FFmpegClocks &          m_clocks;
+diff --git a/src/osgPlugins/ffmpeg/FFmpegParameters.cpp b/src/osgPlugins/ffmpeg/FFmpegParameters.cpp
+index 288e44052..5915ab850 100644
+--- a/src/osgPlugins/ffmpeg/FFmpegParameters.cpp
++++ b/src/osgPlugins/ffmpeg/FFmpegParameters.cpp
+@@ -19,7 +19,7 @@ extern "C"
+     #include <libavutil/pixdesc.h>
+ }
+ 
+-inline PixelFormat osg_av_get_pix_fmt(const char *name) { return av_get_pix_fmt(name); }
++inline AVPixelFormat osg_av_get_pix_fmt(const char *name) { return av_get_pix_fmt(name); }
+ 
+ 
+ namespace osgFFmpeg {
+-- 
+2.13.1
+


### PR DESCRIPTION
Fix openscenegraph build replacing deprecated ffmpeg API.
This patch was backported from openscenegraph master branch.