### PR TITLE
main/imagemagick: 7.0.7.8

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
-pkgver=7.0.7.5
+pkgver=7.0.7.8
 _abiver=7
 _pkgver=${pkgver%.*}-${pkgver##*.}
 pkgrel=0
@@ -17,7 +17,6 @@ makedepends="zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev fontconfig-dev
 	libwebp-dev libxml2-dev librsvg-dev"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-c++:_cxx $pkgname-libs"
 source="http://www.imagemagick.org/download/releases/ImageMagick-$_pkgver.tar.xz"
-
 builddir="$srcdir/ImageMagick-${_pkgver}"
 
 build() {
@@ -73,4 +72,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="8226c5391d00bc5d9a84f2015ac16a17dc8c6730d0f1ac629cab57b08371e79c033be98c49ce6b0e3ba6b4b84fd952228eef497dc620cda5c7fa93792b768810  ImageMagick-7.0.7-5.tar.xz"
+sha512sums="77547f8a0f667b7519f9282d7c2a51ad0f3d07fc29d612f633182eddb78cd8062239e1b738ad2c8090424631b8298ba559c495ade5e52900875b8d7a85d6401a  ImageMagick-7.0.7-8.tar.xz"


### PR DESCRIPTION
ABI is backwards compatible https://abi-laboratory.pro/tracker/timeline/imagemagick/