### PR TITLE
main/mariadb: upgrade to 10.2.13, modernize

### DIFF
--- a/main/mariadb/APKBUILD
+++ b/main/mariadb/APKBUILD
@@ -2,27 +2,34 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
+# Contributor: TBK <alpine@jjtc.eu>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mariadb
-pkgver=10.1.28
-pkgrel=1
+pkgver=10.2.13
+pkgrel=0
 pkgdesc="A fast SQL database server"
 url="http://www.mariadb.org"
 pkgusers="mysql"
 pkggroups="mysql"
 arch="all"
-license="GPL"
+license="GPL-2.0"
 depends="$pkgname-common"
 depends_dev="libressl-dev zlib-dev"
-makedepends="cmake libressl-dev zlib-dev readline-dev libaio-dev ncurses-dev
-	linux-headers"
+makedepends="bison cmake curl-dev libaio-dev libarchive-dev libevent-dev libressl-dev
+	libxml2-dev ncurses-dev pcre-dev readline-dev zlib-dev xz-dev linux-headers"
 install="$pkgname.pre-install"
+subpackages="$pkgname-doc $pkgname-dev $pkgname-common
+	$pkgname-client-libs:_client_libs $pkgname-libs
+	$pkgname-client $pkgname-bench $pkgname-test:mytest
+	mysql mysql-client:_compat_client mysql-bench:_compat_bench"
 source="https://downloads.mariadb.org/interstitial/mariadb-$pkgver/source/mariadb-$pkgver.tar.gz
 	$pkgname.initd
 	fix-mysql-install-db-path.patch
 	fix-ucontext-check.patch
 	ppc-remove-glibc-dep.patch
+	pcre.cmake.patch
 	"
+builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
 #   10.1.22-r0:
@@ -41,22 +48,9 @@ source="https://downloads.mariadb.org/interstitial/mariadb-$pkgver/source/mariad
 #     - CVE-2017-3317
 #     - CVE-2017-3318
 
