### PR TITLE
main/nodejs: upgrade to 6.11.2

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -3,6 +3,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Contributor: Dave Esaias <dave@containership.io>
 # Contributor: Tadahisa Kamijo <kamijin@live.jp>
+# Contributor: Tim Brust <github@timbrust.de>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 #
 # secfixes:
@@ -12,8 +13,8 @@
 pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
-pkgver=6.11.1
-pkgrel=2
+pkgver=6.11.2
+pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="http://nodejs.org/"
 arch="all"
@@ -102,6 +103,6 @@ npm() {
 	mv "$pkgdir"/usr/lib/node_modules/npm "$subpkgdir"/usr/lib/node_modules/
 }
 
-sha512sums="72a622ed5b884ddfc467ca665c5ba0ed03093dff221664359fe5587f24c2c9a95775002089528fad56bdfafce2489c912638e68a7e10c74a730b07cbde28fab6  node-v6.11.1.tar.gz
+sha512sums="1e0a8f3562b54e5e14dda66eaabaabc7c191ec6f5985124e6d8f6607968a0c0913f661d463b48447296477c6b6de0d1295645dbc4f29a075cc02b96e345d3d92  node-v6.11.2.tar.gz
 a8be538158b7c96341a407acba30450ddc5c3ad764e7efe728d1ceff64efc3067b177855b9ef91b54400be6a02600d83da4c21a07ae9d7dc0774f92b2006ea8b  dont-run-gyp-files-for-bundled-deps.patch
 54a96cdc103bdffa9ba5283f59c64a35774e272f3a944d6475e3f669f95f7d75bcca6db3b12b9af76ea463f531763105aeabb302872652ced6a2bcb66f1eace0  ppc-fix-musl-mcontext.patch"


### PR DESCRIPTION
This updates Node.js to the latest LTS release (v6.11.2) - should the `secfixes` comment be removed again? I could find no info about in the contributing document.