### PR TITLE
testing/tsung: Add missing runtime dependencies

### DIFF
--- a/testing/tsung/APKBUILD
+++ b/testing/tsung/APKBUILD
@@ -4,13 +4,18 @@
 pkgname=tsung
 pkgver=1.6.0.1
 _srcver=445d78213bb4360d78df3753b3e23e6a28d701f0
-pkgrel=2
+pkgrel=3
 pkgdesc="Tsung is a high-performance benchmark framework for various protocols including HTTP,XMPP,LDAP,etc."
 url="http://www.process-one.net/en/tsung/"
 license="GPL2"
 arch="noarch !armhf"
 depends="bash
          erlang
+         erlang-crypto
+         erlang-inets
+         erlang-os-mon
+         erlang-sasl
+         erlang-xmerl
          gnuplot
          perl-template-toolkit
          python2


### PR DESCRIPTION
Was based on various runs of tsung and checking the source code of tsung.  There are some build dependencies (like `erlang-snmp` and `erlang-ssl`) which might be used, due to the features specified in a tsung configuration file, but the current list of runtime dependencies keeps the package minimal with the basic dependencies.