### PR TITLE
community/zabbix: add missing php dependencies

### DIFF
--- a/community/zabbix/APKBUILD
+++ b/community/zabbix/APKBUILD
@@ -13,7 +13,7 @@ depends="fping"
 _php=php7
 _php_depends="$_php ${_php}-gd ${_php}-curl ${_php}-bcmath ${_php}-sockets
 	${_php}-iconv ${_php}-xmlreader ${_php}-xmlwriter ${_php}-ctype
-	${_php}-gettext"
+	${_php}-gettext ${_php}-session ${_php}-simplexml ${_php}-json"
 makedepends="postgresql-dev curl-dev net-snmp-dev libevent-dev pcre-dev
 	sqlite-dev mariadb-dev curl-dev openipmi-dev unixodbc-dev
 	libxml2-dev autoconf automake libssh2-dev gnutls-dev


### PR DESCRIPTION
session, simplexml and json php modules are missing in the depency list,
and cause some features in the webinterface not to work.