### PR TITLE
Add KDE Frameworks Tier 1

### DIFF
--- a/testing/attica-qt/APKBUILD
+++ b/testing/attica-qt/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=attica-qt
+pkgver=5.39.0
+pkgrel=0
+arch="all"
+pkgdesc='Qt5 library that implements the Open Collaboration Services API'
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/attica-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+builddir="$srcdir/${pkgname/-qt/}-$pkgver"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="7614a684fc09e721f470b46f00a0f3ba5c9355efa6873d9bdeaabf6e44a087703434c47753f380fe7797ad95d4be984f0074ddbc48cce1e1e27aa733ae5b8be8  attica-5.39.0.tar.xz"

--- a/testing/extra-cmake-modules/APKBUILD
+++ b/testing/extra-cmake-modules/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: k0r10n <k0r10n.dev@gmail.com>
 # Contributor: Ivan Tham <pickfire@riseup.net>
 pkgname=extra-cmake-modules
-pkgver=5.38.0
+pkgver=5.39.0
 pkgrel=0
 pkgdesc="Extra CMake modules"
 url="https://projects.kde.org/projects/kdesupport/extra-cmake-modules"
@@ -27,4 +27,4 @@ package() {
 		"$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 
-sha512sums="c1fd65593732e57fb0822fd5bc2b06f9e35713a78f35269f387f6d9e4c87520b46f3cde039a42993139b478da5aebf1764d0111746af75bb0e5a33822684e501  extra-cmake-modules-5.38.0.tar.xz"
+sha512sums="c41df32aa6641824b7e69b001997fa61ab4d4df9aa0b850d8eecb0e434836e35f7c928952771cb2c5258117ac318e199659991619f37ad3ff82744ab66071ece  extra-cmake-modules-5.39.0.tar.xz"

--- a/testing/karchive/APKBUILD
+++ b/testing/karchive/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=karchive
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Qt 5 addon providing access to numerous types of archives'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+makedepends="extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="5151bfb0ce8b25593b0da34d376bf1c2bccdce80e8ad95ccad0c7d01aa42a8c12ffa3175192a07ae9b62f869c3b4d1df48e134d30d5506c40649fa4930775142  karchive-5.39.0.tar.xz"

--- a/testing/kcodecs/APKBUILD
+++ b/testing/kcodecs/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kcodecs
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Provide a collection of methods to manipulate strings using various encodings'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+makedepends="extra-cmake-modules qt5-qttools-dev gperf doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="66a2b4f73406d826df9e4332c68eb3b10aa1b47a6f3af2f28bfaeb919c9163db9454d517439fa7a8bdef41317e6c2932939b5130aef51a61cff1e8a3235d450f  kcodecs-5.39.0.tar.xz"

--- a/testing/kconfig/APKBUILD
+++ b/testing/kconfig/APKBUILD
@@ -1,0 +1,36 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kconfig
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Configuration system'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+makedepends="extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DKDE_INSTALL_LIBEXECDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+
+sha512sums="d14ee524c7c06eec8f6bb953c203bb4077ccffaaa01b7f25496819bb19bdedce098342e90c357b70eb46815ea1f9a85bb6d00c575f31c9d0519921c33b02860e  kconfig-5.39.0.tar.xz"

--- a/testing/kcoreaddons/APKBUILD
+++ b/testing/kcoreaddons/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kcoreaddons
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Addons to QtCore'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+makedepends="extra-cmake-modules qt5-qttools-dev doxygen shared-mime-info"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="6579087b2d34ae6bc8d8254c420ae2f6f68d55cec587b5a58429bb82b9a2de111221351d58e2514705fda52c9b433bf98add574e4aba6ee0408340dc442707dd  kcoreaddons-5.39.0.tar.xz"

--- a/testing/kdbusaddons/APKBUILD
+++ b/testing/kdbusaddons/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kdbusaddons
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Addons to QtDBus'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+makedepends="extra-cmake-modules qt5-qttools-dev clang doxygen shared-mime-info"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Requires running dbus-daemon
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="0ad0f6221b379ab0f6aa9eb9806a1d4f71110611796f5a0ca0bd729275ccf00065770f74b8bb28e4214b35dd98aa950cbde5c6c09fdbd3a2927e879b5f0b3766  kdbusaddons-5.39.0.tar.xz"

--- a/testing/kguiaddons/APKBUILD
+++ b/testing/kguiaddons/APKBUILD
@@ -1,0 +1,36 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kguiaddons
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Addons to QtGui'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+makedepends="extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+
+sha512sums="a72c516a963d219bf8b2e1cd226e4ab8fae927f3d5d7f01a468e9c3c84f4cd430c494eac8e1b20668f8c48fdbf8161d3b4dae7b8a05152420aece56c41bc0b6e  kguiaddons-5.39.0.tar.xz"

--- a/testing/ki18n/APKBUILD
+++ b/testing/ki18n/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=ki18n
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Advanced internationalization framework'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-qtdeclarative-dev qt5-qtscript-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="0baefd0404a37666fd6d5e66328e94d05e1540e3be098a59aeb28589b3111ff1769fe880b5f8db1379dad229ed5a2bfe7b3535938c753a00fb7bee12c6b5953c  ki18n-5.39.0.tar.xz"

--- a/testing/kidletime/APKBUILD
+++ b/testing/kidletime/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kidletime
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Monitoring user activity'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-x11extras-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="f9eb585b9677f1dd5f9a0cb71fae5fb8faf9319256a7bca79528354244a9275feb061914cf5306f4dc3caa2ce914e23c378140cf3ee190dd5dc5ebdf9b20cef6  kidletime-5.39.0.tar.xz"

--- a/testing/kimageformats/APKBUILD
+++ b/testing/kimageformats/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kimageformats
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Image format plugins for Qt5'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL"
+depends=""
+depends_dev="qt5-qtbase-dev karchive-dev"
+makedepends="$depends_dev extra-cmake-modules openexr-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="20bf2b392becf0c3deea31736577d872cfd58e106746b7df5d929309555d3f85b7c243ecb59a89c5dc26826806267a8d25bec6b43993774503350783bb71770a  kimageformats-5.39.0.tar.xz"

--- a/testing/kirigami2/APKBUILD
+++ b/testing/kirigami2/APKBUILD
@@ -1,0 +1,40 @@
+pkgname=kirigami2
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='A QtQuick based components set'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL"
+depends="qt5-qtgraphicaleffects"
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev qt5-qtsvg-dev qt5-qtquickcontrols2-dev plasma-framework-dev
+			kpackage-dev kcoreaddons-dev kservice-dev kconfig-dev kwindowsystem-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-lang"
+options="!check"
+builddir="$srcdir/build"
+
+prepare() {
+	mkdir "$builddir"
+}
+
+build() {
+	cd "$builddir"
+	cmake "$srcdir"/$pkgname-$pkgver \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_EXAMPLES=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+sha512sums="ed6605072b8cd28bb9a6c70ab0f9d65e559795bf6cdd3118d63d36588a6c397a7b8656e80201ba320ae9b85a38f31550897762dcbee8347cd9e657efc6e8af11  kirigami2-5.39.0.tar.xz"

--- a/testing/kitemmodels/APKBUILD
+++ b/testing/kitemmodels/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kitemmodels
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Models for Qt Model/View system'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="cf00e36915a9a6f6078baadc7783e5e0648c7197aa212a095ef1e2d1ce21e03877261a05a4cf521cbf6d96249a49df13fef760352cca5c9c74b3605534cdb24e  kitemmodels-5.39.0.tar.xz"

--- a/testing/kitemviews/APKBUILD
+++ b/testing/kitemviews/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kitemviews
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Widget addons for Qt Model/View'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-qtbase-dev"
+makedepends="extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="b61238d5a59dedc8c262e572e757a2a5724552f41105b60285b04111c24257663546df3d9b964db9abbe8b6445b29bb4b12c7f7fa78ca29688b1a88d64105371  kitemviews-5.39.0.tar.xz"

--- a/testing/kplotting/APKBUILD
+++ b/testing/kplotting/APKBUILD
@@ -1,0 +1,36 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kplotting
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Lightweight plotting framework'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake "$srcdir"/${pkgname}-${pkgver} \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+
+sha512sums="a4c43260989892d913c7589036579daf74399a9743bc1bc95eead1aaab9db912531b4f764e1a0610080864aa5d0d4f998f2bc65202c27480562b225c5c8e212a  kplotting-5.39.0.tar.xz"

--- a/testing/kwayland/APKBUILD
+++ b/testing/kwayland/APKBUILD
@@ -1,0 +1,37 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kwayland
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Qt-style Client and Server library wrapper for the Wayland libraries'
+arch="all"
+url='https://www.kde.org'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-qtbase-dev wayland-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Fails due to requiring running Wayland compositor
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DKDE_INSTALL_LIBEXECDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="ca71d9a07d38f813f34e05c034acc626d1e5c878d05eb5174764dd695ac18b99d29a3ec8df49f0fd9807dcfb1ce85b8e884c7389eb86cc0e7310ca2b8ec4f4b4  kwayland-5.39.0.tar.xz"

--- a/testing/kwidgetsaddons/APKBUILD
+++ b/testing/kwidgetsaddons/APKBUILD
@@ -1,0 +1,36 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kwidgetsaddons
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Addons to QtWidgets'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="GPL-2.0"
+depends=""
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+
+sha512sums="020f5e0e352743e1adb8f09ca419c886819a855c983db8cd114c949f869deb56dbc9cc93d3605d14c6f18503c983dda00f8e79d2225e45bbeab0228bf2de8186  kwidgetsaddons-5.39.0.tar.xz"

--- a/testing/kwindowsystem/APKBUILD
+++ b/testing/kwindowsystem/APKBUILD
@@ -1,0 +1,36 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kwindowsystem
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Access to the windowing system'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-x11extras-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen libxrender-dev xcb-util-keysyms-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+
+sha512sums="723157c663ed4d9025fe0966c66031f5b2083ddc0cdc5cdbdcc6a4cb3b100ebc72d03356d118683bda666f1cd162004d3782604a29ac0f7a4a7f6ce2b0b74994  kwindowsystem-5.39.0.tar.xz"

--- a/testing/libdmtx/APKBUILD
+++ b/testing/libdmtx/APKBUILD
@@ -1,0 +1,23 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=libdmtx
+pkgver=0.7.4
+pkgrel=6
+pkgdesc="A software for reading and writing Data Matrix 2D barcodes"
+url="https://libdmtx.sourceforge.net/"
+arch="all"
+license="BSD-2"
+source="https://downloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.bz2"
+subpackages="$pkgname-dev $pkgname-libs $pkgname-doc"
+
+build() {
+	./configure --prefix=/usr
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="13066ecefb3da3746c6f1e872ae7493bb3902fb891ef6d96f65a90ca444107662fcad4a7fae3463ab2f6503f0962d248a5dcd754a6eb0b5c624ae68100b9c056  libdmtx-0.7.4.tar.bz2"

--- a/testing/polkit-qt/APKBUILD
+++ b/testing/polkit-qt/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=polkit-qt
+pkgver=0.112.0
+pkgrel=0
+commit=50624e06e88aabd7ae123ad6a4495630f81cd706
+pkgdesc='A library that allows developers to access PolicyKit API with a nice Qt-style API'
+arch="all"
+url='https://www.kde.org/'
+license="LGPL-2.1"
+depends="polkit"
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev cmake automoc4 polkit-dev"
+source="$pkgname-$pkgver.tar.gz::https://github.com/kde/$pkgname-1/archive/$commit.tar.gz"
+subpackages="$pkgname-dev $pkgname-dev"
+builddir="$srcdir/$pkgname-1-$commit"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DLIB_DESTINATION=/usr/lib
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="254e2086492eda93e85a30713681a1cee3eda0889750d854c9cbd920dcc1c0a94933ad230dab3e2bb9bcdbc2f4236844a6dbdf0ad6cd8a90f99e24f0d13639ef  polkit-qt-0.112.0.tar.gz"

--- a/testing/prison/APKBUILD
+++ b/testing/prison/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=prison
+pkgver=5.39.0
+pkgrel=1
+pkgdesc="A barcode API to produce QRCode barcodes and DataMatrix barcodes"
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="MIT"
+depends=""
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev libqrencode-dev libdmtx-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+sha512sums="e93eb3fbf8c516faa6debf02471c23e92c45dd7a51938104b4d828129f23ab307355bc2e3c224b3be531ac712fd2c8d28e8aa0f66937c6823e6897ee28e67078  prison-5.39.0.tar.xz"

--- a/testing/qt5-qtquickcontrols2/APKBUILD
+++ b/testing/qt5-qtquickcontrols2/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=qt5-qtquickcontrols2
+pkgver=5.9.2
+pkgrel=0
+arch="all"
+url='http://qt-project.org/'
+license="GPL-3.0 GPL-2.0 LGPL-3.0"
+pkgdesc='Next generation user interface controls based on Qt Quick'
+depends=""
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev"
+makedepends="$depends_dev"
+source="http://download.qt.io/official_releases/qt/${pkgver%.*}/$pkgver/submodules/qtquickcontrols2-opensource-src-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+builddir="$srcdir/qtquickcontrols2-opensource-src-$pkgver"
+options="!check"
+
+build() {
+	qmake-qt5
+	make
+}
+
+package() {
+	cd "$builddir"
+	make INSTALL_ROOT="$pkgdir" install
+
+	install -d "$pkgdir"/usr/share/licenses
+	ln -s /usr/share/licenses/qt5-base "$pkgdir"/usr/share/licenses/$pkgname
+}
+sha512sums="e283320aabbaa153067c909804cb34bbcbf6fcb7246bb214957b6092ceb0f01c4fae2efd9d7a6cb011274deafff4aaf0a45dbda06a3fdce1154622e48740048c  qtquickcontrols2-opensource-src-5.9.2.tar.xz"

--- a/testing/qt5-qtvirtualkeyboard/0001-include-sys-time.h-for-timeval.patch
+++ b/testing/qt5-qtvirtualkeyboard/0001-include-sys-time.h-for-timeval.patch
@@ -1,0 +1,12 @@
+diff --git a/src/virtualkeyboard/3rdparty/pinyin/include/userdict.h b/src/virtualkeyboard/3rdparty/pinyin/include/userdict.h
+index 1b9673f..924be7b 100644
+--- a/src/virtualkeyboard/3rdparty/pinyin/include/userdict.h
++++ b/src/virtualkeyboard/3rdparty/pinyin/include/userdict.h
+@@ -24,6 +24,7 @@
+ // Debug performance for operations
+ // #define ___DEBUG_PERF___
+ 
++#include <sys/time.h>
+ #ifdef _WIN32
+ #include <winsock.h> // timeval
+ #else

--- a/testing/qt5-qtvirtualkeyboard/APKBUILD
+++ b/testing/qt5-qtvirtualkeyboard/APKBUILD
@@ -1,0 +1,36 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=qt5-qtvirtualkeyboard
+pkgver=5.9.2
+pkgrel=0
+arch="all"
+url='http://qt-project.org/'
+license="GPL-3.0 GPL-2.0 LGPL-3.0"
+pkgdesc='Virtual keyboard framework'
+depends=""
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev qt5-qtsvg-dev"
+makedepends="$depends_dev hunspell-dev"
+source="http://download.qt.io/official_releases/qt/${pkgver%.*}/$pkgver/submodules/${pkgname/qt5-/}-opensource-src-$pkgver.tar.xz
+	0001-include-sys-time.h-for-timeval.patch"
+subpackages="$pkgname-dev"
+builddir="$srcdir/${pkgname/qt5-/}-opensource-src-$pkgver"
+options="!check"
+
+build() {
+	qmake-qt5 CONFIG+="lang-all handwriting"
+	make
+}
+
+package() {
+	cd "$builddir"
+	make INSTALL_ROOT="$pkgdir" install
+
+	# Drop QMAKE_PRL_BUILD_DIR because reference the build dir
+	find "$pkgdir/usr/lib" -type f -name '*.prl' \
+		-exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
+
+	install -d "$pkgdir"/usr/share/licenses
+	ln -s /usr/share/licenses/qt5-base "$pkgdir"/usr/share/licenses/$pkgname
+}
+sha512sums="f8c39b789e877e60389ee9aab4a5c17e6018093f72fc57f526ce2584183135206306d4d5a7c7551a6de45969aa6f55444bb39f4ea3324cdf10611533f0bc2b22  qtvirtualkeyboard-opensource-src-5.9.2.tar.xz
+e801336b9aaf0facdcf7347fa8cf7223362312c92ea5725c5260d777045cc9da9a6de514dc4c17904aab77ae799bdd154c4615b8f2a39d92ce55ca10ad218efb  0001-include-sys-time.h-for-timeval.patch"

--- a/testing/qt5-qtwayland/APKBUILD
+++ b/testing/qt5-qtwayland/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=qt5-qtwayland
+pkgver=5.9.2
+pkgrel=0
+arch="all"
+url='http://qt-project.org/'
+license="GPL-3.0 GPL-2.0 LGPL-3.0"
+pkgdesc='Provides APIs for Wayland'
+depends="qt5-qtdeclarative libxcomposite wayland"
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev libxkbcommon-dev"
+source="http://download.qt.io/official_releases/qt/${pkgver%.*}/${pkgver}/submodules/${pkgname/qt5-/}-opensource-src-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+builddir="$srcdir/${pkgname/qt5-/}-opensource-src-$pkgver"
+options="!check"
+
+build() {
+	qmake-qt5
+	make
+}
+
+package() {
+	cd "$builddir"
+	make INSTALL_ROOT="$pkgdir" install
+
+	# Drop QMAKE_PRL_BUILD_DIR because reference the build dir
+	find "$pkgdir/usr/lib" -type f -name '*.prl' \
+		-exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
+
+	install -d "$pkgdir"/usr/share/licenses
+	ln -s /usr/share/licenses/qt5-base "$pkgdir"/usr/share/licenses/$pkgname
+}
+sha512sums="28b6f77be5289cb9eba0e3e6b220d2c99d2ab4dbae8e02caecd7651b5ae33c09f117545664b01649ca52b27025cc15853806ece8dc10713c3d90832416c7def6  qtwayland-opensource-src-5.9.2.tar.xz"

--- a/testing/solid/APKBUILD
+++ b/testing/solid/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=solid
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Hardware integration and detection'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-qtdeclarative-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen eudev-dev flex-dev bison upower-dev
+			udisks2-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-libs $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="ab6775dbe0cf0f06e3049c4d54552d7231c3ce55176e9d3912c729613e2554be4a750356fe681d4d8f0cf1f4647f42a4076442357a59bd2800a6576199ac9352  solid-5.39.0.tar.xz"

--- a/testing/sonnet/APKBUILD
+++ b/testing/sonnet/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=sonnet
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Spelling framework for Qt5'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-qtbase"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen hunspell-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+sha512sums="4d1a06578812a77febabba8d99fe902108e52ea03fe20a065e900bc47b1254cc78940927307b27b6039f1dd79ccb3bf734a6cbc916ef47a9603c165342be8a1d  sonnet-5.39.0.tar.xz"

--- a/testing/syntax-highlighting/APKBUILD
+++ b/testing/syntax-highlighting/APKBUILD
@@ -1,0 +1,37 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=syntax-highlighting
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='Syntax highlighting engine for structured text and code'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz
+        apkbuild-syntax-highlight.patch"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+
+build() {
+	cmake \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+sha512sums="d7b011950541754b840fe87b82139f3c36b2f582db53ff0b7e2b44c31f6111b5063c77e822dbd4f216761e4e9d556257f7d8954d507541475073bad1fdb3e976  syntax-highlighting-5.39.0.tar.xz
+0722d3c44c52f70eae5636c7f912e8e53491a728c96968705c14621fb38749583d855ffdf07ea84cecfcfce0e6c295fe500a06190f7bc82082d67986d879f66e  apkbuild-syntax-highlight.patch"

--- a/testing/syntax-highlighting/apkbuild-syntax-highlight.patch
+++ b/testing/syntax-highlighting/apkbuild-syntax-highlight.patch
@@ -1,0 +1,11 @@
+--- src/data/syntax/bash.xml~	2013-06-13 09:46:51.569245577 +0000
++++ src/data/syntax/bash.xml	2013-06-13 09:47:31.745637790 +0000
+@@ -8,7 +8,7 @@
+         <!ENTITY noword   "(?![\w$+-])">                <!-- no word, $, + or - following -->
+         <!ENTITY pathpart "([\w_@.&#37;*?+-]|\\ )">     <!-- valid character in a file name -->
+ ]>
+-<language name="Bash" version="4" kateversion="5.0" section="Scripts" extensions="*.sh;*.bash;*.ebuild;*.eclass;*.nix;.bashrc;.bash_profile;.bash_login;.profile" mimetype="application/x-shellscript" casesensitive="1" author="Wilbert Berendsen (wilbert@kde.nl)" license="LGPL">
++<language name="Bash" version="4" kateversion="5.0" section="Scripts" extensions="*.sh;*.bash;*.ebuild;*.eclass;*.nix;.bashrc;.bash_profile;.bash_login;.profile;APKBUILD" mimetype="application/x-shellscript" casesensitive="1" author="Wilbert Berendsen (wilbert@kde.nl)" license="LGPL">
+
+ <!-- (c) 2004 by Wilbert Berendsen (wilbert@kde.nl)
+     Changes by Matthew Woehlke (mw_triad@users.sourceforge.net)

--- a/testing/threadweaver/APKBUILD
+++ b/testing/threadweaver/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=threadweaver
+pkgver=5.39.0
+pkgrel=0
+pkgdesc='High-level multithreading framework'
+arch="all"
+url='https://community.kde.org/Frameworks'
+license="LGPL-2.1"
+depends=""
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+
+sha512sums="3c307c53829d59d370175da05355d1ca3950feafab22a53ae8f36c03545e1b69afaf4947a2325830b33d928868c5b5a645447ddbeb6f76963141077e5a271ad2  threadweaver-5.39.0.tar.xz"


### PR DESCRIPTION
Adds tier 1 packages of the KDE frameworks. Originally packaged for [postmarketOS](https://postmarketos.org).

Only Kirigami2 is missing due to CMake not being able to find the header files of `qt5-qtquickcontrols2`. However, `qt5-qtquickcontrols2` does not seem to have header files as adding the `$pkgname-dev` subpackage fails.