### PR TITLE
testing/flightgear: enable build on ppc64le

### DIFF
--- a/testing/flightgear/APKBUILD
+++ b/testing/flightgear/APKBUILD
@@ -5,7 +5,7 @@ pkgver=2017.1.3
 pkgrel=1
 pkgdesc="Sophisticated flight simulator"
 url="http://flightgear.org"
-arch="all !ppc64le" #openscenegraph not avail on exluded arches
+arch="all"
 license="GPL"
 makedepends="$depends_dev boost-dev cmake curl-dev dbus-dev eudev-dev
 	freeglut-dev libx11-dev libxi-dev libxmu-dev mesa-dev openal-soft-dev 


### PR DESCRIPTION
Enable build on ppc64le because simgear is now available.