### PR TITLE
testing/py-terminaltables: new aport

### DIFF
--- a/testing/py-terminaltables/APKBUILD
+++ b/testing/py-terminaltables/APKBUILD
@@ -1,0 +1,54 @@
+# Contributor: Thomas Boerger <thomas@webhippie.de>
+# Maintainer: Thomas Boerger <thomas@webhippie.de>
+pkgname=py-terminaltables
+_pkgname=terminaltables
+pkgver=3.1.0
+pkgrel=0
+pkgdesc="Easily draw tables in terminal/console applications from a list of lists of strings"
+url="https://pypi.python.org/pypi/terminaltables"
+arch="noarch"
+license="MIT"
+depends=""
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="$pkgname-$pkgver.tar.gz::https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+}
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="f30620f57c4d40b4ee5736d2886e744f7ed34aae702252b2ecf90844d314c4ccce7a7bc9146637504e6996c148567ba16247136f081f086a2b264f2f4920ecd8  py-terminaltables-3.1.0.tar.gz"


### PR DESCRIPTION
This new package is required for py-cli_helpers which is a new
dependency required for the update of mycli/pgcli