### PR TITLE
community/go: don't build cross-compilers

### DIFF
--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -30,8 +30,7 @@ if [ "$CBUILD" = "$CTARGET" ]; then
 	makedepends="go-bootstrap $makedepends"
 	provides="go-bootstrap=$pkgver-r$pkgrel"
 	subpackages="$subpackages $pkgname-tools"
-	_gotools="godoc stringer"
-	_gocross="darwin freebsd openbsd windows"
+	_gotools="cover godoc stringer"
 else
 	pkgname="go-bootstrap"
 	makedepends="go $makedepends"
@@ -43,9 +42,6 @@ else
 fi
 
 _tooldir="$srcdir"/tools-${_toolsver}
-for os in $_gocross; do
-	subpackages="$subpackages $pkgname-cross-${os}:_crosspkg"
-done
 
 case "$CTARGET_ARCH" in
 aarch64)export GOARCH="arm64" ;;
@@ -151,18 +147,6 @@ tools() {
 			ln -s /usr/lib/go/bin/"$tool" "$subpkgdir"/usr/bin/
 		fi
 	done
-}
-
-_crosspkg() {
-	local name="$(echo "${subpkgname}" | cut -d '-' -f3)"
-	pkgdesc="Go cross compiler for $name"
-	depends="$pkgname"
-
-	mkdir -p "$subpkgdir"/usr/lib/go/pkg/tool/
-	mv "$pkgdir"/usr/lib/go/pkg/tool/${name}_* \
-		"$subpkgdir"/usr/lib/go/pkg/tool/
-	mv "$pkgdir"/usr/lib/go/pkg/${name}_* \
-		"$subpkgdir"/usr/lib/go/pkg/
 }
 
 sha512sums="70c4b892b6883fb21fc1a547a2b8d174df8c7aca282a3906e3816b4442b16c5da578b69c19443122a4a45e66fc95d170528d826b70932af09f4afd2a46615d74  go1.9.src.tar.gz


### PR DESCRIPTION
Cross-compiler subpackages like this have not been needed [since Go 1.5](https://dave.cheney.net/2015/08/22/cross-compilation-with-go-1-5).