### PR TITLE
main/libressl: move /etc/ssl to libcrypto subpackage

### DIFF
--- a/main/libressl/APKBUILD
+++ b/main/libressl/APKBUILD
@@ -9,7 +9,7 @@
 pkgname=libressl
 pkgver=2.5.5
 _namever=${pkgname}${pkgver%.*}
-pkgrel=2
+pkgrel=3
 pkgdesc="Version of the TLS/crypto stack forked from OpenSSL"
 url="http://www.libressl.org/"
 arch="all"
@@ -62,6 +62,9 @@ _libs() {
 		mv $f "$subpkgdir"/lib/
 		ln -s ../../lib/${f##*/} "$subpkgdir"/usr/lib/${f##*/}
 	done
+	if [ "$name" = "libcrypto" ]; then
+		mv "$pkgdir"/etc "$subpkgdir"
+	fi
 }
 
 sha512sums="3f576e74ddea17bd72e1bfbe0b57b94e1a2a9e6fa56cee50624cd8d18f0a8674273086225669e6ece56e6b859d2376e36e2c140d37acb52d4cd79374c4ba7096  libressl-2.5.5.tar.gz


### PR DESCRIPTION
#2410 - Libressl is required for php7-openssl package 