### PR TITLE
community/zstd: fix tests in ppc64le

### DIFF
--- a/community/zstd/APKBUILD
+++ b/community/zstd/APKBUILD
@@ -5,11 +5,13 @@ pkgver=1.3.0
 pkgrel=0
 pkgdesc="Zstandard - Fast real-time compression algorithm"
 url="http://www.zstd.net"
-arch="all !armhf !ppc64le"
+arch="all !armhf"
 license="BSD"
 checkdepends="file"
 subpackages="$pkgname-dev $pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/facebook/$pkgname/archive/v$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/facebook/$pkgname/archive/v$pkgver.tar.gz
+	increase-max-number-cores-supported.patch"
+
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -27,4 +29,5 @@ package() {
 	make PREFIX="/usr" DESTDIR="$pkgdir" install
 }
 
-sha512sums="5eb9e001e14d3342e76eb57b672c636fd56839ba8fc0ba9a751484ea93389c72c494ad2125dc2f9be1f72481f3af34568477123f7e9d3c7504e061e4c083cb30  zstd-1.3.0.tar.gz"
+sha512sums="5eb9e001e14d3342e76eb57b672c636fd56839ba8fc0ba9a751484ea93389c72c494ad2125dc2f9be1f72481f3af34568477123f7e9d3c7504e061e4c083cb30  zstd-1.3.0.tar.gz
+b764be95a7b3876b62215ff4feb8c464e9cbf467e410de4e7026e8d10f6287193d16ae76d516f3a2eaa7c526d3a73df1437041930896dd8a29dc91b988d10fcb  increase-max-number-cores-supported.patch"

--- a/community/zstd/increase-max-number-cores-supported.patch
+++ b/community/zstd/increase-max-number-cores-supported.patch
@@ -1,0 +1,11 @@
+--- zstd-1.3.0/lib/compress/zstdmt_compress.c
++++ zstd-1.3.0/lib/compress/zstdmt_compress.c
+@@ -9,7 +9,7 @@
+ 
+ 
+ /* ======   Tuning parameters   ====== */
+-#define ZSTDMT_NBTHREADS_MAX 128
++#define ZSTDMT_NBTHREADS_MAX 256
+ 
+ 
+ /* ======   Compiler specifics   ====== */


### PR DESCRIPTION
some zstd tests are breaking in ppc64le because it defines the max
number of supported cores as 128 (ZSTDMT_NBTHREADS_MAX 128) but the
Alpine ppc64le machine has 160 cores.

I am increasing the max core value to 256 for now and opened a bug[1]
in zstd project.

[1] https://github.com/facebook/zstd/issues/760