### PR TITLE
Try to fix gvfs-fuse and bring back xfce-polkit

### DIFF
--- a/main/gvfs/APKBUILD
+++ b/main/gvfs/APKBUILD
@@ -1,19 +1,18 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gvfs
-pkgver=1.32.1
+pkgver=1.33.3
 pkgrel=0
 pkgdesc="Backends for the gio framework in GLib"
 url="http://ftp.gnome.org/pub/gnome/sources/gvfs/${pkgver%.*}/"
 arch="all"
 license="GPL"
-depends=
+depends=""
 triggers="$pkgname.trigger=/usr/lib/gvfs"
 makedepends="intltool fuse-dev libgudev-dev expat-dev samba-dev
 	libsoup-dev avahi-dev libarchive-dev udisks2-dev libgphoto2-dev
 	libcdio-paranoia-dev libgcrypt-dev libxslt-dev docbook-xsl
 	libmtp-dev gcr-dev libcap-dev"
-install=
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang
 	$pkgname-afp
 	$pkgname-archive
@@ -27,18 +26,9 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang
 	"
 source="http://ftp.gnome.org/pub/gnome/sources/gvfs/${pkgver%.*}/gvfs-$pkgver.tar.xz"
 
-_builddir="$srcdir"/$pkgname-$pkgver
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) patch -p1 -i "$srcdir"/$i || return 1
-		esac
-	done
-}
-
+builddir="$srcdir"/$pkgname-$pkgver
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -50,13 +40,12 @@ build() {
 		--enable-gdu \
 		--enable-http \
 		--enable-libmtp \
-		--enable-samba \
-		|| return 1
-	make || return 1
+		--enable-samba
+	make
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
 
@@ -64,12 +53,13 @@ _mv_files() {
 	local i
 	for i in "$@"; do
 		mkdir -p "$subpkgdir"/${i%/*}
-		mv "$pkgdir"/$i "$subpkgdir"/$i || return 1
+		mv "$pkgdir"/$i "$subpkgdir"/$i
 	done
 }
 
 fuse() {
 	pkgdesc="FUSE support for gvfs"
+	depends="fuse fuse-utils"
 	cd "$pkgdir"
 	_mv_files usr/lib/gvfs/gvfsd-fuse
 }
@@ -155,4 +145,4 @@ dav() {
 #	pkgdesc="AFC support for gvfs"
 #}
 
-sha512sums="7bd4d137437c1704faf6a9c2712bddcc327284e752c552c2cc18c64beb5e6d291af321e92d02d4f09b619762121129cee82c13ec2a4ca39d045196ebeeb28dd8  gvfs-1.32.1.tar.xz"
+sha512sums="96b273b2390f1f0f9434e8a2ee55b2f48e90515084fb118c6031ec21a25724ffe571025127b446321e2906edfffcf101ec8b390023ee9b2659a46df2f4f75376  gvfs-1.33.3.tar.xz"

--- a/testing/fuse-utils/APKBUILD
+++ b/testing/fuse-utils/APKBUILD
@@ -1,0 +1,26 @@
+# Maintainer:
+pkgname=fuse-utils
+pkgver=1.3.2
+pkgrel=0
+pkgdesc="Utils for the Free Unix Spectrum Emulator"
+url="http://fuse-emulator.sourceforge.net"
+arch="all"
+license="GPL"
+depends="libspectrum"
+makedepends="glib-dev"
+subpackages="$pkgname-dev $pkgname-doc"
+source="https://sourceforge.net/projects/fuse-emulator/files/$pkgname/$pkgver/$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure --prefix=/usr
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="26c0b675355d79f5e8a1f28127101d473dd2996ff40c6fd13a92b99d2a54fbecce52cad42b6fb3dfba4d397a0e9b44e58ae5df7d958b9ddabd8702fe147f96f7  fuse-utils-1.3.2.tar.gz"

--- a/testing/libspectrum/APKBUILD
+++ b/testing/libspectrum/APKBUILD
@@ -1,0 +1,26 @@
+# Maintainer:
+pkgname=libspectrum
+pkgver=1.3.4
+pkgrel=0
+pkgdesc="a library designed to make the input and output of some ZX Spectrum emulator files slightly easier"
+url="http://fuse-emulator.sourceforge.net/libspectrum.php"
+arch="all"
+license="GPL"
+depends="bzip2 glib libgcrypt zlib"
+makedepends="glib-dev"
+subpackages="$pkgname-dev $pkgname-doc"
+source="https://downloads.sourceforge.net/project/fuse-emulator/$pkgname/$pkgver/$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure --prefix=/usr
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="15607b3fb6a7c3765be15859a69180934dbc5abe59a11a3283b43836efde9390df197c126d568cbc476e15ba1e7552af04ae3dd3c9072ad713afcabb3eed3d50  libspectrum-1.3.4.tar.gz"

--- a/testing/xfce-polkit/APKBUILD
+++ b/testing/xfce-polkit/APKBUILD
@@ -8,40 +8,28 @@ arch="all"
 license="GPL2"
 depends=""
 depends_dev=""
-makedepends="$depends_dev libxfce4ui-dev polkit-dev glib-dev gtk+2.0-dev"
-install=""
-subpackages=""
+makedepends="$depends_dev libxfce4ui-dev polkit-dev glib-dev gtk+2.0-dev autoconf automake"
 source="https://github.com/ncopa/xfce-polkit/releases/download/v$pkgver/xfce-polkit-$pkgver.tar.gz"
 
-_builddir="$srcdir"/xfce-polkit-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
-
+builddir="$srcdir/$pkgname-$pkgver"
 build() {
-	cd "$_builddir"
+	cd "$builddir"
+	aclocal
+	autoconf
+	automake --add-missing
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--libexecdir=/usr/lib/xfce4 \
-		|| return 1
-	make || return 1
+		--libexecdir=/usr/lib/xfce4
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 
-md5sums="3b9b6ee32d339cd37f1f60dddcebdb6e  xfce-polkit-0.2.tar.gz"
-sha256sums="8947a2582dacad78cfab89b3ee390e1a7810b2457343e6db558d6ee9a872be3a  xfce-polkit-0.2.tar.gz"
 sha512sums="da0d01c8b9805efdd212d8d02cafb95a1663184b17c06b0d27553e2189e44b9d1982aa4f51d6cd74d5e0874475346609a1d7c87eba82c55d9967729f59c7c8ac  xfce-polkit-0.2.tar.gz"


### PR DESCRIPTION
I noticed a problem in Xfce.
If you mount an external NTFS hard-drive by opening Thunar (with thunar-volman, gvfs and gvfs-fuse installed) the drive will be mounted read-only.
Hard-drives that are not NTFS work fine.
And mounting from the terminal with ntfs-3g also works fine.
So the problem is somewhere in thunar, it's not calling ntfs-3g but most likely the kernel ntfs support (which lacks write functionality).
So I think the problem is with gvfs-fuse.

I found some discussions online that point to gvfs-fuse needing fuse-utils as dependency.
This is what I try to accomplish in this PR.

And I also moved xfce-polkit back from unmaintained because it's necessary to mount from thunar as normal user, without root.
