### PR TITLE
testing/py-pgspecial: upgrade to 1.8.0

### DIFF
--- a/testing/py-pgspecial/APKBUILD
+++ b/testing/py-pgspecial/APKBUILD
@@ -2,25 +2,53 @@
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=py-pgspecial
 _pkgname=pgspecial
-pkgver=1.7.0
+pkgver=1.8.0
 pkgrel=0
 pkgdesc="Meta-commands handler for Postgres Database"
 url="https://pypi.python.org/pypi/pgspecial"
 arch="noarch"
 license="BSD"
-depends="python2 py-click py-sqlparse"
-makedepends="python2-dev py-setuptools"
+depends="py-click py-sqlparse"
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="$pkgname-$pkgver.tar.gz::https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgname-$pkgver"
 
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+}
+
 build() {
 	cd "$builddir"
-	python2 setup.py build || return 1
+	python2 setup.py build
+	python3 setup.py build
 }
 
 package() {
-	cd "$builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	mkdir -p "$pkgdir"
 }
 
-sha512sums="b1cad72c333e9a1a178636aa70df979b3a6868b839050e783668ad6294cdbdee50ba19bb0bec127ba90cfecfba63c56e3b3a449ef38346a4e5a298189e64413a  py-pgspecial-1.7.0.tar.gz"
+_py2() {
+	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="8c407d6984b53092e8d6e8b2e2253bb0d2f789ae0e76925babfff46eb3cf0b069bf10bbd5778b357dff864e2c77e52862238041e87f5e9e4176505b631829d8f  py-pgspecial-1.8.0.tar.gz"


### PR DESCRIPTION
The old version had been flagged and the upgrade is required for an
update to pgcli.