### PR TITLE
testing/cloudi: enable with patch fix

### DIFF
--- a/testing/cloudi/0005-Disable-tests-for-aports-buildservers.patch
+++ b/testing/cloudi/0005-Disable-tests-for-aports-buildservers.patch
@@ -9,11 +9,13 @@
    "lib/cloudi_service_filesystem",
    "lib/cloudi_service_http_client",
    "lib/cloudi_service_http_cowboy",
-@@ -17,7 +15,6 @@
+@@ -17,9 +15,7 @@
    "lib/cloudi_service_http_rest",
    "lib/cloudi_service_map_reduce",
    "lib/cloudi_service_monitoring",
 -  "lib/cloudi_service_oauth1",
    "lib/cloudi_service_queue",
-   "lib/cloudi_service_quorum",
+-  "lib/cloudi_service_quorum",
    "lib/cloudi_service_router",
+   "lib/cloudi_service_tcp",
+   "lib/cloudi_service_udp",

--- a/testing/cloudi/APKBUILD
+++ b/testing/cloudi/APKBUILD
@@ -30,11 +30,11 @@
 pkgname=cloudi
 pkgver=1.7.2_rc1
 _srcver=70addfda7133ac209157d48e38be70be7597ce8a
-pkgrel=0
+pkgrel=1
 pkgdesc="Cloud computing framework for efficient, scalable, and stable soft-realtime event processing."
 url="http://cloudi.org/"
 license="MIT"
-arch=""
+arch="all"
 depends="g++"
 makedepends="autoconf
              automake
@@ -114,5 +114,5 @@ package() {
 }
 
 sha512sums="c47d3016002c5cf76782eb45a8c9da8aafa27d2046c82d6339dd59b88fb84e7c17f7df67071d9c3ca4fc8e87cd45980494664cd4ba5fb8900a67e47e909a0e7c  70addfda7133ac209157d48e38be70be7597ce8a.tar.gz
-7134271bb9a183c16aed2de8d3e0909654fa7b2c805abf1b496842f10dc4baf8d49236dd448bc8ba4408013beb350fea69b669751c6f4860e955acbdae63f29a  0005-Disable-tests-for-aports-buildservers.patch
+cf380a2585e6116b3a0bc21b9846d91b96adcb754fa0805b571e99bbd9f696aa636d0bdeb6d85d05e34b65f8880afb01a02abb09e6797af1d4586664427add75  0005-Disable-tests-for-aports-buildservers.patch
 08e930424d4b7f4bbb7888fc9c16f6007a215886ebd0bdf4a296d4870d8d4e48bcc9df11ab79362aae238c3ae30a05dc47d9fbbc54fe07306dd06e8336576ad8  cloudi.initd"


### PR DESCRIPTION
Disable the cloudi_service_quorum test due to failures on alpine build servers
related to a random number rounding problem.

cc @kaniini 