### PR TITLE
main/lxc: fix running systemd based containers under OpenRC

### DIFF
--- a/main/lxc/APKBUILD
+++ b/main/lxc/APKBUILD
@@ -5,7 +5,7 @@
 pkgname=lxc
 pkgver=2.1.0
 _pkgver=${pkgver/_rc/.rc}
-pkgrel=0
+pkgrel=1
 pkgdesc="Userspace interface for the Linux kernel containment features"
 url="https://linuxcontainers.org/lxc/"
 arch="all"
@@ -21,6 +21,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lvm::noarch lua5.2-lxc:_lua52
 source="https://github.com/lxc/lxc/archive/lxc-$_pkgver.tar.gz
 	version.patch
 	lxc.initd
+	lxc.confd
 	lxc.conf
 
 	download-template-tmpfs.patch
@@ -63,6 +64,7 @@ package() {
 	make DESTDIR="$pkgdir" install
 
 	install -Dm755 "$srcdir"/lxc.initd "$pkgdir"/etc/init.d/lxc
+	install -Dm644 "$srcdir"/lxc.confd "$pkgdir"/etc/conf.d/lxc
 	install -d "$pkgdir"/var/lib/lxc
 
 	# XXX: workaround for https://github.com/lxc/lxc/issues/1095.
@@ -151,6 +153,7 @@ EOF
 
 sha512sums="91309bb0e3db894f3bb29805d90f4617521e8dc980229d4626dfb73ce34c57803a3d04bb8a06c99c350cc69bef966f410acb5ffa14a361d7f6969f96c07214ba  lxc-2.1.0.tar.gz
 e2ffcbf55447291a8434a4f37255c3a6a119bc4116c75d205006aa2b070bf6be28535cf6107bead14bbf64bf9fa415346ab544bd1c15e1add7d1c6380e6b2def  version.patch
-1037e0b773553aa04b619cec7cfc8fa504af830e58c8211eda367da7e36aeb88f45fca1f955a08fc4fa3f9da660017d5fe7145a326a2064cf15e24d1772d9e27  lxc.initd
+8df0a0c9d970231e529d4859209474afc0a38baff28bdb4b449b28e9e5e79c9737b9c02b801bdea99d7fd4d7696e4ae640666a1a80d789041f33d023a804053b  lxc.initd
+ab230a653afe08f2f09dca845fbff47b54c72aaa77a46807470af966a561c241256ea81a80435cbc380949a374af9130f7381ddcb25c040f1ef6e6f40b2a03c7  lxc.confd
 5b83b0323e58bf00bd1e124c265729499cee97559b6fe18482962e3bed50d121b4c7a09f25cbce7b1e18d4234627bc4b4581ba2060e33cd022f105b4429cef01  lxc.conf
 02fd192d137cbb5b6db6959275387d05653f41dad5a5e46ae9b53cacead8cef937733927284658d3f0b910de81f9364c7f0248db990efd88806cf3029264c214  download-template-tmpfs.patch"

--- a/main/lxc/lxc.confd
+++ b/main/lxc/lxc.confd
@@ -1,0 +1,2 @@
+# enable cgroup for systemd based containers
+#systemd_container=Y

--- a/main/lxc/lxc.initd
+++ b/main/lxc/lxc.initd
@@ -51,6 +51,15 @@ checkconfig() {
 	fi
 }
 
+systemd_ctr() {
+	# required for lxc-console & services inside systemd containers
+	local cgroup=/sys/fs/cgroup/systemd
+	checkpath -d $cgroup
+	if ! mount | grep $cgroup 1>/dev/null; then
+		mount -t cgroup -o rw,nosuid,nodev,noexec,relatime,none,name=systemd cgroup $cgroup
+	fi
+}
+
 _autostart() {
 	ebegin "$1 LXC containers"
 	shift
@@ -60,6 +69,9 @@ _autostart() {
 
 start() {
 	checkconfig || return 1
+	if [ -n "${systemd_container}" ]; then
+		systemd_ctr
+	fi
 	if [ -z "$CONTAINER" ]; then
 		_autostart "Starting"
 		return


### PR DESCRIPTION
* `systemd` based containers require the `/sys/fs/cgroup/systemd` cgroup
  for `lxc-console` & services inside the containers to work

* `systemd_ctr()` based on recommendations from `lxc`:

https://github.com/lxc/lxc/issues/1704#issuecomment-330935480