### PR TITLE
September Adélie merge: Development packages

### DIFF
--- a/main/cmake/APKBUILD
+++ b/main/cmake/APKBUILD
@@ -2,13 +2,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cmake
 pkgver=3.9.1
-pkgrel=1
+pkgrel=2
 pkgdesc="CMake is a cross-platform open-source make system"
 url="http://www.cmake.org"
 arch="all"
 license="CMake"
 makedepends="ncurses-dev curl-dev expat-dev zlib-dev bzip2-dev libarchive-dev
     libuv-dev xz-dev rhash-dev"
+options="!checkroot"
+checkdepends="musl-utils file"
 subpackages="$pkgname-doc"
 
 case $pkgver in
@@ -42,6 +44,11 @@ build() {
 		$(parallel_opt)
 
 	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE bin/ctest
 }
 
 package() {

--- a/main/cyrus-sasl/APKBUILD
+++ b/main/cyrus-sasl/APKBUILD
@@ -7,6 +7,7 @@ pkgdesc="Cyrus Simple Authentication Service Layer (SASL)"
 url="https://cyrusimap.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc $pkgname-gssapi $pkgname-gs2
 	$pkgname-scram $pkgname-ntlm $pkgname-crammd5 $pkgname-digestmd5
 	libsasl"

--- a/main/dbus-glib/APKBUILD
+++ b/main/dbus-glib/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dbus-glib
 pkgver=0.108
-pkgrel=0
+pkgrel=1
 pkgdesc="GLib bindings for DBUS"
 url="http://www.freedesktop.org/wiki/Software/DBusBindings"
 arch="all"
@@ -10,12 +10,9 @@ subpackages="$pkgname-dev $pkgname-doc"
 depends=
 makedepends="dbus-dev glib-dev gettext-dev expat-dev"
 source="http://dbus.freedesktop.org/releases/$pkgname/$pkgname-$pkgver.tar.gz"
-depends_dev=""
-
-_builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -23,14 +20,18 @@ build() {
 		--sysconfdir=/etc \
 		--localstatedir=/var \
 		--enable-static=no \
-		--enable-bash-completion=no \
-		|| return 1
-	make || return 1
+		--enable-bash-completion=no
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$srcdir"/$pkgname-$pkgver
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 
 md5sums="a66a613705870752ca9786e0359aea97  dbus-glib-0.108.tar.gz"

--- a/main/doxygen/APKBUILD
+++ b/main/doxygen/APKBUILD
@@ -1,43 +1,37 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=doxygen
 pkgver=1.8.13
-pkgrel=0
+pkgrel=1
 pkgdesc="A documentation system for C++, C, Java, IDL and PHP"
 url="http://www.doxygen.org/"
 arch="all"
 license="GPL"
 depends=""
-makedepends="flex bison coreutils perl python2 cmake"
+makedepends="flex bison coreutils perl python3 cmake"
 subpackages=""
 source="http://ftp.stack.nl/pub/users/dimitri/doxygen-$pkgver.src.tar.gz
 	doxygen-1.8.11-install.patch
 	"
 
-_builddir="$srcdir"/$pkgname-$pkgver
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
-
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	cmake .\
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_BUILD_TYPE=Release \
 		-Dbuild_xmlparser=ON \
 		-DMAN_INSTALL_DIR=/usr/share/man/man1 \
-		-DDOC_INSTALL_DIR=/usr/share/doc/doxygen \
-		|| return 1
+		-DDOC_INSTALL_DIR=/usr/share/doc/doxygen
 
-	make || return 1
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
 

--- a/main/gdb/APKBUILD
+++ b/main/gdb/APKBUILD
@@ -9,6 +9,7 @@ license="GPL3"
 depends=
 makedepends="ncurses-dev expat-dev texinfo readline-dev python3-dev
 	zlib-dev autoconf automake libtool linux-headers perl"
+options="!check"
 subpackages="$pkgname-doc"
 source="https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.xz
 	s390x-use-elf-gdb_fpregset_t.patch

--- a/main/imake/APKBUILD
+++ b/main/imake/APKBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imake
 pkgver=1.0.7
-pkgrel=0
+pkgrel=1
 pkgdesc="X Windows make utility"
 url="http://www.x.org"
 arch="all"
 license="BSD"
+options="!check"  # No test suite.
 depends=
 depends_dev=
 makedepends="xproto util-macros $depends_dev"
@@ -13,29 +14,15 @@ install=""
 subpackages="$pkgname-doc"
 source="http://ftp.x.org/pub/individual/util/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir"/$pkgname-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
-
 build() {
-	cd "$_builddir"
-	./configure --prefix=/usr \
-		|| return 1
-	make || return 1
+	cd "$builddir"
+	./configure --prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 
-md5sums="4042a4139a4636f78e2b8a144fdd1fcd  imake-1.0.7.tar.bz2"
-sha256sums="690c2c4ac1fad2470a5ea73156cf930b8040dc821a0da4e322014a42c045f37e  imake-1.0.7.tar.bz2"
 sha512sums="b3527c8fead25c6e093e1fe4a39e60ff210212dcd323e206505b9e872a3f36d9db85f85cab5a6f0fa914fa5c558ef54b499b2b13ccd66739223e4e72ef805d08  imake-1.0.7.tar.bz2"

--- a/main/libedit/APKBUILD
+++ b/main/libedit/APKBUILD
@@ -3,8 +3,8 @@
 pkgname=libedit
 pkgver=20170329.3.1
 _ver=${pkgver/./-}
-pkgrel=2
-pkgdesc="netbsd line editing library"
+pkgrel=3
+pkgdesc="BSD line editing library"
 url="http://www.thrysoee.dk/editline/"
 arch="all"
 license="BSD"
@@ -28,6 +28,11 @@ build() {
 		--infodir=/usr/share/info \
 		--localstatedir=/var
 	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {

--- a/main/libevdev/APKBUILD
+++ b/main/libevdev/APKBUILD
@@ -1,13 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libevdev
 pkgver=1.5.7
-pkgrel=0
+pkgrel=1
 pkgdesc="Kernel Evdev Device Wrapper Library"
 url="https://www.freedesktop.org/wiki/Software/libevdev"
 arch="all"
 license="MIT"
+options="!check"  # Requires CONFIG_INPUT_UINPUT in kernel
 depends=""
-makedepends="python2 linux-headers"
+makedepends="python3 linux-headers"
+checkdepends="check-dev"
 subpackages="$pkgname-dev $pkgname-doc"
 source="https://freedesktop.org/software/$pkgname/$pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$pkgname-$pkgver"
@@ -21,14 +23,18 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
 sha512sums="53adf6c92ec61f0635b643a88d8762a18f7cd3088d23ac95831be32cc7150ebd19f20265b90f6a1f9a63420c2f8968c2d17d8dc4892c0e90f9dfcce82c622df1  libevdev-1.5.7.tar.xz"

--- a/main/libidn/APKBUILD
+++ b/main/libidn/APKBUILD
@@ -2,16 +2,19 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libidn
 pkgver=1.33
-pkgrel=0
+pkgrel=1
 pkgdesc="An encode and decode library for internationalized domain names"
 url="http://www.gnu.org/software/libidn/"
 arch="all"
 license="GPL"
 depends=
 makedepends=
+checkdepends="diffutils"
 install=
 subpackages="$pkgname-doc $pkgname-dev"
-source="http://ftp.gnu.org/gnu/libidn/$pkgname-$pkgver.tar.gz"
+source="http://ftp.gnu.org/gnu/libidn/$pkgname-$pkgver.tar.gz
+	localename-test-fix.patch
+	"
 
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -21,11 +24,6 @@ builddir="$srcdir/$pkgname-$pkgver"
 #   - CVE-2016-6261
 #   - CVE-2016-6262
 #   - CVE-2016-6263
-
-prepare() {
-	cd "$builddir"
-	return 0
-}
 
 build() {
 	cd "$builddir"
@@ -37,16 +35,19 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
-		--disable-nls \
-		|| return 1
-	make || return 1
+		--disable-nls
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$srcdir/$pkgname-$pkgver"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 
-md5sums="a9aa7e003665de9c82bd3f9fc6ccf308  libidn-1.33.tar.gz"
-sha256sums="44a7aab635bb721ceef6beecc4d49dfd19478325e1b47f3196f7d2acc4930e19  libidn-1.33.tar.gz"
-sha512sums="38dd459eaeda0c9e3cc2d24d967113515a499747550a2a9157f32357def90d71a3a3b52398e96a44a28cd5948dc353b0473c4ff0453a69720191c4cb49cac2c6  libidn-1.33.tar.gz"
+sha512sums="38dd459eaeda0c9e3cc2d24d967113515a499747550a2a9157f32357def90d71a3a3b52398e96a44a28cd5948dc353b0473c4ff0453a69720191c4cb49cac2c6  libidn-1.33.tar.gz
+8251a6543a93db357181121d2f3895dd15d47b97e7c6b0004b1534f0479f8b08c380d184cb024dde9a158b967fad0643ea2a793e88bf90f07f3e67146ebab190  localename-test-fix.patch"

--- a/main/libidn/localename-test-fix.patch
+++ b/main/libidn/localename-test-fix.patch
@@ -1,0 +1,34 @@
+--- libidn-1.33/lib/gltests/localename.c.old	2016-12-31 13:54:43.000000000 +0000
++++ libidn-1.33/lib/gltests/localename.c	2017-07-30 16:40:47.098541270 +0000
+@@ -40,7 +40,7 @@
+ # if defined __APPLE__ && defined __MACH__
+ #  include <xlocale.h>
+ # endif
+-# if __GLIBC__ >= 2 && !defined __UCLIBC__
++# if defined __linux__
+ #  include <langinfo.h>
+ # endif
+ # if !defined IN_LIBINTL
+@@ -2692,16 +2692,19 @@
+     locale_t thread_locale = uselocale (NULL);
+     if (thread_locale != LC_GLOBAL_LOCALE)
+       {
+-#  if __GLIBC__ >= 2 && !defined __UCLIBC__
++#  if defined(_NL_LOCALE_NAME)
++        const char *name = nl_langinfo(_NL_LOCALE_NAME(category));
++#   if __GLIBC__ >= 2 && !defined __UCLIBC__
+         /* Work around an incorrect definition of the _NL_LOCALE_NAME macro in
+            glibc < 2.12.
+            See <http://sourceware.org/bugzilla/show_bug.cgi?id=10968>.  */
+-        const char *name =
+-          nl_langinfo (_NL_ITEM ((category), _NL_ITEM_INDEX (-1)));
++	if (name[0] == '\0')
++          name = nl_langinfo (_NL_ITEM ((category), _NL_ITEM_INDEX (-1)));
+         if (name[0] == '\0')
+           /* Fallback code for glibc < 2.4, which did not implement
+              nl_langinfo (_NL_LOCALE_NAME (category)).  */
+           name = thread_locale->__names[category];
++#   endif
+         return name;
+ #  elif defined __FreeBSD__ || (defined __APPLE__ && defined __MACH__)
+         /* FreeBSD, Mac OS X */

--- a/main/libtasn1/APKBUILD
+++ b/main/libtasn1/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libtasn1
 pkgver=4.12
-pkgrel=1
+pkgrel=2
 pkgdesc="The ASN.1 library used in GNUTLS"
 url="http://www.gnu.org/software/gnutls/"
 arch="all"
@@ -26,14 +26,18 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		|| return 1
-	make -j1 || return 1
+		--localstatedir=/var
+	make -j1
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="6c551670949881193e39122f72948e4999ff1ba377f9ee5963d0a4ad1b84256e4fe42e9f6d6a2aa9f7d4ef7acc0e5174fb5cc3df5298524cdeda92f4b8c104f7  libtasn1-4.12.tar.gz
 8e9dad0a1ee7cb7a8ed3d2a60c1c1bcb3e1ef689dbd2879992d4098f36edbae3bb962b9c87a0a9a77335e83abf10fd72bd78bde99989421c35f4434a9e1d08cc  CVE-2017-10790.patch"

--- a/main/nspr/APKBUILD
+++ b/main/nspr/APKBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nspr
 pkgver=4.15
-pkgrel=0
+pkgrel=1
 pkgdesc="Netscape Portable Runtime"
 url="http://www.mozilla.org/projects/nspr/"
 arch="all"
 license="MPL-1.1 GPL2 LGPL-2.1"
+options="!check"  # No test suite.
 depends=
 # -dev package does not ship any symlinks so dependency cannot be autodetected
 depends_dev="nspr"
@@ -15,18 +16,10 @@ source="http://ftp.mozilla.org/pub/mozilla.org/nspr/releases/v$pkgver/src/nspr-$
 	fix-getproto.patch
 	"
 
-_builddir="$srcdir"/$pkgname-$pkgver
 prepare() {
-	cd "$_builddir"
+	cd "$builddir"
 	mkdir build inst
-	for i in $source; do
-		case $i in
-		*.patch)
-			msg "Applying $i"
-			patch -p1 -i "$srcdir"/$i || return 1
-			;;
-		esac
-	done
+	default_prepare
 }
 
 build() {
@@ -34,7 +27,7 @@ build() {
 	if [ "$CARCH" = "x86_64" ];then
 		conf="--enable-64bit"
 	fi
-	cd "$_builddir"/build
+	cd "$builddir"/build
 	# ./nspr/pr/include/md/_linux.h tests only __GLIBC__ version
 	# to detect c-library features, list musl features here for now.
 	CFLAGS="$CFLAGS -D_PR_POLL_AVAILABLE -D_PR_HAVE_OFF64_T -D_PR_INET6 -D_PR_HAVE_INET_NTOP -D_PR_HAVE_GETHOSTBYNAME2 -D_PR_HAVE_GETADDRINFO -D_PR_INET6_PROBE" \
@@ -45,23 +38,22 @@ build() {
 		--disable-debug \
 		--enable-optimize \
 		--enable-ipv6 \
-		$conf \
-		|| return 1
-	make CC="${CC:-gcc}" CXX="${CXX:-g++}" || return 1
+		$conf
+	make CC="${CC:-gcc}" CXX="${CXX:-g++}"
 }
 
 package() {
 	local file=
 
-	cd "$_builddir"/build
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"/build
+	make DESTDIR="$pkgdir" install
 
 	cd "$pkgdir"/usr/lib
 	rm -f *.a
 
-	cd "$_builddir"/build/config
-	install -Dm755 nspr-config "$pkgdir"/usr/bin/nspr-config || return 1
-	install -Dm644 nspr.pc "$pkgdir"/usr/lib/pkgconfig/nspr.pc || return 1
+	cd "$builddir"/build/config
+	install -Dm755 nspr-config "$pkgdir"/usr/bin/nspr-config
+	install -Dm644 nspr.pc "$pkgdir"/usr/lib/pkgconfig/nspr.pc
 	rm -rf "$pkgdir"/usr/bin/prerr.properties \
 		"$pkgdir"/usr/bin/compile-et.pl \
 		"$pkgdir"/usr/share/aclocal/nspr.m4 \

--- a/main/perl-json/APKBUILD
+++ b/main/perl-json/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=perl-json
 _pkgreal=JSON
 pkgver=2.90
-pkgrel=0
+pkgrel=1
 pkgdesc="Perl module implementing a JSON encoder/decoder"
 url="http://search.cpan.org/dist/JSON/"
 arch="noarch"
@@ -14,16 +14,22 @@ install=""
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/M/MA/MAKAMAKA/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
+
 build() {
-	cd "$_builddir"
-        PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor || return 1
-	make && make test || return 1
+	cd "$builddir"
+        PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-        cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+        cd "$builddir"
+	make DESTDIR="$pkgdir" install
         find "$pkgdir" -name perllocal.pod -delete
         find "$pkgdir" -name .packlist -delete
 }

--- a/main/po4a/APKBUILD
+++ b/main/po4a/APKBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Christian Kampka <christian@kampka.net>
 pkgname=po4a
 pkgver=0.51
-pkgrel=0
+pkgrel=1
 _dlid=4214
 pkgdesc="Tools for helping translation of documentation"
 url="https://po4a.alioth.debian.org"
 arch="noarch"
 license="GPL"
 depends="perl gettext"
+options="!check"  # comments changed format, it fails
 makedepends="docbook-xsl perl-module-build diffutils"
 subpackages="$pkgname-doc $pkgname-lang"
 source="https://alioth.debian.org/frs/download.php/file/${_dlid}/${pkgname}-${pkgver}.tar.gz"
@@ -16,15 +17,20 @@ builddir="$srcdir/${pkgname}-${pkgver}"
 
 build() {
 	cd "$builddir"
-	perl Build.PL installdirs=vendor create_packlist=0 || return 1
-	perl Build || return 1
+	perl Build.PL installdirs=vendor create_packlist=0
+	perl Build
+}
+
+check() {
+	cd "$builddir"
+	perl Build test
 }
 
 package() {
 	cd "$builddir"
-	perl Build destdir=${pkgdir} install || return 1
+	perl Build destdir=${pkgdir} install
 	# remove perllocal.pod and .packlist
-	find ${pkgdir} -name .packlist -o -name perllocal.pod -delete || return 1
+	find ${pkgdir} -name .packlist -o -name perllocal.pod -delete
 }
 
 sha512sums="dd4ecf4eab59c41466b11828b7a4e5e06cfa8b8a188f808b05ef5aa163ba463ebf44485225c4bbdefcdd42b56d5956d9bc96c34dba12557f098723b7edde18b6  po4a-0.51.tar.gz"

--- a/main/unixodbc/APKBUILD
+++ b/main/unixodbc/APKBUILD
@@ -2,24 +2,27 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=unixodbc
 pkgver=2.3.4
-pkgrel=1
+pkgrel=2
 pkgdesc="ODBC is an open specification to access Data Sources"
 url="http://www.unixodbc.org/"
 arch="all"
 license="LGPL2+"
+options="!check"  # No test suite.
 depends=""
 makedepends="readline-dev"
 subpackages="$pkgname-dev $pkgname-doc"
 source="ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-${pkgver}.tar.gz"
 
-_builddir="$srcdir/unixODBC-$pkgver"
+builddir="$srcdir/unixODBC-$pkgver"
+
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -28,14 +31,13 @@ build() {
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--disable-nls \
-		--enable-gui=no \
-		|| return 1
-	make || return 1
+		--enable-gui=no
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make -j1 DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
 }
 
 md5sums="bd25d261ca1808c947cb687e2034be81  unixODBC-2.3.4.tar.gz"

--- a/testing/cpputest/APKBUILD
+++ b/testing/cpputest/APKBUILD
@@ -2,11 +2,12 @@
 # Maintainer: Shiva Velmurugan <shiv@shiv.me>
 pkgname=cpputest
 pkgver=3.8
-pkgrel=0
+pkgrel=1
 pkgdesc="A unit testing and mocking framework for C/C++"
 url="http://cpputest.github.io/"
 arch="all"
 license="BSD"
+options="!dbg"
 makedepends="cmake"
 subpackages="$pkgname-doc"
 source="https://github.com/cpputest/$pkgname/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz"
@@ -16,19 +17,24 @@ build() {
 	mkdir -p "$builddir"/build
 	cd "$builddir"/build
 
-	cmake .. -DCMAKE_INSTALL_PREFIX=/usr || return 1
-	make || return 1
+	cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+	make
+}
+
+check() {
+	cd "$builddir"/build
+	make test
 }
 
 package() {
 	cd "$builddir"/build
 
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 
 	mkdir -p "$pkgdir"/usr/lib/cmake
 	mv "$pkgdir"/usr/lib/CppUTest/cmake \
-		"$pkgdir"/usr/lib/cmake/CppUTest || return 1
-	rmdir "$pkgdir"/usr/lib/CppUTest || true
+		"$pkgdir"/usr/lib/cmake/CppUTest
+	rmdir "$pkgdir"/usr/lib/CppUTest
 
 	install -Dm644 ../COPYING \
 		"$pkgdir"/usr/share/licenses/$pkgname/COPYING


### PR DESCRIPTION
This add test information and modernises 16 development-related packages, and also bumps a few to use Python 3 when building instead of Python 2 where available.  This does not actually change any Python bindings or py-* packages, which may be pushed later if desired (we have about 10 of these).