### PR TITLE
testing/weston: upgrade to 3.0.0

### DIFF
--- a/testing/weston/APKBUILD
+++ b/testing/weston/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=weston
-pkgver=2.0.0
+pkgver=3.0.0
 pkgrel=0
 _libname=lib$pkgname
 _libdir=$_libname-${pkgver%%.*}
@@ -27,7 +27,8 @@ subpackages="$pkgname-dev $pkgname-doc $subpackages
 	$pkgname-clients $_libname-desktop:_libd $_libname:libs
 	$pkgname-xwayland $pkgname-desktop-x11:_x11:noarch
 	"
-source="http://wayland.freedesktop.org/releases/$pkgname-$pkgver.tar.xz"
+source="http://wayland.freedesktop.org/releases/$pkgname-$pkgver.tar.xz
+	timespec.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 options="!check"
 
@@ -47,8 +48,7 @@ build() {
 		--enable-clients \
 		--enable-demo-clients-install \
 		--disable-weston-launch \
-		--disable-setuid-install \
-		|| return 1
+		--disable-setuid-install
 	make
 }
 
@@ -127,4 +127,5 @@ _sub() {
 	mv "$pkgdir"/$path/$name "$subpkgdir"/$path
 }
 
-sha512sums="085a0ba278932d41b50edd6e89db5df31cd6a1179c6cfe9a8ac5ac64e63b25cfc3da1ad8c587259273c3812593029b803867195e2d82b12b5cdd2588ac59acc6  weston-2.0.0.tar.xz"
+sha512sums="b824c39f2a884f6d50d607613f447090621f684c96f7d905f25f6e500dabd03ecb2b1cd1030babc193c3417223cb220103abb792437e1a5ead7229a76b5c7a58  weston-3.0.0.tar.xz
+3e596af4bf0a6b06a5d28376043db111fe1c161ead04501fa6d2c667b5a21889cca3354d1bdc4ac794841bef68ed5e1a7a84e44e7d510e947e3673195706caed  timespec.patch"

--- a/testing/weston/timespec.patch
+++ b/testing/weston/timespec.patch
@@ -1,0 +1,10 @@
+--- a/tests/timespec-test.c
++++ b/tests/timespec-test.c
+@@ -25,6 +25,7 @@
+ 
+ #include "config.h"
+ 
++#include <time.h>
+ #include <stdlib.h>
+ #include <stdint.h>
+ #include <stdio.h>


### PR DESCRIPTION
configure: error: Package requirements (wayland-protocols >= 1.8) were not met

So #2109  must be accepted first