### PR TITLE
testing/pdal: pkgrel bump

### DIFF
--- a/testing/pdal/APKBUILD
+++ b/testing/pdal/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Bradley J Chambers <brad.chambers@gmail.com>
 pkgname=pdal
 pkgver=1.5.0
-pkgrel=0
+pkgrel=1
 pkgdesc="PDAL"
 url="https://github.com/pdal/pdal"
 arch="x86 x86_64"


### PR DESCRIPTION
HDF5 dependency had an ABI change, prompting need to rebuild PDAL package.