### PR TITLE
alpine-mirrors: remove broken unicamp mirror

### DIFF
--- a/main/alpine-mirrors/mirrors.yaml
+++ b/main/alpine-mirrors/mirrors.yaml
@@ -60,10 +60,6 @@
   location: Helsinki, Finland
   urls:
   - http://alpine.mirror.far.fi/
-- name: LASCA - Institute of Computing - UNICAMP
-  location: South America, Brazil, São Paulo, Campinas
-  urls:
-  - http://lasca.ic.unicamp.br/pub/alpine/
 - name: C3SL - Centro de Computação Científica e Software Livre
   location: South America, Brazil, Paraná
   urls:


### PR DESCRIPTION
The mirror is down, remove it from the list of mirrors. 

A user reported on IRC this mirror has been down for a while.