### PR TITLE
add gatttool to bluez-deprecated

### DIFF
--- a/main/bluez/APKBUILD
+++ b/main/bluez/APKBUILD
@@ -84,7 +84,7 @@ deprecated() {
 	pkgdesc="Deprecated bluetooth tools"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/ciptool \
-		"$builddir"/attrib/gatttool \
+		"$srcdir"/attrib/gatttool \
 		"$pkgdir"/usr/bin/hciattach \
 		"$pkgdir"/usr/bin/hciconfig \
 		"$pkgdir"/usr/bin/hcidump \

--- a/main/bluez/APKBUILD
+++ b/main/bluez/APKBUILD
@@ -84,7 +84,7 @@ deprecated() {
 	pkgdesc="Deprecated bluetooth tools"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/ciptool \
-		"$srcdir"/attrib/gatttool \
+		"$builddir"/attrib/gatttool \
 		"$pkgdir"/usr/bin/hciattach \
 		"$pkgdir"/usr/bin/hciconfig \
 		"$pkgdir"/usr/bin/hcidump \

--- a/main/bluez/APKBUILD
+++ b/main/bluez/APKBUILD
@@ -84,7 +84,7 @@ deprecated() {
 	pkgdesc="Deprecated bluetooth tools"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/ciptool \
-		"$pkgdir"/usr/bin/gatttool \
+		"$builddir"/attrib/gatttool \
 		"$pkgdir"/usr/bin/hciattach \
 		"$pkgdir"/usr/bin/hciconfig \
 		"$pkgdir"/usr/bin/hcidump \

--- a/main/bluez/APKBUILD
+++ b/main/bluez/APKBUILD
@@ -84,6 +84,7 @@ deprecated() {
 	pkgdesc="Deprecated bluetooth tools"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/ciptool \
+		"$pkgdir"/usr/bin/gatttool \
 		"$pkgdir"/usr/bin/hciattach \
 		"$pkgdir"/usr/bin/hciconfig \
 		"$pkgdir"/usr/bin/hcidump \


### PR DESCRIPTION
gatttool is being build but not installed. Therefore we move the binary to /usr/bin