### PR TITLE
testing/virt-what: upgrade to 1.18

### DIFF
--- a/testing/virt-what/APKBUILD
+++ b/testing/virt-what/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Henrik Riomar <henrik.riomar@gmail.com>
 # Maintainer:
 pkgname=virt-what
-pkgver=1.15
+pkgver=1.18
 pkgrel=0
 pkgdesc="Detect if we are running in a virtual machine"
 url="https://people.redhat.com/~rjones/virt-what/"
@@ -9,7 +9,8 @@ arch="x86 x86_64"
 license="GPL2+"
 makedepends="automake autoconf perl-dev"
 subpackages="$pkgname-doc"
-source="http://people.redhat.com/~rjones/$pkgname/files/$pkgname-$pkgver.tar.gz"
+source="http://people.redhat.com/~rjones/$pkgname/files/$pkgname-$pkgver.tar.gz
+	skip-ldoms-test-if-not-sparc64.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
@@ -39,4 +40,5 @@ package() {
 	make install DESTDIR="$pkgdir"
 }
 
-sha512sums="b85d02eb632328031be93dd33be1e42603e55182c4458fca9b9d98465ff7487fc399d01ebd117a8311960091c1b166547380b9a54c0054ebf2c0aa454d9a41e5  virt-what-1.15.tar.gz"
+sha512sums="8085a38111d5664f411f5bb9d2ee221bc22e5b0f2d993e8d518718b3f63b16ba73e052b1623c090493cf8fef52fd237ba823377503a32b4b7d03cc5380d5c613  virt-what-1.18.tar.gz
+d47d5cfaf3c79eb7d7e1fd5d24cb620628d8038cc724e738fca55dad7fdf312616e13d4149114ad8913f691c0b2e2548ad5fe12d789eeca9a50e500911b3c731  skip-ldoms-test-if-not-sparc64.patch"

--- a/testing/virt-what/skip-ldoms-test-if-not-sparc64.patch
+++ b/testing/virt-what/skip-ldoms-test-if-not-sparc64.patch
@@ -1,0 +1,14 @@
+diff -urN virt-what-1.18/tests/test-ldoms.sh virt-what-1.18-ldoms-unknown/tests/test-ldoms.sh
+--- virt-what-1.18/tests/test-ldoms.sh	2017-07-31 15:57:56.000000000 +0200
++++ virt-what-1.18-ldoms-unknown/tests/test-ldoms.sh	2017-07-31 19:51:37.542994885 +0200
+@@ -17,6 +17,10 @@
+ 
+ root=tests/ldoms
+ 
++cpu=$(arch -p)
++# test only for sparc64
++[ x"$cpu" = x"sparc64" ] || exit 77
++
+ output="$(./virt-what --test-root=$root 2>&1)"
+ expected="ldoms
+ ldoms-guest"


### PR DESCRIPTION
SKIP a new test only valid on sparc64.