### PR TITLE
testing/libgeotiff: new aport

### DIFF
--- a/testing/libgeotiff/APKBUILD
+++ b/testing/libgeotiff/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bradley J Chambers <brad.chambers@gmail.com>
+# Maintainer: Bradley J Chambers <brad.chambers@gmail.com>
+pkgname=libgeotiff
+pkgver=1.4.2
+pkgrel=0
+pkgdesc="TIFF based interchange format for georeferenced raster imagery."
+url="https://trac.osgeo.org/geotiff"
+arch="all"
+license="Public Domain"
+options="!check"
+depends="libgcc libstdc++ musl"
+makedepends="autoconf automake libtool tiff-dev proj4-dev"
+install=""
+subpackages="$pkgname-dev $pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::http://download.osgeo.org/geotiff/libgeotiff/$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+        mkdir -p "$builddir"
+        cd "$builddir"
+
+        ./autogen.sh
+        ./configure --prefix=/usr
+        make
+}
+
+package() {
+        cd "$builddir"
+        make DESTDIR="$pkgdir" install
+}
+
+sha512sums="059c6e05eb0c47f17b102c7217a2e1636e76d622c4d1bdcf0bd89fb3505f3130bffa881e21c73cfd2ca0d6863b81322f85784658ba3539b53b63c3a8f38d1deb  libgeotiff-1.4.2.tar.gz"

--- a/testing/libgeotiff/APKBUILD
+++ b/testing/libgeotiff/APKBUILD
@@ -8,7 +8,6 @@ url="https://trac.osgeo.org/geotiff"
 arch="all"
 license="Public Domain"
 options="!check"
-depends="libgcc libstdc++ musl"
 makedepends="autoconf automake libtool tiff-dev proj4-dev"
 install=""
 subpackages="$pkgname-dev $pkgname-doc"
@@ -16,7 +15,6 @@ source="$pkgname-$pkgver.tar.gz::http://download.osgeo.org/geotiff/libgeotiff/$p
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-        mkdir -p "$builddir"
         cd "$builddir"
 
         ./autogen.sh


### PR DESCRIPTION
https://trac.osgeo.org/geotiff
TIFF based interchange format for georeferenced raster imagery.