### PR TITLE
testing/libspatialite: new aport

### DIFF
--- a/testing/libspatialite/APKBUILD
+++ b/testing/libspatialite/APKBUILD
@@ -9,7 +9,7 @@ url="https://www.gaia-gis.it/fossil/libspatialite/index"
 arch="all"
 license="MPLv1.1"
 options="!check"
-makedepends="automake geos-dev sqlite-dev proj4-dev zlib-dev libxml2-dev"
+makedepends="geos-dev sqlite-dev proj4-dev zlib-dev libxml2-dev"
 install=""
 subpackages="$pkgname-dev"
 source="$pkgname-$pkgver.tar.gz::http://www.gaia-gis.it/gaia-sins/$pkgname-$_pkgver.tar.gz"
@@ -19,7 +19,9 @@ build() {
         cd "$builddir"
 
         ./configure \
-                -prefix=/usr \
+                --prefix=/usr \
+                --build=$CBUILD \
+                --host=$CHOST \
                 --enable-freexl=no
         make
 }
@@ -27,6 +29,10 @@ build() {
 package() {
         cd "$builddir"
         make DESTDIR="$pkgdir" install
+}
+
+prepare() {
+        update_config_sub
 }
 
 sha512sums="adfd63e8dde0f370b07e4e7bb557647d2bfb5549205b60bdcaaca69ff81298a3d885e7c1ca515ef56dd0aca152ae940df8b5dbcb65bb61ae0a9337499895c3c0  libspatialite-4.3.0.tar.gz"

--- a/testing/libspatialite/APKBUILD
+++ b/testing/libspatialite/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bradley J Chambers <brad.chambers@gmail.com>
+# Maintainer: Bradley J Chambers <brad.chambers@gmail.com>
+pkgname=libspatialite
+pkgver=4.3.0
+_pkgver="$pkgver"a
+pkgrel=0
+pkgdesc="SpatiaLite is an open source library intended to extend the SQLite core to support fully fledged Spatial SQL capabilities."
+url="https://www.gaia-gis.it/fossil/libspatialite/index"
+arch="all"
+license="MPLv1.1"
+options="!check"
+makedepends="automake geos-dev sqlite-dev proj4-dev zlib-dev libxml2-dev"
+install=""
+subpackages="$pkgname-dev"
+source="$pkgname-$pkgver.tar.gz::http://www.gaia-gis.it/gaia-sins/$pkgname-$_pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$_pkgver"
+
+build() {
+        cd "$builddir"
+
+        ./configure \
+                -prefix=/usr \
+                --enable-freexl=no
+        make
+}
+
+package() {
+        cd "$builddir"
+        make DESTDIR="$pkgdir" install
+}
+
+sha512sums="adfd63e8dde0f370b07e4e7bb557647d2bfb5549205b60bdcaaca69ff81298a3d885e7c1ca515ef56dd0aca152ae940df8b5dbcb65bb61ae0a9337499895c3c0  libspatialite-4.3.0.tar.gz"


### PR DESCRIPTION
https://www.gaia-gis.it/fossil/libspatialite/index
SpatiaLite is an open source library intended to extend the SQLite core to
support fully fledged Spatial SQL capabilities.