### PR TITLE
main/nodejs: upgrade to 6.11.4

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -3,6 +3,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Contributor: Dave Esaias <dave@containership.io>
 # Contributor: Tadahisa Kamijo <kamijin@live.jp>
+# Contributor: Tim Brust <github@timbrust.de>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 #
 # secfixes:
@@ -12,7 +13,7 @@
 pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
-pkgver=6.11.3
+pkgver=6.11.4
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="http://nodejs.org/"
@@ -102,6 +103,6 @@ npm() {
 	mv "$pkgdir"/usr/lib/node_modules/npm "$subpkgdir"/usr/lib/node_modules/
 }
 
-sha512sums="7937d3d72c27b130159c356303db89be288b265f9d8cc640db82fd835adf8aa24fe499367b9f5651c0a3fa7918c0815d952fd57820da22cd9ffbfaae3f798dd9  node-v6.11.3.tar.gz
+sha512sums="ab71d06b460dca4b1153796fa1824d87a49ea47f907e3934ab160c5276dc8f61f110839065e2e89daa1454a8abd586488d9e3d162009b76436b8630c720da25c  node-v6.11.4.tar.gz
 a8be538158b7c96341a407acba30450ddc5c3ad764e7efe728d1ceff64efc3067b177855b9ef91b54400be6a02600d83da4c21a07ae9d7dc0774f92b2006ea8b  dont-run-gyp-files-for-bundled-deps.patch
 54a96cdc103bdffa9ba5283f59c64a35774e272f3a944d6475e3f669f95f7d75bcca6db3b12b9af76ea463f531763105aeabb302872652ced6a2bcb66f1eace0  ppc-fix-musl-mcontext.patch"


### PR DESCRIPTION
This updates Node.js to the latest LTS release (v6.11.4)