### PR TITLE
community/alpine-desktop: build on aarch64

### DIFF
--- a/community/alpine-desktop/APKBUILD
+++ b/community/alpine-desktop/APKBUILD
@@ -1,12 +1,11 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=alpine-desktop
 pkgver=2.5
-pkgrel=2
+pkgrel=3
 pkgdesc="Meta package for Alpine Desktop"
 url="http://alpinelinux.org"
-arch="noarch !aarch64" #firefox-esr not avail on excluded arches
+arch="noarch"
 license="GPL"
-makedepends=""
 depends="
 	abiword
 	audacious
@@ -29,8 +28,7 @@ depends="
 	"
 install=alpine-desktop.post-install
 options="!check"
-source=""
-builddir="$srcdir"/$pkgname-$pkgver
+builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	return 0


### PR DESCRIPTION
firefox-esr is available on aarch64 again