### PR TITLE
testing/nitro: bump pkgrel

### DIFF
--- a/testing/nitro/APKBUILD
+++ b/testing/nitro/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Bradley J Chambers <brad.chambers@gmail.com>
 # Maintainer: Bradley J Chambers <brad.chambers@gmail.com>
 pkgname=nitro
-pkgver=2.7
-_pkgver="$pkgver"dev-2
-pkgrel=1
+pkgver=2.7_beta2
+_ver=${pkgver/_beta/dev-}
+pkgrel=0
 pkgdesc="The Nitro NITF project"
 url="https://github.com/hobu/nitro"
 arch="all"
@@ -12,10 +12,10 @@ depends=""
 makedepends="cmake linux-headers"
 install=""
 subpackages="$pkgname-dev"
-source="$pkgname-$_pkgver.tar.gz::https://github.com/hobu/$pkgname/archive/$_pkgver.tar.gz
+source="$pkgname-$_ver.tar.gz::https://github.com/hobu/$pkgname/archive/$_ver.tar.gz
 	fix-path-max.patch
 	"
-builddir="$srcdir/$pkgname-$_pkgver"
+builddir="$srcdir/$pkgname-$_ver"
 options="!check"
 
 build() {

--- a/testing/nitro/APKBUILD
+++ b/testing/nitro/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=nitro
 pkgver=2.7
 _pkgver="$pkgver"dev-2
-pkgrel=0
+pkgrel=1
 pkgdesc="The Nitro NITF project"
 url="https://github.com/hobu/nitro"
 arch="all"


### PR DESCRIPTION
The previous commit updated _pkgver, but not pkgver, hence no updates to the
package in the testing repository. This commit bumps the pkgrel to pick up the
change and trigger builds.