### PR TITLE
testing/kimchi: Upgraded to version 2.5.0 and added a patch to make novnc console work

### DIFF
--- a/testing/kimchi/APKBUILD
+++ b/testing/kimchi/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=kimchi
-pkgver=2.4.0
+pkgver=2.5.0
 pkgrel=0
 pkgdesc="An HTML5 management interface for KVM"
 url="https://github.com/kimchi-project/kimchi"
@@ -21,6 +21,7 @@ depends="
 	py-websockify
 	py2-pillow
 	qemu
+	qemu-img
 	py2-configobj
 	py2-six
 	py2-paramiko
@@ -34,6 +35,7 @@ depends="
 	spice-html5
 	websockify
 	py-numpy
+	novnc	
 	"
 makedepends="
 	automake
@@ -58,6 +60,7 @@ makedepends="
 options="!check"
 subpackages="$pkgname-lang"
 source="$pkgname-$pkgver.tar.gz::https://github.com/kimchi-project/$pkgname/archive/$pkgver.tar.gz
+	alpine-specific-kimchi.api.patch
 	systemd-substitution-with-openrc.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -77,5 +80,6 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="d51fa52b420cc6b775225e410fa7f222700d351cccca8eb0fda492bf4973c1808f3bf13d5a01a825b2163124c8925ffba810ec80f0110c9978e4566bdc9b2733  kimchi-2.4.0.tar.gz
+sha512sums="bcf20590d60cf3c82e34cb32e3a65aa7c87426eb721af7098234c5e1ff6fd1766b44d45d4ff4283e7122f370914e58b67fed1ba7b97df0cc26e614a4b66eb2d1  kimchi-2.5.0.tar.gz
+ac0cb9517161262109d754a469507dbb81607f52443514b227c3088ea11271ee465f017d6076519b820bc4021fd69eca3484059553072062f18334c69c5fb36a  alpine-specific-kimchi.api.patch
 a78c51237233b629c84106cfcdc8398a030889dd8bc641630a8c4e05fdad8d32a9b457c36188e1752a1277ef884437c1765c897bc2a33ca87c07e3bafdfdd5bf  systemd-substitution-with-openrc.patch"

--- a/testing/kimchi/alpine-specific-kimchi.api.patch
+++ b/testing/kimchi/alpine-specific-kimchi.api.patch
@@ -1,0 +1,20 @@
+--- a/ui/js/src/kimchi.api.js
++++ b/ui/js/src/kimchi.api.js
+@@ -324,7 +324,7 @@
+                 url += server_root;
+                 url += "/plugins/kimchi/serial/html/serial.html";
+                 url += "?port=" + proxy_port;
+-                url += "&path=" + server_root + "/websockify";
++                url += "&path=" + server_root + "websockify";
+                 url += "?token=" + wok.urlSafeB64Encode(vm+'-console').replace(/=*$/g, "");
+                 url += '&encrypt=1';
+                 window.open(url);
+@@ -348,7 +348,7 @@
+             url += server_root;
+             url += "/plugins/kimchi/novnc/vnc_auto.html";
+             url += "?port=" + proxy_port;
+-            url += "&path=" + server_root + "/websockify";
++            url += "&path=" + server_root + "websockify";
+             /*
+              * From python documentation base64.urlsafe_b64encode(s)
+              * substitutes - instead of + and _ instead of / in the


### PR DESCRIPTION
Upgraded version to the latest version 2.5.0
Fixed a bug preventing novnc from working. Should be fixed in kimchi project but all current distro's they support use an old version of websockify. So for now I added a alpine linux specific patch.