### PR TITLE
Tomcat native openssl

### DIFF
--- a/community/tomcat-native/APKBUILD
+++ b/community/tomcat-native/APKBUILD
@@ -9,14 +9,17 @@ url="http://tomcat.apache.org/native-doc/"
 arch="all"
 license="ASL-2.0"
 depends="openjdk8-jre-base openssl"
-makedepends="apr-dev chrpath openjdk8 openssl-dev"
+makedepends="apr-dev chrpath openjdk8 openssl-dev apache-ant"
 subpackages="$pkgname-dev"
-source="http://www-eu.apache.org/dist/tomcat/tomcat-connectors/native/$pkgver/source/$pkgname-$pkgver-src.tar.gz"
-builddir="$srcdir/$pkgname-$pkgver-src/native"
-options=!check
+source="http://www-eu.apache.org/dist/tomcat/tomcat-connectors/native/$pkgver/source/$pkgname-$pkgver-src.tar.gz enable-tests.patch"
+builddir="$srcdir/$pkgname-$pkgver-src"
+
+prepare()	{
+	default_prepare || return 1
+}
 
 build() {
-	cd "$builddir"
+	cd "$builddir/native"
 
 	./configure --prefix=/usr \
 		--with-apr=/usr/bin/apr-1-config \
@@ -25,8 +28,10 @@ build() {
 }
 
 package() {
-	cd "$builddir"
+	cd "$builddir/native"
 
+	echo PKGDIR: $pkgdir
+	rm -f "$pkgdir"/usr/lib/libtcnative-1.la
 	make DESTDIR="$pkgdir" install || return 1
 
 	# Remove redundant rpath.
@@ -36,9 +41,15 @@ package() {
 	rmdir "$pkgdir"/usr/bin
 }
 
+check()	{
+	cd "$srcdir/$pkgname-$pkgver-src"
+	ant download test || return 1
+}
+
 dev()  {
 	default_dev || return 1
 	mv "$subpkgdir"/usr/lib/libtcnative-1.so "$pkgdir"/usr/lib/
 }
 
-sha512sums="87543ab353545563001ac339834ec5b230a139bbeb7382c0b5b269d0d00875bfc3f5a3212923ca941e0d31aa0f60c34f34310e89794a99f37aafdaf9ecca7a99  tomcat-native-1.2.12-src.tar.gz"
+sha512sums="87543ab353545563001ac339834ec5b230a139bbeb7382c0b5b269d0d00875bfc3f5a3212923ca941e0d31aa0f60c34f34310e89794a99f37aafdaf9ecca7a99  tomcat-native-1.2.12-src.tar.gz
+0126ad82c292c26da82b4498bd21c99caa5080199dcf7faad46666109a11da0817ca9262e7df75770005ae03a413c47783112addd53f49ff011b4886702f363b  enable-tests.patch"

--- a/community/tomcat-native/APKBUILD
+++ b/community/tomcat-native/APKBUILD
@@ -1,27 +1,26 @@
 # Contributor: Sean Summers <seansummers@gmail.com>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
-# TODO: Patch for LibreSSL and enable SSL support.
+# TODO: Patch for LibreSSL
 pkgname=tomcat-native
 pkgver=1.2.12
-pkgrel=0
+pkgrel=1
 pkgdesc="Native resources optional component for Apache Tomcat"
 url="http://tomcat.apache.org/native-doc/"
 arch="all"
 license="ASL-2.0"
-depends="openjdk8-jre-base"
-makedepends="apr-dev chrpath openjdk8"
+depends="openjdk8-jre-base openssl"
+makedepends="apr-dev chrpath openjdk8 openssl-dev"
 subpackages="$pkgname-dev"
 source="http://www-eu.apache.org/dist/tomcat/tomcat-connectors/native/$pkgver/source/$pkgname-$pkgver-src.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver-src/native"
+options=!check
 
 build() {
 	cd "$builddir"
 
 	./configure --prefix=/usr \
 		--with-apr=/usr/bin/apr-1-config \
-		--with-java-home=/usr/lib/jvm/default-jvm \
-		--with-ssl=no \
-		--disable-openssl || return 1
+		--with-java-home=/usr/lib/jvm/default-jvm || return 1
 	make || return 1
 }
 
@@ -33,7 +32,7 @@ package() {
 	# Remove redundant rpath.
 	chrpath --delete "$pkgdir"/usr/lib/libtcnative-1.so || return 1
 
-	rm -f "$pkgdir"/usr/lib/libtcnative-1.la || return 1
+	rm -f "$pkgdir"/usr/lib/libtcnative-1.la
 	rmdir "$pkgdir"/usr/bin
 }
 

--- a/community/tomcat-native/APKBUILD
+++ b/community/tomcat-native/APKBUILD
@@ -8,10 +8,13 @@ pkgdesc="Native resources optional component for Apache Tomcat"
 url="http://tomcat.apache.org/native-doc/"
 arch="all"
 license="ASL-2.0"
-depends="openjdk8-jre-base openssl"
-makedepends="apr-dev chrpath openjdk8 openssl-dev apache-ant"
+depends="openjdk8-jre-base !tomcat-native-openssl"
+replaces="tomcat-native-openssl"
+makedepends="apr-dev chrpath openjdk8"
+checkdepends="apache-ant"
 subpackages="$pkgname-dev"
-source="http://www-eu.apache.org/dist/tomcat/tomcat-connectors/native/$pkgver/source/$pkgname-$pkgver-src.tar.gz enable-tests.patch"
+source="http://www-eu.apache.org/dist/tomcat/tomcat-connectors/native/$pkgver/source/$pkgname-$pkgver-src.tar.gz
+	enable-tests.patch"
 builddir="$srcdir/$pkgname-$pkgver-src"
 
 prepare()	{
@@ -22,8 +25,10 @@ build() {
 	cd "$builddir/native"
 
 	./configure --prefix=/usr \
-		--with-apr=/usr/bin/apr-1-config \
-		--with-java-home=/usr/lib/jvm/default-jvm || return 1
+  		--with-apr=/usr/bin/apr-1-config \
+ 			--with-java-home=/usr/lib/jvm/default-jvm \
+ 			--with-ssl=no \
+ 			--disable-openssl || return 1
 	make || return 1
 }
 

--- a/community/tomcat-native/enable-tests.patch
+++ b/community/tomcat-native/enable-tests.patch
@@ -1,0 +1,47 @@
+diff -upN tomcat-native-1.2.12-src/build.properties updated-src/build.properties
+--- tomcat-native-1.2.12-src/build.properties	1970-01-01 00:00:00.000000000 +0000
++++ updated-src/build.properties	2017-07-28 05:09:42.000000000 +0000
+@@ -0,0 +1,4 @@
++base.path=${basedir}/test-deps
++junit.home=${base.path}
++hamcrest.home=${base.path}
++test.failonerror=true
+diff -upN tomcat-native-1.2.12-src/build.xml updated-src/build.xml
+--- tomcat-native-1.2.12-src/build.xml	2017-01-31 11:37:29.000000000 +0000
++++ updated-src/build.xml	2017-07-28 05:05:44.000000000 +0000
+@@ -143,11 +143,16 @@
+ 
+       <mkdir dir="${base.path}"/>
+ 
+-      <antcall target="downloadzip">
++      <antcall target="downloadfile">
+         <param name="sourcefile" value="${junit.loc}"/>
+         <param name="destfile" value="${junit.jar}"/>
+         <param name="destdir" value="${base.path}"/>
+       </antcall>
++      <antcall target="downloadfile">
++        <param name="sourcefile" value="${hamcrest.loc}"/>
++        <param name="destfile" value="${hamcrest.jar}"/>
++        <param name="destdir" value="${base.path}"/>
++      </antcall>
+     </target>
+ 
+     <!-- =================================================================== -->
+@@ -310,7 +315,7 @@ limitations under the License.--&gt;">
+ 
+             <classpath refid="test.classpath" />
+ 
+-            <batchtest todir="${basedir}/logs">
++            <batchtest skipNonTests="true" todir="${basedir}/logs">
+                 <fileset dir="test" />
+             </batchtest>
+         </junit>
+Common subdirectories: tomcat-native-1.2.12-src/dist and updated-src/dist
+Common subdirectories: tomcat-native-1.2.12-src/docs and updated-src/docs
+Common subdirectories: tomcat-native-1.2.12-src/examples and updated-src/examples
+Common subdirectories: tomcat-native-1.2.12-src/java and updated-src/java
+Common subdirectories: tomcat-native-1.2.12-src/logs and updated-src/logs
+Common subdirectories: tomcat-native-1.2.12-src/native and updated-src/native
+Common subdirectories: tomcat-native-1.2.12-src/test and updated-src/test
+Common subdirectories: tomcat-native-1.2.12-src/test-deps and updated-src/test-deps
+Common subdirectories: tomcat-native-1.2.12-src/xdocs and updated-src/xdocs

--- a/testing/tomcat-native-openssl/APKBUILD
+++ b/testing/tomcat-native-openssl/APKBUILD
@@ -1,0 +1,56 @@
+# Contributor: Andrew Madigan <amadigan@gmail.com>
+# Maintainer: Jakub Jirutka <jakub@jirutka.cz>
+pkgname=tomcat-native-openssl
+pkgver=1.2.12
+pkgrel=0
+pkgdesc="Native resources optional component for Apache Tomcat, includes SSL support using OpenSSL"
+url="http://tomcat.apache.org/native-doc/"
+arch="all"
+license="ASL-2.0"
+depends="openjdk8-jre-base openssl !tomcat-native"
+replaces="tomcat-native"
+makedepends="apr-dev chrpath openjdk8 openssl-dev"
+checkdepends="apache-ant"
+subpackages="$pkgname-dev"
+source="http://www-eu.apache.org/dist/tomcat/tomcat-connectors/native/$pkgver/source/tomcat-native-$pkgver-src.tar.gz
+	enable-tests.patch"
+builddir="$srcdir/tomcat-native-$pkgver-src"
+
+prepare()	{
+	default_prepare || return 1
+}
+
+build() {
+	cd "$builddir/native"
+
+	./configure --prefix=/usr \
+		--with-apr=/usr/bin/apr-1-config \
+		--with-java-home=/usr/lib/jvm/default-jvm || return 1
+	make || return 1
+}
+
+package() {
+	cd "$builddir/native"
+
+	echo PKGDIR: $pkgdir
+	rm -f "$pkgdir"/usr/lib/libtcnative-1.la
+	make DESTDIR="$pkgdir" install || return 1
+
+	# Remove redundant rpath.
+	chrpath --delete "$pkgdir"/usr/lib/libtcnative-1.so || return 1
+
+	rm -f "$pkgdir"/usr/lib/libtcnative-1.la
+	rmdir "$pkgdir"/usr/bin
+}
+
+check()	{
+	cd "$srcdir/tomcat-native-$pkgver-src"
+	ant download test || return 1
+}
+
+dev()  {
+	default_dev || return 1
+	mv "$subpkgdir"/usr/lib/libtcnative-1.so "$pkgdir"/usr/lib/
+}
+sha512sums="87543ab353545563001ac339834ec5b230a139bbeb7382c0b5b269d0d00875bfc3f5a3212923ca941e0d31aa0f60c34f34310e89794a99f37aafdaf9ecca7a99  tomcat-native-1.2.12-src.tar.gz
+0126ad82c292c26da82b4498bd21c99caa5080199dcf7faad46666109a11da0817ca9262e7df75770005ae03a413c47783112addd53f49ff011b4886702f363b  enable-tests.patch"

--- a/testing/tomcat-native-openssl/enable-tests.patch
+++ b/testing/tomcat-native-openssl/enable-tests.patch
@@ -1,0 +1,47 @@
+diff -upN tomcat-native-1.2.12-src/build.properties updated-src/build.properties
+--- tomcat-native-1.2.12-src/build.properties	1970-01-01 00:00:00.000000000 +0000
++++ updated-src/build.properties	2017-07-28 05:09:42.000000000 +0000
+@@ -0,0 +1,4 @@
++base.path=${basedir}/test-deps
++junit.home=${base.path}
++hamcrest.home=${base.path}
++test.failonerror=true
+diff -upN tomcat-native-1.2.12-src/build.xml updated-src/build.xml
+--- tomcat-native-1.2.12-src/build.xml	2017-01-31 11:37:29.000000000 +0000
++++ updated-src/build.xml	2017-07-28 05:05:44.000000000 +0000
+@@ -143,11 +143,16 @@
+ 
+       <mkdir dir="${base.path}"/>
+ 
+-      <antcall target="downloadzip">
++      <antcall target="downloadfile">
+         <param name="sourcefile" value="${junit.loc}"/>
+         <param name="destfile" value="${junit.jar}"/>
+         <param name="destdir" value="${base.path}"/>
+       </antcall>
++      <antcall target="downloadfile">
++        <param name="sourcefile" value="${hamcrest.loc}"/>
++        <param name="destfile" value="${hamcrest.jar}"/>
++        <param name="destdir" value="${base.path}"/>
++      </antcall>
+     </target>
+ 
+     <!-- =================================================================== -->
+@@ -310,7 +315,7 @@ limitations under the License.--&gt;">
+ 
+             <classpath refid="test.classpath" />
+ 
+-            <batchtest todir="${basedir}/logs">
++            <batchtest skipNonTests="true" todir="${basedir}/logs">
+                 <fileset dir="test" />
+             </batchtest>
+         </junit>
+Common subdirectories: tomcat-native-1.2.12-src/dist and updated-src/dist
+Common subdirectories: tomcat-native-1.2.12-src/docs and updated-src/docs
+Common subdirectories: tomcat-native-1.2.12-src/examples and updated-src/examples
+Common subdirectories: tomcat-native-1.2.12-src/java and updated-src/java
+Common subdirectories: tomcat-native-1.2.12-src/logs and updated-src/logs
+Common subdirectories: tomcat-native-1.2.12-src/native and updated-src/native
+Common subdirectories: tomcat-native-1.2.12-src/test and updated-src/test
+Common subdirectories: tomcat-native-1.2.12-src/test-deps and updated-src/test-deps
+Common subdirectories: tomcat-native-1.2.12-src/xdocs and updated-src/xdocs


### PR DESCRIPTION
I realize that Alpine has switched to LibreSSL (save for easy-rsa, also in community), but the upstream for this package does not yet support LibreSSL (https://bz.apache.org/bugzilla/show_bug.cgi?id=58434). The default Tomcat install logs an error (but does start) when the current tomcat-native is used. For various reasons it is useful to be able to run SSL in Tomcat, and I think it would be better to avoid having to choose between using tomcat-native and using SSL in Tomcat.

Sorry for submitting the PR twice, I realized after that tomcat-native did have tests, but there were some issues with the ant build.xml that executes them. I've added a patch to enable the tests, which do pass. I also tested manually with Tomcat 8.5.16 with SSL enabled.