### PR TITLE
wireguard: bump to 0.0.20171001

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20170918
-_mypkgrel=0
+_ver=0.0.20171001
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -31,7 +31,7 @@ pkgver=$_kver
 pkgrel=$(($_kpkgrel + $_mypkgrel))
 pkgdesc="Next generation secure network tunnel: kernel modules for $_flavor"
 arch='x86 x86_64 armhf'
-url='https://www.wireguard.io'
+url='https://www.wireguard.com'
 license="GPLv2"
 depends="linux-${_flavor}=${_kpkgver}"
 makedepends="linux-${_flavor}-dev=$_kpkgver libmnl-dev"
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="88e647e83f5d823cdfadcdc3d6a540f780401310c5f23ada5fb64446c3b2170d5ac66a8069f1f18fd3975f46d8d41d19b3ec076c4e6bfb4517476b78c3f9ccc9  WireGuard-0.0.20170918.tar.xz"
+sha512sums="20689980b1137e5800676606dfa737602293347559e75011cc7f32925333c1df29b2c630aa7c95cf075c4fbbf2c45af600d483bb7433bc8ecb652f371d06e625  WireGuard-0.0.20171001.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,11 +2,11 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20170918
+pkgver=0.0.20171001
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
-url='https://www.wireguard.io'
+url='https://www.wireguard.com'
 license="GPLv2"
 makedepends="libmnl-dev"
 subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch"
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="88e647e83f5d823cdfadcdc3d6a540f780401310c5f23ada5fb64446c3b2170d5ac66a8069f1f18fd3975f46d8d41d19b3ec076c4e6bfb4517476b78c3f9ccc9  WireGuard-0.0.20170918.tar.xz"
+sha512sums="20689980b1137e5800676606dfa737602293347559e75011cc7f32925333c1df29b2c630aa7c95cf075c4fbbf2c45af600d483bb7433bc8ecb652f371d06e625  WireGuard-0.0.20171001.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20170918
-_mypkgrel=0
+_ver=0.0.20171001
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -31,7 +31,7 @@ pkgver=$_kver
 pkgrel=$(($_kpkgrel + $_mypkgrel))
 pkgdesc="Next generation secure network tunnel: kernel modules for $_flavor"
 arch='all'
-url='https://www.wireguard.io'
+url='https://www.wireguard.com'
 license="GPLv2"
 depends="${_kpkg}=${_kpkgver}"
 makedepends="linux-vanilla-dev=$_kpkgver libmnl-dev"
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="88e647e83f5d823cdfadcdc3d6a540f780401310c5f23ada5fb64446c3b2170d5ac66a8069f1f18fd3975f46d8d41d19b3ec076c4e6bfb4517476b78c3f9ccc9  WireGuard-0.0.20170918.tar.xz"
+sha512sums="20689980b1137e5800676606dfa737602293347559e75011cc7f32925333c1df29b2c630aa7c95cf075c4fbbf2c45af600d483bb7433bc8ecb652f371d06e625  WireGuard-0.0.20171001.tar.xz"


### PR DESCRIPTION
Version bump.

Changelog:
https://lists.zx2c4.com/pipermail/wireguard/2017-October/001770.html