### PR TITLE
community/firefox-esr: update to 52.4.0

### DIFF
--- a/community/firefox-esr/APKBUILD
+++ b/community/firefox-esr/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: William Pitcock <nenolod@dereferenced.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox-esr
-pkgver=52.3.0
+pkgver=52.4.0
 _pkgver=$pkgver
 _xulver=$pkgver
 pkgrel=0
@@ -229,7 +229,7 @@ dev() {
 	default_dev
 }
 
-sha512sums="36da8f14b50334e36fca06e09f15583101cadd10e510268255587ea9b09b1fea918da034d6f1d439ab8c34612f6cebc409a0b8d812dddb3f997afebe64d09fe9  firefox-52.3.0esr.source.tar.xz
+sha512sums="be3be7f9dbf4bd0344d5d76f26d1a5090bb012154d25833d5cd58e5e707c080515b42ed751e1f7e58b15b96939d7da634cafb6e8aa9bb1627ff420836b802183  firefox-52.4.0esr.source.tar.xz
 0b3f1e4b9fdc868e4738b5c81fd6c6128ce8885b260affcb9a65ff9d164d7232626ce1291aaea70132b3e3124f5e13fef4d39326b8e7173e362a823722a85127  stab.h
 7e123144bc2b1efed149dfb41b255c447d43ea93a63ebe114d01945e6a6d69edc2f2a3c36980a93279106c1842355851b8b6c1d96679ee6be7b9b30513e0b1a8  0002-Use-C99-math-isfinite.patch
 09bc32cf9ee81b9cc6bb58ddbc66e6cc5c344badff8de3435cde5848e5a451e0172153231db85c2385ff05b5d9c20760cb18e4138dfc99060a9e960de2befbd5  fix-fortify-inline.patch


### PR DESCRIPTION
Contains fixes for font rendering issues caused by changes in freetype
2.8.1