### PR TITLE
Add freedreno support to mesa and libdrm

### DIFF
--- a/main/libdrm/APKBUILD
+++ b/main/libdrm/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libdrm
 pkgver=2.4.81
-pkgrel=0
+pkgrel=1
 pkgdesc="Userspace interface to kernel DRM services"
 url="http://dri.freedesktop.org/"
 arch="all"
@@ -23,6 +23,7 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
+                --enable-freedreno \
 		--enable-udev \
 		--disable-manpages \
 		--disable-valgrind \

--- a/main/mesa/APKBUILD
+++ b/main/mesa/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mesa
 pkgver=17.1.4
-pkgrel=0
+pkgrel=1
 pkgdesc="Mesa DRI OpenGL library"
 url="http://www.mesa3d.org"
 arch="all"
@@ -10,6 +10,7 @@ depends=
 subpackages="$pkgname-dev
 	$pkgname-dri-ati:_dri
 	$pkgname-dri-nouveau:_dri
+	$pkgname-dri-freedreno:_dri
 	$pkgname-dri-swrast:_dri
 	$pkgname-dri-vmwgfx:_dri
 	$pkgname-dri-virtio:_dri
@@ -37,7 +38,7 @@ replaces="mesa-dricore"
 
 _dri_driverdir=/usr/lib/xorg/modules/dri
 _dri_drivers="r200,radeon,nouveau,swrast"
-_gallium_drivers="r300,r600,radeonsi,nouveau,svga,swrast,virgl"
+_gallium_drivers="r300,r600,radeonsi,nouveau,freedreno,svga,swrast,virgl"
 _vulkan_drivers="radeon"
 
 builddir="$srcdir/mesa-$pkgver"
@@ -217,6 +218,9 @@ _dri() {
 		_mv_dri nouveau_dri nouveau_vieux_dri \
 			&& _mv_vdpau nouveau \
 			&& _mv_gpipe nouveau
+		;;
+	freedreno)
+		_mv_dri msm_dri kgsl_dri 
 		;;
 	swrast)
 		_mv_dri swrast_dri kms_swrast_dri && _mv_gpipe swrast


### PR DESCRIPTION
I have tested these changes with my z2 tablet so they should work fine for other adreno devices.