### PR TITLE
main/nodejs: upgrade to 6.11.5

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -8,11 +8,13 @@
 # secfixes:
 #   6.11.1-r0:
 #     - CVE-2017-1000381
+#   6.11.5-r0:
+#     - CVE-2017-14919
 #
 pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
-pkgver=6.11.4
+pkgver=6.11.5
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="http://nodejs.org/"
@@ -102,6 +104,6 @@ npm() {
 	mv "$pkgdir"/usr/lib/node_modules/npm "$subpkgdir"/usr/lib/node_modules/
 }
 
-sha512sums="ab71d06b460dca4b1153796fa1824d87a49ea47f907e3934ab160c5276dc8f61f110839065e2e89daa1454a8abd586488d9e3d162009b76436b8630c720da25c  node-v6.11.4.tar.gz
+sha512sums="63b80b68cda08121993db7c35bb4db4823c4c9c0fc596a20713bea55290bb434b940c42b0f3c7da64283842625870449c602bdafd7ad230de1b54b0280183f37  node-v6.11.5.tar.gz
 a8be538158b7c96341a407acba30450ddc5c3ad764e7efe728d1ceff64efc3067b177855b9ef91b54400be6a02600d83da4c21a07ae9d7dc0774f92b2006ea8b  dont-run-gyp-files-for-bundled-deps.patch
 54a96cdc103bdffa9ba5283f59c64a35774e272f3a944d6475e3f669f95f7d75bcca6db3b12b9af76ea463f531763105aeabb302872652ced6a2bcb66f1eace0  ppc-fix-musl-mcontext.patch"


### PR DESCRIPTION
This updates Node.js LTS to v6.11.5 - it also includes a secfix for CVE-2017-14919, see https://nodejs.org/en/blog/vulnerability/oct-2017-dos/ for more information.