### PR TITLE
testing/gcompat: Create symlink for lib64

### DIFF
--- a/testing/gcompat/APKBUILD
+++ b/testing/gcompat/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=gcompat
 pkgver=0.0.1
-pkgrel=0
+pkgrel=1
 pkgdesc="enhanced glibc compatibility layer"
 url="http://github.com/kaniini/gcompat"
 arch="all"
@@ -32,6 +32,9 @@ build() {
 package() {
 	cd "$builddir"
 	make LINKER_PATH="/lib/ld-musl-${CARCH}.so.1" LOADER_NAME="$_ld" DESTDIR="$pkgdir" install
+	if [ "$CARCH" = "x86_64" ]; then
+		ln -s lib "$pkgdir"/lib64
+	fi
 }
 
 sha512sums="ab12ec00159b4d269d415977b316b28308e06e0b26e3604efe391cdc5f9e0c2a6d015d71ff6a497d4c92f9cb514774c3d3de658eb74a1ea892c7f973223c16a9  gcompat-0.0.1.tar.gz"


### PR DESCRIPTION
Some precompiled binaries use /lib64 instead of /lib, so this change is needed to make them work. This workaround is also used in musl/libc6-compat. This is also a recommended behaviour in gcompat's documentation.