### PR TITLE
update Haxe and Neko

### DIFF
--- a/testing/neko/APKBUILD
+++ b/testing/neko/APKBUILD
@@ -17,6 +17,7 @@ subpackages="$pkgname-dev $pkgname-libs"
 source="$pkgname-$pkgver.tar.gz::https://github.com/HaxeFoundation/neko/archive/v${pkgver//./-}.tar.gz
 	compilation-fixes.patch
 	nojit.patch
+	mincoming-stack-boundary.patch
 	"
 
 builddir="$srcdir/$pkgname-${pkgver//./-}"
@@ -41,4 +42,5 @@ package() {
 }
 sha512sums="a3a4e1064cf3a73b07d39eba62b261b3e954a74d71f588e90904ebdab2f3fc9f75c37a0788de0a354df9fddff412076cc321b6b33d529e69acccf403889a01b0  neko-2.1.0.tar.gz
 8d2c7be3db571f1bd1efe75209941fb1c2feb133015950be70aa31a7d55e4f5918ddb84bde4bbcce514b876c93173d7d7157481e7ce9e96d98c4229e7695d9ee  compilation-fixes.patch
-60023ab071fdaed40ccfcf452b7490f52bde04eac1586e66d93206dec66d2fb5f00a013dc93e4310dd40a0ca3e340e3b27a67ae9bb55a7a604d81e7a60acc01d  nojit.patch"
+60023ab071fdaed40ccfcf452b7490f52bde04eac1586e66d93206dec66d2fb5f00a013dc93e4310dd40a0ca3e340e3b27a67ae9bb55a7a604d81e7a60acc01d  nojit.patch
+bf6a42154070e9d7d5b65f9094f070e8d4965e4828f6b98d46ae4959a6cc13fbb3b46739e12b5125941da6ea9293ed0dd4d149885331925356395940d14e94ac  mincoming-stack-boundary.patch"

--- a/testing/neko/APKBUILD
+++ b/testing/neko/APKBUILD
@@ -2,10 +2,10 @@
 # Maintainer: Andy Li <andy@onthewings.net>
 pkgname=neko
 pkgver=2.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="High-level dynamically typed programming language"
 url="http://nekovm.org/"
-arch=""
+arch="all"
 license="LGPL"
 depends=""
 depends_dev="neko"
@@ -16,6 +16,7 @@ install=""
 subpackages="$pkgname-dev $pkgname-libs"
 source="$pkgname-$pkgver.tar.gz::https://github.com/HaxeFoundation/neko/archive/v${pkgver//./-}.tar.gz
 	compilation-fixes.patch
+	nojit.patch
 	"
 
 builddir="$srcdir/$pkgname-${pkgver//./-}"
@@ -38,9 +39,6 @@ package() {
 	cd "$builddir"
 	DESTDIR="$pkgdir" ninja -C build install || return 1
 }
-md5sums="142d511a9eb6f9a9649f109c09e9a7e6  neko-2.1.0.tar.gz
-1c8b5dc0979d1b36cf49c3c9895ac1a4  compilation-fixes.patch"
-sha256sums="330b3fc474b5ceb2bd0828bb57d08a8530aa56262cac3b7b19120e1d3cb1fbb9  neko-2.1.0.tar.gz
-d13fe905a0425d1ce0ec126aa3abc1940944572b92b72ec22d1e670623863949  compilation-fixes.patch"
 sha512sums="a3a4e1064cf3a73b07d39eba62b261b3e954a74d71f588e90904ebdab2f3fc9f75c37a0788de0a354df9fddff412076cc321b6b33d529e69acccf403889a01b0  neko-2.1.0.tar.gz
-8d2c7be3db571f1bd1efe75209941fb1c2feb133015950be70aa31a7d55e4f5918ddb84bde4bbcce514b876c93173d7d7157481e7ce9e96d98c4229e7695d9ee  compilation-fixes.patch"
+8d2c7be3db571f1bd1efe75209941fb1c2feb133015950be70aa31a7d55e4f5918ddb84bde4bbcce514b876c93173d7d7157481e7ce9e96d98c4229e7695d9ee  compilation-fixes.patch
+60023ab071fdaed40ccfcf452b7490f52bde04eac1586e66d93206dec66d2fb5f00a013dc93e4310dd40a0ca3e340e3b27a67ae9bb55a7a604d81e7a60acc01d  nojit.patch"

--- a/testing/neko/mincoming-stack-boundary.patch
+++ b/testing/neko/mincoming-stack-boundary.patch
@@ -1,0 +1,36 @@
+From 4b78044643c459a63bc87f6eadd50991df0301c7 Mon Sep 17 00:00:00 2001
+From: Andy Li <andy@onthewings.net>
+Date: Mon, 6 Jun 2016 22:22:57 +0000
+Subject: [PATCH] only use -mincoming-stack-boundary when it is available
+ From upstream: https://github.com/HaxeFoundation/neko/commit/4b78044643c459a63bc87f6eadd50991df0301c7
+
+---
+ CMakeLists.txt | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+Index: neko-debian/CMakeLists.txt
+===================================================================
+--- neko-debian.orig/CMakeLists.txt
++++ neko-debian/CMakeLists.txt
+@@ -1,5 +1,6 @@
+ cmake_minimum_required(VERSION 2.8.7)
+ 
++include(CheckCCompilerFlag)
+ project(neko C)
+ 
+ set(CMAKE_OSX_ARCHITECTURES x86_64)
+@@ -191,7 +192,13 @@ if(UNIX)
+ 
+ 	# https://github.com/HaxeFoundation/neko/pull/17
+ 	if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+-		add_compile_options(-mincoming-stack-boundary=2)
++		check_c_compiler_flag(-mincoming-stack-boundary=2 HAS_MINCOMING_STACK_BOUNDARY)
++		check_c_compiler_flag(-mstack-alignment=2 HAS_MSTACK_ALIGNMENT)
++		if(HAS_MINCOMING_STACK_BOUNDARY)
++			add_compile_options(-mincoming-stack-boundary=2)
++		elseif(HAS_MSTACK_ALIGNMENT)
++			add_compile_options(-mstack-alignment=2)
++		endif()
+ 	endif()
+ 
+ 	find_package(PkgConfig REQUIRED)

--- a/testing/neko/nojit.patch
+++ b/testing/neko/nojit.patch
@@ -1,0 +1,11 @@
+--- a/vm/jit_x86.c
++++ b/vm/jit_x86.c
+@@ -37,7 +37,7 @@
+ #define tmp_free(ptr)	free(ptr)
+ 
+ #if defined(NEKO_X86) && !defined(NEKO_MAC)
+-#define JIT_ENABLE
++//#define JIT_ENABLE
+ #endif
+ 
+ #ifdef NEKO_MAC


### PR DESCRIPTION
Update testing/haxe to 3.4.4. Add check(), change arch to all.
Add myself as maintainer. (I'm a member of the Haxe Foundation, which is the org behind Haxe and Neko. I'm also the Haxe/Neko package maintainer of Debian/Fedora/openSUSE)