### PR TITLE
testing/wok: Upgrade to 2.5.0 and fix for startup failure

### DIFF
--- a/testing/wok/APKBUILD
+++ b/testing/wok/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=wok
-pkgver=2.4.0
+pkgver=2.5.0
 pkgrel=0
 pkgdesc="Webserver of Kimchi - a cherrypy framework for multi-purpose plug-ins"
 url="http://kimchi-project.github.io/wok/"
@@ -17,6 +17,7 @@ options="!check"
 subpackages="$pkgname-lang $pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/kimchi-project/$pkgname/archive/$pkgver.tar.gz
 	wokd.initd
+	alpine-specific-pushserver.patch
 	alpine-specific-wokd.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -38,6 +39,7 @@ package() {
 		"$pkgdir"/etc/init.d/wokd
 }
 
-sha512sums="7ae1e32a621fc8b72ef66031e55e79edc21e1737325660da30d49242464940673722f09b52a38e922b7ac1aeb0e277f9a325bffe0f4a467364843165b1e8fb03  wok-2.4.0.tar.gz
+sha512sums="780bbb3e7fe37b4a91f222ba5004efbc05f59555779b55c836fda856d5c2db244ee45b61b0f4099219ac8f8b74afa5268e41e9f416b7af441c8de4a0de04af76  wok-2.5.0.tar.gz
 a05554686e0ea2d069a5b9e9b83f6aee678ed299269d86d1192ae417ba98fa8e727d55be8f396360c70846f549f46e64028956e5f7f5c50bbf5601f548c8bd71  wokd.initd
+f257815edbd44baee4a3fbb680a8aa25a9804db1d2ef9326512dc7888c089c212d78e5b2cc7f6e28443dc64b10c7b7f4266e899570bcd2b25bc8bf6b4510a20d  alpine-specific-pushserver.patch
 eb7a9f61d40d7edb11cc451ef25b6b2b920be23ddab7477798592bfe8a2bce8c3be21ac3d75b00d4ed3d2817af779799889fdd906d50039dec00c0c677d2c30c  alpine-specific-wokd.patch"

--- a/testing/wok/alpine-specific-pushserver.patch
+++ b/testing/wok/alpine-specific-pushserver.patch
@@ -1,0 +1,11 @@
+--- a/src/wok/pushserver.py
++++ b/src/wok/pushserver.py
+@@ -67,7 +67,7 @@
+     def set_socket_file(self):
+         if not os.path.isdir(BASE_DIRECTORY):
+             try:
+-                os.mkdir(BASE_DIRECTORY)
++                os.makedirs(BASE_DIRECTORY)
+             except OSError:
+                 raise RuntimeError('PushServer base UNIX socket dir %s '
+                                    'not found.' % BASE_DIRECTORY)


### PR DESCRIPTION
Upgraded wok to latest released version 2.5.0.
Fixed a bug preventing the server from starting up.