### PR TITLE
testing/openscenegraph: fix build on ppc64le

### DIFF
--- a/testing/openscenegraph/APKBUILD
+++ b/testing/openscenegraph/APKBUILD
@@ -4,7 +4,7 @@ pkgver=3.4.0
 pkgrel=5
 pkgdesc="High performance 3D graphics toolkit"
 url="https://openscenegraph.org"
-arch="all !ppc64le"
+arch="all"
 license="Custom"
 depends=
 depends_dev=
@@ -15,6 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 source="http://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-$pkgver.zip
 	musl-fixes.patch
 	replace-deprecated-FFmpeg-API-to-fix-build-with-ffmp.patch
+	add-missing-include-for-ppc64le.patch
 	"
 builddir="$srcdir"/OpenSceneGraph-$pkgver
 
@@ -41,4 +42,5 @@ package() {
 
 sha512sums="b598a7d68c9e5bf840d7b0a59a334037c3b6efe4d2dce333280b63a8ccef1b9a37cd5ff32b98f18e110ff9cbc48226f588e143cb1d68405edda3c60ab2f3f73a  OpenSceneGraph-3.4.0.zip
 016b09874bd6ca14cf1dba9274df4fc0413d2d97c3438135ecf6c5726029963f1ff279eb4986afe86173739512799e1e8ee5f7443e30fe1131524405a9d002be  musl-fixes.patch
-8fa606d29ff7f45b9ada05482f61f99541d6b7803ba2fcb1d82c2b4c4045db7706334075a90a100cad5b9c1e25d290c4be6899fb12b36593e004b830cf1bdb64  replace-deprecated-FFmpeg-API-to-fix-build-with-ffmp.patch"
+8fa606d29ff7f45b9ada05482f61f99541d6b7803ba2fcb1d82c2b4c4045db7706334075a90a100cad5b9c1e25d290c4be6899fb12b36593e004b830cf1bdb64  replace-deprecated-FFmpeg-API-to-fix-build-with-ffmp.patch
+a3e69609b2e3c51002f4babd1c5bd64fc9c32b14fc9232f4b4f345c6e96134bc80a0fe54ce3445059b4d0512d5ac1ec434101fe976b71f24c68b3569265e21d9  add-missing-include-for-ppc64le.patch"

--- a/testing/openscenegraph/add-missing-include-for-ppc64le.patch
+++ b/testing/openscenegraph/add-missing-include-for-ppc64le.patch
@@ -1,0 +1,13 @@
+--- OpenSceneGraph-3.4.0/src/OpenThreads/pthreads/PThread.cpp
++++ OpenSceneGraph-3.4.0/src/OpenThreads/pthreads/PThread.cpp
+@@ -57,6 +57,10 @@
+ 
+ #include <iostream>
+ 
++#ifdef __powerpc64__
++#include <string.h>
++#endif
++
+ using namespace OpenThreads;
+ 
+ #ifdef DEBUG


### PR DESCRIPTION
Add missing include for string.h, that was not been included for ppc64le