### PR TITLE
testing/rabbitmq-server: update to 3.6.10

### DIFF
--- a/testing/rabbitmq-server/APKBUILD
+++ b/testing/rabbitmq-server/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Nathan Johnson <nathan@nathanjohnson.info>
 # Maintainer: Nathan Johnson <nathan@nathanjohnson.info>
 pkgname=rabbitmq-server
-pkgver=3.6.9
+pkgver=3.6.10
 _realver=${pkgver//\./_}
 pkgrel=0
 pkgdesc="RabbitMQ is an open source multi-protocol messaging broker."
@@ -11,7 +11,7 @@ license="MPL 1.1"
 depends="erlang erlang-tools erlang-runtime-tools erlang-stdlib
 	logrotate erlang-ssl erlang-crypto erlang-parsetools
 	erlang-mnesia erlang-sasl erlang-inets erlang-syntax-tools
-	erlang-eldap erlang-xmerl erlang-os-mon"
+	erlang-eldap erlang-xmerl erlang-os-mon erlang-asn1 erlang-public-key"
 depends_dev=""
 makedepends="$depends_dev erlang-dev python2 py2-simplejson xmlto libxslt
 	rsync zip gawk grep erlang-compiler erlang-erl-docgen
@@ -78,12 +78,6 @@ package() {
 	chown -R $pkgusers:$pkggroups "$pkgdir"/var/log/rabbitmq
 }
 
-md5sums="12287613dfb924d4cde19202de6eb313  rabbitmq-server.initd
-f24af11867cddc5a17fefa8bf4276d52  rabbitmq-server.logrotate
-30dc144263dcce89e041913c24be61df  rabbitmq-server-3.6.9.tar.xz"
-sha256sums="b1ffe4a47550474c7a5b8ab47f4cd40549b84ede361302fa58863f27f17be3ec  rabbitmq-server.initd
-9cce79e90835317b9704ecdf44e7dbc71803a17c85c1402f2bb4b2edb0232ab2  rabbitmq-server.logrotate
-2df4f09860167de803f592a45792f3f83533bd97acdd7e18569c5bafcf2e470f  rabbitmq-server-3.6.9.tar.xz"
 sha512sums="a8bb02a7cae1f8720e5c7aaabfe6a2c0e731cffbe0d8f99bdcb6597daa654dc49e6d41943974601435700cf469eaa8286dc91a3255a6b9023754c3861fbb5cd9  rabbitmq-server.initd
 b8655cb048ab3b32001d4e6920bb5366696f3a5da75c053605e9b270e771c548e36858dca8338813d34376534515bba00af5e6dd7b4b1754a0e64a8fb756e3f3  rabbitmq-server.logrotate
-a003d2343c97e546ac01a5aadc46e94e2dbcc78349072b362950e5c5e11229e2a6fc4020d281f9fbb5cc0f577d2a166ef09671e931ec1470ab2edcdd98443662  rabbitmq-server-3.6.9.tar.xz"
+64e618e51ab259463029ad75b981dbf64687515e52d19854f225d4c68077e683ef56f0f6bb92cbbf91f140bc829d905473d687d083d12f36dd2cdfab3defaed6  rabbitmq-server-3.6.10.tar.xz"


### PR DESCRIPTION
update deps to include erlang-asn1 and erlang-public-key
per Miguel Terron.