### PR TITLE
main/weechat: add missing dependency

### DIFF
--- a/main/weechat/APKBUILD
+++ b/main/weechat/APKBUILD
@@ -7,7 +7,7 @@ url="http://www.weechat.org"
 arch="all"
 license="GPL3+"
 depends_dev="cmake libintl ncurses-dev gnutls-dev libgcrypt-dev curl-dev
-	aspell-dev lua-dev perl-dev python2-dev ruby-dev"
+	aspell-dev lua-dev perl-dev python2-dev ruby-dev zlib-dev"
 makedepends="$depends_dev"
 subpackages="$pkgname-dev $pkgname-aspell:_plugin $pkgname-lua:_plugin
 	$pkgname-perl:_plugin $pkgname-python:_plugin $pkgname-ruby:_plugin"


### PR DESCRIPTION
add zlib-dev as a dependency to fix build error:
CMake Error at cmake/FindPackageHandleStandardArgs.cmake:91 (MESSAGE):
Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR)