### PR TITLE
testing/gdal: enable curl support

### DIFF
--- a/testing/gdal/APKBUILD
+++ b/testing/gdal/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Trevor R.H. Clarke <trevor@notcows.com>
 pkgname=gdal
 pkgver=2.1.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A translator library for raster and vector geospatial data formats"
 url="http://gdal.org"
 arch="all"
 license="MIT"
 depends=""
 depends_dev="gdal"
-makedepends="giflib-dev jpeg-dev libjpeg-turbo-dev libpng-dev tiff-dev zlib-dev swig python2-dev"
+makedepends="giflib-dev jpeg-dev libjpeg-turbo-dev libpng-dev tiff-dev zlib-dev swig python2-dev curl-dev"
 subpackages="$pkgname-dev py-$pkgname:py"
 source="http://download.osgeo.org/$pkgname/$pkgver/$pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$pkgname-$pkgver"
@@ -41,6 +41,4 @@ py() {
 	install -d "$subpkgdir"/usr/bin
 	install -m755 scripts/*.py "$subpkgdir"/usr/bin/
 }
-md5sums="66f36c08b7ec6d31bda99083f179d183  gdal-2.1.3.tar.xz"
-sha256sums="b489793627e6cb8d2ff8d7737b61daf58382fe189fae4c581ddfd48c04b49005  gdal-2.1.3.tar.xz"
 sha512sums="3903f7480f0fbfd3022e11b0d2a13702a45a074b225d9b78202202dc427e850ee1238c0d970e6b25ae2b79acaf0f76fc04435767b5c88a609c96b03095b92678  gdal-2.1.3.tar.xz"


### PR DESCRIPTION
Enable CURL support within GDAL by adding curl-dev as a make dependency.