### PR TITLE
main/live-media: upgrade to 2017.10.28

### DIFF
--- a/community/vlc/APKBUILD
+++ b/community/vlc/APKBUILD
@@ -5,7 +5,7 @@ pkgname=vlc
 pkgver=2.2.6
 _pkgver=${pkgver/_/-}
 _ver=${_pkgver%[a-z]}
-pkgrel=0
+pkgrel=1
 pkgdesc="A multi-platform MPEG, VCD/DVD, and DivX player"
 triggers="vlc-libs.trigger=/usr/lib/vlc/plugins"
 pkgusers="vlc"

--- a/main/live-media/APKBUILD
+++ b/main/live-media/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=live-media
-pkgver=2017.04.26
+pkgver=2017.10.28
 pkgrel=0
 pkgdesc="A set of C++ libraries for multimedia streaming"
 url="http://live555.com/liveMedia"
@@ -53,4 +53,4 @@ utils() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="444b3c63e30b2ddd0fac8b11f09efff3796953f6bad558cc59c093273a351ef6b1631abc5d89a8be422caf54b1c46104c59b507fc104785795c3e8622a8a4efd  live.2017.04.26.tar.gz"
+sha512sums="eea5bdb8d89e76c8b6aeb6ec04b77af3048cb41f228d230ba4da6045e9bc691a456023d44d8650fe690b08143567ed5af5b633f5b6522debff79344a813dc7d0  live.2017.10.28.tar.gz"


### PR DESCRIPTION
version 2017.04.26 is no longer available upstream