### PR TITLE
testing/py-backports-csv: new aport

### DIFF
--- a/testing/py-backports-csv/APKBUILD
+++ b/testing/py-backports-csv/APKBUILD
@@ -1,0 +1,54 @@
+# Contributor: Thomas Boerger <thomas@webhippie.de>
+# Maintainer: Thomas Boerger <thomas@webhippie.de>
+pkgname=py-backports-csv
+_pkgname=backports.csv
+pkgver=1.0.5
+pkgrel=0
+pkgdesc="Backport of Python 3 CSV API"
+url="https://pypi.python.org/pypi/backports.csv"
+arch="noarch"
+license="custom"
+depends=""
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="$pkgname-$pkgver.tar.gz::https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+}
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="0b3885d818153bd50da2c7d931f64464cb344100622d9692925f9eaca056bf973f7d1d3546520e54e03472766c7d8b600c53e0674eb5958e768f713ec16a96a8  py-backports-csv-1.0.5.tar.gz"


### PR DESCRIPTION
This new package is required for py-cli_helpers which is a new
dependency required for the update of mycli/pgcli