### PR TITLE
community/php7: remove duplicate configure option

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -332,7 +332,6 @@ build() {
 
 	# phpdbg
 	_build --enable-phpdbg \
-		--enable-phpdbg \
 		--enable-phpdbg-webhelper \
 		--disable-cgi \
 		--disable-cli


### PR DESCRIPTION
This patch removes duplicate --enable-phpdbg option of configure