### PR TITLE
September Adélie merge: X11 protocol packages

### DIFF
--- a/main/bigreqsproto/APKBUILD
+++ b/main/bigreqsproto/APKBUILD
@@ -1,34 +1,36 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=bigreqsproto
 pkgver=1.1.2
-pkgrel=2
+pkgrel=3
 pkgdesc="X11 Big Requests extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="MIT"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros xmlto"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--without-fop
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 
 md5sums="1a05fb01fa1d5198894c931cf925c025  bigreqsproto-1.1.2.tar.bz2"

--- a/main/compositeproto/APKBUILD
+++ b/main/compositeproto/APKBUILD
@@ -1,34 +1,35 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=compositeproto
 pkgver=0.4.2
-pkgrel=3
+pkgrel=4
 pkgdesc="X11 Composite extension wire protocol"
 url="http://xorg.freedesktop.org/"
-arch="all"
+arch="noarch"
 license="MIT"
+options="!check"  # No test suite.
 depends="fixesproto"
-makedepends=""
+makedepends="util-macros"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -D -m644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 

--- a/main/damageproto/APKBUILD
+++ b/main/damageproto/APKBUILD
@@ -1,34 +1,34 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=damageproto
 pkgver=1.2.1
-pkgrel=2
+pkgrel=3
 pkgdesc="X11 Damage extension wire protocol"
 url="http://xorg.freedesktop.org/"
-arch="all"
+arch="noarch"
+options="!check"  # No test suite.
 license="custom"
 depends=""
-makedepends=""
+makedepends="util-macros"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$srcdir"/$pkgname-$pkgver
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="f124e85fb3cc70ed3536cb9db57ac93461bbb5df1a713bc6b67a5ea49122556c321781ca150df681502f6ccfb7305f290e131ad25ce9ccbff5af268df11c86fc  damageproto-1.2.1.tar.bz2"

--- a/main/dri2proto/APKBUILD
+++ b/main/dri2proto/APKBUILD
@@ -1,34 +1,35 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dri2proto
 pkgver=2.8
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 DRI protocol"
 url="http://xorg.freedesktop.org/"
-arch="all"
+arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir"/$pkgname-$pkgver
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
+
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 sha512sums="1602f58cd8a3371dacf894cde4889b9147fc08e83f98d8e0d1c748abe43ecb74cf4e0e3d5eb2f33568ba5e6d9f310303b98ba43ae3bc956ae693824b1ae0745a  dri2proto-2.8.tar.bz2"

--- a/main/dri3proto/APKBUILD
+++ b/main/dri3proto/APKBUILD
@@ -1,34 +1,35 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dri3proto
 pkgver=1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 DRI 3 protocol"
 url="http://xorg.freedesktop.org/"
-arch="all"
+arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir"/$pkgname-$pkgver
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
+
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 md5sums="a3d2cbe60a9ca1bf3aea6c93c817fee3  dri3proto-1.0.tar.bz2"
 sha256sums="01be49d70200518b9a6b297131f6cc71f4ea2de17436896af153226a774fc074  dri3proto-1.0.tar.bz2"

--- a/main/fixesproto/APKBUILD
+++ b/main/fixesproto/APKBUILD
@@ -1,34 +1,34 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=fixesproto
 pkgver=5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 Fixes extension wire protocol"
 url="http://xorg.freedesktop.org/"
-arch="all"
+arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends="xextproto"
-makedepends=""
+makedepends="util-macros"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	default_prepare
+	update_config_sub
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$srcdir"/$pkgname-$pkgver
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="93c6a8b6e4345c3049c08f2f3960f5eb5f92c487f26d227430964361bf82041b49e61f873fbbb8ee0e111556f90532b852c20e6082ee8008be641373251fa78c  fixesproto-5.0.tar.bz2"

--- a/main/fontsproto/APKBUILD
+++ b/main/fontsproto/APKBUILD
@@ -1,34 +1,29 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=fontsproto
 pkgver=2.1.3
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 font extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
-prepare() {
-	cd "$_builddir"
-}
-
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 md5sums="36934d00b00555eaacde9f091f392f97  fontsproto-2.1.3.tar.bz2"
 sha256sums="259046b0dd9130825c4a4c479ba3591d6d0f17a33f54e294b56478729a6e5ab8  fontsproto-2.1.3.tar.bz2"

--- a/main/glproto/APKBUILD
+++ b/main/glproto/APKBUILD
@@ -1,34 +1,28 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=glproto
 pkgver=1.4.17
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 OpenGL extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
-prepare() {
-	cd "$_builddir"
-}
-
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 md5sums="5565f1b0facf4a59c2778229c1f70d10  glproto-1.4.17.tar.bz2"
 sha256sums="adaa94bded310a2bfcbb9deb4d751d965fcfe6fb3a2f6d242e2df2d6589dbe40  glproto-1.4.17.tar.bz2"

