### PR TITLE
main/gtk-doc: fix build on ppc64le

### DIFF
--- a/main/gtk-doc/APKBUILD
+++ b/main/gtk-doc/APKBUILD
@@ -1,13 +1,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gtk-doc
 pkgver=1.26
-pkgrel=1
+pkgrel=2
 pkgdesc="Documentation tool for public library API"
 url="http://www.gtk.org/gtk-doc/"
 arch="noarch"
 license="GPL FDL"
 depends="docbook-xsl gnome-doc-utils perl python2 py2-six pkgconf glib-dev highlight"
-makedepends="rarian-dev py-libxml2 gettext itstool"
+makedepends="rarian-dev py-libxml2 gettext itstool autoconf automake libtool"
 checkdepends="bc"
 source="https://download.gnome.org/sources/$pkgname/$pkgver/$pkgname-$pkgver.tar.xz
 	0001-tests-Label-parts-with-decimals-not-roman-numerals.patch
@@ -16,6 +16,11 @@ source="https://download.gnome.org/sources/$pkgname/$pkgver/$pkgname-$pkgver.tar
 # disable checks for now
 options="!check"
 builddir="$srcdir/$pkgname-$pkgver"
+
+prepare() {
+	cd "$builddir"
+	autoreconf -vif
+}
 
 build() {
 	cd "$builddir"


### PR DESCRIPTION
Run autoreconf in prepare to fix build error in ppc64le. It was
failing with error:
/bin/bash: line 4: 101512 Segmentation fault
itstool -m "${mo}" ${d}/C/index.docbook ${d}/C/fdl-appendix.xml