### PR TITLE
testing/py-cli_helpers: new aport

### DIFF
--- a/testing/py-cli_helpers/APKBUILD
+++ b/testing/py-cli_helpers/APKBUILD
@@ -1,0 +1,54 @@
+# Contributor: Thomas Boerger <thomas@webhippie.de>
+# Maintainer: Thomas Boerger <thomas@webhippie.de>
+pkgname=py-cli_helpers
+_pkgname=cli_helpers
+pkgver=0.2.2
+pkgrel=0
+pkgdesc="A helper library for command-line interfaces"
+url="https://pypi.python.org/pypi/cli-helpers"
+arch="noarch"
+license="BSD"
+depends="py-terminaltables py-backports-csv"
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="$pkgname-$pkgver.tar.gz::https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+}
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="a0a0db3bd83ae366ae5e5fcd249fa19c758c6d5ddacfb7f248c868e28033fffc0e5eaf5ee7e4251a05f1a333a982a887c2cce014806a570b9a87ee1e1f8a9460  py-cli_helpers-0.2.2.tar.gz"


### PR DESCRIPTION
This new package is required for the update of mycli/pgcli