### PR TITLE
community/tomcat-native: add openssl support

### DIFF
--- a/community/tomcat-native/APKBUILD
+++ b/community/tomcat-native/APKBUILD
@@ -1,27 +1,26 @@
 # Contributor: Sean Summers <seansummers@gmail.com>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
-# TODO: Patch for LibreSSL and enable SSL support.
+# TODO: Patch for LibreSSL
 pkgname=tomcat-native
 pkgver=1.2.12
-pkgrel=0
+pkgrel=1
 pkgdesc="Native resources optional component for Apache Tomcat"
 url="http://tomcat.apache.org/native-doc/"
 arch="all"
 license="ASL-2.0"
-depends="openjdk8-jre-base"
-makedepends="apr-dev chrpath openjdk8"
+depends="openjdk8-jre-base openssl"
+makedepends="apr-dev chrpath openjdk8 openssl-dev"
 subpackages="$pkgname-dev"
 source="http://www-eu.apache.org/dist/tomcat/tomcat-connectors/native/$pkgver/source/$pkgname-$pkgver-src.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver-src/native"
+options=!check
 
 build() {
 	cd "$builddir"
 
 	./configure --prefix=/usr \
 		--with-apr=/usr/bin/apr-1-config \
-		--with-java-home=/usr/lib/jvm/default-jvm \
-		--with-ssl=no \
-		--disable-openssl || return 1
+		--with-java-home=/usr/lib/jvm/default-jvm || return 1
 	make || return 1
 }
 
@@ -33,7 +32,7 @@ package() {
 	# Remove redundant rpath.
 	chrpath --delete "$pkgdir"/usr/lib/libtcnative-1.so || return 1
 
-	rm -f "$pkgdir"/usr/lib/libtcnative-1.la || return 1
+	rm -f "$pkgdir"/usr/lib/libtcnative-1.la
 	rmdir "$pkgdir"/usr/bin
 }
 


### PR DESCRIPTION
I realize that Alpine has switched to LibreSSL (save for easy-rsa, also in community), but the upstream for this package does not yet support LibreSSL (https://bz.apache.org/bugzilla/show_bug.cgi?id=58434). The default Tomcat install generates an error (but does start) when the current tomcat-native is used. For various reasons it is useful to be able to run SSL in Tomcat, and I think it would be better to avoid having to choose between using tomcat-native and using SSL in Tomcat.

I have tested this with Tomcat 8.5.16 (the current version) with SSL enabled.

Apologies if this has been discussed and rejected before, I didn't find any archived discussions on the topic.