### PR TITLE
community/go: upgrade to 1.9

### DIFF
--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Eivind Uggedal <eivind@uggedal.com>
 pkgname=go
-pkgver=1.8.3
+pkgver=1.9
 # This should be the latest commit on the corresponding release branch
-_toolsver="5682db0e919ed9cfc6f52ac32e170511a106eb3b"
+_toolsver="5d2fd3ccab986d52112bf301d47a819783339d0e"
 pkgrel=0
 pkgdesc="Go programming language compiler"
 url="http://www.golang.org/"
@@ -29,7 +29,7 @@ if [ "$CBUILD" = "$CTARGET" ]; then
 	makedepends="go-bootstrap $makedepends"
 	provides="go-bootstrap=$pkgver-r$pkgrel"
 	subpackages="$subpackages $pkgname-tools"
-	_gotools="cover godoc stringer"
+	_gotools="godoc stringer"
 	_gocross="darwin freebsd openbsd windows"
 else
 	pkgname="go-bootstrap"
@@ -164,7 +164,7 @@ _crosspkg() {
 		"$subpkgdir"/usr/lib/go/pkg/
 }
 
-sha512sums="c6e67dd9e3acdf2aa776d920f91f3fb1802d624ba5d51e06b2c7c6b71bcfaf91f4024f7a442cecde69175c589f7f1163f0ae86d887e15ddde710e53ce0961284  go1.8.3.src.tar.gz
-343fca47f250278b22df1c1cd92cce91e01009043d05d8ccce095e4386fa0f5ca8ccaa58232635332c7288ceca9d2a240f774f8bb3b08129a681a582cba60248  go-tools-1.8.3.tar.gz
-9857c71108652b8907117abf0b41ded5e332bcf864320235aadbf3a7b6afbfc0e5051f91fe143f0654b4c8d6fe9adbe7d22ca2ce50cd75c0ab7a050dfb437773  default-buildmode-pie.patch
+sha512sums="70c4b892b6883fb21fc1a547a2b8d174df8c7aca282a3906e3816b4442b16c5da578b69c19443122a4a45e66fc95d170528d826b70932af09f4afd2a46615d74  go1.9.src.tar.gz
+d679873082dbac6a47b7c43ac74c47cb19616fb053a4faa3e6ee78004ece86aa5c432fba3d24c030d47396089d7ec7c6357af5648bd767341056396066ff9a04  go-tools-1.9.tar.gz
+ef9da66d76e4698314eaf2aa88cf40a8430a15f8f6cb9ad17ee9d72498ec049b60e63e1ff5acf13a916c5ea365f9d9a282b6f2b06e28de9e3484eb9a3d7dd98e  default-buildmode-pie.patch
 6b36f3780ab10e5c4902473a8ab5c0417220ece584b537517e9e60979bdc5a548ed14dd2546605392c89ec5ea6691769d337d34e2e19b92eba5bbca1898f4ada  set-external-linker.patch"

--- a/community/go/default-buildmode-pie.patch
+++ b/community/go/default-buildmode-pie.patch
@@ -1,12 +1,13 @@
---- go/src/cmd/go/build.go.orig	2016-07-07 11:52:03.315793199 +0300
-+++ go/src/cmd/go/build.go	2016-04-20 02:50:07.000000000 +0300
-@@ -363,7 +363,8 @@
+diff -upr src/go.orig/src/cmd/go/internal/work/build.go src/go/src/cmd/go/internal/work/build.go
+--- go.orig/src/cmd/go/internal/work/build.go	2017-08-27 17:38:26.354750979 +0200
++++ go/src/cmd/go/internal/work/build.go	2017-08-27 17:40:27.555130105 +0200
+@@ -304,7 +304,8 @@ func BuildModeInit() {
  		ldBuildmode = "c-shared"
  	case "default":
  		switch platform {
-+		case "linux/386", "linux/amd64", "linux/arm", "linux/arm64", "linux/ppc64le", "linux/s390x",
-+			"android/amd64", "android/arm", "android/arm64", "android/386":
 -		case "android/arm", "android/arm64", "android/amd64", "android/386":
++		case "linux/386", "linux/amd64", "linux/arm", "linux/arm64", "linux/ppc64le", "linux/s390x",
++			"android/arm", "android/arm64", "android/amd64", "android/386":
  			codegenArg = "-shared"
  			ldBuildmode = "pie"
- 		default:
+ 		case "darwin/arm", "darwin/arm64":


### PR DESCRIPTION
Also remove cover:

> For Go releases 1.5 and later, this tool lives in the standard
repository. The code here is not maintained.

See: https://godoc.org/golang.org/x/tools/cmd/cover