### PR TITLE
community/php7: Libressl is required for php7-openssl package

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -38,6 +38,8 @@ _depends_phar="$pkgname"
 # openssl is actually transitive dependency here, but we need to because of
 # load index based on number of dependencies.
 _depends_mysqli="$pkgname-mysqlnd $pkgname-openssl"
+# https://bugs.php.net/bug.php?id=75219
+_depends_openssl="libressl"
 makedepends="
 	autoconf
 	apache2-dev


### PR DESCRIPTION
This patch is related to [https://bugs.php.net/bug.php?id=75219](https://bugs.php.net/bug.php?id=75219). Currently php7-openssl automatically requires only libressl2.5-libcrypto and libressl2.5-libssl which don't provide the required `/etc/ssl/openssl.cnf` file.

Thanks.