### PR TITLE
testing/sane: some improvements

### DIFF
--- a/testing/sane/APKBUILD
+++ b/testing/sane/APKBUILD
@@ -2,25 +2,26 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=sane
+_pkgname=sane-backends
 pkgver=1.0.27
-pkgrel=0
+pkgrel=1
 pkgdesc="Scanner Access Now Easy - an universal scanner interface"
 url="http://www.sane-project.org/"
 arch="all"
 license="GPL"
 depends=""
 depends_dev=""
-makedepends="libtool libusb-dev v4l-utils-dev net-snmp-dev avahi-dev libjpeg-turbo-dev tiff-dev libgphoto2-dev"
+makedepends="diffutils file libtool libusb-dev v4l-utils-dev net-snmp-dev avahi-dev libpng-dev
+	libjpeg-turbo-dev tiff-dev libgphoto2-dev libieee1284-dev linux-headers"
 install="$pkgname-saned.pre-install $pkgname.pre-install"
 pkgusers="saned"
 pkggroups="scanner"
-_backends="abaton agfafocus apple artec artec_eplus48u as6e avision bh canon canon630u canon_dr cardscan
-	coolscan coolscan2 coolscan3 dc25 dc210 dc240 dell1600n_net dmc epjitsu epson epson2 epsonds
-	fujitsu genesys gphoto2 gt68xx hp hp3500 hp3900 hp4200 hp5400 hp5590 hpljm1005 hs2p ibm kodak kodakaio
-	kvs1025 kvs20xx kvs40xx leo lexmark ma1509 magicolor matsushita microtek microtek2 mustek mustek_usb
-	mustek_usb2 nec net niash pie pieusb pixma plustek plustek_pp ricoh rts8891 s9036 sceptre sharp sm3600
-	sm3840 snapscan sp15c st400 stv680 tamarack teco1 teco2 teco3 test u12 umax umax_pp umax1220u xerox_mfp p5"
-
+_backends="abaton agfafocus apple artec artec_eplus48u as6e avision bh canon canon630u canon_dr canon_pp cardscan
+	coolscan coolscan2 coolscan3 dc25 dc210 dc240 dell1600n_net dmc epjitsu epson epson2 epsonds fujitsu genesys
+	gphoto2 gt68xx hp hp3500 hp3900 hp4200 hp5400 hp5590 hpsj5s hpljm1005 hs2p ibm kodak kodakaio kvs1025 kvs20xx
+	kvs40xx leo lexmark ma1509 magicolor matsushita microtek microtek2 mustek mustek_pp mustek_usb mustek_usb2
+	nec net niash pie pieusb pixma plustek plustek_pp ricoh rts8891 s9036 sceptre sharp sm3600 sm3840 snapscan
+	sp15c st400 stv680 tamarack teco1 teco2 teco3 test u12 umax umax_pp umax1220u v4l xerox_mfp p5"
 case "$CARCH" in
 x86*) _backends="$_backends qcam";;
 esac
@@ -29,15 +30,16 @@ _pkgdesc_dell1600n_net="SANE backend for Dell 1600n that supports colour and mon
 for _backend in $_backends; do
 	subpackages="$subpackages $pkgname-backend-$_backend:_backend"
 done
-subpackages="$pkgname-doc $pkgname-dev $subpackages $pkgname-utils $pkgname-saned"
-# https://alioth.debian.org/frs/?group_id=30186
-source="https://alioth.debian.org/frs/download.php/file/4224/sane-backends-$pkgver.tar.gz
+subpackages="$pkgname-doc $pkgname-dev $subpackages $pkgname-utils $pkgname-saned
+	$pkgname-udev::noarch $_pkgname::noarch"
+source="https://alioth.debian.org/frs/download.php/file/4224/$_pkgname-$pkgver.tar.gz
 	$pkgname-saned.initd
 	include.patch
 	network.patch
 	pidfile.patch
+	check.patch
 	"