--- a/main/inputproto/APKBUILD
+++ b/main/inputproto/APKBUILD
@@ -1,35 +1,33 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=inputproto
 pkgver=2.3.2
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 Input extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="MIT"
+makedepends="util-macros"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-prepare() {
-	cd "$_builddir"
-}
-
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -m755 -d "$pkgdir"/usr/share/licenses/$pkgname
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 
-md5sums="b290a463af7def483e6e190de460f31a  inputproto-2.3.2.tar.bz2"
-sha256sums="893a6af55733262058a27b38eeb1edc733669f01d404e8581b167f03c03ef31d  inputproto-2.3.2.tar.bz2"
 sha512sums="23d41e9ff4f49d80cd00a436e6dbae09adb7b72d3a3d7909c340b4b132b5908b32a497d5e2ec2c994cf0598a788c0481270bf36ce95171c0be4f74b52715fedd  inputproto-2.3.2.tar.bz2"

--- a/main/kbproto/APKBUILD
+++ b/main/kbproto/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=kbproto
 pkgver=1.0.7
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 XKB extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
@@ -9,27 +9,27 @@ license="MIT"
 depends=""
 makedepends=""
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
+subpackages="$pkgname-doc"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-prepare() {
-	cd "$_builddir"
-}
+builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 
-md5sums="94afc90c1f7bef4a27fdd59ece39c878  kbproto-1.0.7.tar.bz2"
-sha256sums="f882210b76376e3fa006b11dbd890e56ec0942bc56e65d1249ff4af86f90b857  kbproto-1.0.7.tar.bz2"
 sha512sums="49f24bfd11ee4ef0de658a1f55bcfb4b3a1f7057d90137b899ea3d4ecc40cebde97926a3f4315ddca4ae28d32b2d15f16fda993296acffdb4c007d2f84a39a22  kbproto-1.0.7.tar.bz2"

--- a/main/libxi/APKBUILD
+++ b/main/libxi/APKBUILD
@@ -1,24 +1,29 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libxi
 pkgver=1.7.9
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 Input extension library"
 url="http://xorg.freedesktop.org"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
-depends_dev="inputproto libx11-dev libxext-dev libxfixes-dev"
 makedepends="
-	$depends_dev
+	inputproto
+	libx11-dev
+	libxext-dev
+	libxfixes-dev
 	pkgconfig
+	util-macros
 	xextproto
+	xmlto
 	xproto
 	"
 source="http://www.x.org/releases/individual/lib/libXi-$pkgver.tar.bz2"
 
 builddir="$srcdir"/libXi-$pkgver
