### PR TITLE
main/nodejs: upgrade to 6.11.1

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -7,7 +7,7 @@
 pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
-pkgver=6.11.0
+pkgver=6.11.1
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="http://nodejs.org/"
@@ -97,6 +97,6 @@ npm() {
 	mv "$pkgdir"/usr/lib/node_modules/npm "$subpkgdir"/usr/lib/node_modules/
 }
 
-sha512sums="a298232f6393735f2d459eb23f78089dd7eb1bae4907dfe61b286ceb8f93d3131c2dd45f09643089d00e2a4bef0f35739c9c8984f88b34c0ab515793f38eda46  node-v6.11.0.tar.gz
+sha512sums="72a622ed5b884ddfc467ca665c5ba0ed03093dff221664359fe5587f24c2c9a95775002089528fad56bdfafce2489c912638e68a7e10c74a730b07cbde28fab6  node-v6.11.1.tar.gz
 a8be538158b7c96341a407acba30450ddc5c3ad764e7efe728d1ceff64efc3067b177855b9ef91b54400be6a02600d83da4c21a07ae9d7dc0774f92b2006ea8b  dont-run-gyp-files-for-bundled-deps.patch
 54a96cdc103bdffa9ba5283f59c64a35774e272f3a944d6475e3f669f95f7d75bcca6db3b12b9af76ea463f531763105aeabb302872652ced6a2bcb66f1eace0  ppc-fix-musl-mcontext.patch"


### PR DESCRIPTION
- [Security updates for all active release lines, July 2017 | Node.js](https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/)

> Updates are now available for all active Node.js release lines as well as the 7.x line. These include the fix for the high severity vulnerability identified in the initial announcement, one additional lower priority Node.js vulnerability in the 4.x release line, as well as some lower priority fixes for Node.js dependencies across the current release lines.