### PR TITLE
Rename gst-plugins-base1-dev dependency to gst-plugins-base-dev

### DIFF
--- a/main/farstream/APKBUILD
+++ b/main/farstream/APKBUILD
@@ -2,13 +2,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=farstream
 pkgver=0.2.8
-pkgrel=1
+pkgrel=2
 pkgdesc="Libraries for videoconferencing"
 url="http://www.freedesktop.org/wiki/Software/Farstream"
 arch="all"
 license="LGPLv2+"
 depends=""
-depends_dev="libnice-dev gstreamer-dev gst-plugins-base1-dev"
+depends_dev="libnice-dev gstreamer-dev gst-plugins-base-dev"
 makedepends="$depends_dev gobject-introspection-dev py-gobject-dev python2-dev"
 install=""
 subpackages="$pkgname-dev $pkgname-doc"


### PR DESCRIPTION
The gst-plugins-base1-dev dependency was renamed to gst-plugins-base-dev, so I've updated farstream to use this.