### PR TITLE
testing/wireguard: version bump to 0.0.20170810

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20170726
-_mypkgrel=0
+_ver=0.0.20170810
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="64f7583f0031ab79d70a494ce734fbb5a31b508d3dd4ac00214cce7fdd0eb61468ab49410c92d9e0dc07a382d83c9cf7af9298e6e794b18c081e1089f969729b  WireGuard-0.0.20170726.tar.xz"
+sha512sums="41aa997fa9d333a8d93096e5a4a776be7bdd14d227c4cffe3027ff1db6dff36b2fa56c1d028a574aa05b5e1572badbf5af3c1612334382f405caa30e92cfd34e  WireGuard-0.0.20170810.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20170726
+pkgver=0.0.20170810
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="64f7583f0031ab79d70a494ce734fbb5a31b508d3dd4ac00214cce7fdd0eb61468ab49410c92d9e0dc07a382d83c9cf7af9298e6e794b18c081e1089f969729b  WireGuard-0.0.20170726.tar.xz"
+sha512sums="41aa997fa9d333a8d93096e5a4a776be7bdd14d227c4cffe3027ff1db6dff36b2fa56c1d028a574aa05b5e1572badbf5af3c1612334382f405caa30e92cfd34e  WireGuard-0.0.20170810.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20170726
-_mypkgrel=0
+_ver=0.0.20170810
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="64f7583f0031ab79d70a494ce734fbb5a31b508d3dd4ac00214cce7fdd0eb61468ab49410c92d9e0dc07a382d83c9cf7af9298e6e794b18c081e1089f969729b  WireGuard-0.0.20170726.tar.xz"
+sha512sums="41aa997fa9d333a8d93096e5a4a776be7bdd14d227c4cffe3027ff1db6dff36b2fa56c1d028a574aa05b5e1572badbf5af3c1612334382f405caa30e92cfd34e  WireGuard-0.0.20170810.tar.xz"


### PR DESCRIPTION
Pretty simple version bump. Release notes:

  * android: fix readme
  * contrib: move Android tools to wireguard-android repo
  
  All the Android tools have been moved to an Android-specific repo,
  which, in addition to having all the wg-quick CLI things, will also
  have a nice UI that Samuel, one of our GSoC students, has been
  working on. Stay tuned, exciting things coming.
  
  * socket: move print function from compat
  * compat: work around odd kernels that backport kv[mz]alloc
  * compat: get rid of warnings on frankenkernels
  * compat: support grsecurity with our compat padata implementation
  * netns: work around linux 3.10 issues
  
  The usual set of compat fixups for weird kernels. With regards to
  Grsecurity, we make a change that _should_ make this part of the
  compat layer work with Grsecurity, but unfortunately I really have
  no way of knowing, since I don't actually have access to their
  source code. I assume, though, if this doesn't work, I'll receive
  more complaints and will take another stab in the dark. The general
  situation saddens me, as I really liked that project and wish I
  could still play with it.
  
  * recieve: cleanup variable usage
  * receive: single line if style
  * recieve: pskb_trim already checks length
  * receive: move lastminute guard into timer event
  * selftest: more checking in ratelimiter
  * blake2s: satisfy sparse
  * routingtable: unbloat BUG()
  * timers: rename confusingly named functions and variables
  * noise: infer initiator or not from handshake state
  
  Usual set of code quality cleanups.
  
  * tools: stricter userspace ipc parsing
  * netns: explictly test reply to sender routing
  * timers: do not send out double keepalive
  
  Some logic fixes and a more expansive test suite.
  
  * hashtables: allow up to 2^20 peers per interface
  * hashtables: if we have an index match, don't search further ever
  
  This allows for nearly 1 million peers per interface, which should be
  more than enough. If needed later, this number could easily be increased
  beyond this. We also increase the size of the hashtables to accommodate
  this upper bound. In the future, it might be smart to dynamically expand
  the hashtable instead of this hard coded compromise value between small
  systems and large systems. Ongoing work includes figuring out the most
  optimal scheme for these hashtables and for the insertion to mask their
  order from timing inference.