### PR TITLE
testing/py-prompt_toolkit: upgrade to 1.0.14

### DIFF
--- a/testing/py-prompt_toolkit/APKBUILD
+++ b/testing/py-prompt_toolkit/APKBUILD
@@ -2,27 +2,53 @@
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=py-prompt_toolkit
 _pkgname=prompt_toolkit
-pkgver=1.0.3
+pkgver=1.0.14
 pkgrel=0
 pkgdesc="Library for building powerful interactive command lines in Python"
 url="https://pypi.python.org/pypi/prompt_toolkit"
 arch="noarch"
 license="BSD"
-depends="python2 py-six py-wcwidth"
-makedepends="python2-dev py-setuptools"
+depends="py-six py-wcwidth"
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="$pkgname-$pkgver.tar.gz::https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgname-$pkgver"
 
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+}
+
 build() {
 	cd "$builddir"
-	python2 setup.py build || return 1
+	python2 setup.py build
+	python3 setup.py build
 }
 
 package() {
-	cd "$builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	mkdir -p "$pkgdir"
 }
 
-md5sums="6c4133d099603f496c761491043bf0ef  py-prompt_toolkit-1.0.3.tar.gz"
-sha256sums="805e026f0cbad27467e93f9dd3e3777718d401a62788c1e84ca038e967ad8ba2  py-prompt_toolkit-1.0.3.tar.gz"
-sha512sums="c7615c42c7923bb2cefb8db536405976975d25a7df110698e9664f205d3428b6bbf6ca2aba8b0d85957296fcac0bf65752d025cabdb25c80f149f9b92c0c445d  py-prompt_toolkit-1.0.3.tar.gz"
+_py2() {
+	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="909bf50bf0095a8cc37581fc7384f9035eb9d6fd0d16a914e8912693476262cfe0b0c78643ba1c629bd907c861981a9740155927148fcff554446ebb4fd80959  py-prompt_toolkit-1.0.14.tar.gz"


### PR DESCRIPTION
The old version had been flagged and the upgrade is required for an
update to pgcli/mycli.