### PR TITLE
main/protobuf: upgrade to 3.4.1

### DIFF
--- a/community/mumble/APKBUILD
+++ b/community/mumble/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Johannes Matheis <jomat+alpinebuild@jmt.gr>
 pkgname=mumble
 pkgver=1.2.19
-pkgrel=2
+pkgrel=3
 pkgdesc="A low-latency, high quality voice chat software"
 url="http://wiki.mumble.info"
 arch="all"

--- a/community/namecoin/APKBUILD
+++ b/community/namecoin/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=namecoin
 pkgver=0.13.0_rc1
 _ver=${pkgver/_/}
-pkgrel=7
+pkgrel=8
 pkgdesc="Namecoin is a peer to peer DNS based on bitcoin"
 url="http://www.namecoin.org/"
 arch="all"

--- a/main/mosh/APKBUILD
+++ b/main/mosh/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=mosh
 pkgver=1.3.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Mobile shell surviving disconnects with local echo and line editing"
 url="https://mosh.org"
 arch="all"

--- a/main/protobuf/APKBUILD
+++ b/main/protobuf/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=protobuf
 _gemname=google-protobuf
-pkgver=3.3.2
+pkgver=3.4.1
 pkgrel=1
 pkgdesc="Library for extensible, efficient structure packing"
 url="https://github.com/google/protobuf"
@@ -86,6 +86,6 @@ vim() {
 		"$subpkgdir"/usr/share/vim/vimfiles/syntax/proto.vim
 }
 
-sha512sums="795b2b438e6c3628f574bdb2929b7a3771a8105af2d320ca0f9b144b93d9be4f713fb389f5a08c1c771ce93585b7aefc9b272c9cb57299d9ee6827e06e7ff557  protobuf-3.3.2.tar.gz
+sha512sums="471e52198fa878a79183dc8fbc39d9c65239be4d9dff799e12281ee9b1af61a427584534b1baae1773bc6e4c86467f89ca2e7911a21effd86bc5f40cc7d94c34  protobuf-3.4.1.tar.gz
 66b430c81f34f49a86dfca50edbb517e4ad1a5ea922625b6266410c5feacfb621fe583c2998ac8994c6de45470652d2408c6c731d9746b74891a627564ca01f0  musl-fix.patch
 e1f6483b7e8d38b07cd01883bda439b2017fa0a87626fa49628f1d2042b5097ba8a68bdf1a03cd385e3e9a7c0bd2af6fbccec25e1c061617c3cceccabd17dce4  trim-rakefile.patch"

--- a/testing/ostinato/APKBUILD
+++ b/testing/ostinato/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Corentin Henry <corentinhenry@gmail.com>
 pkgname=ostinato
 pkgver=0.8
-pkgrel=0
+pkgrel=1
 pkgdesc="Packet/Traffic Generator and Analyzer"
 url="http://www.ostinato.org/"
 arch="all"


### PR DESCRIPTION
ABI is not backward compatibility - https://abi-laboratory.pro/tracker/timeline/protobuf/