### PR TITLE
testing/vdr: fix build on ppc64le

### DIFF
--- a/testing/vdr/APKBUILD
+++ b/testing/vdr/APKBUILD
@@ -30,7 +30,8 @@ source="ftp://ftp.tvdr.de/vdr/Developer/vdr-${pkgver}.tar.bz2
 	musl-compat.patch
 	softhddevice-musl.patch
 	streamdev-for-2.3.7.patch
-	Make.config"
+	Make.config
+	include-missing-limits-ppc64le.patch"
 
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -100,4 +101,5 @@ a9047da75cc11e675123d418c15a9712ac019658836630c7949699e39a0ade555dd2d52845abffd2
 f47461445515e44f5cdb9c6d3b1bcae323bb83ba3de7c77a3be4d9ac99ed9e76ebe2ee720660c5593fa4b6995366b9d98bf1683f7b8786518a444de7754731ca  musl-compat.patch
 c6f89ba45bf02c0d85963797ff579f3ae0616a827f2b883685b44241bddea7916c3d6da21790553d161884c39d12ee21fc10f7d9d5aee9767cdde10cde02baac  softhddevice-musl.patch
 60262ccb296bb098a469cce102f97da191af811ba7b0cbabc9d071275b1262f71e57933541b9a30fa0f4336384b2a5a711577e772ff7c751ddb07a9cbdd067dc  streamdev-for-2.3.7.patch
-0add913727ebc2ab290211354e2310573f7ece14fcad8636b0a1d7cff49e32027e2d5a6aab3050e577f62387efff8aecc73dfc16e0f876ae28c5257fc9b6c67f  Make.config"
+0add913727ebc2ab290211354e2310573f7ece14fcad8636b0a1d7cff49e32027e2d5a6aab3050e577f62387efff8aecc73dfc16e0f876ae28c5257fc9b6c67f  Make.config
+b77b705601f583eda11f72d9f5e55f5d9af447f4a0d5d80c01dc10cbb4a5e3c3a1c457cd07f276dbcd907b321e607fec26efdae79bc3bddc7d89184edf7febfc  include-missing-limits-ppc64le.patch"

--- a/testing/vdr/include-missing-limits-ppc64le.patch
+++ b/testing/vdr/include-missing-limits-ppc64le.patch
@@ -1,0 +1,28 @@
+vdr package uses some macros like HOST_NAME_MAX, NAME_MAX, which are defined
+in limits.h and needs to be explicitly included on ppc64le.
+----
+  
+--- vdr-2.3.8/config.h
++++ vdr-2.3.8/config.h
+@@ -19,6 +19,9 @@
+ #include "i18n.h"
+ #include "font.h"
+ #include "tools.h"
++#ifdef __powerpc64__
++#include <limits.h> 
++#endif
+ 
+ // VDR's own version number:
+ 
+--- vdr-2.3.8/tools.c
++++ vdr-2.3.8/tools.c
+@@ -27,6 +27,9 @@
+ #include <utime.h>
+ #include "i18n.h"
+ #include "thread.h"
++#ifdef __powerpc64__
++#include <limits.h>
++#endif
+ 
+ int SysLogLevel = 3;
+ 


### PR DESCRIPTION
vdr package uses some macros like HOST_NAME_MAX, NAME_MAX, which are defined
in limits.h and needs to be explicitly included on ppc64le.