-builddir="$srcdir"/$pkgname-backends-$pkgver
+builddir="$srcdir"/$_pkgname-$pkgver
 
 build() {
 	cd "$builddir"
@@ -50,7 +52,12 @@ build() {
 	--disable-rpath \
 	--disable-locking \
 	|| return 1
-	make || return 1
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
@@ -58,9 +65,6 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 	echo -n "" > "$pkgdir"/etc/$pkgname.d/dll.conf
 	install -Dm644 backend/dll.aliases "$pkgdir"/etc/$pkgname.d/dll.aliases
-	install -Dm644 tools/udev/lib$pkgname.rules \
-		"$pkgdir"/usr/lib/udev/rules.d/49-$pkgname.rules
-	sed -i 's|NAME="%k", ||g' "$pkgdir"/usr/lib/udev/rules.d/49-$pkgname.rules
 }
 
 saned() {
@@ -77,6 +81,25 @@ utils() {
 	mkdir -p "$subpkgdir"/usr
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr
 	rm -fr "$pkgdir"/usr/share
+}
+
+udev() {
+	pkgdesc="$pkgdesc (udev rules)"
+	install_if="$pkgname=$pkgver-r$pkgrel udev"
+	install -Dm644 "$builddir"/tools/udev/lib$pkgname.rules \
+		"$subpkgdir"/usr/lib/udev/rules.d/49-$pkgname.rules || return 1
+	sed -i 's|NAME="%k", ||g' "$subpkgdir"/usr/lib/udev/rules.d/49-$pkgname.rules
+}
+
+backends() {
+	local _backend;
+	pkgdesc="$pkgdesc (metapackage)"
+	depends="$pkgname-utils $pkgname-saned"
+	for _backend in $_backends; do
+		[ "$_backend" = "test" ] && continue
+		depends="$depends $pkgname-backend-$_backend"
+	done
+	mkdir -p "$subpkgdir"
 }
 
 _backend() {
@@ -108,4 +131,5 @@ sha512sums="c6552768bfc10216730fc11011c82f74ca0952182019ded3916072147ec09be5c975
 0a06eaa28b345202f2bdf8361e06f843bb7a010b7d8f80132f742672c94249c43f64031cefa161e415e2e2ab3a53b23070fb63854283f9e040f5ff79394ac7d1  sane-saned.initd
 1779ff8beb1ba5f9238c25d819a7f0045f7e257c19b511315feb85650e445ca86450a9e1d7ff8650499d3dae808589a6c2e358d5f3f39a3f40ce4999179b86d6  include.patch
 9cb595841f59b5105ecc85e4c0ad8781c52caa2354fb823c920ec467e88afbe47f2b3f4a7a3980bef5dbf22983c5786f051a9d10aea97b4bf7c4a05378592029  network.patch
-09505943f9441854a6c333f19e2535b4a646a8cc060fe82c6261e7d29c72773ebe98d43a91acc951f4336a3c8b4c84ab7c7b0763426136b4b59d9546bc2fa8c0  pidfile.patch"
+09505943f9441854a6c333f19e2535b4a646a8cc060fe82c6261e7d29c72773ebe98d43a91acc951f4336a3c8b4c84ab7c7b0763426136b4b59d9546bc2fa8c0  pidfile.patch
+cfa327209efd9a2a2db7cbcf571852959823aaa19b43d5f6415834cd5ae38b6324ecae16779f6f896aa0d7ac890fe23244100b7d6a68e5e9d52cd38ec82bfac8  check.patch"

--- a/testing/sane/APKBUILD
+++ b/testing/sane/APKBUILD
@@ -8,7 +8,7 @@ pkgrel=1
 pkgdesc="Scanner Access Now Easy - an universal scanner interface"
 url="http://www.sane-project.org/"
 arch="all"
-license="GPL"
+license="GPLv2.0+ GPLv2.0+-with-sane-exception public-domain"
 depends=""
 depends_dev=""
 makedepends="diffutils file libtool libusb-dev v4l-utils-dev net-snmp-dev avahi-dev libpng-dev
@@ -65,6 +65,13 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 	echo -n "" > "$pkgdir"/etc/$pkgname.d/dll.conf
 	install -Dm644 backend/dll.aliases "$pkgdir"/etc/$pkgname.d/dll.aliases
+}
+
+doc() {
+	default_doc || return 1
+	mkdir -p "$subpkgdir"/usr/share/licenses/$_pkgname || return 1
+	mv "$subpkgdir"/usr/share/doc/$_pkgname/LICENSE \
+		"$subpkgdir"/usr/share/licenses/$_pkgname
 }
 
 saned() {

--- a/testing/sane/check.patch
+++ b/testing/sane/check.patch
@@ -1,0 +1,11 @@
+--- a/testsuite/sanei/Makefile.in
++++ b/testsuite/sanei/Makefile.in
+@@ -77,7 +77,7 @@
+ POST_UNINSTALL = :
+ build_triplet = @build@
+ host_triplet = @host@
+-check_PROGRAMS = sanei_usb_test$(EXEEXT) test_wire$(EXEEXT) \
++check_PROGRAMS = test_wire$(EXEEXT) \
+ 	sanei_check_test$(EXEEXT) sanei_config_test$(EXEEXT) \
+ 	sanei_constrain_test$(EXEEXT)
+ subdir = testsuite/sanei


### PR DESCRIPTION
added to makedepends: linux-headers, libpng-dev, libieee1284-dev
new backends: canon_pp, hpsj5s, mustek_pp, v4l

udev rules moved to separate subpackage
added 'sane-backends' metapackage to install all at once