### PR TITLE
community/tor: upgrade to 0.3.0.9

### DIFF
--- a/community/tor/APKBUILD
+++ b/community/tor/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Christine Dodrill <me@christine.website>
 # Maintainer: Christine Dodrill <me@christine.website>
 pkgname=tor
-pkgver=0.3.0.8
+pkgver=0.3.0.9
 pkgrel=0
 pkgdesc="Anonymous network connectivity"
 url="https://www.torproject.org"
@@ -53,7 +53,7 @@ package() {
 		"$pkgdir"/etc/conf.d/$pkgname || return 1
 }
 
-sha512sums="93267e51578266f6f6eea57e7fcd7ec5f8fbeb2e880675956724a0b1c1dfe1826945aaba4ca3075b577505d0ce70fd7def2f2a9e06af78f52190e15a7aad2ee1  tor-0.3.0.8.tar.gz
+sha512sums="19b662840ee0c6aaba04c6db7f172def070d0773553f90bc3d1f210266bbcb572b3dd1f383359e36583103235a85a0a4052cf7299a534fde137bee41376ffa02  tor-0.3.0.9.tar.gz
 6de4ada16ba58264a247da70343eabd763e992d6b6683977fc1c67b7b4a9731748a7ec9751e869ad4b4ae9c72cf71b2e12dc289bb6e2aee499917f7663f4a735  tor.initd
 2b0de119bfdf9eb57e13317b7392190b1b8272c8f96023c71d3fc29215d887e9a3d0ffcef37cdb50b18d34e4b2251f75a739e258e0bb72aabd3339418b22fd67  tor.confd
 da386ff7e387312e647f04d360517a1f4cb1efbee36f4a3a6feb89a979bb12fa350fe6dfed49af0cb076ae30bb0c527b5d54127683eaa5aa45d6940dddd89dfb  torrc.sample.patch"


### PR DESCRIPTION
Changes in version 0.3.0.9 - 2017-06-29
Major bugfixes (path selection, security, backport from 0.3.1.4-alpha):    
When choosing which guard to use for a circuit, avoid the exit's family along with the exit itself. Previously, the new guard selection logic avoided the exit, but did not consider its family. Fixes bug 22753 (https://bugs.torproject.org/22753); bugfix on 0.3.0.1-alpha. Tracked as TROVE-2016- 006 and CVE-2017-0377.  

Major bugfixes (entry guards, backport from 0.3.1.1-alpha):  
Don't block bootstrapping when a primary bridge is offline and we can't get its descriptor. Fixes bug 22325 (https://bugs.torproject.org/22325); fixes one case of bug 21969 (https://bugs.torproject.org/21969); bugfix on 0.3.0.3-alpha.  

 
Major bugfixes (entry guards, backport from 0.3.1.4-alpha):    
When starting with an old consensus, do not add new entry guards unless the consensus is "reasonably live" (under 1 day old). Fixes one root cause of bug 22400 (https://bugs.torproject.org/22400); bugfix on 0.3.0.1-alpha.  

Minor features (geoip):    
Update geoip and geoip6 to the June 8 2017 Maxmind GeoLite2 Country database.  

Minor bugfixes (voting consistency, backport from 0.3.1.1-alpha):    
Reject version numbers with non-numeric prefixes (such as +, -, or whitespace). Disallowing whitespace prevents differential version parsing between POSIX-based and Windows platforms. Fixes bug 21507 (https://bugs.torproject.org/21507) and part of 21508; bugfix on 0.0.8pre1.  

Minor bugfixes (linux seccomp2 sandbox, backport from 0.3.1.4-alpha):    
Permit the fchmod system call, to avoid crashing on startup when starting with the seccomp2 sandbox and an unexpected set of permissions on the data directory or its contents. Fixes bug 22516 (https://bugs.torproject.org/22516); bugfix on 0.2.5.4-alpha.  

Minor bugfixes (defensive programming, backport from 0.3.1.4-alpha):  
Fix a memset() off the end of an array when packing cells. This bug should be harmless in practice, since the corrupted bytes are still in the same structure, and are always padding bytes, ignored, or immediately overwritten, depending on compiler behavior. Nevertheless, because the memset()'s purpose is to make sure that any other cell-handling bugs can't expose bytes to the network, we need to fix it. Fixes bug 22737 (https://bugs.torproject.org/22737); bugfix on 0.2.4.11-alpha. Fixes CID 1401591.  