### PR TITLE
main/libvncserver: take ownership, also modernise testing/x11vnc

### DIFF
--- a/main/libvncserver/APKBUILD
+++ b/main/libvncserver/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Sergei Lukin <sergej.lukin@gmail.com>
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
-# Maintainer:
+# Maintainer: A. Wilcox <awilfox@adelielinux.org>
 pkgname=libvncserver
 pkgver=0.9.11
-pkgrel=0
+pkgrel=1
 pkgdesc="Library to make writing a vnc server easy"
 url="http://libvncserver.sourceforge.net/"
 arch="all"
@@ -24,13 +24,8 @@ source="https://github.com/LibVNC/libvncserver/archive/LibVNCServer-$pkgver.tar.
 
 builddir="$srcdir"/libvncserver-LibVNCServer-$pkgver
 prepare() {
-	local i
 	cd "$builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
+	default_prepare
 	./autogen.sh
 }
 
@@ -40,14 +35,19 @@ build() {
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--disable-static \
-		|| return 1
-	make || return 1
+		--disable-static
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+	test/tjunittest
 }
 
 package() {
 	cd "$builddir"
-	make install DESTDIR="$pkgdir" || return 1
+	make install DESTDIR="$pkgdir"
 }
 
 md5sums="7f06104d5c009813e95142932c4ddb06  LibVNCServer-0.9.11.tar.gz"

--- a/testing/x11vnc/APKBUILD
+++ b/testing/x11vnc/APKBUILD
@@ -17,7 +17,7 @@ builddir="$srcdir"/x11vnc-$pkgver
 
 prepare() {
 	cd "$builddir"
-	default_prepare || return 1
+	default_prepare
 	autoreconf -v --install
 }
 
@@ -30,14 +30,13 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
 }
 
 package() {
 	cd "$builddir"
-	make -j1 DESTDIR="$pkgdir" install || return 1
+	make -j1 DESTDIR="$pkgdir" install
 }
 
 check() {


### PR DESCRIPTION
I would like to maintain main/libvncserver.  I use it on a daily basis (to connect to my desktop from my tablet) and have it starred on GitHub so I would already know when new versions come out.

I have modernised and added a test suite to the APKBUILD.  Additionally, I modernised testing/x11vnc.