### PR TITLE
scripts/bootstrap.sh: ghc moved from testing to community

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -103,7 +103,7 @@ for PKG in fortify-headers linux-headers musl libc-dev pkgconf zlib \
 	   attr libcap patch sudo acl fakeroot tar \
 	   pax-utils abuild openssh \
 	   ncurses libcap-ng util-linux lvm2 popt xz cryptsetup kmod lddtree mkinitfs \
-	   community/go libffi testing/ghc \
+	   community/go libffi community/ghc \
 	   $KERNEL_PKG ; do
 
 	CHOST=$TARGET_ARCH BOOTSTRAP=bootimage APKBUILD=$(apkbuildname $PKG) abuild -r


### PR DESCRIPTION
Commit 3b5707d385eecf499b59ce4e41763a4f2dc20595 moved ghc from
testing to community, but bootstrap.sh was not updated.