### PR TITLE
testing/cloudi: configuration fixes

### DIFF
--- a/testing/cloudi/0010-Set-configured-log-path.patch
+++ b/testing/cloudi/0010-Set-configured-log-path.patch
@@ -1,0 +1,11 @@
+--- src/cloudi_minimal.conf.in
++++ src/cloudi_minimal.conf.in
+@@ -14,7 +14,7 @@
+   [{prefix, "/cloudi/log/"},
+    {module, cloudi_service_filesystem},
+    {args,
+-    [{directory, "@prefix@/var/log/cloudi"},
++    [{directory, "/var/log/cloudi"},
+      {read, [{"/cloudi/log/cloudi.log", -16384}]},
+      {refresh, 10}]},
+    {dest_refresh, none}],

--- a/testing/cloudi/APKBUILD
+++ b/testing/cloudi/APKBUILD
@@ -30,19 +30,19 @@
 pkgname=cloudi
 pkgver=1.7.2_rc1
 _srcver=70addfda7133ac209157d48e38be70be7597ce8a
-pkgrel=1
+pkgrel=2
 pkgdesc="Cloud computing framework for efficient, scalable, and stable soft-realtime event processing."
 url="http://cloudi.org/"
 license="MIT"
 arch="all"
-depends="g++"
+depends="erlang
+         g++"
 makedepends="autoconf
              automake
              binutils-dev
              boost-dev
              boost-system
              boost-thread
-             erlang
              erlang-asn1
              erlang-common-test
              erlang-crypto
@@ -74,6 +74,7 @@ install=""
 subpackages=""
 source="https://github.com/$pkgname/$pkgname/archive/$_srcver.tar.gz
         0005-Disable-tests-for-aports-buildservers.patch
+        0010-Set-configured-log-path.patch
         $pkgname.initd"
 builddir="$srcdir/CloudI-$_srcver/src"
 
@@ -115,4 +116,5 @@ package() {
 
 sha512sums="c47d3016002c5cf76782eb45a8c9da8aafa27d2046c82d6339dd59b88fb84e7c17f7df67071d9c3ca4fc8e87cd45980494664cd4ba5fb8900a67e47e909a0e7c  70addfda7133ac209157d48e38be70be7597ce8a.tar.gz
 cf380a2585e6116b3a0bc21b9846d91b96adcb754fa0805b571e99bbd9f696aa636d0bdeb6d85d05e34b65f8880afb01a02abb09e6797af1d4586664427add75  0005-Disable-tests-for-aports-buildservers.patch
-08e930424d4b7f4bbb7888fc9c16f6007a215886ebd0bdf4a296d4870d8d4e48bcc9df11ab79362aae238c3ae30a05dc47d9fbbc54fe07306dd06e8336576ad8  cloudi.initd"
+cea17814085d40cc56ce21465bff1f8dd9f37f93e237e63b333d9f5d7093d6880b3204879eb8e2175e056d73928cff3d42efab897713d04f8cac87e7f07f970e  0010-Set-configured-log-path.patch
+053f860f656617012208a0e1909e43b2f8979d381a90d3fa5a745a9cf5021fe54556a641fef2badaa9955f2394d00e32183389cb9b501169dcbf8cbe4fbb0329  cloudi.initd"

--- a/testing/cloudi/cloudi.initd
+++ b/testing/cloudi/cloudi.initd
@@ -15,16 +15,16 @@ depend() {
 	after firewall
 }
 start() {
-	$command start
+	HOME="/" $command start
 }
 stop() {
-	$command stop
+	HOME="/" $command stop
 }
 restart() {
-	$command restart
+	HOME="/" $command restart
 }
 status() {
-	$command test
+	HOME="/" $command test
 	if [ $? -eq 0 ]; then
 		einfo "status: started"
 		return 0


### PR DESCRIPTION
* cloudi.initd required the HOME environment variable due to erlang's erlexec
* 0010-Set-configured-log-path.patch was necessary to fix a path in /etc/cloudi/cloudi.conf
* Make the erlang package a runtime dependency

# DETAILS

## `cloudi.initd` environment variable fix

The Erlang VM uses an executable called erlexec which requires that the
environment variable `HOME` be defined, though it is not set by `openrc-run`.
These changes set the `HOME` path to `"/"` instead of `"/root"` to avoid any
usage by the Erlang VM, which is attempting to pull in the user's custom
settings (from files like `.erlang` and `.erlang.cookie`).

## `cloudi.conf` log path fix

A patch is added to modify the minimal `cloudi.conf` file to have the
`"localstatedir"` path set by using the configure script argument in
`APKBUILD`.  It is best to use this additional patch to avoid adding
sed usage in the makefile or something similar, due to autoconf's difficulty
expanding its own variables (i.e., since the default value for `@localstatedir@` expands to
`"${prefix}/var"`, autoconf can't handle this change in the CloudI repo).

## `erlang` package needs to be a runtime dependency instead of a buildtime dependency

The local erl script in the installation uses the installation's erlexec executable to call the erlang package's erl binary, executing the Erlang VM.  While this may sound convoluted, it is part of how a normal Erlang release is setup.