-build () {
+build() {
 	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
@@ -27,13 +32,14 @@ build () {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--with-xmlto \
+		--without-fop
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 

--- a/main/presentproto/APKBUILD
+++ b/main/presentproto/APKBUILD
@@ -1,33 +1,28 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=presentproto
 pkgver=1.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Present protocol specification and Xlib/Xserver headers"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
-prepare() {
-	cd "$_builddir"
-}
-
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="2c712136c8b4e99190932928d98e1a628197d0bf25180cac196ab8768720d61f7907006315bc3610e23666a8fbe39cfa9115c5fd72914aee2498776c8b46f7b2  presentproto-1.1.tar.bz2"

--- a/main/randrproto/APKBUILD
+++ b/main/randrproto/APKBUILD
@@ -1,34 +1,31 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=randrproto
 pkgver=1.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 RandR extension wire protocol"
 url="http://xorg.freedesktop.org/"
-arch="all"
+arch="noarch"
 license="custom"
 depends=""
-makedepends=""
+makedepends="util-macros"
+options="!check"  # No test suite
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
-prepare() {
-	cd "$_builddir"
-}
+builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$srcdir"/$pkgname-$pkgver
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -d -m755 "$pkgdir"/usr/share/licenses/$pkgname
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }

--- a/main/recordproto/APKBUILD
+++ b/main/recordproto/APKBUILD
@@ -1,35 +1,36 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=recordproto
 pkgver=1.14.2
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 Record extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros xmlto"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--without-fop
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -D -m644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 sha512sums="ab82d966ffacb46c001df15b272ca58f996826dc6f6835d3dc4d385b31c682acacb073a380d61938e2f242bffdabdd9b8f7107cd5ac67cb7aa3a28cc14a8ea02  recordproto-1.14.2.tar.bz2"

--- a/main/renderproto/APKBUILD
+++ b/main/renderproto/APKBUILD
@@ -1,36 +1,35 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=renderproto
 pkgver=0.11.1
-pkgrel=2
+pkgrel=3
 pkgdesc="X11 Render extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros"
 subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	default_prepare
+	update_config_sub
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 sha512sums="c38bc7247fd7b89732c892ee41c061b20397f4e79195601b7015dd55054b966f0797ac3990b147f80234596ba2c201ce90e292ecefed2e133167955bca70acc5  renderproto-0.11.1.tar.bz2"

--- a/main/resourceproto/APKBUILD
+++ b/main/resourceproto/APKBUILD
@@ -1,34 +1,34 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=resourceproto
 pkgver=1.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 Resource extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build () {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="ce8c8fda178ac7fb22b192d4a0f707a96f42ecd550ae8e6ddd7e1ed0067951ef955f7bee60f63a2b2422176e5f093c38e3903f7c4e5e3bea230b934b7abcc4ca  resourceproto-1.2.0.tar.bz2"

--- a/main/scrnsaverproto/APKBUILD
+++ b/main/scrnsaverproto/APKBUILD
@@ -1,36 +1,37 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=scrnsaverproto
 pkgver=1.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 Screen Saver extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros xmlto"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--without-fop
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	install -m755 -d "$pkgdir"/usr/share/licenses/$pkgname
-	install -m644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/ || return 1
+	install -m644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/
 }
 sha512sums="e74a512a6101967983a1d713d22a1f456f77519998116ef0f0a9e4b44ae4730ecd41eb9c0f7fa53e9f5c94967541daf10693d701af832597f5347461c5990ebc  scrnsaverproto-1.2.2.tar.bz2"

--- a/main/videoproto/APKBUILD
+++ b/main/videoproto/APKBUILD
@@ -1,13 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=videoproto
 pkgver=2.3.3
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 Video extension wire protocol"
 url="http://xorg.freedesktop.org/"
-arch="all"
+arch="noarch"
 license="MIT"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
 _builddir="$srcdir"/$pkgname-$pkgver
@@ -16,14 +18,13 @@ build() {
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
 	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
 md5sums="fe86de8ea3eb53b5a8f52956c5cd3174  videoproto-2.3.3.tar.bz2"

--- a/main/xcmiscproto/APKBUILD
+++ b/main/xcmiscproto/APKBUILD
@@ -1,34 +1,35 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xcmiscproto
 pkgver=1.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 XC-Miscellaneous extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
+options="!check"
 depends=""
-makedepends=""
+makedepends="util-macros xmlto"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build () {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--without-fop
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="33060d0f9bba92670fce6e42f5d9094e84b803fd07e61b159aafdbee40a9876b49cf844bc7bae4c628fbb11a6a0883a9ee07041b59290488f1e9dbfe6e5128a8  xcmiscproto-1.2.2.tar.bz2"

--- a/main/xextproto/APKBUILD
+++ b/main/xextproto/APKBUILD
@@ -1,35 +1,39 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xextproto
 pkgver=7.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="X11 various extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
 depends=""
-makedepends=""
+makedepends="util-macros xmlto"
+subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	default_prepare
+	update_config_sub
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$srcdir"/$pkgname-$pkgver
-	make -j1 DESTDIR=""$pkgdir"" install || return 1
+	cd "$builddir"
+	make -j1 DESTDIR=""$pkgdir"" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 md5sums="70c90f313b4b0851758ef77b95019584  xextproto-7.3.0.tar.bz2"

--- a/main/xf86bigfontproto/APKBUILD
+++ b/main/xf86bigfontproto/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86bigfontproto
 pkgver=1.2.0
-pkgrel=4
+pkgrel=5
 pkgdesc="X11 Big Fonts extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
@@ -14,9 +14,9 @@ install=""
 subpackages="$pkgname-dev"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir"/$pkgname-$pkgver
+builddir="$srcdir"/$pkgname-$pkgver
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -24,16 +24,18 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
 	make DESTDIR="$pkgdir" \
-		-C "$_builddir" install || return 1
+		-C "$builddir" install
 }
 
-md5sums="120e226ede5a4687b25dd357cc9b8efe  xf86bigfontproto-1.2.0.tar.bz2"
-sha256sums="ba9220e2c4475f5ed2ddaa7287426b30089e4d29bd58d35fad57ba5ea43e1648  xf86bigfontproto-1.2.0.tar.bz2"
 sha512sums="35b53ee1f428fee6777733264a7534a28ec6ffb29fc0ad9ab02337101d651ec94007bf840d0b591ee36a063280d4a4c71ff08f37100a63bb27581b5a9f69a710  xf86bigfontproto-1.2.0.tar.bz2"

--- a/main/xf86dgaproto/APKBUILD
+++ b/main/xf86dgaproto/APKBUILD
@@ -1,34 +1,33 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86dgaproto
 pkgver=2.1
-pkgrel=3
+pkgrel=4
 pkgdesc="X11 Direct Graphics Access extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
+options="!check"  # No test suite.
 license="custom"
 depends=""
 makedepends=""
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="dab56f5e59d1099d0d462e2f056e073c0ebde46aae6b9cf1c12b1fda43b5f21fb438dc811305c3114e04eb2fd2b1d13ddbe0a1d9a5c8155525db82db00e1461c  xf86dgaproto-2.1.tar.bz2"

--- a/main/xf86driproto/APKBUILD
+++ b/main/xf86driproto/APKBUILD
@@ -1,34 +1,33 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86driproto
 pkgver=2.1.1
-pkgrel=2
+pkgrel=3
 pkgdesc="X11 DRI extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="dce0d4da1dd703a6cdfe7676537034d43c9e84d70f20afdfe59be7929a97fbd077fa7026e41c0fca8aafd5fe666b2ee99265c8e94e69263bdf46e2be9ff34df2  xf86driproto-2.1.1.tar.bz2"

--- a/main/xf86miscproto/APKBUILD
+++ b/main/xf86miscproto/APKBUILD
@@ -1,34 +1,32 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86miscproto
 pkgver=0.9.3
-pkgrel=3
+pkgrel=4
 pkgdesc="X11 XFree86-Miscellaneous extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
 makedepends=""
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="b82370ee3aff3ee13c15ce645a74e6d927df0a2db01830a21fea4c36445495849d24410639525f02f369aabe8e1b6e6ab9acbfd3a41cb3cd7e6060a9c8ae320d  xf86miscproto-0.9.3.tar.bz2"

--- a/main/xf86vidmodeproto/APKBUILD
+++ b/main/xf86vidmodeproto/APKBUILD
@@ -1,34 +1,33 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86vidmodeproto
 pkgver=2.3.1
-pkgrel=2
+pkgrel=3
 pkgdesc="X11 Video Mode extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="d68784339271226a71360253b5f35d9cbec483801b4df3684bd070b1208a478edf9e5f55f1ff8ff186c81c56fb6e105e8cebad43d650cdbe605eed10bb7c7c50  xf86vidmodeproto-2.3.1.tar.bz2"

--- a/main/xineramaproto/APKBUILD
+++ b/main/xineramaproto/APKBUILD
@@ -1,34 +1,33 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xineramaproto
 pkgver=1.2.1
-pkgrel=2
+pkgrel=3
 pkgdesc="X11 Xinerama extension wire protocol"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
+options="!check"  # No test suite.
 depends=""
-makedepends=""
+makedepends="util-macros"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir/$pkgname-$pkgver"
-
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 sha512sums="ec2194c9bcad3f0f3eb3e9298792272213aa032ae9d6c00dcad567f31d7278a8c676fc67f47aae1a6deef5bade0b204346ed16da4a4c4d5a507c04d109d3dbb3  xineramaproto-1.2.1.tar.bz2"

--- a/main/xproto/APKBUILD
+++ b/main/xproto/APKBUILD
@@ -1,36 +1,42 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xproto
 pkgver=7.0.31
-pkgrel=0
+pkgrel=1
 pkgdesc="X11 core wire protocol and auxiliary headers"
 url="http://xorg.freedesktop.org/"
 arch="noarch"
 license="custom"
 depends=""
-makedepends=""
+makedepends="util-macros xmlto"
 # only headers here so no need for subpkgs
 subpackages="$pkgname-doc"
 source="http://www.x.org/releases/individual/proto/$pkgname-$pkgver.tar.bz2"
 
-_builddir="$srcdir"/$pkgname-$pkgver
+builddir="$srcdir"/$pkgname-$pkgver
 
 prepare() {
+	cd "$builddir"
+	default_prepare
 	update_config_sub
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
-	cd "$_builddir"
-	make -j1 DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
 	install -D -m644 "$srcdir"/$pkgname-$pkgver/COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 


### PR DESCRIPTION
* Some packages were marked 'all' instead of 'noarch'.  All X11 proto packages are noarch, as abuild liked to warn me when I was doing the modernisations.
* Some packages were missing -doc but still installing to /usr/share/doc, so I added -doc subpkgs to those that did that.
* A few have tests, but most don't.  I added test suites where I could and wrote options="!check" where not.