### PR TITLE
testing/py-wcwidth: added py2/py3 sub-packages

### DIFF
--- a/testing/py-wcwidth/APKBUILD
+++ b/testing/py-wcwidth/APKBUILD
@@ -8,21 +8,47 @@ pkgdesc="Measures number of Terminal column cells of wide-character codes"
 url="https://pypi.python.org/pypi/wcwidth"
 arch="noarch"
 license="MIT"
-depends="python2"
-makedepends="python2-dev py-setuptools"
+depends=""
+makedepends="python2-dev py-setuptools python3-dev"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="$pkgname-$pkgver.tar.gz::https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgname-$pkgver"
 
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+}
+
 build() {
 	cd "$builddir"
-	python2 setup.py build || return 1
+	python2 setup.py build
+	python3 setup.py build
 }
 
 package() {
-	cd "$builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	mkdir -p "$pkgdir"
 }
 
-md5sums="b3b6a0a08f0c8a34d1de8cf44150a4ad  py-wcwidth-0.1.7.tar.gz"
-sha256sums="3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e  py-wcwidth-0.1.7.tar.gz"
+_py2() {
+	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
 sha512sums="5bc9625fbd10721a50a3ac7d7f91012cca8e4f83533f265cf56890498bc52a53b155c82e67d6bc5523a5593c8d7992a1dec2a0f590318170eddf987c56f9c368  py-wcwidth-0.1.7.tar.gz"


### PR DESCRIPTION
This is required by https://github.com/alpinelinux/aports/pull/1967 and https://github.com/alpinelinux/aports/pull/1968 to switch to python3.