### PR TITLE
main/sshguard: sysconfdir fix

### DIFF
--- a/main/sshguard/APKBUILD
+++ b/main/sshguard/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=sshguard
 pkgver=2.0.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Log monitor that blocks with iptables on bad behaviour"
 url="http://www.sshguard.net/"
 arch="all"
@@ -24,6 +24,7 @@ build() {
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
+		--sysconfdir=/etc \
 		|| return 1
 	make || return 1
 }


### PR DESCRIPTION
I think, main/* apps should keep config files in /etc, not in /usr/etc.