### PR TITLE
testing/getssl: Fix the runtime dependency

### DIFF
--- a/testing/getssl/APKBUILD
+++ b/testing/getssl/APKBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Leo Unglaub <leo@unglaub.at>
 pkgname=getssl
 pkgver=2.10
-pkgrel=0
+pkgrel=1
 pkgdesc="A pure shell implementation of the LetsEncrypt ACME protocol."
 url="https://github.com/srvrco/getssl"
 arch="noarch"
 license="GPL-3.0"
-depends="curl"
+depends="curl bash"
 source="$pkgname-$pkgver.tar.gz::https://github.com/srvrco/$pkgname/archive/v$pkgver.tar.gz"
 
 package () {


### PR DESCRIPTION
The port currently needs bash. There is an open ticket
to fix this, but there is no progress in the issue.

    * https://github.com/srvrco/getssl/issues/31

Signed-off-by: Leo Unglaub <leo@unglaub.at>