### PR TITLE
community/rspamd: dependency cleanup

### DIFF
--- a/community/rspamd/APKBUILD
+++ b/community/rspamd/APKBUILD
@@ -4,7 +4,7 @@
 # Contributor: TBK <alpine@jjtc.eu>
 pkgname=rspamd
 pkgver=1.6.4
-pkgrel=0
+pkgrel=1
 pkgdesc="Fast, free and open-source spam filtering system"
 url="https://rspamd.com"
 arch="x86_64 x86 armhf ppc64le"
@@ -139,7 +139,7 @@ controller() {
 }
 
 proxy() {
-	depends="$pkgname rmilter"
+	depends="$pkgname"
 	pkgdesc="$pkgdesc (milter support)"
 	mkdir -p "$subpkgdir"/etc/$pkgname
 	mv "$pkgdir"/etc/$pkgname/worker-proxy.* \


### PR DESCRIPTION
https://bugs.alpinelinux.org/issues/8027

The previously replated package "testing/rmilter" is no longer maintained by the developer should it be moved to unmaintained?