### PR TITLE
php5-suhosin / php5-apcu: restore to community

### DIFF
--- a/community/php5-apcu/APKBUILD
+++ b/community/php5-apcu/APKBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+# Contributor: Valery Kartel <valery.kartel@gmail.com>
+_php=php5
+pkgname=${_php}-apcu
+_pkgreal=apcu
+# release 5 is php7+
+pkgver=4.0.11
+_pkgver=${pkgver/_rc/RC}
+pkgrel=1
+pkgdesc="PHP extension APC User Cache"
+url="http://pecl.php.net/package/$_pkgreal"
+arch="all"
+license="PHP"
+depends=
+pecldepends="${_php}-dev autoconf"
+makedepends="$pecldepends pcre-dev"
+source="http://pecl.php.net/get/$_pkgreal-$_pkgver.tgz"
+
+_builddir="$srcdir"/$_pkgreal-$_pkgver
+
+build() {
+	cd "$_builddir"
+	phpize5
+	./configure \
+		--prefix=/usr \
+		--with-php-config=/usr/bin/php-config5
+	make
+}
+
+check() {
+	cd "$_builddir"
+	# test failures reported to php
+	# the test asks for an email address due to this failure
+	# make test
+}
+
+package() {
+	cd "$_builddir"
+	make INSTALL_ROOT="$pkgdir"/ install
+	install -d "$pkgdir"/etc/$_php/conf.d
+	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/$_php/conf.d/$_pkgreal.ini
+}
+
+sha512sums="e3b97066240e33850419e96f0fd9df0e66ee3b0fa238c418e07ac639d07439e9edfa1696e56a620e33f1ffc0993c57bde585b0c170b22995e7d5c0ae550b7899  apcu-4.0.11.tgz"

--- a/community/php5-suhosin/APKBUILD
+++ b/community/php5-suhosin/APKBUILD
@@ -1,0 +1,45 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+_php=php5
+_realname=suhosin
+pkgname=${_php}-$_realname
+pkgver=0.9.38
+pkgrel=0
+pkgdesc="SUHOSIN - 수호신 - The PHP security extension."
+url="https://www.suhosin.org"
+arch="all"
+license="PHP 3"
+depends=""
+makedepends="${_php}-dev autoconf linux-headers"
+source="https://download.suhosin.org/suhosin-$pkgver.tar.gz
+	fix-LOCK-undeclared.patch
+	"
+builddir="$srcdir/suhosin-$pkgver"
+
+build() {
+	cd "$builddir"
+	phpize5
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--with-php-config=/usr/bin/php-config5
+	make
+}
+
+check() {
+	cd "$builddir"
+	# tests/funcs/crypt_blowfish.phpt failure reported to php
+	# the test asks for an email address due to this failure
+	# make test
+}
+
+package() {
+	cd "$builddir"
+	make INSTALL_ROOT="$pkgdir" install
+	mkdir -p "$pkgdir"/etc/${_php}/conf.d
+	echo "extension=suhosin.so" > "$pkgdir"/etc/${_php}/conf.d/suhosin.ini
+}
+
+sha512sums="cc4eb38b5d6673cc3f2dc395e5a8b5461d3221019ac9849b747b6d5bae423cd5bd01a75b9432414dc7c26c78bab9f2381a5414712a6906a999f3ec9dc77ebc45  suhosin-0.9.38.tar.gz
+8d41d5cf3cf31c086ecc07fa786232df3e821a659dc4ff4e08f9d30f57bce453abcf16345b911b6dba683dd421c2cbe11e0966ef3bb7976d1d6627d8bc66a15e  fix-LOCK-undeclared.patch"

--- a/community/php5-suhosin/fix-LOCK-undeclared.patch
+++ b/community/php5-suhosin/fix-LOCK-undeclared.patch
@@ -1,0 +1,11 @@
+--- suhosin-0.9.38/log.c
++++ suhosin-0.9.38/log.c.new
+@@ -27,7 +27,7 @@
+ #include "php.h"
+ #include "php_ini.h"
+ #include "php_suhosin.h"
+-#include <fcntl.h>
++#include <linux/fcntl.h>
+ #include "SAPI.h"
+ #include "ext/standard/datetime.h"
+ #include "ext/standard/flock_compat.h"


### PR DESCRIPTION
Both of these packages were removed due to being [non core extensions](https://github.com/alpinelinux/aports/commit/71d024f91830436d4007f82ec37a25da282dbca9). I've been using them both for almost a year without any problems.

[suhosin](https://suhosin.org) improves the security of `php5`.