### PR TITLE
main/bluez: add gatttool to bluez-deprecated

### DIFF
--- a/main/bluez/APKBUILD
+++ b/main/bluez/APKBUILD
@@ -84,6 +84,7 @@ deprecated() {
 	pkgdesc="Deprecated bluetooth tools"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/ciptool \
+		"$pkgdir"/usr/bin/gatttool \
 		"$pkgdir"/usr/bin/hciattach \
 		"$pkgdir"/usr/bin/hciconfig \
 		"$pkgdir"/usr/bin/hcidump \


### PR DESCRIPTION
gatttool is being built but missing in package bluez-deprecated