### PR TITLE
September Adélie merge: X11 libraries

### DIFF
--- a/main/libepoxy/APKBUILD
+++ b/main/libepoxy/APKBUILD
@@ -2,28 +2,22 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libepoxy
 pkgver=1.4.3
-pkgrel=0
+pkgrel=1
 pkgdesc="Direct Rendering Manager runtime library"
 url="http://github.com/anholt/libepoxy"
 arch="all"
 license="MIT"
+options="!check"  # Requires dlvsym
 depends=""
 depends_dev="libx11-dev mesa-dev"
-makedepends="$depends_dev autoconf automake libtool util-macros python2"
+makedepends="$depends_dev autoconf automake libtool util-macros python3"
 install=""
 subpackages="$pkgname-dev"
-source="libepoxy-$pkgver.tar.gz::https://codeload.github.com/anholt/libepoxy/tar.gz/v$pkgver"
 source="https://github.com/anholt/libepoxy/releases/download/$pkgver/libepoxy-$pkgver.tar.xz"
 
-builddir="$srcdir"/libepoxy-$pkgver
 prepare() {
-	local i
 	cd "$builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
+	default_prepare
 	autoreconf -vif
 }
 
@@ -35,14 +29,18 @@ build() {
 		--prefix=/usr \
 		--mandir=/usr/share/man \
 		--disable-static \
-		--enable-shared \
-		|| return 1
-	make || return 1
+		--enable-shared
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
 	cd "$builddir"
-	make install DESTDIR="$pkgdir" || return 1
+	make install DESTDIR="$pkgdir"
 }
 
 sha512sums="f5d9fc74b062a0a90aea3abd7621ee4e2e27db359b82cacfbc8df64bceb4b7e4910755a078b46793b25e89d2e87ecb75556313dbad986aa4346f763dd43d2749  libepoxy-1.4.3.tar.xz"

--- a/main/libfontenc/APKBUILD
+++ b/main/libfontenc/APKBUILD
@@ -1,24 +1,19 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libfontenc
 pkgver=1.1.3
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 font encoding library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 depends=
-makedepends="xproto zlib-dev"
+makedepends="util-macros xproto zlib-dev"
 subpackages="$pkgname-dev"
 source="http://www.x.org/releases/individual/lib/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