-subpackages="$pkgname-doc $pkgname-dev $pkgname-common
-	$pkgname-client-libs:_client_libs $pkgname-libs
-	$pkgname-client $pkgname-bench $pkgname-test:mytest
-	mysql mysql-client:_compat_client mysql-bench:_compat_bench"
-
-builddir="$srcdir/$pkgname-$pkgver"
-
-prepare() {
-	cd "$builddir"
-	for i in $source; do
-		case $i in
-			*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
-
+# Notes:
+# Available plugins https://mariadb.com/kb/en/library/list-of-plugins/
+# All cmake configuration options can be displayed with: cmake ../server -LH
 build() {
 	cd "$builddir"
 	cmake . -DBUILD_CONFIG=mysql_release \
@@ -77,43 +71,65 @@ build() {
 		-DINSTALL_MYSQLSHAREDIR=share/mysql \
 		-DINSTALL_DOCDIR=share/mysql/docs \
 		-DINSTALL_SHAREDIR=share/mysql \
-		-DWITH_READLINE=ON \
-		-DWITH_ZLIB=system \
-		-DWITH_SSL=system \
-		-DWITH_LIBWRAP=OFF \
-		-DWITH_JEMALLOC=no \
-		-DWITH_EXTRA_CHARSETS=complex \
-		-DWITH_EMBEDDED_SERVER=ON \
-		-DWITH_ARCHIVE_STORAGE_ENGINE=1 \
-		-DWITH_BLACKHOLE_STORAGE_ENGINE=1 \
-		-DWITH_INNOBASE_STORAGE_ENGINE=1 \
-		-DWITH_PARTITION_STORAGE_ENGINE=1 \
+		-DCONNECT_WITH_MYSQL=ON \
+		-DCONNECT_WITH_LIBXML2=system \
+		-DCONNECT_WITH_ODBC=NO \
+		-DCONNECT_WITH_JDBC=NO \
+		-DPLUGIN_ARCHIVE=YES \
+		-DPLUGIN_ARIA=YES \
+		-DPLUGIN_BLACKHOLE=YES \
+		-DPLUGIN_CASSANDRA=NO \
+		-DPLUGIN_CSV=YES \
+		-DPLUGIN_MYISAM=YES \
+		-DPLUGIN_MROONGA=NO \
+		-DPLUGIN_OQGRAPH=NO \
+		-DPLUGIN_PARTITION=YES \
+		-DPLUGIN_ROCKSDB=NO \
+		-DPLUGIN_SPHINX=NO \
 		-DPLUGIN_TOKUDB=NO \
-		-DWITHOUT_EXAMPLE_STORAGE_ENGINE=1 \
-		-DWITHOUT_FEDERATED_STORAGE_ENGINE=1 \
-		-DWITHOUT_PBXT_STORAGE_ENGINE=1 \
-		|| return 1
-	make || return 1
+		-DPLUGIN_AUTH_PAM=NO \
+		-DPLUGIN_AUTH_GSSAPI=NO \
+		-DPLUGIN_AUTH_GSSAPI_CLIENT=NO \
+		-DPLUGIN_CRACKLIB_PASSWORD_CHECK=NO \
+		-DWITH_ASAN=OFF \
+		-DWITH_EMBEDDED_SERVER=ON \
+		-DWITH_EXTRA_CHARSETS=complex \
+		-DWITH_INNODB_BZIP2=OFF \
+		-DWITH_INNODB_LZ4=OFF \
+		-DWITH_INNODB_LZMA=ON \
+		-DWITH_INNODB_LZO=OFF \
+		-DWITH_INNODB_SNAPPY=OFF \
+		-DWITH_JEMALLOC=NO \
+		-DWITH_LIBARCHIVE=system \
+		-DWITH_LIBNUMA=NO \
+		-DWITH_LIBWRAP=OFF \
+		-DWITH_LIBWSEP=OFF \
+		-DWITH_MARIABACKUP=ON \
+		-DWITH_PCRE=system \
+		-DWITH_READLINE=ON \
+		-DWITH_SYSTEMD=no \
+		-DWITH_SSL=system \
+		-DWITH_VALGRIND=OFF \
+		-DWITH_ZLIB=system \
+		-DSKIP_TESTS=ON # Disables the client lib tests since a running server is needed
+	make -j8
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir/" install || return 1
+	make DESTDIR="$pkgdir/" install
 
 	install -Dm 755 "$startdir"/$pkgname.initd \
-		"$pkgdir"/etc/init.d/$pkgname || return 1
+		"$pkgdir"/etc/init.d/$pkgname
 
 	# use small example config as default, which has tcp disabled
 	install -Dm 640 -o mysql  "$pkgdir"/usr/share/mysql/my-medium.cnf \
-		"$pkgdir"/etc/mysql/my.cnf || return 1
-
-	# libmysqlclient_r is no more.  Upstream tries to replace it with
-	# symlinks but that really doesn't work (wrong soname in particular).
-	# We'll keep just the devel libmysqlclient_r.so link, so that
-	# rebuilding without any source change is enough to get rid of
-	# dependency on libmysqlclient_r.
-	rm -f "$pkgdir"/usr/lib/libmysqlclient_r.so*
-	ln -s libmysqlclient.so "$pkgdir"/usr/lib/libmysqlclient_r.so
+		"$pkgdir"/etc/mysql/my.cnf
 
 	# mysql-test includes one executable that doesn't belong under
 	# /usr/share, so move it and provide a symlink
@@ -123,7 +139,7 @@ package() {
 		"$pkgdir"/usr/mysql-test/lib/My/SafeProcess/my_safe_process
 }
 
-dev(){
+dev() {
 	default_dev
 	replaces="libmysqlclient mysql-dev"
 	provides="mysql-dev=$pkgver-r$pkgrel"
@@ -136,11 +152,9 @@ _client_libs() {
 	replaces="mariadb libmysqlclient"
 	depends="mariadb-common"
 	mkdir -p "$subpkgdir"/usr/lib \
-		"$subpkgdir"/usr/share/mysql \
-		|| return 1
-	mv "$pkgdir"/usr/lib/libmysqlclient.so* \
-		"$subpkgdir"/usr/lib/ \
-		|| return 1
+		"$subpkgdir"/usr/share/mysql
+	mv "$pkgdir"/usr/lib/libmariadb.so* \
+		"$subpkgdir"/usr/lib/
 }
 
 common() {
@@ -150,40 +164,39 @@ common() {
 	mkdir -p "$subpkgdir"/usr/share/mysql \
 		"$subpkgdir"/etc \
 		"$subpkgdir"/usr/lib/mysql/plugin
-	mv "$pkgdir"/etc/mysql "$subpkgdir"/etc/ || return 1
+	mv "$pkgdir"/etc/mysql "$subpkgdir"/etc/
 	mv "$pkgdir"/usr/lib/mysql/plugin/dialog.so \
 		"$pkgdir"/usr/lib/mysql/plugin/mysql_clear_password.so \
-		"$subpkgdir"/usr/lib/mysql/plugin/ || return 1
+		"$subpkgdir"/usr/lib/mysql/plugin/
 	local lang="charsets danish english french greek italian korean norwegian-ny
 		portuguese russian slovak swedish czech dutch estonian german
 		hungarian japanese norwegian polish romanian serbian spanish
 		ukrainian"
 	for l in $lang; do
 		mv "$pkgdir"/usr/share/mysql/$l \
-			"$subpkgdir"/usr/share/mysql/ || return 1
+			"$subpkgdir"/usr/share/mysql/
 	done
 }
 
 mytest() {
 	pkgdesc="The test suite distributed with MariaDB"
-	mkdir -p "$subpkgdir"/usr/bin || return 1
+	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/mysql_client_test \
 		"$pkgdir"/usr/mysql-test \
 		"$pkgdir"/usr/bin/my_safe_process \
-		"$subpkgdir"/usr/bin/ \
-		|| return 1
+		"$subpkgdir"/usr/bin/
 }
 
 client() {
-	pkgdesc="client for the MariaDB database"
+	pkgdesc="Client for the MariaDB database"
 	depends="mariadb-common"
 	install=""
-	local bins="myisam_ftdump mysql mysqlaccess mysqladmin mysqlbug
+	local bins="myisam_ftdump mysql mysqlaccess mysqladmin
 		mysqlcheck mysqldump mysqldumpslow mysql_find_rows
 		mysql_fix_extensions mysqlimport mysqlshow mysql_waitpid"
-	mkdir -p "$subpkgdir"/usr/bin/ || return 1
+	mkdir -p "$subpkgdir"/usr/bin/
 	for i in $bins; do
-		mv "$pkgdir"/usr/bin/${i} "$subpkgdir"/usr/bin/ || return 1
+		mv "$pkgdir"/usr/bin/${i} "$subpkgdir"/usr/bin/
 	done
 }
 
@@ -204,8 +217,9 @@ mysql() { _compat mysql mariadb; }
 _compat_client() { _compat mysql-client mariadb-client; }
 _compat_bench() { _compat mysql-bench mariadb-client; }
 
-sha512sums="ca10d28f6b966719c7488c2b4ba928b65cbe9dc32ccf2a28d29c4d0c2d46ea1c59c3e339230017b317132dcd216925a71769dfba80a7d6321079c74ac41926d8  mariadb-10.1.28.tar.gz
+sha512sums="4c6038f134a32f50daa3172b367588240ef20a6f6cfe36d830e427cf52d315284481f5300d3db32d9e81ddd352dbea01fd4230f4e4d79e175d97c0c49331a4ca  mariadb-10.2.13.tar.gz
 06751768cb00d2e433655635c38d267ef25084a5830ff40e719ac579223c7192dc34b43f919ab6faf480094632327511cbd22456064dde2d04dc15648b9e3b9f  mariadb.initd
-f85e96490de56aa4e6115f931bf256bef4e1b93cadbe4ac947d6abdc03072bf2d0872e0268ae37cd98edf13538ece73e9f8b6efa8133bab23168a825c5066ab1  fix-mysql-install-db-path.patch
-82fa93411483f5d1b57d978087a891bcab6a011e45c2d79b08d28718f5717994b423fc81d2170dad2fe65303153ac29655a81ce5039e73e37cebb159392a86cf  fix-ucontext-check.patch
-a352661d19becae717c16ac67a0e47ed93787653851a75d27e7764133b31dc02e18c38dbbce6d3138e4db08da616dfc75a0141865cd042cef669d6afe4463127  ppc-remove-glibc-dep.patch"
+88d9084c8ca3a94e6e1a7fa91091f577ee063f4b13046cc805f61f3be37993b98c79665e5995d8b6b7fa10efbe00fcbde638db5b0b59f0d5e0e951b24b5108e9  fix-mysql-install-db-path.patch
+021db7a2f783b517e63d16eb31a3d251a2b02eedfd1edbfde3026efaccd77c594f83a49b632acbccebed863578e197a4e57851ea84460006a10c5881870b55cb  fix-ucontext-check.patch
+81d2a95bfbce35fab6e1780f4201320e5621f470591020d707801dcf31f5fad3cb5d7b781a186b2914c6559a8fdc8f13e31e7cdde0af360ad56cedf80e491bc0  ppc-remove-glibc-dep.patch
+70da971aa78815495098205bcbd28428430aa83c3f1050fec0231ca86af9d9def2d2108a48ee08d86812c8dc5ad8ab1ef4e17a49b4936ed5187ae0f6a7ef8f63  pcre.cmake.patch"

--- a/main/mariadb/fix-mysql-install-db-path.patch
+++ b/main/mariadb/fix-mysql-install-db-path.patch
@@ -1,6 +1,6 @@
 --- a/scripts/CMakeLists.txt
 +++ b/scripts/CMakeLists.txt
-@@ -175,23 +175,13 @@
+@@ -167,23 +167,13 @@
  # i.e. makes access relative the current directory. This matches
  # the documentation, so better not change this.
  

--- a/main/mariadb/fix-ucontext-check.patch
+++ b/main/mariadb/fix-ucontext-check.patch
@@ -1,10 +1,9 @@
-diff -ru mariadb-10.1.12.orig/configure.cmake mariadb-10.1.12/configure.cmake
---- mariadb-10.1.12.orig/configure.cmake	2016-02-24 16:25:21.000000000 +0200
-+++ mariadb-10.1.12/configure.cmake	2016-03-08 21:11:52.767533395 +0200
-@@ -1087,9 +1087,12 @@
- CHECK_STRUCT_HAS_MEMBER("struct dirent" d_ino "dirent.h"  STRUCT_DIRENT_HAS_D_INO)
- CHECK_STRUCT_HAS_MEMBER("struct dirent" d_namlen "dirent.h"  STRUCT_DIRENT_HAS_D_NAMLEN)
- SET(SPRINTF_RETURNS_INT 1)
+--- a/configure.cmake
++++ b/configure.cmake
+@@ -1018,9 +1018,12 @@
+ 
+ SET(CMAKE_EXTRA_INCLUDE_FILES) 
+ 
 -CHECK_INCLUDE_FILE(ucontext.h HAVE_UCONTEXT_H)
 -IF(NOT HAVE_UCONTEXT_H)
 -  CHECK_INCLUDE_FILE(sys/ucontext.h HAVE_UCONTEXT_H)

--- a/main/mariadb/pcre.cmake.patch
+++ b/main/mariadb/pcre.cmake.patch
@@ -1,0 +1,15 @@
+--- a/cmake/pcre.cmake
++++ b/cmake/pcre.cmake
+@@ -8,11 +8,7 @@
+     CHECK_LIBRARY_EXISTS(pcre pcre_stack_guard "" HAVE_PCRE_STACK_GUARD)
+     IF(NOT CMAKE_CROSSCOMPILING)
+       SET(CMAKE_REQUIRED_LIBRARIES "pcre")
+-      CHECK_C_SOURCE_RUNS("
+-        #include <pcre.h>
+-        int main() {
+-        return -pcre_exec(NULL, NULL, NULL, -999, -999, 0, NULL, 0) < 256;
+-        }"  PCRE_STACK_SIZE_OK)
++      SET(PCRE_STACK_SIZE_OK TRUE)
+       SET(CMAKE_REQUIRED_LIBRARIES)
+     ENDIF()
+   ENDIF()

--- a/main/mariadb/ppc-remove-glibc-dep.patch
+++ b/main/mariadb/ppc-remove-glibc-dep.patch
@@ -27,12 +27,14 @@ directly was the first solution adopted in MariaDB [2].
 
 --- a/storage/xtradb/include/ut0ut.h
 +++ b/storage/xtradb/include/ut0ut.h
-@@ -86,8 +86,7 @@
+@@ -85,9 +85,8 @@
+    the YieldProcessor macro defined in WinNT.h. It is a CPU architecture-
     independent way by using YieldProcessor. */
  #  define UT_RELAX_CPU() YieldProcessor()
- # elif defined(__powerpc__)
+-# elif defined(__powerpc__) && defined __GLIBC__
 -#include <sys/platform/ppc.h>
 -#  define UT_RELAX_CPU() __ppc_get_timebase()
++# elif defined(__powerpc__)
 +#  define UT_RELAX_CPU() __builtin_ppc_get_timebase()
  # else
  #  define UT_RELAX_CPU() ((void)0) /* avoid warning for an empty statement */
@@ -44,32 +46,34 @@ directly was the first solution adopted in MariaDB [2].
 -#include <sys/platform/ppc.h>
 -#  define UT_LOW_PRIORITY_CPU() __ppc_set_ppr_low()
 -#  define UT_RESUME_PRIORITY_CPU() __ppc_set_ppr_med()
-+#  define UT_LOW_PRIORITY_CPU()    __asm__ __volatile__ ("or 1,1,1")
++#  define UT_LOW_PRIORITY_CPU() __asm__ __volatile__ ("or 1,1,1")
 +#  define UT_RESUME_PRIORITY_CPU() __asm__ __volatile__ ("or 2,2,2")
  # else
  #  define UT_LOW_PRIORITY_CPU() ((void)0)
  #  define UT_RESUME_PRIORITY_CPU() ((void)0)
 --- a/storage/innobase/include/ut0ut.h
 +++ b/storage/innobase/include/ut0ut.h
-@@ -89,8 +89,7 @@
+@@ -70,9 +70,8 @@
+    the YieldProcessor macro defined in WinNT.h. It is a CPU architecture-
     independent way by using YieldProcessor. */
- #  define UT_RELAX_CPU() YieldProcessor()
- # elif defined(__powerpc__)
--#include <sys/platform/ppc.h>
--#  define UT_RELAX_CPU() __ppc_get_timebase()
-+#  define UT_RELAX_CPU() __builtin_ppc_get_timebase()
- # else
- #  define UT_RELAX_CPU() ((void)0) /* avoid warning for an empty statement */
- # endif
-@@ -104,9 +103,8 @@
+ # define UT_RELAX_CPU() YieldProcessor()
+-#elif defined(__powerpc__) && defined __GLIBC__
+-# include <sys/platform/ppc.h>
+-# define UT_RELAX_CPU() __ppc_get_timebase()
++#elif defined(__powerpc__)
++# define UT_RELAX_CPU() __builtin_ppc_get_timebase()
+ #else
+ # define UT_RELAX_CPU() do { \
+      volatile int32	volatile_var; \
+@@ -90,9 +89,8 @@
  #endif
  
- # if defined(HAVE_HMT_PRIORITY_INSTRUCTION)
--#include <sys/platform/ppc.h>
--#  define UT_LOW_PRIORITY_CPU() __ppc_set_ppr_low()
--#  define UT_RESUME_PRIORITY_CPU() __ppc_set_ppr_med()
-+#  define UT_LOW_PRIORITY_CPU()    __asm__ __volatile__ ("or 1,1,1")
-+#  define UT_RESUME_PRIORITY_CPU() __asm__ __volatile__ ("or 2,2,2")
- # else
- #  define UT_LOW_PRIORITY_CPU() ((void)0)
- #  define UT_RESUME_PRIORITY_CPU() ((void)0)
+ #if defined(HAVE_HMT_PRIORITY_INSTRUCTION)
+-# include <sys/platform/ppc.h>
+-# define UT_LOW_PRIORITY_CPU() __ppc_set_ppr_low()
+-# define UT_RESUME_PRIORITY_CPU() __ppc_set_ppr_med()
++# define UT_LOW_PRIORITY_CPU() __asm__  __volatile__ ("or 1,1,1")
++# define UT_RESUME_PRIORITY_CPU() __asm__ __volatile__ ("or 2,2,2")
+ #else
+ # define UT_LOW_PRIORITY_CPU() ((void)0)
+ # define UT_RESUME_PRIORITY_CPU() ((void)0)


### PR DESCRIPTION
After a lot of fiddeling and 3 hours of compiling I think it is in a state where it is ready for some feedback.

Things that I question:
- Should the cmake flags be updated?
- Related to the previous question - the official deb build uses quite a few more makedepends. Should more be added? (https://github.com/MariaDB/server/blob/10.2/debian/control)
- All of the symlinks for the mariadb-client-libs are missing. I am not sure how to fix that:
```
libmariadb.so -> libmariadb.so.3
libmariadb.so.3
libmysqlclient_r.so -> libmariadb.so.3
libmysqlclient.so -> libmariadb.so.3
```
- Should there be added a check function to run the test suite?