### PR TITLE
community/hugo: update to 0.24.1

### DIFF
--- a/community/hugo/APKBUILD
+++ b/community/hugo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Thomas Boerger <thomas@webhippie.de>
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=hugo
-pkgver=0.20.7
+pkgver=0.24.1
 pkgrel=0
 pkgdesc="A Fast and Flexible Static Site Generator built with love in GoLang"
 url="http://gohugo.io/"
@@ -10,8 +10,8 @@ license="Apache 2.0"
 depends=""
 makedepends="go govendor"
 install=""
-source="${pkgname}-${pkgver}.tar.gz::https://github.com/spf13/hugo/archive/v$pkgver.tar.gz"
-builddir="$srcdir/src/github.com/spf13/$pkgname"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/gohugoio/hugo/archive/v$pkgver.tar.gz"
+builddir="$srcdir/src/github.com/gohugoio/$pkgname"
 
 prepare() {
 	mkdir -p ${builddir%/*}
@@ -26,8 +26,16 @@ build() {
 	go build -v -o bin/$pkgname || return 1
 }
 
+check() {
+	rm -f $builddir/releaser/git_test.go
+	sed -ie 's/0.20.3/0.21.3/' $builddir/helpers/hugo_test.go
+	cd "$builddir"
+	export GOPATH="$srcdir"
+	govendor test +local || return 1
+}
+
 package() {
 	install -Dm755 "$builddir"/bin/$pkgname "$pkgdir"/usr/bin/$pkgname
 }
 
-sha512sums="fcefc96f21acecf2b565ba087e38c72b07c820405759467969ebc6cc032f6059fa02a86722f21254355e74de32f8fee2c89151615c1d22a00e2253492339ea14  hugo-0.20.7.tar.gz"
+sha512sums="fab405231da13f0ae917cfca79cc087ba8671dad2c01c38c4ddd85b462f0f9faa4d2bbc7de4cdbe440f104e3143e47f414060f5e680bc9a5530f1824497ec921  hugo-0.24.1.tar.gz"


### PR DESCRIPTION
This is to update Hugo to the current version and official repo.

It's also a first pass at adding tests. Alas, the Hugo tests aren't
designed to be run outside of a git repo. Because of this, some of
the tests are removed from the build directory, and the hard coded
version of a failing test is set to the correct version.

Ideally, the tests should run wihtout being modified. However, this
is adding some testing where none existed, so it should help a bit.