### PR TITLE
main/perl-term-table: upgrade to 0.012

### DIFF
--- a/main/perl-term-table/APKBUILD
+++ b/main/perl-term-table/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=perl-term-table
 _pkgreal=Term-Table
-pkgver=0.008
+pkgver=0.012
 pkgrel=0
 pkgdesc="Format a header and rows into a table"
 url="http://search.cpan.org/dist/Term-Table/"
@@ -45,4 +45,4 @@ check() {
 	make test
 }
 
-sha512sums="d741313933c8925ca3451056d05172c440ab4a46f5a4cbaeae3c6d4b82d29314e69643e8c3e60dced42768f2102277461b2d2dc4bf945d982df9265f49339d06  Term-Table-0.008.tar.gz"
+sha512sums="913541de3bdf694d44aca82ae7e87144d24f062824df345dba55865c1d535c3830de9fa3df27c6f566f5ac994c24a654bebf72b6fdbc173c7754a89ebec8ea6a  Term-Table-0.012.tar.gz"


### PR DESCRIPTION
version 0.008 is no more available upstream