### PR TITLE
main/dovecot: upgrade to 2.2.32, pidgeonhole-plugin upgrade to 0.4.20, fixes

### DIFF
--- a/main/dovecot/APKBUILD
+++ b/main/dovecot/APKBUILD
@@ -3,15 +3,16 @@
 # Contributor: Michael Mason <ms13sp@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dovecot
-pkgver=2.2.29.1
+pkgver=2.2.32
 _pkgvermajor=2.2
 pkgrel=0
-_pigeonholever=0.4.18
+_pigeonholever=0.4.20
 _pluginextdataver=39
 _pigeonholevermajor=${_pigeonholever%.*}
 pkgdesc="IMAP and POP3 server"
 url="http://www.dovecot.org/"
 arch="all"
+options="!check"
 license="LGPL2+"
 depends="libressl"
 pkgusers="dovecot dovenull"
@@ -20,10 +21,9 @@ makedepends="libcap-dev zlib-dev libressl-dev bzip2-dev postgresql-dev
 	mariadb-dev sqlite-dev heimdal-dev openldap-dev linux-headers autoconf
 	automake libtool"
 install="dovecot.pre-install dovecot.post-install"
-subpackages="$pkgname-doc $pkgname-dev
-	$pkgname-sql $pkgname-pgsql $pkgname-mysql $pkgname-sqlite
-	$pkgname-gssapi $pkgname-ldap $pkgname-pigeonhole-plugin:pigeonhole
-	$pkgname-pigeonhole-plugin-extdata:pigeonhole_extdata
+subpackages="$pkgname-doc $pkgname-dev $pkgname-pigeonhole-plugin-extdata:_sieve_extdata
+	$pkgname-pigeonhole-plugin-ldap:_sieve_ldap $pkgname-pigeonhole-plugin:_sieve $pkgname-sql
+	$pkgname-pgsql $pkgname-mysql $pkgname-sqlite $pkgname-gssapi $pkgname-ldap
 	"
 source="http://www.dovecot.org/releases/$_pkgvermajor/$pkgname-$pkgver.tar.gz
 	http://pigeonhole.dovecot.org/releases/$_pkgvermajor/$pkgname-$_pkgvermajor-pigeonhole-$_pigeonholever.tar.gz
