### PR TITLE
main/glib: upgrade to 2.54.1

### DIFF
--- a/main/glib/APKBUILD
+++ b/main/glib/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=glib
-pkgver=2.54.0
+pkgver=2.54.1
 pkgrel=0
 pkgdesc="Common C routines used by Gtk+ and other libs"
-url="http://www.gtk.org"
+url="https://developer.gnome.org/glib/"
 arch="all"
 license='GPL'
 depends=
@@ -16,22 +16,19 @@ source="http://ftp.gnome.org/pub/gnome/sources/$pkgname/${pkgver%.*}/$pkgname-$p
 	0001-gquark-fix-initialization-with-c-constructors.patch
 	"
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-static $pkgname-dev $pkgname-lang $pkgname-bash-completion:bashcomp:noarch"
+builddir="$srcdir"/$pkgname-$pkgver
 
-_builddir="$srcdir"/$pkgname-$pkgver
 prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-	# workaround packaing issue. gtk-doc.make timestamp was newer than
+	cd "$builddir"
+	default_prepare
+
+	# workaround packaging issue. gtk-doc.make timestamp was newer than
 	# Makefile.am, which triggers automake re-run
 	touch -r docs/reference/glib/Makefile.am gtk-doc.make
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -42,14 +39,13 @@ build() {
 		--disable-selinux \
 		--with-pcre=system \
 		--with-pic \
-		--enable-static \
-		|| return 1
-	make || return 1
+		--enable-static
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	rm -rf "$pkgdir"/usr/lib/charset.alias
 }
 
@@ -83,5 +79,5 @@ bashcomp() {
 	[ "$(ls -A "$pkgdir"/usr/share)" ] || rmdir "$pkgdir"/usr/share
 }
 
-sha512sums="c2da947beb23ff93df0313613743e5941b0b734d0e9405ccc1e1d88d8f7cfb16e6467d8a540cdff8e497fb854c84743f257e2537a7b765d6593457f98531596f  glib-2.54.0.tar.xz
+sha512sums="2971feede03540f5cd2b4bd60b0c3fcbd5ad95ba96d07f6e6d3f4a6b90c31555e52f3480b51976574642fd5ab99dd557061ee5db1a1855fc601297cd74a8f1a8  glib-2.54.1.tar.xz
 32e5aca9a315fb985fafa0b4355e4498c1f877fc1f0b58ad4ac261fb9fbced9f026c7756a5f2af7d61ce756b55c8cd02811bb08df397040e93510056f073756b  0001-gquark-fix-initialization-with-c-constructors.patch"


### PR DESCRIPTION
ABI is backwards compatiable - https://abi-laboratory.pro/tracker/timeline/glib/