### PR TITLE
main/rsync: include rrsync

### DIFF
--- a/main/rsync/APKBUILD
+++ b/main/rsync/APKBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=rsync
 pkgver=3.1.2
-pkgrel=5
+pkgrel=6
 pkgdesc="A file transfer program to keep remote files in sync"
 url="https://rsync.samba.org/"
 arch="all"
 license="GPL3"
+options="!check" # included test suite fails some tests
 makedepends="perl acl-dev popt-dev"
-subpackages="$pkgname-doc"
+subpackages="$pkgname-doc rrsync"
 source="https://download.samba.org/pub/$pkgname/$pkgname-$pkgver.tar.gz
 	rsyncd.initd
 	rsyncd.confd
@@ -39,6 +40,16 @@ package() {
 	install -D -m 644 "$srcdir"/rsyncd.conf "$pkgdir"/etc/rsyncd.conf
 	install -D -m 644 "$srcdir"/rsyncd.confd "$pkgdir"/etc/conf.d/rsyncd
 	install -D -m 644 "$srcdir"/rsyncd.logrotate "$pkgdir"/etc/logrotate.d/rsyncd
+
+}
+
+rrsync() {
+	pkgdesc="Restricted rsync, restricts rsync to a subdir declared in .ssh/authorized_keys"
+	depends="rsync perl"
+	arch="noarch"
+
+	cd "$builddir"
+	install -D -m 755 ./support/rrsync "$subpkgdir"/usr/bin/rrsync
 }
 
 sha512sums="4c55fd69f436ead0cb5a0b7c6fdfef9bb28ddb9c63534eb619e756b118d5b08cfc5e696498650932c86e865b37e06633da947e6720ca0c27ed5c034313ae208b  rsync-3.1.2.tar.gz


### PR DESCRIPTION
rrsync is used to restrict rsync to a subdirectory declared in .ssh/authorized_keys

rrsync put in /usr/share in order to avoid a perl dependency for the package.