### PR TITLE
main/e2fsprogs: upgrade to 1.43.7

### DIFF
--- a/main/e2fsprogs/APKBUILD
+++ b/main/e2fsprogs/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=e2fsprogs
-pkgver=1.43.6
+pkgver=1.43.7
 pkgrel=0
 pkgdesc="Standard Ext2/3/4 filesystem utilities"
 url="http://e2fsprogs.sourceforge.net"
@@ -13,8 +13,8 @@ options="!check"
 makedepends="$depends_dev linux-headers"
 subpackages="$pkgname-dev $pkgname-doc libcom_err $pkgname-libs $pkgname-extra"
 source="https://www.kernel.org/pub/linux/kernel/people/tytso/$pkgname/v$pkgver/$pkgname-$pkgver.tar.xz"
-
 builddir="$srcdir/$pkgname-$pkgver"
+
 build () {
 	cd "$builddir"
 	./configure \
@@ -66,4 +66,4 @@ extra() {
 	mv "$pkgdir"/usr "$subpkgdir"/
 }
 
-sha512sums="a9d825e756f93c4b5ac2a6fae08eb27277c550c9c64ba5d86f64a06be9b5389f0b6b6dea247eb680f9881169fcdfa738bee619a55e2af286635269496255a53a  e2fsprogs-1.43.6.tar.xz"
+sha512sums="2ef270364d3cea620db3c3b9932849d0ff5b49d4a9a9b24f0d1ac36888199bd67432edc5f939d9f697ee0342b71a063e1ad4ce8119528a7adab7a777c1de57ba  e2fsprogs-1.43.7.tar.xz"


### PR DESCRIPTION
ABI is backwards compatible - https://abi-laboratory.pro/tracker/timeline/e2fsprogs/