### PR TITLE
testing/ofono: Update to 1.21

### DIFF
--- a/testing/ofono/0001-nokia-gpio-do-not-create-links-to-gpios-in-dev-cmt.patch
+++ b/testing/ofono/0001-nokia-gpio-do-not-create-links-to-gpios-in-dev-cmt.patch
@@ -1,0 +1,104 @@
+From 20642bfed99dac5559f88743c3043f33fa3e7796 Mon Sep 17 00:00:00 2001
+From: Clayton Craft <clayton@craftyguy.net>
+Date: Tue, 26 Sep 2017 19:42:11 -0700
+Subject: [PATCH] nokia-gpio: do not create links to gpios in /dev/cmt
+
+The nokia-gpio plugin should not try to create symlinks to relevant gpio
+pins under /dev/cmt, since the location it is looking is no longer
+correct on newer kernels and it might change again in the future. This
+patch removes code from nokia-gpio that tries to create a symlink.
+
+Users will now need to symlink the modem gpios to /dev/cmt themselves.
+On the 4.13 kernel, this can be done by, for example, adding a udev rule
+to:
+ # ln -sf /sys/bus/hsi/devices/n900-modem /dev/cmt
+---
+ plugins/nokia-gpio.c | 67 ++++------------------------------------------------
+ 1 file changed, 4 insertions(+), 63 deletions(-)
+
+diff --git a/plugins/nokia-gpio.c b/plugins/nokia-gpio.c
+index 7a93106c..1d014337 100644
+--- a/plugins/nokia-gpio.c
++++ b/plugins/nokia-gpio.c
+@@ -632,74 +632,15 @@ static void phonet_status_cb(GIsiModem *idx, enum GIsiPhonetLinkState state,
+ 
+ static int gpio_probe_links(void)
+ {
+-	char const *gpiodir = "/sys/class/gpio";
+ 	char const *cmtdir = "/dev/cmt";
+-	DIR *gpio;
+-	struct dirent *d;
+ 
+-	if (file_exists(cmtdir)) {
+-		DBG("Using %s", cmtdir);
+-		return 0;
+-	}
+-
+-	DBG("Using %s: trying to make links to %s", gpiodir, cmtdir);
+-
+-	if (!dir_exists(cmtdir)) {
+-		if (mkdir(cmtdir, 0755) == -1) {
+-			DBG("%s: %s", cmtdir, strerror(errno));
+-			return -(errno = ENODEV);
+-		}
+-	}
+-
+-	gpio = opendir(gpiodir);
+-	if (gpio == NULL) {
+-		DBG("%s: %s", "gpiodir", strerror(errno));
++	if (!file_exists(cmtdir)) {
++		DBG("%s: %s", cmtdir, strerror(errno));
+ 		return -(errno = ENODEV);
+ 	}
+ 
+-	while ((d = readdir(gpio)) != NULL) {
+-		char nn[PATH_MAX], name[PATH_MAX], from[PATH_MAX], to[PATH_MAX];
+-		FILE *nf;
+-		size_t len;
+-
+-		snprintf(nn, sizeof nn, "%s/%s/name", gpiodir, d->d_name);
+-
+-		nf = fopen(nn, "rb");
+-		if (nf == NULL) {
+-			DBG("%s: %s", nn, strerror(errno));
+-			continue;
+-		}
+-
+-		len = fread(name, sizeof name, 1, nf);
+-
+-		if (ferror(nf)) {
+-			DBG("read from %s: %s", nn, strerror(errno));
+-			fclose(nf);
+-			continue;
+-		}
+-
+-		fclose(nf);
+-
+-		if (len < 4)
+-			continue;
+-
+-		name[--len] = '\0';
+-
+-		if (strncmp(name, "cmt_", 4))
+-			continue;
+-
+-		snprintf(from, sizeof from, "%s/%s", gpiodir, d->d_name);
+-		snprintf(to, sizeof to, "%s/%s", cmtdir, name);
+-
+-		if (symlink(from, to) == -1)
+-			DBG("%s: %s", to, strerror(errno));
+-	}
+-
+-	DBG("%s: %s", "/sys/class/gpio", strerror(errno));
+-
+-	(void) closedir(gpio);
+-
+-	return -(errno = ENODEV);
++	DBG("Using %s", cmtdir);
++	return 0;
+ }
+ 
+ 
+-- 
+2.14.1
+

--- a/testing/ofono/APKBUILD
+++ b/testing/ofono/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=ofono
-pkgver=1.20
+pkgver=1.21
 pkgrel=0
 pkgdesc="Infrastructure for building mobile telephony (GSM/UMTS) applications"
 url="https://01.org/ofono"
@@ -9,11 +9,13 @@ arch="all"
 license="GPL2"
 depends="bluez mobile-broadband-provider-info"
 makedepends="glib-dev dbus-dev eudev-dev
-	linux-headers bsd-compat-headers libexecinfo-dev"
+	linux-headers bsd-compat-headers libexecinfo-dev
+	mobile-broadband-provider-info"
 options="!check"
 subpackages="$pkgname-dev $pkgname-doc"
 source="https://www.kernel.org/pub/linux/network/$pkgname/$pkgname-$pkgver.tar.xz
-	$pkgname.initd"
+	$pkgname.initd
+	0001-nokia-gpio-do-not-create-links-to-gpios-in-dev-cmt.patch"
 builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
@@ -29,8 +31,10 @@ build() {
 package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install
+	install -Dm644 "$srcdir/$pkgname-${pkgver}/plugins/ofono.rules" "$pkgdir/usr/lib/udev/rules.d/60-ofono.rules"
 	install -Dm755 "$srcdir/$pkgname.initd" "$pkgdir/etc/init.d/$pkgname"
 }
 
-sha512sums="8dc86654ae8a1dc1761c95df5f0de55566db20012e523f11bcd5ab5e1540f4cd9fc7bd6bf1665dcbeb31f2925f9322c21fd05fb00034e408b5d85b265e2fe840  ofono-1.20.tar.xz
-7f17143545e1a229254b34da76a449d2c1dea238ee988d606de1a12a54fe691cd946f73e446ae786624abbcdc539338334c1d3b0d1e49fdd8ba8ba6aa51b15ff  ofono.initd"
+sha512sums="bbc7fdb1d05294839eee5f31ec345866315a80feac8ccc2a67e0ca2c1030c55e0fb4fd6faee82133c00ec287730a5fd8df0610146a4f6a099e6b90703e621945  ofono-1.21.tar.xz
+7f17143545e1a229254b34da76a449d2c1dea238ee988d606de1a12a54fe691cd946f73e446ae786624abbcdc539338334c1d3b0d1e49fdd8ba8ba6aa51b15ff  ofono.initd
+a1f66f3f40c1aa4af5f5b66436414408b46f3c90f2a2c88fa12e09ca6a1732334d2f47687478d652a3a176ee93c1905752635246fd01412834565626c021ca64  0001-nokia-gpio-do-not-create-links-to-gpios-in-dev-cmt.patch"


### PR DESCRIPTION
This updates ofono to 1.21, adds a patch upstreamed to ofono but not
merged in time for the 1.21 release, and installs the ofono udev rules.