### PR TITLE
testing/zsh-syntax-highlighting: new aport

### DIFF
--- a/testing/zsh-syntax-highlighting/APKBUILD
+++ b/testing/zsh-syntax-highlighting/APKBUILD
@@ -1,0 +1,26 @@
+# Contributor: Dawid Dziurla <dawidd0811@gmail.com>
+# Maintainer: Dawid Dziurla <dawidd0811@gmail.com>
+pkgname=zsh-syntax-highlighting
+pkgver=0.5.0
+pkgrel=0
+pkgdesc="Fish shell like syntax highlighting for Zsh."
+url="https://github.com/zsh-users/zsh-syntax-highlighting"
+arch="noarch"
+license="BSD-3"
+depends="zsh"
+makedepends=""
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz"
+options="!check"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	make
+}
+
+package() {
+	cd "$builddir"
+	make install DESTDIR="$pkgdir" PREFIX="/usr" SHARE_DIR="$pkgdir/usr/share/zsh/plugins/$pkgname"
+}
+sha512sums="dd0dcb772add597eb6f04e9958fb960688a5a2e316d51792d573fbfe1fd43e5a63c0de2242f87837818f27d732d8872576978c950640c1d1eea92b7b01ae84b4  zsh-syntax-highlighting-0.5.0.tar.gz"


### PR DESCRIPTION
Fish shell-like like syntax highlighting for Zsh.