### PR TITLE
testing/wireguard: version bump to 0.0.20171011

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171005
-_mypkgrel=1
+_ver=0.0.20171011
+_mypkgrel=0
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="c131351e1a5591d3aa1c9172d9c2dbc7c8d5ee3ca11e8efecfa32b51bfdb80939efe714b7d41f0e3ce5559d0de20a55675eb6af4f06d67811196682e6e9ed87d  WireGuard-0.0.20171005.tar.xz"
+sha512sums="7ec5959becf96d214b0b6a0f2c638c986c7b330ce24c323a77f06a2ab853affb85c3cc6ab54d01ece525aef9bfd627bf4b69f21167ee86b16442659d202fcd77  WireGuard-0.0.20171011.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20171005
+pkgver=0.0.20171011
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="c131351e1a5591d3aa1c9172d9c2dbc7c8d5ee3ca11e8efecfa32b51bfdb80939efe714b7d41f0e3ce5559d0de20a55675eb6af4f06d67811196682e6e9ed87d  WireGuard-0.0.20171005.tar.xz"
+sha512sums="7ec5959becf96d214b0b6a0f2c638c986c7b330ce24c323a77f06a2ab853affb85c3cc6ab54d01ece525aef9bfd627bf4b69f21167ee86b16442659d202fcd77  WireGuard-0.0.20171011.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171005
-_mypkgrel=1
+_ver=0.0.20171011
+_mypkgrel=0
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="c131351e1a5591d3aa1c9172d9c2dbc7c8d5ee3ca11e8efecfa32b51bfdb80939efe714b7d41f0e3ce5559d0de20a55675eb6af4f06d67811196682e6e9ed87d  WireGuard-0.0.20171005.tar.xz"
+sha512sums="7ec5959becf96d214b0b6a0f2c638c986c7b330ce24c323a77f06a2ab853affb85c3cc6ab54d01ece525aef9bfd627bf4b69f21167ee86b16442659d202fcd77  WireGuard-0.0.20171011.tar.xz"


### PR DESCRIPTION
Routine version bump. Release notes [from the list](https://lists.zx2c4.com/pipermail/wireguard/2017-October/001815.html):

```

  * receive: do not consider 0 jiffies as being set
  
  This should fix some issues on 32-bit platforms with sending cookie reply
  messages when they're not required.
  
  * socket: compare while unlocked first
  * socket: don't bother recomparing afterwards
  * socket: gcc inlining makes this faster
  
  We no longer take a lock when updating the endpoint, which should yield
  some performance benefits.
  
  * tools: try again if dump is interrupted
  
  The tools will now try again to get information about a device if somebody
  tries to modify the device while a dump is occurring.
  
  * Makefile: quiet recursive make
  
  Our makefile produces slightly slicker output now.
  
  * qemu: bump stable kernel
  
  Usual test suite house maintenance.
  
  * crypto/x86_64: satisfy stack validation 2.0
  
  The kernel's new objtool used to warn on some things in our AVX
  implementations, especially code generated from qhasm which uses its own
  stack layout. This commit works around it to squelch warnings.
  
  * routingtable: only use device's mutex, not a special rt one
  * routingtable: iterate progressively
  * tools: store tail pointer to make coalescing peers fast
  
  We replace the Netlink algorithms for grabbing the allowed IPs, so
  that they're now O(n) instead of O(n^2).
  
  * tools: warn once on unrecognized items
  
  This follows this LKML discussion:
  https://www.spinics.net/lists/netdev/msg457468.html
  
  * compat: move version logic to compat.h and out of main .c
  * contrib: filter compat lines
  
  Should make it easier to produce a compat-free WireGuard tree.
  
  * send: do not requeue if packet is dead
  * socket: set skb->mark in addition to flowi
  
  Mangle tables now work with wg-quick.
  
  * tools: man: include kill-switch documentation using fwmark
  
  Essentially:
  iptables -I OUTPUT ! -o %i -m mark ! --mark $(wg show %i fwmark) -j REJECT
  
  * receive: disable bh before using stats seq lock
  
  This avoids a potential deadlock with interrupts and the stats counters.
```