### PR TITLE
testing/wireguard: update to 0.0.20171101

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171017
-_mypkgrel=0
+_ver=0.0.20171101
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="134a1cbcdae6f3fa56e2c557f08eaae89e14f6b8455ffb818e1bb4113905298f26c170b3ee73129f895089407e86809047ae6813cd7a31db55b6b9a89f361edb  WireGuard-0.0.20171017.tar.xz"
+sha512sums="c3a394256cf3cc2dce75dcb299f54969f74d4076a351b61972f10fb3e69191756c0c32552a5acc7e0cd5919c248f12035e6a33f15e43fdad64c6cf1230511ee3  WireGuard-0.0.20171101.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20171017
+pkgver=0.0.20171101
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="134a1cbcdae6f3fa56e2c557f08eaae89e14f6b8455ffb818e1bb4113905298f26c170b3ee73129f895089407e86809047ae6813cd7a31db55b6b9a89f361edb  WireGuard-0.0.20171017.tar.xz"
+sha512sums="c3a394256cf3cc2dce75dcb299f54969f74d4076a351b61972f10fb3e69191756c0c32552a5acc7e0cd5919c248f12035e6a33f15e43fdad64c6cf1230511ee3  WireGuard-0.0.20171101.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171017
-_mypkgrel=0
+_ver=0.0.20171101
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="134a1cbcdae6f3fa56e2c557f08eaae89e14f6b8455ffb818e1bb4113905298f26c170b3ee73129f895089407e86809047ae6813cd7a31db55b6b9a89f361edb  WireGuard-0.0.20171017.tar.xz"
+sha512sums="c3a394256cf3cc2dce75dcb299f54969f74d4076a351b61972f10fb3e69191756c0c32552a5acc7e0cd5919c248f12035e6a33f15e43fdad64c6cf1230511ee3  WireGuard-0.0.20171101.tar.xz"


### PR DESCRIPTION
Simple version bump. Changes:

* netns: use read built-in instead of ncat hack for dmesg
* netns: use time-based test instead of quantity-based
* qemu: allow for cross compilation
* qemu: work around ccache bugs
* qemu: test using four cores
* selftest: initialize mutex in routingtable selftest

We now cross compile and run in QEMU for x86_64, i686,
ARMv7, Aarch64, and MIPS. You can see the current build
status on: https://www.wireguard.com/build-status/

* stats: more robust accounting
* compat: fix up stat calculation for udp tunnel

The statistics from `ip link -stats` or from `wg show` are
now much more accurate.

* global: accept decent check_patch.pl suggestions
* global: infuriating kernel iterator style
* global: style nits
* global: use fewer BUG_ONs
* global: get rid of useless forward declarations
* blake2: include headers for macros
* tools: correct type for CTRL_ATTR_FAMILY_ID

Lots of style cleanups.

* crypto/avx: make sure we can actually use ymm registers

This fixes an issue on some Xen platforms that expose
conflicting CPU features.

* peer: get rid of peer_for_each magic
* peer: store total number of peers instead of iterating

A major cleanup of our peer iteration logic, getting rid
of a big ugly macro and clarifying our locking semantics.

* compat: be sure to include header before testing

* wg-quick: allow specifiying multiple hooks

You can now specify {Post,Pre}{Down,Up} multiple times, and
the commands will then run in succession.

* wg-quick: remember to rewind DNS settings on failure

Small consistency fix.

* wg-quick: allow for saving existing interface

There is now a 'save' option for saving an existing
configuration without having to bring down the device.

* wg-quick: fsync the temporary file before renaming

In case the system looses power, you are now left with
either the old file or the new file but not an empty file.

* wg-quick: allow for the hatchet, but not by default

In order to account for distributions that do not have an
implementation of resolvconf(8), the contrib directory ships
with an alternative implementation that may be patched in.
This was extensively discussed and debated on the mailing
list.

* device: only take reference if netns is different

Solves an important memory leak when tearing down network
namespaces that haven't moved the wireguard device.

* device: expand scope of destruct lock
* timers: guard entire setting in block

Just to be certain.

* curve25519: only enable int128 if compiler support is sound

Allows building for Aarch64 with old gcc (such as that used
by Android) where we don't want to branch to a __multi3.

* contrib: add reresolve-dns

A small script that's been passed around for a while now for
reresolving DNS entries from a cronjob.
