### PR TITLE
testing/pavucontrol: new aport

### DIFF
--- a/testing/pavucontrol/APKBUILD
+++ b/testing/pavucontrol/APKBUILD
@@ -1,0 +1,36 @@
+# Contributor: Fredrick Brennan <copypaste@kittens.ph>
+# Maintainer: Fredrick Brennan <copypaste@kittens.ph>
+pkgname=pavucontrol
+pkgver="20171007"
+pkgrel=1
+pkgdesc="A graphical interface for changing the volume of PulseAudio streams and other PulseAudio related tasks"
+url="https://freedesktop.org/software/pulseaudio/pavucontrol/"
+arch="all"
+license="GPL2+"
+depends="pulseaudio dbus gtkmm3 libsigc++ libcanberra"
+makedepends="automake autoconf gtkmm3-dev libsigc++-dev libcanberra-dev pulseaudio-dev"
+install=""
+subpackages="$pkgname-doc $pkgname-lang"
+_commit="335c26c57c18d95cc7d4ca693a75ef94fe919e1d"
+source="https://github.com/pulseaudio/$pkgname/archive/$_commit.zip"
+builddir="$srcdir/$pkgname-$_commit"
+
+build() {
+	cd "$builddir"
+	./autogen.sh
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="dee0fb2a7c5ea096fa7798bb9202beb76261ccb85ac25334a4fce885232e09b41bf307bf434cbf68eece8c481e5063869cdedb3a18814fa97f980dd629956d1a  $_commit.zip"


### PR DESCRIPTION
https://freedesktop.org/software/pulseaudio/pavucontrol/
A graphical interface (GTK3) for changing the volume of PulseAudio streams and other PulseAudio related tasks

This port only works on Edge, as it requires the `pulseaudio` package.