### PR TITLE
testing/wireguard: version bump to 0.0.20171005

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171001
-_mypkgrel=1
+_ver=0.0.20171005
+_mypkgrel=0
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="20689980b1137e5800676606dfa737602293347559e75011cc7f32925333c1df29b2c630aa7c95cf075c4fbbf2c45af600d483bb7433bc8ecb652f371d06e625  WireGuard-0.0.20171001.tar.xz"
+sha512sums="c131351e1a5591d3aa1c9172d9c2dbc7c8d5ee3ca11e8efecfa32b51bfdb80939efe714b7d41f0e3ce5559d0de20a55675eb6af4f06d67811196682e6e9ed87d  WireGuard-0.0.20171005.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20171001
+pkgver=0.0.20171005
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -16,7 +16,6 @@ builddir="$srcdir"/WireGuard-$pkgver
 
 build() {
 	cd "$builddir"
-	rm contrib/examples/sticky-sockets/a.out
 	make -C src/tools
 }
 
@@ -43,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="20689980b1137e5800676606dfa737602293347559e75011cc7f32925333c1df29b2c630aa7c95cf075c4fbbf2c45af600d483bb7433bc8ecb652f371d06e625  WireGuard-0.0.20171001.tar.xz"
+sha512sums="c131351e1a5591d3aa1c9172d9c2dbc7c8d5ee3ca11e8efecfa32b51bfdb80939efe714b7d41f0e3ce5559d0de20a55675eb6af4f06d67811196682e6e9ed87d  WireGuard-0.0.20171005.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171001
-_mypkgrel=1
+_ver=0.0.20171005
+_mypkgrel=0
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="20689980b1137e5800676606dfa737602293347559e75011cc7f32925333c1df29b2c630aa7c95cf075c4fbbf2c45af600d483bb7433bc8ecb652f371d06e625  WireGuard-0.0.20171001.tar.xz"
+sha512sums="c131351e1a5591d3aa1c9172d9c2dbc7c8d5ee3ca11e8efecfa32b51bfdb80939efe714b7d41f0e3ce5559d0de20a55675eb6af4f06d67811196682e6e9ed87d  WireGuard-0.0.20171005.tar.xz"


### PR DESCRIPTION
Straight-forward version bump. Release notes [from](https://lists.zx2c4.com/pipermail/wireguard/2017-October/001791.html) the mailing list:

```
  * community: code welcomed
  
  There's a small disorganized list of things to do, some of which are large
  projects, and others are just little cleanups:
  
  https://www.wireguard.com/todo/
  
  If anybody is interested in working on something, please don't hesitate to
  send an email to this list, team at wireguard.com, or me directly.
  
  * tools: simmer down silly compilers
  * tools: compile on non-Linux
  * contrib: remove worthless build artifact
  * kernel-tree: remember UAPI in patch creation
  * curve25519-neon-arm: force ARM encoding, since this is unrepresentable in Thumb
  * compat: support ptr_ring for old kernels
  * compat: conditionally redefine GENL_UNS_ADMIN_PERM
  * compat: RHEL backported netlink changes
  
  These here are all compatibility-related fixes mostly left over from churn of
  the previous snapshots, where we lost some compatibility with old kernels and
  weird toolchains. The above series of fixes brings us back up to par, and
  should make life slightly easier for a few packagers who had to work-around
  things in the last snapshot.
  
  * compat: macro rewrite netlink instead of cluttering
  * global: satisfy bitshift pedantry
  * global: use _WG prefix for include guards
  * global: add space around variable declarations
  * queueing: cleanup skb_padding
  
  Style, mostly.
  
  * Makefile: add non-verbose mode to tools
  * Makefile: clang now builds the kernel, so use scan-build
  
  One touch static analysis: `make check`.
  
  * receive: simplify message type validation
  * receive: use local keypair, not ctx keypair in error path
  * send: put keypair reference
  * receive: we're not planning on turning that into a while loop now
  * queueing: use ptr_ring instead of linked lists
  * receive: do not store endpoint in ctx
  * queueing: move from ctx to cb
  
  This is another huge change, and the main motivation for releasing this
  snapshot. We move from using a linked list-based queue to a ring buffer-based
  queue, which yields considerable performance increases. It also allows us to
  entirely rid ourselves of a memory cache object, which further increases
  performance and decreases latency. The move to a ring buffer will also make
  writing lock-less algorithms easier, which will eventually increase our
  performance on systems with extremely high core counts.
```

