### PR TITLE
community/php7: security upgrade to 7.0.25

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=php7
 _pkgreal=php
-pkgver=7.0.21
+pkgver=7.0.25
 pkgrel=0
 pkgdesc="The PHP language runtime engine - 7th branch"
 url="http://www.php.net/"
@@ -62,6 +62,8 @@ _apiver="20151012"
 #     - CVE-2017-9227
 #     - CVE-2017-9228
 #     - CVE-2017-9229
+#   7.0.25-r0:
+#     - CVE-2016-1283
 
 prepare() {
 	cd "$builddir"
@@ -346,7 +348,7 @@ _package_ext() {
 		> "$subpkgdir"/etc/$pkgname/conf.d/${elo}_${extname}.ini
 }
 
-md5sums="c6459c27adbbb174ce58165e39a5d580  php-7.0.21.tar.bz2
+md5sums="f9decbaf25edca395b5947dbbe6ad98a  php-7.0.25.tar.bz2
 4115cbd0843c72adc3bd42fecd6d4540  php7-fpm.initd
 25bde13e7894c2930d97fad68d5dd3b3  php7-fpm.logrotate
 47be6cd1ed92f21579e15bf2003a709f  php7-module.conf
@@ -355,7 +357,7 @@ md5sums="c6459c27adbbb174ce58165e39a5d580  php-7.0.21.tar.bz2
 d872e633c9b33c3c9f629dd2edd2e5c5  includedir.patch
 fa807a684fa853720b7523eb99869b34  fix-asm-constraints-in-aarch64-multiply-macro.patch
 6ba762ab7a105163b8e5b3913deae109  pid_log.patch"
-sha256sums="2ba133c392de6f86aacced8c54e0adefd1c81d3840ac323b9926b8ed3dc6231f  php-7.0.21.tar.bz2
+sha256sums="95a24d96d126a196e1550e394182b43a6460cdd2026f1a77bef01e422415cc25  php-7.0.25.tar.bz2
 a7e4fc0eeba18aec019f62ed966915afd82b6b5fb1e1af93b59f964b5bd66172  php7-fpm.initd
 6e4406f21b69085714cdb9d9a67c08e27a1c737ab353f9813cb2fc268352d2c6  php7-fpm.logrotate
 276c823ee666ea73b36d4e97174eeea05713125b61f7f8681e350453c4123143  php7-module.conf
@@ -364,7 +366,7 @@ f739ca427a1dd53a388bad0823565299c5d4a5796b1171b892884e4d7d099bab  install-pear.p
 ea74966a23b1b54548ee35e9ccc2fc8d2b7c2285c385c44d6b23d9e2f25ea1a7  includedir.patch
 86f4186699f0bc61ce91986fe5efdd7b0da77ff9568c10ba52ca1094da94ed6e  fix-asm-constraints-in-aarch64-multiply-macro.patch
 0cca8729c64682387a8c44ed74f0966da697f2817152d8d05bb25bedc7eaafec  pid_log.patch"
-sha512sums="c3c439fc79bef5492d3be94afea11125768cdd10f09f26caa140a6946c82eb2e49c817af616048c723bf9d6456d4ed1d9de844cfba862761b1cfc54f495367dd  php-7.0.21.tar.bz2
+sha512sums="c6c964ac3a043e3c2c43218c157385a5cc0c90918e0bd9338eed294855f58778dacd64da8e2a31163c119f796a645c7ed672c44d6c0b2a5d4a5cffea963e0878  php-7.0.25.tar.bz2
 1c708de82d1086f272f484faf6cf6d087af7c31750cc2550b0b94ed723961b363f28a947b015b2dfc0765caea185a75f5d2c2f2b099c948b65c290924f606e4f  php7-fpm.initd
 cacce7bf789467ff40647b7319e3760c6c587218720538516e8d400baa75651f72165c4e28056cd0c1dc89efecb4d00d0d7823bed80b29136262c825ce816691  php7-fpm.logrotate
 fbf9a1572d37370ec0d126502e1d066e045a992484d8fc4f1e2ede330134c1a15f4029f29fa4daebd48eed78b045dc051ced69fbf1f11efc7ad81d884a639a99  php7-module.conf


### PR DESCRIPTION
This upgrade should go to **3.5 only** http://php.net/archive/2017.php#id2017-10-26-1 **CVE-2016-1283**