### PR TITLE
testing/rspamd: fix for proxy worker

### DIFF
--- a/testing/rspamd/APKBUILD
+++ b/testing/rspamd/APKBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Contributor: Nathan Angelacos <nangel@alpinelinux.org>
+# Contributor: TBK <alpine@jjtc.eu>
 pkgname=rspamd
 pkgver=1.6.3
-pkgrel=0
+pkgrel=1
 pkgdesc="Fast, free and open-source spam filtering system"
 url="https://rspamd.com"
 arch="x86_64 x86 armhf"
@@ -30,17 +31,19 @@ builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
 	local worker
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	for worker in proxy:2 normal:3 controller:4 fuzzy:5; do
 		sed -e "s/@name@/${worker%:*}/g" -e "s/@port@/${worker#*:}/g" \
 			"$srcdir"/worker.conf.in > conf/worker-${worker%:*}.conf
 	done
+	sed -ri -e 's/worker /&"rspamd_proxy" /' \
+		conf/worker-proxy.conf
 	sed "$(grep -n -m1 'worker {' conf/rspamd.conf|cut -d: -f1),\$d" \
 		 -i conf/rspamd.conf && \
 		 echo '.include(glob=true) "$CONFDIR/worker-*.conf"' >> \
-		conf/rspamd.conf || return 1
+		conf/rspamd.conf
 	sed -ri -e 's~DBDIR(/rspamd.sock)~RUNDIR\1~' \
 		-e 's~rspamd_dynamic~dynamic~' \
 		conf/options.inc
@@ -59,40 +62,39 @@ build() {
 		-DENABLE_HIREDIS=ON \
 		-DENABLE_REDIRECTOR=ON \
 		-DENABLE_URL_INCLUDE=ON \
-		-DINSTALL_EXAMPLES=ON \
-		|| return 1
-	make || return 1
+		-DINSTALL_EXAMPLES=ON
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 
 	mkdir -p "$pkgdir"/etc/$pkgname/local.d \
-		"$pkgdir"/etc/$pkgname/override.d || return 1
+		"$pkgdir"/etc/$pkgname/override.d
 
 	install -Dm644 "$srcdir"/$pkgname.logrotated \
-		"$pkgdir"/etc/logrotate.d/$pkgname || return 1
+		"$pkgdir"/etc/logrotate.d/$pkgname
 	install -Dm755 "$srcdir"/$pkgname.initd \
-		"$pkgdir"/etc/init.d/$pkgname || return 1
+		"$pkgdir"/etc/init.d/$pkgname
 	install -Dm644 "$srcdir"/$pkgname.confd \
-		"$pkgdir"/etc/conf.d/$pkgname || return 1
+		"$pkgdir"/etc/conf.d/$pkgname
 
 	install -dm750 -o $pkgname -g $pkgname \
-		"$pkgdir"/var/lib/$pkgname/dynamic || return 1
+		"$pkgdir"/var/lib/$pkgname/dynamic
 	install -dm750 -g $pkgname \
-		"$pkgdir"/var/log/$pkgname || return 1
-	chown $pkgname:$pkgname "$pkgdir"/var/lib/$pkgname || return 1
+		"$pkgdir"/var/log/$pkgname
+	chown $pkgname:$pkgname "$pkgdir"/var/lib/$pkgname
 
-	mkdir "$pkgdir"/usr/sbin || return 1
-	find "$pkgdir"/usr/bin -type l -delete || return 1
+	mkdir "$pkgdir"/usr/sbin
+	find "$pkgdir"/usr/bin -type l -delete
 	mv "$pkgdir"/usr/bin/rspamd-$pkgver \
-		"$pkgdir"/usr/sbin/rspamd || return 1
+		"$pkgdir"/usr/sbin/rspamd
 	mv "$pkgdir"/usr/bin/rspamadm-$pkgver \
-		"$pkgdir"/usr/bin/rspamadm || return 1
+		"$pkgdir"/usr/bin/rspamadm
 
 	mv "$pkgdir"/usr/share/examples \
-		"$pkgdir"/usr/share/doc || return 1
+		"$pkgdir"/usr/share/doc
 	mv "$pkgdir"/usr/share/$pkgname/www/README.md \
 		"$pkgdir"/usr/share/$pkgname/www/plugins.txt \
 		"$pkgdir"/usr/share/doc/$pkgname
@@ -100,7 +102,7 @@ package() {
 
 client() {
 	pkgdesc="$pkgdesc (console client)"
-	mkdir -p "$subpkgdir"/usr/bin || return 1
+	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/rspamc-$pkgver \
 		"$subpkgdir"/usr/bin/rspamc
 }
@@ -108,18 +110,18 @@ client() {
 utils() {
 	depends="perl"
 	pkgdesc="$pkgdesc (utilities)"
-	mkdir -p "$subpkgdir"/usr/bin || return 1
+	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/${pkgname}_stats \
-		"$subpkgdir"/usr/bin/${pkgname}-stats || return 1
+		"$subpkgdir"/usr/bin/${pkgname}-stats
 	mv "$pkgdir"/usr/bin/${pkgname}-redirector "$subpkgdir"/usr/bin
 }
 
 fuzzy() {
 	depends="$pkgname"
 	pkgdesc="$pkgdesc (local fuzzy storage)"
-	mkdir -p "$subpkgdir"/etc/$pkgname/modules.d || return 1
+	mkdir -p "$subpkgdir"/etc/$pkgname/modules.d
 	mv "$pkgdir"/etc/$pkgname/worker-fuzzy.* \
-		"$subpkgdir"/etc/$pkgname || return 1
+		"$subpkgdir"/etc/$pkgname
 	mv "$pkgdir"/etc/$pkgname/modules.d/fuzzy_* \
 		"$subpkgdir"/etc/$pkgname/modules.d
 }
@@ -129,9 +131,9 @@ controller() {
 	depends="$pkgname"
 	pkgdesc="$pkgdesc (controller web interface)"
 	mkdir -p "$subpkgdir"/usr/share/$pkgname \
-		"$subpkgdir"/etc/$pkgname || return 1
+		"$subpkgdir"/etc/$pkgname
 	mv "$pkgdir"/usr/share/$pkgname/www \
-		"$subpkgdir"/usr/share/$pkgname || return 1
+		"$subpkgdir"/usr/share/$pkgname
 	mv "$pkgdir"/etc/$pkgname/worker-controller.* \
 		"$subpkgdir"/etc/$pkgname
 }
@@ -139,7 +141,7 @@ controller() {
 proxy() {
 	depends="$pkgname rmilter"
 	pkgdesc="$pkgdesc (milter support)"
-	mkdir -p "$subpkgdir"/etc/$pkgname || return 1
+	mkdir -p "$subpkgdir"/etc/$pkgname
 	mv "$pkgdir"/etc/$pkgname/worker-proxy.* \
 		"$subpkgdir"/etc/$pkgname
 }


### PR DESCRIPTION
The worker-proxy.conf file is missing the worker type declaration, so with the current build the proxy worker is not spawned.

This PR fixes the proxy issue and also removes the unnecessary "return 1".

Current:
![image](https://user-images.githubusercontent.com/858296/29868364-e9d1c962-8d7e-11e7-9894-d5988f96d58b.png)


Reference https://github.com/vstakhov/rspamd/blob/master/conf/rspamd.conf:
`worker "rspamd_proxy" {
    bind_socket = "*:11332";
    .include "$CONFDIR/worker-proxy.inc"
    .include(try=true; priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/worker-proxy.inc"
    .include(try=true; priority=10) "$LOCAL_CONFDIR/override.d/worker-proxy.inc"
}`