### PR TITLE
testing/flatpak-builder: upgrade to 0.10.1

### DIFF
--- a/testing/flatpak-builder/APKBUILD
+++ b/testing/flatpak-builder/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: André Klitzing <aklitzing@gmail.com>
 # Maintainer: André Klitzing <aklitzing@gmail.com>
 pkgname=flatpak-builder
-pkgver=0.9.99
+pkgver=0.10.1
 pkgrel=0
 pkgdesc="Tool to build flatpaks from source"
 url="http://flatpak.org"
@@ -44,5 +44,5 @@ package() {
 	install -D -m644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 
-sha512sums="b853555b2964ad00d997b905269541c7ed1ce2b5b0fabb391036f6d4dda88abbad2b6849737bf0f6d120ea76bd3d457cc088a46518440eb37cf6a7a7ebdd2ef3  flatpak-builder-0.9.99.tar.xz
+sha512sums="c531511d28672727a00abaefb5b26dff9885f437a5cf18b452687a7657fb36550fa8b1a49fa074adb2fa21d469bafa1574d39e5eec7f7b71d6e2a61f714240c7  flatpak-builder-0.10.1.tar.xz
 9287ed146bf71665aa436a2c2110cc5edc829a7b4a3e3190947580850fe9ecfd2bb6adb015c692af022d425fb5259390fcdcbd402e8b0d12ee5d2c1a1071ed4f  musl-fixes.patch"


### PR DESCRIPTION
Dependent on https://github.com/alpinelinux/aports/pull/2605