### PR TITLE
main/irssi: security uprade to 1.0.4

### DIFF
--- a/main/irssi/APKBUILD
+++ b/main/irssi/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=irssi
-pkgver=1.0.3
+pkgver=1.0.4
 pkgrel=0
 pkgdesc="A modular textUI IRC client with IPv6 support"
 url="http://irssi.org/"
@@ -12,6 +12,10 @@ source="https://github.com/irssi/irssi/releases/download/$pkgver/irssi-$pkgver.t
 builddir="$srcdir"/$pkgname-$pkgver
 
 # secfixes:
+#   1.0.4.-r0:
+#     - CVE-2017-10965
+#     - CVE-2017-10966
+
 #   1.0.3-r0:
 #     - CVE-2017-9468
 #     - CVE-2017-9469
@@ -27,13 +31,12 @@ build() {
 		--with-perl=module \
 		--with-perl-lib=vendor \
 		--with-proxy \
-		|| return 1
-	make || return 1
+	make 
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install 
 	find "$pkgdir" -name perllocal.pod -delete
 }
 
@@ -50,7 +53,7 @@ perl() {
 	mv "$pkgdir"/usr/lib/perl5 "$subpkgdir"/usr/lib/
 	#need write permission when stripping
 	for i in TextUI/TextUI.so Irssi.so Irc/Irc.so UI/UI.so; do
-		chmod +w "$subpkgdir"/usr/lib/perl5/vendor_perl/auto/Irssi/$1 || return 1
+		chmod +w "$subpkgdir"/usr/lib/perl5/vendor_perl/auto/Irssi/$1 
 	done
 }
 
@@ -61,4 +64,4 @@ proxy() {
 	mv "$pkgdir"/usr/lib/irssi/modules/libirc_proxy.* "$subpkgdir"/usr/lib/irssi/modules/
 }
 
-sha512sums="3a369d9bad4e2016a6a0395b35e3db1f1a6ff7ff6b8361fe5d828c29dd6f81c4b8d1bdfe0304cb05402eecddde97f6d369a5e98f215bfd177287f303d3d714eb  irssi-1.0.3.tar.xz"
+sha512sums="8025c3b90275e5c0b910c08efcac80f56da4400662cd4a9f09cc6035ce23840fe6ed0ac5297b9631a5b28bd798b4ebca2bb5550f9e0e01aefc7a69e9f787195d  irssi-1.0.4.tar.xz"


### PR DESCRIPTION
Fixes CVE-2017-10965 and CVE-2017-10966
More details: https://irssi.org/security/irssi_sa_2017_07.txt