### PR TITLE
Fix bugs in 2 packages by removing Unicode whitespace.

### DIFF
--- a/community/rng-tools/APKBUILD
+++ b/community/rng-tools/APKBUILD
@@ -27,12 +27,12 @@ build() {
 		--libexecdir=/usr/lib/rng-tools \
 		--sysconfdir=/etc \
 		--disable-silent-rules
-	make || return 1
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="${pkgdir}" install || return 1
+	make DESTDIR="${pkgdir}" install
 
 	install -m644 -D "${srcdir}/rngd.confd" "${pkgdir}/etc/conf.d/rngd" || return 1
 	install -m755 -D "${srcdir}/rngd.initd" "${pkgdir}/etc/init.d/rngd" || return 1

--- a/community/rng-tools/APKBUILD
+++ b/community/rng-tools/APKBUILD
@@ -27,12 +27,12 @@ build() {
 		--libexecdir=/usr/lib/rng-tools \
 		--sysconfdir=/etc \
 		--disable-silent-rules
-	make || return 1
+	make || return 1
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="${pkgdir}" install || return 1
+	make DESTDIR="${pkgdir}" install || return 1
 
 	install -m644 -D "${srcdir}/rngd.confd" "${pkgdir}/etc/conf.d/rngd" || return 1
 	install -m755 -D "${srcdir}/rngd.initd" "${pkgdir}/etc/init.d/rngd" || return 1

--- a/main/xen/APKBUILD
+++ b/main/xen/APKBUILD
@@ -283,7 +283,7 @@ build_docs() {
 	munge_cflags
 
 	msg "Building documentation..."
-	make docs || return 1
+	make docs
 }
 
 build_stubdom() {

--- a/main/xen/APKBUILD
+++ b/main/xen/APKBUILD
@@ -283,7 +283,7 @@ build_docs() {
 	munge_cflags
 
 	msg "Building documentation..."
-	make docs || return 1
+	make docs || return 1
 }
 
 build_stubdom() {


### PR DESCRIPTION
I found these problems by parsing all APKBUILD scripts with my shell
(http://www.oilshell.org/).

The problem only occurs if 'make' fails.  Here is an excerpt:

```
$ od -c unicode-space.sh
0000000   m   a   k   e       |   | 302 240   r   e   t   u   r   n
0000020   1  \n
0000022
```

`\302 \204` is a utf-8 whitespace.  No shells accept this -- it's parsed
as part of the 'return' word, which makes it an invalid command.

```
$ busybox ash unicode-space.sh
make: *** No targets specified and no makefile found.  Stop.
unicode-space.sh: line 1:  return: not found

$ bash unicode-space.sh
make: *** No targets specified and no makefile found.  Stop.
unicode-space.sh: line 1:  return: command not found

$ dash unicode-space.sh
make: *** No targets specified and no makefile found.  Stop.
unicode-space.sh: 1: unicode-space.sh:  return: not found
```