### PR TITLE
eudev: logic fix in setup-udev, modernize aport

### DIFF
--- a/main/eudev/APKBUILD
+++ b/main/eudev/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=eudev
 pkgver=3.2.4
-pkgrel=0
+pkgrel=1
 pkgdesc="OpenRC compatible fork of systemd-udev"
 url="https://wiki.gentoo.org/wiki/Project:Eudev"
 arch="all"
@@ -67,8 +67,8 @@ libs() {
 
 	mkdir -p "$subpkgdir"/lib
 	local i; for i in "$pkgdir"/usr/lib/libudev.so.*; do
-		mv $i "$subpkgdir"/lib || return 1
-		ln -s ../../lib/${i##*/} "$pkgdir"/usr/lib/${i##*/} || return 1
+		mv $i "$subpkgdir"/lib
+		ln -s ../../lib/${i##*/} "$pkgdir"/usr/lib/${i##*/}
 	done
 }
 
@@ -84,4 +84,4 @@ sha512sums="1843a42d8c670379fec034e4401120202ae9383b74f81e52d93d83199a69016c27f7
 683e3c26ca4f058303f8db7d4977e436d728386ee6866719c4f11ff31db27572d3f486f51d3173310e1ec2cf995fa4c396f2415bdf45dabdd80e6e55e798a314  default-rules.patch
 ff5928fd555e095d9f3234dd004ac4c5925405d308777e9b018e8e03112cd109935b51d75a3bc4a2a1018eb486e8a5e5ef6ee978860002a8fff93b116e9721f5  load-fbcon.patch
 8ef1b911843ab13acb1c1b9b7a0a5cd76659f395c3db9e579429556f23eacebb414507dc0231e2455e7589bc70054fa1e6b6dd93dd833f7101c0da0597aabf88  udev-postmount.initd
-8092593c6dd68bdda3c1878753893f080c54ef32059bfbb0a09a0a700e2e85db1bdc53cc97f6cb2e8d8b77e5268b86e49a5e409c041f6f716583cfb1a4e5b7aa  setup-udev"
+d79c44e2879f00a0f87cdfb4971936ec201706690014b2a11634deb564cba0d53aba37b97b5595e6bc2f4bd258be33c52aba6236dc2f1a79fbb37027fde60a3d  setup-udev"

--- a/main/eudev/setup-udev
+++ b/main/eudev/setup-udev
@@ -2,7 +2,7 @@
 
 while getopts "hn" opt; do
 	case "$opt" in
-	h)	echo "remove mdev and enable udev from boot"	
+	h)	echo "remove mdev and enable udev from boot"
 		echo "usage: $0 [-n]"
 		echo "options:"
 		echo "  -n  Do not start udev"
@@ -18,10 +18,11 @@ for i in udev-trigger udev udev-postmount; do
 	if ! [ -e /etc/runlevels/sysinit/$i ]; then
 		ln -s /etc/init.d/$i /etc/runlevels/sysinit/$i
 	fi
-	if [ -z "$dryrun" ] && ! rc-service --quiet udev status; then
-		rc-service udev start
-		rc-service udev-postmount start
-		rc-service udev-trigger start
-		rc-service udev-settle start
-	fi
 done
+
+if [ -z "$dryrun" ] && ! rc-service --quiet udev status; then
+	rc-service udev start
+	rc-service udev-postmount start
+	rc-service udev-trigger start
+	rc-service udev-settle start
+fi


### PR DESCRIPTION
This PR moves the `if`-block outside of the `for` loop in `setup-udev` and modernizes the APKBUILD.