### PR TITLE
main/perl-text-quoted: fix make depends

### DIFF
--- a/main/perl-text-quoted/APKBUILD
+++ b/main/perl-text-quoted/APKBUILD
@@ -2,40 +2,33 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=perl-text-quoted
 pkgver=2.08
-pkgrel=1
+pkgrel=2
 pkgdesc="Text::Quoted perl module"
 url="http://search.cpan.org/dist/Text-Quoted/"
 arch="noarch"
 license="GPLv2 or Artistic"
 depends="perl perl-text-autoformat"
 makedepends="perl-dev perl-module-install"
-install=""
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/T/TS/TSIBLEY/Text-Quoted-$pkgver.tar.gz"
 
-_builddir="$srcdir"/Text-Quoted-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir/Text-Quoted-$pkgver"
 
 build() {
-	cd "$_builddir"
-	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor || return 1
-	make && make test || return 1
+	cd "$builddir"
+	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="2ddedd6541460a32223cf91c7e16fcb7  Text-Quoted-2.08.tar.gz"
-sha256sums="faf0b6fa314c31b264bc1d8d6523ed32a098040fdc513075ccaecbab0526cfdb  Text-Quoted-2.08.tar.gz"
 sha512sums="bbe48bf580e6628008728cbff5d6eba8f47664bde71920ff3cb55e45992cb8500730c5228726451e2bee1b6028fd56401e51e80ea73cd9b1f1386211dfce6fde  Text-Quoted-2.08.tar.gz"

--- a/main/perl-text-quoted/APKBUILD
+++ b/main/perl-text-quoted/APKBUILD
@@ -2,13 +2,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=perl-text-quoted
 pkgver=2.08
-pkgrel=0
+pkgrel=1
 pkgdesc="Text::Quoted perl module"
 url="http://search.cpan.org/dist/Text-Quoted/"
 arch="noarch"
 license="GPLv2 or Artistic"
 depends="perl perl-text-autoformat"
-makedepends="perl-dev"
+makedepends="perl-dev perl-module-install"
 install=""
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/T/TS/TSIBLEY/Text-Quoted-$pkgver.tar.gz"


### PR DESCRIPTION
Add perl-module-install as a make dependency to fix build error:
Can't locate inc/Module/Install.pm in @INC (you may need to install
the inc::Module::Install module)