### PR TITLE
Package gitg

### DIFF
--- a/testing/gitg/APKBUILD
+++ b/testing/gitg/APKBUILD
@@ -1,0 +1,39 @@
+# Contributor: Kiyoshi Aman <kiyoshi.aman@gmail.com>
+# Maintainer: Kiyoshi Aman <kiyoshi.aman@gmail.com>
+pkgname=gitg
+pkgver=3.26.0
+pkgrel=0
+pkgdesc="GTK-based application for working with git."
+url="https://wiki.gnome.org/Apps/Gitg"
+arch="all"
+license="GPL2+"
+depends="gtk+3.0 glib libgit2 libgee libsoup libsecret gsettings-desktop-schemas gobject-introspection libgit2-glib gtksourceview3 libpeas gtkspell3"
+depends_dev="libgit2-dev libgee-dev libsoup-dev libsecret-dev gsettings-desktop-schemas gobject-introspection-dev libgit2-glib-dev gtksourceview3-dev libpeas-dev gtkspell3-dev"
+makedepends="intltool gtk+3.0-dev glib-dev libxml2-utils $depends_dev"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+source="http://ftp.gnome.org/pub/GNOME/sources/$pkgname/3.26/$pkgname-$pkgver.tar.xz"
+builddir="$srcdir/gitg-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="782aa02e2f0f4d8c86ad726045502d545877d835f0449d2ec646d93a78bbfa50f84662d3a437c922eb168b2737c00ec088dc2c73487742f332e3910f041b519d  gitg-3.26.0.tar.xz"

--- a/testing/gtksourceview3/APKBUILD
+++ b/testing/gtksourceview3/APKBUILD
@@ -1,0 +1,45 @@
+# Contributor: Kiyoshi Aman <kiyoshi.aman@gmail.com>
+# Maintainer: Kiyoshi Aman <kiyoshi.aman@gmail.com>
+pkgname=gtksourceview3
+_pkgname=gtksourceview
+_pkgver=3.24
+pkgver=3.24.4
+pkgrel=0
+pkgdesc="A text widget adding syntax highlighting and more to GNOME"
+url="http://live.gnome.org/GtkSourceView"
+arch="all"
+license="GPL2+"
+depends="glib gtk+3.0 libxml2"
+depends_dev="glib-dev gtk+3.0-dev libxml2-dev"
+makedepends="$depends_dev"
+checkdepends="libxml2-utils"
+install=""
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+source="https://ftp.gnome.org/pub/gnome/sources/$_pkgname/$_pkgver/$_pkgname-$pkgver.tar.xz"
+builddir="$srcdir/gtksourceview-$pkgver"
+# broken test suite which requires X to be running, etc.
+options="!check"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="fef2008dccae6bca859f99b7171851b84f30e7b4cdb00500972039bf111ab5901498820c91926374a7b446491330c55f7179e8522b90279d0169371981bc90fd  gtksourceview-3.24.4.tar.xz"

--- a/testing/libgit2-glib/APKBUILD
+++ b/testing/libgit2-glib/APKBUILD
@@ -1,0 +1,43 @@
+# Contributor: Kiyoshi Aman <kiyoshi.aman@gmail.com>
+# Maintainer: Kiyoshi Aman <kiyoshi.aman@gmail.com>
+pkgname=libgit2-glib
+_pkgver=0.26
+pkgver=0.26.0
+pkgrel=0
+pkgdesc="Library for integrating libgit2 and glib"
+url="https://projects.gnome.org"
+arch="all"
+license="GPL2+"
+depends="glib libgit2 gobject-introspection"
+depends_dev="glib-dev libgit2-dev gobject-introspection-dev"
+makedepends="automake autoconf libtool gtk-doc $depends_dev"
+install=""
+subpackages="$pkgname-dev $pkgname-doc"
+source="libgit2-glib-$pkgver.tar.xz::https://ftp.gnome.org/pub/gnome/sources/$pkgname/$_pkgver/$pkgname-$pkgver.tar.xz"
+builddir="$srcdir/libgit2-glib-$pkgver"
+# remove when musl's encoding support isn't broken garbage
+options="!check"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="322f99b6273f0e56fcccdccd3b1193e1b62ca9dd495144e7c5fc59520dd693b1ceea4bab7335de1201ab09ecd7e146daa86afd9256d16649c144adb0b6de97c6  libgit2-glib-0.26.0.tar.xz"


### PR DESCRIPTION
These aports package gitg, a Gnome interface for git; the impetus for this was that I was told a few weeks ago that gitk was the only GUI-based interface for git currently in Alpine.