### PR TITLE
community/php7: bump pkgrel due to libbsd upgrade

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -20,7 +20,7 @@
 pkgname=php7
 _pkgreal=php
 pkgver=7.1.10
-pkgrel=0
+pkgrel=1
 _apiver=20160303
 _suffix=${pkgname#php}
 # Is this package the default (latest) PHP version?


### PR DESCRIPTION
Package php7-gd depends on `libbsd`

Steps to reproduce
- `apk add php7 php7-gd`
- `php -v`

reports:
```
# php -v
PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php7/modules/gd.so' - Error relocating /usr/lib/libbsd.so.0: fopencookie: symbol not found in Unknown on line 0
PHP 7.1.10 (cli) (built: Oct  3 2017 12:31:32) ( NTS )
...
```