-prepare() {
-	cd "$_builddir"
-}
-
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -26,14 +21,13 @@ build() {
 		--sysconfdir=/etc \
 		--localstatedir=/var \
 		--disable-static \
-		--with-encodingsdir=/usr/share/fonts/encodings \
-		|| return 1
-	make || return 1
+		--with-encodingsdir=/usr/share/fonts/encodings
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 md5sums="0920924c3a9ebc1265517bdd2f9fde50  libfontenc-1.1.3.tar.bz2"
 sha256sums="70588930e6fc9542ff38e0884778fbc6e6febf21adbab92fd8f524fe60aefd21  libfontenc-1.1.3.tar.bz2"

--- a/main/libice/APKBUILD
+++ b/main/libice/APKBUILD
@@ -1,37 +1,40 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libice
 pkgver=1.0.9
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 Inter-Client Exchange library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
 depends=
-depends_dev="xproto"
-makedepends="xproto xtrans"
+makedepends="xproto xtrans util-macros xmlto check-dev"
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://www.x.org/releases/individual/lib/libICE-$pkgver.tar.bz2"
 
-_builddir="$srcdir/libICE-$pkgver"
-
-prepare() {
-	cd "$_builddir"
-}
+builddir="$srcdir/libICE-$pkgver"
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
 		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--enable-ipv6 \
+		--enable-docs \
+		--with-xmlto \
+		--without-fop
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$srcdir"/libICE-$pkgver
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 md5sums="addfb1e897ca8079531669c7c7711726  libICE-1.0.9.tar.bz2"
 sha256sums="8f7032f2c1c64352b5423f6b48a8ebdc339cc63064af34d66a6c9aa79759e202  libICE-1.0.9.tar.bz2"

--- a/main/libpciaccess/APKBUILD
+++ b/main/libpciaccess/APKBUILD
@@ -1,11 +1,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libpciaccess
 pkgver=0.13.5
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 PCI access library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
+makedepends="util-macros"
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://www.x.org/releases/individual/lib/$pkgname-$pkgver.tar.bz2
 	fix-arm.patch
@@ -17,14 +19,13 @@ build() {
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 

--- a/main/libsm/APKBUILD
+++ b/main/libsm/APKBUILD
@@ -1,32 +1,41 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libsm
 pkgver=1.2.2
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 Session Management library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
 depends=
 subpackages="$pkgname-dev $pkgname-doc"
-makedepends="libice-dev e2fsprogs-dev xproto xtrans"
+makedepends="libice-dev xproto xtrans util-linux-dev util-macros xmlto"
+checkdepends="check-dev"
 source="http://www.x.org/releases/individual/lib/libSM-$pkgver.tar.bz2"
 
-depends_dev="libice-dev xproto"
+builddir="$srcdir"/libSM-$pkgver
 
 build () {
-	cd "$srcdir"/libSM-$pkgver
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
 		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--with-libuuid \
+		--enable-docs \
+		--with-xmlto \
+		--without-fop
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$srcdir"/libSM-$pkgver
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 md5sums="499a7773c65aba513609fe651853c5f3  libSM-1.2.2.tar.bz2"

--- a/main/libvdpau/APKBUILD
+++ b/main/libvdpau/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libvdpau
 pkgver=1.1.1
-pkgrel=0
-pkgdesc="Nvidia VDPAU library"
+pkgrel=1
+pkgdesc="Hardware-accelerated video playback library"
 url="http://cgit.freedesktop.org/~aplattner/libvdpau"
 arch="all"
 license="custom"
@@ -13,15 +13,8 @@ install=
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://people.freedesktop.org/~aplattner/vdpau/${pkgname}-${pkgver}.tar.gz"
 
-_builddir="$srcdir"/$pkgname-$pkgver
-
-prepare() {
-	cd "$_builddir"
-	# apply patches here
-}
-
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	LIBS="-lX11" \
 	./configure \
 		--build=$CBUILD \
@@ -29,16 +22,20 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--infodir=/usr/share/info \
-		|| return 1
-	make || return 1
+		--infodir=/usr/share/info
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -d -m755 "${pkgdir}/usr/share/licenses/${pkgname}"
-	install -m644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/" || return 1
+	install -m644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/"
 }
 
 md5sums="ac8b21012035c04fd1ec8a9ae6934264  libvdpau-1.1.1.tar.gz"

--- a/main/libx11/APKBUILD
+++ b/main/libx11/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libx11
 pkgver=1.6.5
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 client-side library"
 url="http://xorg.freedesktop.org/"
 arch="all"
@@ -10,7 +10,7 @@ depends=
 subpackages="$pkgname-dev $pkgname-doc"
 depends_dev="libxcb-dev xextproto xf86bigfontproto-dev xtrans
 	inputproto"
-makedepends="$depends_dev util-macros xproto kbproto"
+makedepends="$depends_dev util-macros xproto kbproto xmlto"
 source="http://www.x.org/releases/individual/lib/libX11-$pkgver.tar.bz2"
 
 builddir="$srcdir"/libX11-$pkgver
@@ -23,14 +23,18 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
-		--with-xcb \
-		|| return 1
-	make || return 1
+		--with-xcb
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 

--- a/main/libxau/APKBUILD
+++ b/main/libxau/APKBUILD
@@ -1,33 +1,38 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxau
 pkgver=1.0.8
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 authorisation library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
 depends=
-makedepends="xproto"
+makedepends="xproto util-macros"
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://www.x.org/releases/individual/lib/libXau-$pkgver.tar.bz2"
 
+builddir="$srcdir"/libXau-$pkgver
+
 build() {
-	cd "$srcdir"/libXau-$pkgver
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--sysconfdir=/etc
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$srcdir"/libXau-$pkgver
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -m755 -d "$pkgdir"/usr/share/licenses/$pkgname
-	install -m644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING || return 1
+	install -m644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
-md5sums="685f8abbffa6d145c0f930f00703b21b  libXau-1.0.8.tar.bz2"
-sha256sums="fdd477320aeb5cdd67272838722d6b7d544887dfe7de46e1e7cc0c27c2bea4f2  libXau-1.0.8.tar.bz2"
+
 sha512sums="9f933d22f8f2411ae770094589cbe170c631a1437d572664e0fa6b9608e6ec39deef752f2dd6408ab45acdf01bf1827ef3ced640a33da787d9cfb546f12397b5  libXau-1.0.8.tar.bz2"

--- a/main/libxcursor/APKBUILD
+++ b/main/libxcursor/APKBUILD
@@ -1,41 +1,32 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxcursor
 pkgver=1.1.14
-pkgrel=1
+pkgrel=2
 pkgdesc="X cursor management library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
-depends_dev="xproto libx11-dev libxrender-dev libxfixes-dev"
-makedepends="$depends_dev"
+makedepends="util-macros xproto libx11-dev libxrender-dev libxfixes-dev"
 source="http://www.x.org/releases/individual/lib/libXcursor-$pkgver.tar.bz2"
 
-_builddir="$srcdir"/libXcursor-$pkgver
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/libXcursor-$pkgver
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--sysconfdir=/etc
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 md5sums="1e7c17afbbce83e2215917047c57d1b3  libXcursor-1.1.14.tar.bz2"
 sha256sums="9bc6acb21ca14da51bda5bc912c8955bc6e5e433f0ab00c5e8bef842596c33df  libXcursor-1.1.14.tar.bz2"

--- a/main/libxdmcp/APKBUILD
+++ b/main/libxdmcp/APKBUILD
@@ -1,13 +1,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxdmcp
 pkgver=1.1.2
-pkgrel=3
+pkgrel=4
 pkgdesc="X11 Display Manager Control Protocol library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="MIT"
 depends=
-makedepends="xproto libbsd-dev"
+makedepends="xproto libbsd-dev util-macros xmlto"
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://www.x.org/releases/individual/lib/libXdmcp-$pkgver.tar.bz2"
 
@@ -22,13 +22,17 @@ build() {
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--sysconfdir=/etc
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$srcdir"/libXdmcp-$pkgver
-	make -j1 DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
 }
 sha512sums="f96005934b8bc752059106f8caf7df0574f5ef3c7a83bd797497b56ca556a7ff4dc1d28195e421259e82ea027b5c738094add3ec107a22544c9070725d8d46bb  libXdmcp-1.1.2.tar.bz2"

--- a/main/libxext/APKBUILD
+++ b/main/libxext/APKBUILD
@@ -1,43 +1,36 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxext
 pkgver=1.3.3
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 miscellaneous extensions library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
 depends=
-depends_dev="libx11-dev libxau-dev"
-makedepends="$depends_dev xproto"
+depends_dev="libxau-dev"
+makedepends="$depends_dev libx11-dev xproto util-macros xmlto"
 subpackages="$pkgname-dev $pkgname-doc"
+options="!check"
 source="http://www.x.org/releases/individual/lib/libXext-$pkgver.tar.bz2
 	"
 
-
-_builddir="$srcdir"/libXext-$pkgver
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/libXext-$pkgver
 
 build() {
-	cd "$srcdir"/libXext-$pkgver
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
 		--sysconfdir=/etc \
-		|| return 1
+		--with-xmlto \
+		--without-fop
 	make
 }
 
 package() {
-	cd "$srcdir"/libXext-$pkgver
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 md5sums="52df7c4c1f0badd9f82ab124fb32eb97  libXext-1.3.3.tar.bz2"
 sha256sums="b518d4d332231f313371fdefac59e3776f4f0823bcb23cf7c7305bfb57b16e35  libXext-1.3.3.tar.bz2"

--- a/main/libxfixes/APKBUILD
+++ b/main/libxfixes/APKBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxfixes
 pkgver=5.0.3
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 miscellaneous 'fixes' extension library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 depends=
-depends_dev="xproto fixesproto libx11-dev"
-makedepends="$depends_dev xextproto"
+makedepends="fixesproto libx11-dev util-macros xextproto xproto"
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://www.x.org/releases/individual/lib/libXfixes-$pkgver.tar.bz2"
 
@@ -22,14 +22,13 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
 md5sums="07e01e046a0215574f36a3aacb148be0  libXfixes-5.0.3.tar.bz2"

--- a/main/libxfont/APKBUILD
+++ b/main/libxfont/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxfont
 pkgver=1.5.2
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 font rasterisation library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev"
 depends=""
-depends_dev="xproto fontsproto libfontenc-dev freetype-dev"
-makedepends="$depends_dev xtrans zlib-dev"
+makedepends="xproto fontsproto libfontenc-dev freetype-dev xtrans zlib-dev util-macros"
 source="http://www.x.org/archive/individual/lib/libXfont-$pkgver.tar.bz2"
 
 builddir="$srcdir/libXfont-$pkgver"
@@ -20,14 +20,13 @@ build() {
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--sysconfdir=/etc
+	make
 }
 
 package() {
-	make DESTDIR="$pkgdir" \
-		-C "$builddir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 md5sums="254ee42bd178d18ebc7a73aacfde7f79  libXfont-1.5.2.tar.bz2"
 sha256sums="02945ea68da447102f3e6c2b896c1d2061fd115de99404facc2aca3ad7010d71  libXfont-1.5.2.tar.bz2"

--- a/main/libxfont2/APKBUILD
+++ b/main/libxfont2/APKBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxfont2
 pkgver=2.0.1
-pkgrel=0
+pkgrel=1
 pkgdesc="X.Org X11 libXfont2 runtime library"
 url="http://www.x.org"
 arch="all"
 license="MIT"
+options="!check"  # No test suite.
 depends=""
 depends_dev=""
 makedepends="$depends_dev libfontenc-dev freetype-dev fontsproto zlib-dev
@@ -33,13 +34,13 @@ build() {
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
 		--disable-static \
-		|| return 1
-	make || return 1
+		--without-fop
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
 sha512sums="5e4dcb587b4d25dd41124bb50d71c30b5e29663ce675b0830def82fb6e00b64ba34e1b1ed7fad947fd0da95007aa55d14f587383e4cff08c3e0a0241c8879d16  libXfont2-2.0.1.tar.bz2

--- a/main/libxft/APKBUILD
+++ b/main/libxft/APKBUILD
@@ -1,37 +1,33 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxft
 pkgver=2.3.2
-pkgrel=1
+pkgrel=2
 pkgdesc="FreeType-based font drawing library for X"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
 depends_dev="zlib-dev"
-makedepends="$depends_dev fontconfig-dev freetype-dev xproto libxrender-dev"
+makedepends="$depends_dev fontconfig-dev freetype-dev xproto libxrender-dev util-macros"
 source="http://www.x.org/releases/individual/lib/libXft-$pkgver.tar.bz2"
 
-_builddir="$srcdir/libXft-$pkgver"
-
-prepare() {
-	cd "$_builddir"
-}
+builddir="$srcdir/libXft-$pkgver"
 
 build () {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--sysconfdir=/etc
+	make
 }
 
 package() {
-	cd "$srcdir"/libXft-$pkgver
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 md5sums="331b3a2a3a1a78b5b44cfbd43f86fcfe  libXft-2.3.2.tar.bz2"

--- a/main/libxinerama/APKBUILD
+++ b/main/libxinerama/APKBUILD
@@ -1,41 +1,32 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxinerama
 pkgver=1.1.3
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 Xinerama extension library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
-depends_dev="xineramaproto libx11-dev libxext-dev"
-makedepends="$depends_dev"
+makedepends="xineramaproto libx11-dev libxext-dev util-macros"
 source="http://www.x.org/releases/individual/lib/libXinerama-$pkgver.tar.bz2
 	"
 
-_builddir="$srcdir"/libXinerama-$pkgver
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/libXinerama-$pkgver
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 md5sums="9336dc46ae3bf5f81c247f7131461efd  libXinerama-1.1.3.tar.bz2"
 sha256sums="7a45699f1773095a3f821e491cbd5e10c887c5a5fce5d8d3fced15c2ff7698e2  libXinerama-1.1.3.tar.bz2"

--- a/main/libxkbcommon/APKBUILD
+++ b/main/libxkbcommon/APKBUILD
@@ -2,12 +2,13 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=libxkbcommon
 pkgver=0.7.1
-pkgrel=0
+pkgrel=1
 pkgdesc="a keyboard handling library"
 url="http://www.xkbcommon.org/"
 arch="all"
 license="MIT"
-makedepends="$depends_dev bison flex libxcb-dev"
+makedepends="bison flex libxcb-dev xproto kbproto util-macros"
+checkdepends="bash"
 subpackages="$pkgname-dev"
 source="http://xkbcommon.org/download/libxkbcommon-$pkgver.tar.xz"
 
@@ -24,6 +25,11 @@ build() {
 		--infodir=/usr/share/info \
 		--localstatedir=/var
 	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {

--- a/main/libxkbfile/APKBUILD
+++ b/main/libxkbfile/APKBUILD
@@ -1,39 +1,38 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxkbfile
 pkgver=1.0.9
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 keyboard file manipulation library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
 depends=
-makedepends="libx11-dev"
+makedepends="libx11-dev util-macros"
 subpackages="$pkgname-dev"
 source="http://www.x.org/releases/individual/lib/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
-prepare() {
-	cd "$_builddir"
-}
+builddir="$srcdir/$pkgname-$pkgver"
 
 build () {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--sysconfdir=/etc
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -D -m644 "$srcdir"/$pkgname-$pkgver/COPYING \
 		"$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
-md5sums="4a4cfeaf24dab1b991903455d6d7d404  libxkbfile-1.0.9.tar.bz2"
-sha256sums="51817e0530961975d9513b773960b4edd275f7d5c72293d5a151ed4f42aeb16a  libxkbfile-1.0.9.tar.bz2"
+
 sha512sums="5fa268f10d7c4bd7b1e0c9f12adaa53d86b149f193d228fc620b3b81d360b37e4ede0192f5a0dc715bf830a57bd1388af01399fb33609413fc64623ee91cb8d1  libxkbfile-1.0.9.tar.bz2"

--- a/main/libxkbui/APKBUILD
+++ b/main/libxkbui/APKBUILD
@@ -1,35 +1,35 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxkbui
 pkgver=1.0.2
-pkgrel=7
+pkgrel=8
 pkgdesc="X11 keyboard UI presentation library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev"
 depends=
-depends_dev="libx11-dev xproto libxt-dev"
-makedepends="$depends_dev libsm-dev libice-dev libxkbfile-dev"
+depends_dev="xproto"
+makedepends="$depends_dev libsm-dev libice-dev libx11-dev libxkbfile-dev libxt-dev"
 source="http://www.x.org/releases/individual/lib/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir"/$pkgname-$pkgver
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
-build () {
-	cd "$_builddir"
+build() {
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="ccfa2c8f740ae66e5b7c2ed19a8243696a34fb60d45d8d01bb540eb925d69c95ebe16b7a54f4362acc3170b1543f44eea8910135b11c4af88abce3637726062d  libxkbui-1.0.2.tar.bz2"

--- a/main/libxmu/APKBUILD
+++ b/main/libxmu/APKBUILD
@@ -1,33 +1,35 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxmu
 pkgver=1.1.2
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 miscellaneous micro-utility library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
 makedepends="libxext-dev libxt-dev libx11-dev libsm-dev
-	util-linux-dev"
+	util-linux-dev util-macros xmlto"
 source="http://www.x.org/releases/individual/lib/libXmu-$pkgver.tar.bz2"
-depends_dev="xproto libx11-dev libxt-dev libxext-dev util-linux-dev"
+depends_dev="util-linux-dev"
 
-build ()
+builddir="$srcdir"/libXmu-$pkgver
+build()
 {
-	cd "$srcdir"/libXmu-$pkgver
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
 		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--without-fop
+	make
 }
 
 package() {
-	cd "$srcdir"/libXmu-$pkgver
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -Dm644 $srcdir/libXmu-$pkgver/COPYING \
 		$pkgdir/usr/share/licenses/$pkgname/COPYING
 }

--- a/main/libxpm/APKBUILD
+++ b/main/libxpm/APKBUILD
@@ -6,27 +6,28 @@ pkgdesc="X11 pixmap library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom:BELL"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
-makedepends="libxt-dev libxext-dev libx11-dev util-linux-dev"
+makedepends="libxt-dev libxext-dev libx11-dev util-linux-dev util-macros"
 source="http://www.x.org/releases/individual/lib/libXpm-$pkgver.tar.bz2"
 
-depends_dev="libx11-dev"
+builddir="$srcdir"/libXpm-$pkgver
+
 build() {
-	cd "$srcdir"/libXpm-$pkgver
+	cd "$builddir"
 	ac_cv_search_gettext=no \
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--sysconfdir=/etc
+	make
 }
 
 package() {
-	cd "$srcdir"/libXpm-$pkgver
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 md5sums="20f4627672edb2bd06a749f11aa97302  libXpm-3.5.12.tar.bz2"

--- a/main/libxrandr/APKBUILD
+++ b/main/libxrandr/APKBUILD
@@ -1,15 +1,16 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxrandr
 pkgver=1.5.1
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 RandR extension library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
 subpackages="$pkgname-dev $pkgname-doc"
+options="!check"  # No test suite.
 depends=
 depends_dev="randrproto libxext-dev"
-makedepends="$depends_dev libx11-dev libxrender-dev xproto"
+makedepends="$depends_dev libx11-dev libxrender-dev xproto util-macros"
 source="http://www.x.org/releases/individual/lib/libXrandr-$pkgver.tar.bz2
 	"
 
@@ -22,14 +23,13 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 

--- a/main/libxrender/APKBUILD
+++ b/main/libxrender/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxrender
 pkgver=0.9.10
-pkgrel=1
+pkgrel=2
 pkgdesc="X Rendering Extension client library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
 subpackages="$pkgname-dev $pkgname-doc"
+options="!check"  # No test suite.
 depends=
-depends_dev="renderproto libx11-dev"
-makedepends="$depends_dev"
+makedepends="renderproto libx11-dev util-macros"
 source="http://www.x.org/releases/individual/lib/libXrender-$pkgver.tar.bz2"
 
 builddir="$srcdir"/libXrender-$pkgver
@@ -21,14 +21,13 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
 md5sums="802179a76bded0b658f4e9ec5e1830a4  libXrender-0.9.10.tar.bz2"

--- a/main/libxres/APKBUILD
+++ b/main/libxres/APKBUILD
@@ -1,42 +1,34 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxres
 pkgver=1.0.7
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 Resource extension library"
 url="http://xorg.freedesktop.org"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
-depends_dev="xproto resourceproto libx11-dev libxext-dev"
-makedepends="$depends_dev"
+depends_dev="resourceproto"
+makedepends="$depends_dev libx11-dev libxext-dev util-macros xproto"
 source="http://www.x.org/releases/individual/lib/libXres-$pkgver.tar.bz2
 	"
 
-_builddir="$srcdir"/libXres-$pkgver
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/libXres-$pkgver
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--sysconfdir=/etc
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -D -m644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 

--- a/main/libxshmfence/APKBUILD
+++ b/main/libxshmfence/APKBUILD
@@ -2,44 +2,37 @@
 # Maintainer:
 pkgname=libxshmfence
 pkgver=1.2
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 shared memory fences"
 url="http://www.x.org/"
 arch="all"
 license="MIT"
 depends=""
-depends_dev="xproto linux-headers"
-makedepends="$depends_dev"
+depends_dev="linux-headers"
+makedepends="$depends_dev util-macros xproto"
 install=""
 subpackages="$pkgname-dev"
 source="http://www.x.org/releases/individual/lib/libxshmfence-$pkgver.tar.bz2"
 
-_builddir="$srcdir"/libxshmfence-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
-
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
 		--disable-static \
-		--enable-futex \
-		|| return 1
-	make || return 1
+		--enable-futex
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 
 md5sums="66662e76899112c0f99e22f2fc775a7e  libxshmfence-1.2.tar.bz2"

--- a/main/libxt/APKBUILD
+++ b/main/libxt/APKBUILD
@@ -1,43 +1,39 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxt
 pkgver=1.1.5
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 toolkit intrinsics library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
-depends_dev="xproto libx11-dev libsm-dev"
-makedepends="$depends_dev libice-dev e2fsprogs-dev"
+depends_dev="libsm-dev"
+makedepends="$depends_dev libice-dev libx11-dev util-macros xproto"
+checkdepends="glib-dev"
 source="http://www.x.org/releases/individual/lib/libXt-$pkgver.tar.bz2
 	"
 
-_builddir="$srcdir"/libXt-$pkgver
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/libXt-$pkgver
 
-
-build () {
-	cd "$_builddir"
+build() {
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--sysconfdir=/etc \
-		|| return 1
-	make || return 1
+		--sysconfdir=/etc
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$_builddir"
-	make -j1 DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
 }
 md5sums="8f5b5576fbabba29a05f3ca2226f74d3  libXt-1.1.5.tar.bz2"
 sha256sums="46eeb6be780211fdd98c5109286618f6707712235fdd19df4ce1e6954f349f1a  libXt-1.1.5.tar.bz2"

--- a/main/libxtst/APKBUILD
+++ b/main/libxtst/APKBUILD
@@ -1,15 +1,17 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxtst
 pkgver=1.2.3
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 Testing -- Resource extension library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
-depends_dev="recordproto libx11-dev libxext-dev inputproto libxi-dev"
-makedepends="$depends_dev"
+depends_dev="inputproto"
+makedepends="$depends_dev recordproto libx11-dev libxext-dev libxi-dev
+	util-macros"
 source="http://www.x.org/releases/individual/lib/libXtst-$pkgver.tar.bz2
 	"
 
@@ -22,14 +24,13 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 

--- a/main/libxv/APKBUILD
+++ b/main/libxv/APKBUILD
@@ -1,14 +1,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxv
 pkgver=1.0.11
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 Video extension library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
 depends=""
-depends_dev="libxext-dev"
-makedepends="$depends_dev libx11-dev videoproto xproto"
+makedepends="libx11-dev libxext-dev util-macros videoproto xproto"
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://www.x.org/releases/individual/lib/libXv-$pkgver.tar.bz2
 	"
@@ -22,14 +21,18 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -D -m644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 

--- a/main/libxvmc/APKBUILD
+++ b/main/libxvmc/APKBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxvmc
 pkgver=1.0.10
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 Video Motion Compensation extension library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
 depends_dev="libxext-dev"
@@ -22,14 +23,13 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
 md5sums="4cbe1c1def7a5e1b0ed5fce8e512f4c6  libXvMC-1.0.10.tar.bz2"

--- a/main/libxxf86dga/APKBUILD
+++ b/main/libxxf86dga/APKBUILD
@@ -1,40 +1,30 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxxf86dga
 pkgver=1.1.4
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 Direct Graphics Access extension library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
-depends_dev="xf86dgaproto libxext-dev libx11-dev"
-makedepends="$depends_dev"
+makedepends="xf86dgaproto libxext-dev libx11-dev util-macros"
 source="http://www.x.org/releases/individual/lib/libXxf86dga-$pkgver.tar.bz2"
 
-_builddir="$srcdir"/libXxf86dga-$pkgver
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
-
+builddir="$srcdir"/libXxf86dga-$pkgver
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 md5sums="d7dd9b9df336b7dd4028b6b56542ff2c  libXxf86dga-1.1.4.tar.bz2"
 sha256sums="8eecd4b6c1df9a3704c04733c2f4fa93ef469b55028af5510b25818e2456c77e  libXxf86dga-1.1.4.tar.bz2"

--- a/main/libxxf86misc/APKBUILD
+++ b/main/libxxf86misc/APKBUILD
@@ -1,38 +1,37 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxxf86misc
 pkgver=1.0.3
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 XFree86 miscellaneous extension library"
 url="http://xorg.freedesktop.org/"
 arch="all"
+options="!check"  # No test suite.
 license="custom"
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
-makedepends="libxext-dev libx11-dev xf86miscproto"
+makedepends="libxext-dev libx11-dev util-macros xf86miscproto"
 source="http://www.x.org/releases/individual/lib/libXxf86misc-$pkgver.tar.bz2"
-depends_dev="xf86miscproto libx11-dev libxext-dev"
 
-_builddir="$srcdir/libXxf86misc-$pkgver"
+builddir="$srcdir/libXxf86misc-$pkgver"
 
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--mandir=/usr/share/man \
-		|| return 1
-	make || return 1
+		--mandir=/usr/share/man
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 md5sums="6bc0bf78909fd71021c466c793d4385c  libXxf86misc-1.0.3.tar.bz2"
 sha256sums="563f4200862efd3334c33a669e0a0aae5bab31f3998db75b87a99a697cc26b5b  libXxf86misc-1.0.3.tar.bz2"

--- a/main/libxxf86vm/APKBUILD
+++ b/main/libxxf86vm/APKBUILD
@@ -1,41 +1,32 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxxf86vm
 pkgver=1.1.4
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 XFree86 video mode extension library"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
-depends_dev="xf86vidmodeproto libx11-dev libxext-dev"
-makedepends="$depends_dev"
+makedepends="libx11-dev libxext-dev util-macros xf86vidmodeproto"
 source="http://www.x.org/releases/individual/lib/libXxf86vm-$pkgver.tar.bz2
 	"
 
-_builddir="$srcdir"/libXxf86vm-$pkgver
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/libXxf86vm-$pkgver
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 md5sums="298b8fff82df17304dfdb5fe4066fe3a  libXxf86vm-1.1.4.tar.bz2"


### PR DESCRIPTION
Modernise and fix dependencies on a lot of X11 libraries.  Most of them need util-macros to be able to properly mark things like font encodings dirs and such so they are all bumped when util-macros is added.  Also, libepoxy has said upstream they are deprecating Python 2 support so that package now uses Python 3.