@@ -43,6 +43,7 @@ build() {
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
+		--libexecdir=/usr/lib/$pkgname \
 		--localstatedir=/var \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
@@ -69,6 +70,7 @@ build() {
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--with-dovecot="$builddir" \
+		--with-ldap=plugin \
 		--disable-static
 	make
 
@@ -144,16 +146,24 @@ dev() {
 		"$subpkgdir"/usr/lib/dovecot/
 }
 
-pigeonhole() {
+_sieve() {
 	pkgdesc="Sieve plugin for dovecot"
 	depends="$pkgname"
 	_mv $(cd "$pkgdir" && find usr -name '*sieve_extprograms*')
 	_mv $(cd "$pkgdir" && find usr -name '*sieve_imapsieve*')
+	_mv $(cd "$pkgdir" && find usr -name '*sieve*')
 	_mv $(cd "$pkgdir" && find usr -name '*pigeonhole*')
 	_mv $(cd "$pkgdir" && find etc/dovecot -name '*sieve*')
 }
 
-pigeonhole_extdata() {
+_sieve_ldap() {
+	pkdesc="Sieve plugin for dovecot (ldap support)"
+	depends="$pkgname-pigeonhole-plugin $pkgname-ldap"
+	_mv $(cd "$pkgdir" && find usr -name '*_sieve_storage_ldap_*')
+	mkdir -p "$subpkgdir"
+}
+
+_sieve_extdata() {
 	pkgdesc="Pigeonhole Sieve Extdata Plugin"
 	depends="$pkgname-pigeonhole-plugin"
 	_mv $(cd "$pkgdir" && find usr -name '*sieve_extdata*')
@@ -188,7 +198,7 @@ gssapi() {
 ldap() {
 	pkgdesc="LDAP auth plugin for dovecot"
 	depends="$pkgname"
-	_mv $(cd "$pkgdir" && find usr -name '*_ldap*')
+	_mv $(cd "$pkgdir" && find usr -name '*[_-]ldap*')
 	_mv $(cd "$pkgdir" && find etc/dovecot -name '*-ldap.conf*')
 }
 
@@ -199,9 +209,9 @@ sql() {
 	_mv $(cd "$pkgdir" && find etc/dovecot -name '*-sql.conf*')
 }
 
-sha512sums="1e5ea6080ebe7dd4afe6fcfe8e98ed6d2ad2735655a18cc96e439dd044ccc3a1a6a80428bc746b4d6250820895d6a62121562e97e4b46c8b1cf88a19443bc111  dovecot-2.2.29.1.tar.gz
-6f49a6a6435b0e4dcbe29f852ce17c016df2f367f5460301a2a2c6bd5f5ba6260b23bfe1c5e78b91c6041554ee67d1ce14ad3adf219505f692c61681d9e70cc4  dovecot-2.2-pigeonhole-0.4.18.tar.gz
+sha512sums="a26ce763fdea7d72ff9801d3b7d57a1f0d00278e4a1aa60d1be070fe5a6d2c6a15f266a519119492bee7a3e7a6b7d0732e9879e5c5841adbab8c0952cd1b7c7c  dovecot-2.2.32.tar.gz
+84a28842be206e05cb96c07cf1c1b62c9c378ba4c952caa47cf79a44b9428e076f4182eadd9c4fb8f45d3605b881f91e8e520c41705017ac4039240d4bcace39  dovecot-2.2-pigeonhole-0.4.20.tar.gz
 832a80264fb9bd3021c4e192eb7594c203100783df547aff35acf4dc4d8de5eddfd676fcc5a07a0691d9bb6eb884c9497a692b72a2af5bf9e9bb7a2d3f38923e  39.tar.gz
 9f19698ab45969f1f94dc4bddf6de59317daee93c9421c81f2dbf8a7efe6acf89689f1d30f60f536737bb9526c315215d2bce694db27e7b8d7896036a59c31f0  dovecot.logrotate
-6ec75a8396f4d826390e69aa8177593573eaf0e0ab537b2a4720573e04c92ff615f39e1559b48313b2cd2f03704cd977bb594a568ecc5dd22e38926c12f3c48c  dovecot.initd
+d2758a22e5b3d1d1be867fd237466a1b5fe7ecd4355fdc51fa9e5ceab48a862f8a5d83992d2ae17a3e0b2c611ff92d0de833d7e1c5f00c6f4bfb94403dbda8e4  dovecot.initd
 7aa66cbd2a520d863fc8ff2ec48520c6fe4629ec345545b362e16c3072843f5315c6e12513ed86200d66b7c55e17f5bb21c7a12d86721968a9e03cc595dc5bcd  extdata.conf"

--- a/main/dovecot/dovecot.initd
+++ b/main/dovecot/dovecot.initd
@@ -1,6 +1,6 @@
 #!/sbin/openrc-run
 
-[ "${SVCNAME}" != "${SVCNAME##*.}" ] && instance=${SVCNAME##*.}
+[ "$RC_SVCNAME" != "${RC_SVCNAME##*.}" ] && instance=${RC_SVCNAME##*.}
 
 description="Secure POP3/IMAP server"
 
@@ -28,13 +28,13 @@ start_pre() {
 }
 
 reload() {
-	ebegin "Reloading ${SVCNAME} configs and restarting auth/login processes"
+	ebegin "Reloading $RC_SVCNAME configs and restarting auth/login processes"
 	start_pre && start-stop-daemon --signal HUP --pidfile $pidfile
 	eend $?
 }
 
 reopen() {
-	ebegin "Reopening ${SVCNAME} log files"
+	ebegin "Reopening $RC_SVCNAME log files"
 	start-stop-daemon --signal USR1 --pidfile $pidfile
 	eend $?
 }


### PR DESCRIPTION
- cosmetic fixes in init-script

- move /usr/libexec/dovecot to /usr/lib/dovecot

- add pidgeonhole (sieve) ldap storage plugin as subpackage

- move all sieve-related stuff to pidgeonhole-plugin subpackage,
  so now dovecot package have no sieve-dependent libs and binaries.

- move all ldap-related libs to dovecot-ldap subpackage,
  so now dovecot package doesn't depends on libldap.
