### PR TITLE
main/py-dbus: update to 1.2.4 and py3

### DIFF
--- a/main/py-dbus/APKBUILD
+++ b/main/py-dbus/APKBUILD
@@ -1,39 +1,68 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=py-dbus
-pkgver=1.2.0
-pkgrel=2
+pkgver=1.2.4
+pkgrel=0
 pkgdesc="Python bindings for DBUS"
 url="http://www.freedesktop.org/wiki/Software/DBusBindings"
 arch="all"
 license="GPL LGPL"
-depends="python2"
-depends_dev="py-dbus"
-makedepends="dbus-glib-dev python2-dev"
-subpackages="$pkgname-dev $pkgname-doc"
+depends=""
+#depends_dev="py-dbus"
+makedepends="dbus-glib-dev python2-dev python3-dev automake autoconf-archive"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3 $pkgname-doc $pkgname-dev"
 source="http://dbus.freedesktop.org/releases/dbus-python/dbus-python-$pkgver.tar.gz"
 
 _builddir="$srcdir"/dbus-python-$pkgver
 
 prepare() {
-	cd "$_builddir"
-	update_config_sub || return 1
-}
-build() {
-	cd "$_builddir"
-	./configure \
-		--build=$CBUILD \
-		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
-	make test || return 1
+	local python; for python in python2 python3; do
+		cp -r "$_builddir" "$_builddir-$python"
+	done
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	mkdir -p "$pkgdir"
 }
 
-md5sums="b09cd2d1a057cc432ce944de3fc06bf7  dbus-python-1.2.0.tar.gz"
-sha256sums="e12c6c8b2bf3a9302f75166952cbe41d6b38c3441bbc6767dbd498942316c6df  dbus-python-1.2.0.tar.gz"
-sha512sums="013b23e08fa1ed43f53a756587fefbc9770f7c51e93510e555acbd77230b7200693419bba9a69680d790bbaf123f4a195afa38b3eee1143da950fee0b5130bce  dbus-python-1.2.0.tar.gz"
+_py2() {
+	replaces="$pkgname"
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	# should this line be here ?
+	# install_if="$pkgname-$pkgver-r$pkgrel $python"
+	cd "$_builddir-$python"
+	PYTHON=$python ./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr
+	make
+	make DESTDIR="$subpkgdir" install
+	rm -rf "$pkgdir"/docpkg "$pkgdir"/devpkg
+	mkdir -p "$pkgdir"/docpkg "$pkgdir"/devpkg
+	mv "$subpkgdir"/usr/share/doc "$pkgdir"/docpkg
+	mv "$subpkgdir"/usr/lib/pkgconfig "$pkgdir"/devpkg
+	mv "$subpkgdir"/usr/include "$pkgdir"/devpkg
+	rmdir "$subpkgdir"/usr/share
+}
+
+doc() {
+	mkdir -p "$subpkgdir"/usr/share/
+	mv "$pkgdir"/docpkg/doc "$subpkgdir"/usr/share/doc
+}
+
+dev() {
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/devpkg/pkgconfig "$subpkgdir"/usr/lib/
+	mv "$pkgdir"/devpkg/include "$subpkgdir"/usr/
+}
+
+sha512sums="efdd9d96a8b56e813c93208d34777f1ca2db96c076d31f13afbcaec3c7770a16a623d5531fe23443130c555240949802503f171f2064d45eee97546d6251304b  dbus-python-1.2.4.tar.gz"


### PR DESCRIPTION
python2 -c "import dbus"
python3 -c "import dbus"
both work

Please see the comments (line 10 and 40) and give me feedback what to improve.
Also these "mv" commands used for the dev and the doc packages aren't beautiful. How should I handle that?

Travis is failing because autoconf-archive is only in edge/testing.