### PR TITLE
main/clutter: add libxi-dev to depends_dev

### DIFF
--- a/main/clutter/APKBUILD
+++ b/main/clutter/APKBUILD
@@ -9,7 +9,7 @@ arch="all"
 license="LGPL"
 depends=
 depends_dev="gdk-pixbuf-dev json-glib-dev atk-dev pango-dev mesa-dev
-	libxcomposite-dev cairo-dev cogl-dev"
+	libxcomposite-dev libxi-dev cairo-dev cogl-dev"
 makedepends="$depends_dev gobject-introspection-dev intltool"
 install=""
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"


### PR DESCRIPTION
libxi-dev is needed for Clutter to be built with X11 input extension support,
otherwise touch screen input won't work in apps relying on X11 backend, such
as hildon-desktop in postmarketOS.