### PR TITLE
Package libpipeline and man-db, courtesy Mx Wilcox.

### DIFF
--- a/testing/libpipeline/APKBUILD
+++ b/testing/libpipeline/APKBUILD
@@ -1,0 +1,36 @@
+# Contributor: A. Wilcox <awilfox@adelielinux.org>
+# Maintainer: A. Wilcox <awilfox@adelielinux.org>
+pkgname=libpipeline
+pkgver=1.4.1
+pkgrel=0
+pkgdesc="C pipeline manipulation library"
+url="http://libpipeline.nongnu.org/"
+arch="all"
+license="GPL-3+"
+checkdepends="check-dev"
+subpackages="$pkgname-dev $pkgname-doc"
+source="http://download.savannah.nongnu.org/releases/libpipeline/libpipeline-$pkgver.tar.gz"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+sha512sums="835d65aa3f9436398b5421544ca7857fe9caed52cd2e70320ea04d6315825e648df930e1c225d4aaf0f2edda2a438f6c00f15c556fb9fd30311560fb8d966797  libpipeline-1.4.1.tar.gz"

--- a/testing/man-db/APKBUILD
+++ b/testing/man-db/APKBUILD
@@ -1,0 +1,41 @@
+# Contributor: A. Wilcox <awilfox@adelielinux.org>
+# Maintainer: A. Wilcox <awilfox@adelielinux.org>
+pkgname=man-db
+pkgver=2.7.6.1
+pkgrel=1
+pkgdesc="The man command and related utilities for examining on-line help files"
+url="http://www.nongnu.org/man-db/"
+arch="all"
+license="GPL-2+"
+depends="groff less"
+makedepends="db-dev gettext-dev libpipeline-dev zlib-dev"
+subpackages="$pkgname-lang $pkgname-doc"
+source="http://download.savannah.nongnu.org/releases/man-db/man-db-$pkgver.tar.xz
+	man-db.trigger"
+triggers="man-db.trigger=/usr/share/man"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var \
+		--disable-setuid \
+		--with-sections="1 1p 1x 2 2x 3 3p 3x 4 4x 5 5x 6 6x 7 7x 8 8x 9 0p tcl n l p o" \
+		--enable-nls \
+		--with-db=db
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+	rm "${pkgdir}"/usr/lib/charset.alias
+	rm -r "${pkgdir}"/usr/lib/tmpfiles.d  # systemd
+}
+
+sha512sums="623c5e7f8b7c289908b2c926f8777293b8d39aeceef0d2509d701a8b0bfa81408650f655c8608318221786c751a79ee91124b07993de5298cd7fa6d8bb737301  man-db-2.7.6.1.tar.xz
+0d2ab0b42888178ffb83c5dd5eaac8005f047de56af55eb3046291318fd8ed8c4999a4ea0148367ea07c0a0490eb8b9bc726a03b46533ef51bec6a5747719b64  man-db.trigger"

--- a/testing/man-db/man-db.trigger
+++ b/testing/man-db/man-db.trigger
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/bin/mandb /usr/share/man


### PR DESCRIPTION
I've found mandoc (mdocml) to be deficient, primarily as mandoc's `man` produces cryptic error messages regarding its database. Consequently, here's an alternate `man` implementation.