### PR TITLE
main/znc: disable build on s390x for now

### DIFF
--- a/main/znc/APKBUILD
+++ b/main/znc/APKBUILD
@@ -5,7 +5,7 @@ pkgver=1.6.5
 pkgrel=2
 pkgdesc="An advanced IRC bouncer"
 url="http://znc.in"
-arch="all"
+arch="all !s390x"  # guile is disabled for s390x
 license="ASL-2.0"
 makedepends="perl-dev libressl-dev cyrus-sasl-dev python2-dev c-ares-dev swig
 	gettext-dev tcl-dev autoconf automake python3-dev"


### PR DESCRIPTION
Guile package is currently disable for s390x because
of a build failure and is a dependency for znc.