### PR TITLE
main/atk: upgrade to 2.27.1

### DIFF
--- a/main/atk/APKBUILD
+++ b/main/atk/APKBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=atk
-pkgver=2.26.1
+pkgver=2.27.1
 pkgrel=0
 pkgdesc="A library providing a set of interfaces for accessibility"
-url="http://www.gtk.org/"
+url="https://developer.gnome.org/atk/"
 arch="all"
 license="LGPL2+"
 depends=""
@@ -27,4 +27,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="9a802f1856f0f608c3b4ef6de27dc8174e103dbb32431a4dcffcac48c685cc48efb087ab73f661d7327341e8074b73bb7877c596f93228283ca5907910d64a6b  atk-2.26.1.tar.xz"
+sha512sums="ae38343e465f10f0d8b88bb20d24b0a2efda539de0aa659c0b333e11ae0788fc8b7ab632c7fef47d6817951490136f71851556e5c92c999c6e2b80db64098997  atk-2.27.1.tar.xz"


### PR DESCRIPTION
ABI is backwards compatiable - https://abi-laboratory.pro/tracker/timeline/atk/