### PR TITLE
testing/colormake: snapshot from 20170221

### DIFF
--- a/testing/colormake/APKBUILD
+++ b/testing/colormake/APKBUILD
@@ -1,17 +1,18 @@
 # Contributor: Henrik Riomar <henrik.riomar@gmail.com>
 # Maintainer: Henrik Riomar <henrik.riomar@gmail.com>
 pkgname=colormake
-pkgver=0.9.20140503
+pkgver=0.9.20170221
 pkgrel=0
+_sha=93dd19b5143b124208caab5e9b6d57b5e6ec02cb
 pkgdesc="A simple wrapper around make to colorize the output"
 url="http://bre.klaki.net/programs/colormake"
 arch="noarch"
 license="GPL2+"
 checkdepends="make"
-depends="bash perl"
+depends="bash less perl"
 subpackages="$pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/pagekite/Colormake/archive/$pkgver.tar.gz"
-builddir="$srcdir/Colormake-$pkgver"
+source="$pkgname-$pkgver.tar.gz::https://github.com/pagekite/Colormake/archive/$_sha.tar.gz"
+builddir="$srcdir/Colormake-$_sha"
 
 check() {
 	cd "$builddir"
@@ -25,6 +26,14 @@ package() {
 	install -Dm0755 colormake "$pkgdir"/usr/bin/colormake
 	install -Dm0755 colormake.pl "$pkgdir"/usr/share/colormake/colormake.pl
 	install -Dm0644 colormake.1 "$pkgdir"/usr/share/man/man1/colormake.1
+
+	# symlinks
+	ln -s /usr/bin/colormake \
+		"$pkgdir"/usr/bin/clmake
+	ln -s /usr/bin/colormake \
+		"$pkgdir"/usr/bin/clmake-short
+	ln -s /usr/bin/colormake \
+		"$pkgdir"/usr/bin/colormake-short
 }
 
-sha512sums="91ca0a22b1ab34c729228f14eab6232df11576c3ac66398e2a6cbbe36a7a1ab5434897f44b411deb7e3c703aac2c9a13e0d0d9906b86339252832edc7b44f271  colormake-0.9.20140503.tar.gz"
+sha512sums="2f36db7e8ee3e936d709bfb31cf95451f2897c1202ea83c08cf3110067d5dcc2602e038ed1ee82ba11cfe3b095d01f918c7487efcb95a03623129f6b3509b87e  colormake-0.9.20170221.tar.gz"


### PR DESCRIPTION
While at it add symlinks:
 clmake like colormake but piped through less
 colormake-short and clmake-short versions of the commands will massage the output so lines do not wrap