### PR TITLE
community/erlang: Fix for https://bugs.alpinelinux.org/issues/5700 

### DIFF
--- a/community/erlang/APKBUILD
+++ b/community/erlang/APKBUILD
@@ -1,4 +1,5 @@
 # Contributor: Michael Mason <ms13sp@gmail.com>
+# Contributor: Gabriele Santomaggio <g.santomaggio@gmail.com>
 # Maintainer: Marlus Saraiva <marlus.saraiva@gmail.com>
 
 pkgname=erlang
@@ -86,7 +87,6 @@ build() {
 		--enable-threads \
 		--enable-shared-zlib \
 		--enable-ssl=dynamic-ssl-lib \
-		--disable-hipe \
 		|| return 1
 	make -j1 || return 1
 }


### PR DESCRIPTION
Fix for https://bugs.alpinelinux.org/issues/5700

Remove `--disable-hipe` parameter, in thi way the `hipe` module works in the right way

Current behavior ( with the problem):  
```
alpine:~/hipe_c/community/erlang$ sudo apk add erlang-hipe
(1/1) Installing erlang-hipe (19.3.0-r3)
OK: 899 MiB in 169 packages
alpine:~/hipe_c/community/erlang$ erl
Erlang/OTP 19 [erts-8.3] [source] [64-bit] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V8.3  (abort with ^G)
1> l(hipe).
{error,nofile}
2>
```

With this fix :

```
alpine:~/hipe_c/community/erlang$ sudo apk add --allow-untrusted /home/gb/packages/community/x86_64/erlang-hipe-19.3.0-r3.apk
(1/1) Replacing erlang-hipe (19.3.0-r3 -> 19.3.0-r3)
OK: 902 MiB in 169 packages
alpine:~/hipe_c/community/erlang$ erl
Erlang/OTP 19 [erts-8.3] [source] [64-bit] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V8.3  (abort with ^G)
1> l(hipe).
{module,hipe}
2>
```

raised here: https://github.com/docker-library/rabbitmq/issues/151