### PR TITLE
Add community/consolekit2

### DIFF
--- a/testing/consolekit2/APKBUILD
+++ b/testing/consolekit2/APKBUILD
@@ -1,0 +1,38 @@
+# Contributor: Bart Ribbers <bart.ribbers@openmailbox.org>
+# Maintainer: Bart Ribbers <bart.ribbers@openmailbox.org>
+pkgbase=ConsoleKit2
+pkgname=consolekit2
+pkgver=1.2.0
+pkgrel=1
+pkgdesc="A framework for defining and tracking users, login sessions, and seats. "
+arch=all
+url="https://consolekit2.github.io/ConsoleKit2"
+license=GPL2
+depends="gettext glib zlib polkit eudev libdrm cgmanager libnih"
+makedepends="git automake autoconf gettext-dev glib-dev zlib-dev libxslt-dev
+			 polkit-dev eudev-dev libdrm-dev cgmanager-dev libnih-dev libtool
+			 xorg-server-dev"
+source="$pkgname-$pkgver.tar.gz::https://github.com/${pkgname}/${pkgname}/archive/${pkgver}.tar.gz
+		ac_disable_static.patch"
+subpackages="$pkgname-doc $pkgname-lang"
+
+prepare() {
+	cd "$srcdir"/$pkgbase-$pkgver
+	patch -p1 < "$srcdir"/ac_disable_static.patch
+	NOCONFIGURE=1 ./autogen.sh
+}
+
+build() {
+	cd "$srcdir"/$pkgbase-$pkgver
+	./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var \
+		--disable-static
+	sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+	make
+}
+
+package() {
+	cd "$srcdir"/$pkgbase-$pkgver
+	make DESTDIR="$pkgdir" install
+}
+sha512sums="30f2ceec14044669f40676e9b17513874350e2b70f0a918be934f7e64309c8595dbec4ac0937044c98dda51eb97c99443dc9d1de33f08365d72da8600296ad78  consolekit2-1.2.0.tar.gz
+0f628fd1589b1790ad9adcb2278de504b75cc6b4ec7284a1cbda44ebd34b9966014989f47f343cb936d8503acc4eeec43ddff07cb11f55388e47256b8420e2e8  ac_disable_static.patch"

--- a/testing/consolekit2/ac_disable_static.patch
+++ b/testing/consolekit2/ac_disable_static.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 071a0d8..7469697 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -30,7 +30,6 @@ AC_SEARCH_LIBS([strerror],[cposix])
+ AC_PROG_CC
+ AM_PROG_CC_C_O
+ AC_HEADER_STDC
+-AC_DISABLE_STATIC
+-LT_INIT
++LT_INIT([disable-static])
+ AC_HEADER_STDC
+ AC_FUNC_FORK


### PR DESCRIPTION
As part of a larger effort to [package Plasma Mobile](https://github.com/postmarketOS/pmbootstrap/tree/37981fccd0635b13a9d23c27ea0ce3989a559c54/aports/kde) for the [postmarketOS](https://postmarketos.org) project, and thus also for Alpine Linux, I'd like to add the consolekit2 package. It's a fork of the consolekit already packaged, with the difference of actually being maintained. It should be a drop in replacement.

The patch included makes it build on systems other than x86_64 (specifically armhf), but is already upstreamed in consolekit2 and can be removed in a next release.

Since this is the first package I'm submitting, ever, there is probably some stuff which could be improved in here.