### PR TITLE
main/openrc: avoid modloop error with `BOOT_IMAGE=(loop)/boot/vmlinuz-hardened`

### DIFF
--- a/main/openrc/modloop.initd
+++ b/main/openrc/modloop.initd
@@ -10,8 +10,7 @@ depend() {
 
 # read kernel options
 init_KOPT() {
-	eval set -- $(cat /proc/cmdline 2>/dev/null)
-	for opt; do
+	for opt in $(cat /proc/cmdline 2>/dev/null); do
 	        case "$opt" in
 			modloop=*)
 				eval "KOPT_${opt%%=*}='${opt#*=}'" ;;


### PR DESCRIPTION
cf. alpinelinux/mkinitfs#16; this can happen with grub2, when the following `grub.cfg` snippet is used:
```
menuentry "Alpine" {
	search --no-floppy --file --set=pia /iso/alpine.iso
	loopback loop ($pia)/iso/alpine.iso
	linux	(loop)/boot/vmlinuz-hardened modules=loop,squashfs,isofs,ntfs,sd-mod,usb-storage quiet
	initrd	(loop)/boot/initramfs-hardened
}
```