### PR TITLE
main/php5: upgrade to 5.6.32

### DIFF
--- a/main/php5/APKBUILD
+++ b/main/php5/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
-pkgver=5.6.31
+pkgver=5.6.32
 pkgrel=0
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
@@ -131,6 +131,8 @@ _peardir=/usr/share/pear
 #     - CVE-2017-9227
 #     - CVE-2017-9228
 #     - CVE-2017-9229
+#   5.6.32-r0:
+#     - CVE-2016-1283
 
 prepare() {
 	cd "$_srcdir"
@@ -509,17 +511,17 @@ pdo_dblib()	{ _mv_ext pdo_dblib "$pkgname-pdo freetds"; }
 wddx()		{ _mv_ext wddx; }
 opcache()	{ _mv_ext opcache; }
 
-md5sums="620abe25e0d6cd5f041a360a30ce5783  php-5.6.31.tar.bz2
+md5sums="9617d5272da7bb70e09ed20c4e69f266  php-5.6.32.tar.bz2
 63b16caff0d7aa881a31a1e02f3080c3  php-fpm.initd
 67719f428f44ec004da18705cbabe2ee  php5-module.conf
 483bc0a85c50a9a9aedbe14a19ed4526  php-install-pear-xml.patch
 7200972a23adae799921c4ca20ff0074  gd-iconv.patch"
-sha256sums="8f397169cb65f0539f3bcb04060f97770d73e19074a37bd2c58b98ebf6ecb10f  php-5.6.31.tar.bz2
+sha256sums="3ee44e7a5fa42b563652b3ea0d3487bc236fcc9e5ea74b583775cab867abcb51  php-5.6.32.tar.bz2
 be9bfdab10a994fe553119b181be7015325a7618de454a58bdee06bcfb711454  php-fpm.initd
 ceec4d5b2a128c6a97e49830af604f0bb555bca1a86a9cd0366b828ba392257f  php5-module.conf
 f739ca427a1dd53a388bad0823565299c5d4a5796b1171b892884e4d7d099bab  php-install-pear-xml.patch
 98de37c650a36870a543225f6a6b81813ccd447a484f0881511be4eb6e901844  gd-iconv.patch"
-sha512sums="fe0a0572917287a89910cc4d1bca7a8be17fb09d0459d68fea7b32f4b9fd94efbf36d90f8d7d34baee60efc6b0aeac1414a658fc0b451c5eb2f8e3864e20e3c0  php-5.6.31.tar.bz2
+sha512sums="d3f53a9c14e05726ec80785ee2db482d73cfd9bfca751041150da63e5e9273a2ea9a0027d3d9c80434ae8c1f93e7a4556b050969c271e696a841ec785efbeedc  php-5.6.32.tar.bz2
 1f5cb18f85a2e279e24344d993f5c51c7bfbcbecc0e9bfcf075bebd1b0b893e2ffb793d95a632c9333033597d4b4f74840bfd00520a6dc700444d1a054225da1  php-fpm.initd
 895e94c791bd82060ad820fef049d366a09c932097faa6b7b9a2c2e9e00a18cb7c0f9b128679c7659b404379266fd0f95dba5c0333f626194cf60f7bf6044102  php5-module.conf
 f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c939768584f3e4edbe52e8bd6103fb6777462326a9d94e8ab1f505  php-install-pear-xml.patch


### PR DESCRIPTION
Security release http://php.net/archive/2017.php#id2017-10-26-3

It should go to 3.5 & 3.4 because 3.6 & edge already upgraded