### PR TITLE
testing/php7-libsodium: upgrade to 2.0.8

### DIFF
--- a/testing/php7-libsodium/APKBUILD
+++ b/testing/php7-libsodium/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
 pkgname=php7-libsodium
 _pkgreal=libsodium
-pkgver=2.0.7
+pkgver=2.0.8
 pkgrel=0
 pkgdesc="A simple, low-level PHP extension for libsodium"
 url="http://pecl.php.net/package/$_pkgreal"
@@ -28,4 +28,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/50_$_pkgreal.ini
 }
 
-sha512sums="1aadbfb150b3d86d98c7ac5e099a2b0be45b695f7c5b57ec59d01acc7dc27a58141c5177565fa900007dd2457cbda0577dcb561a7cdeeaf62294b9bf7e7dc939  libsodium-2.0.7.tgz"
+sha512sums="3f63d7ac852355dd1a877e6292c04d30b6f7bbd8137ce875f2b3db3f4788534309bba40f5916a59051a70404f5517935bea5338856982c2dba8c604e964512f9  libsodium-2.0.8.tgz"


### PR DESCRIPTION
This brings compatibility with libsodium 1.0.15 that Alpine using

https://pecl.php.net/package-changelog.php?package=libsodium&release=2.0.8