### PR TITLE
community/tor: upgrade to 0.3.1.7

### DIFF
--- a/community/tor/APKBUILD
+++ b/community/tor/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Christine Dodrill <me@christine.website>
 # Maintainer: Christine Dodrill <me@christine.website>
 pkgname=tor
-pkgver=0.3.0.10
+pkgver=0.3.1.7
 pkgrel=0
 pkgdesc="Anonymous network connectivity"
 url="https://www.torproject.org"
@@ -18,6 +18,7 @@ source="https://www.torproject.org/dist/$pkgname-$pkgver.tar.gz
 	tor.confd
 	torrc.sample.patch"
 builddir="$srcdir/$pkgname-$pkgver"
+options="!check"
 
 # secfixes:
 #   0.3.0.8-r0:
@@ -53,7 +54,7 @@ package() {
 		"$pkgdir"/etc/conf.d/$pkgname || return 1
 }
 
-sha512sums="e39d56afb6a10194303483552f28f07e5d7b7c5d470de554d92723c8d3c0d5d5a98fc44d23aa9d51bfda51e7d7cbb48fc4d1e3ac82150aeb4ce3e1616695225a  tor-0.3.0.10.tar.gz
+sha512sums="a835526984187fad88cffc39ea8f6a4b61d5f8d2579b5a66425612607a22ff82e0f9da96e029e134e04d25ae0f59a1b4f771e9e8c19ebb563e1a0f5b3a3849e4  tor-0.3.1.7.tar.gz
 6de4ada16ba58264a247da70343eabd763e992d6b6683977fc1c67b7b4a9731748a7ec9751e869ad4b4ae9c72cf71b2e12dc289bb6e2aee499917f7663f4a735  tor.initd
 2b0de119bfdf9eb57e13317b7392190b1b8272c8f96023c71d3fc29215d887e9a3d0ffcef37cdb50b18d34e4b2251f75a739e258e0bb72aabd3339418b22fd67  tor.confd
 da386ff7e387312e647f04d360517a1f4cb1efbee36f4a3a6feb89a979bb12fa350fe6dfed49af0cb076ae30bb0c527b5d54127683eaa5aa45d6940dddd89dfb  torrc.sample.patch"


### PR DESCRIPTION
Upgrades users to the [latest and greatest](https://blog.torproject.org/tor-0317-now-released) onion routing tool everyone knows and loves.