### PR TITLE
main/xen: Add openrc-init-script for xendriverdomain

### DIFF
--- a/main/xen/APKBUILD
+++ b/main/xen/APKBUILD
@@ -196,6 +196,7 @@ source="https://downloads.xenproject.org/release/$pkgname/$pkgver/$pkgname-$pkgv
 	xen-consoles.logrotate
 	xenqemu.confd
 	xenqemu.initd
+	xendriverdomain.initd
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver
@@ -346,6 +347,8 @@ package() {
 
 	# remove default xencommons
 	rm -rf "$pkgdir"/etc/init.d/xencommons
+	# remove default xendriverdomain
+	rm -rf "$pkgdir"/etc/init.d/xendriverdomain
 
 	for i in $source; do
 		case $i in
@@ -465,4 +468,5 @@ e76816c6ad0e91dc5f81947f266da3429b20e6d976c3e8c41202c6179532eec878a3f0913921ef3a
 c7c0eecd5f454d903b57a710902da27dcb2c6b200f88d4eadfab33a447be6b41454109d482aab849a690446ea5c928e619dfc6cf95b7955f00a476f2317bb82b  xendomains.confd
 ab2105c75cfe01768aecd5bcbb56269d63666e8a44e42b6a83aee87df6c84ee2f9ab249171c21b2e09f8fec2cae8318f6e87d160989398a3e7dd68db8d52c426  xen-consoles.logrotate
 bdbe15c924071cdc2d0f23e53ba8e3f837d4b5369bfb218abd3405f9bef25d105269aaf0784baeb69c073a5786b8c82ffdfd414e86874da34293cfdc2c497928  xenqemu.confd
-8475119369409efb8ad930c7735cd3d782191d18fab4fc322a51120c395162ff88e381182876036d1078afd30079dbf3f94a3568689e9b52ba235adead4b97d3  xenqemu.initd"
+8475119369409efb8ad930c7735cd3d782191d18fab4fc322a51120c395162ff88e381182876036d1078afd30079dbf3f94a3568689e9b52ba235adead4b97d3  xenqemu.initd
+85afec835a374aac3d307b3226eee7a08a676b1daac7e39bb7463d564ef72438dc27dd188a871cfd031e80c6992b756951f26bdca0d445e07eab6dba5245de46  xendriverdomain.initd"

--- a/main/xen/xendriverdomain.initd
+++ b/main/xen/xendriverdomain.initd
@@ -1,0 +1,52 @@
+#!/sbin/openrc-run
+
+description="Starts and stops xen driver domain daemon"
+
+depend() 
+{
+        after syslog
+}
+
+start() 
+{
+        # not running in Xen dom0 or domU
+        if ! test -d /proc/xen ; then
+                exit 0
+        fi
+
+        # mount xenfs in dom0 or domU with a pv_ops kernel
+        if [ ! -f /proc/xen/capabilities  ] && \
+                ! grep '^xenfs ' /proc/mounts >/dev/null;
+        then
+                mount -t xenfs xenfs /proc/xen
+        fi
+
+        # run this script only in domU:
+        # no capabilities file in xenlinux domU kernel
+        # empty capabilities file in pv_ops domU kernel
+        if [ ! -f /proc/xen/capabilities ] || \
+                grep -q "control_d" /proc/xen/capabilities ; then
+                exit 0
+        fi
+
+        [ -n "${PIDFILE}" ] || PIDFILE=/var/run/xldevd.pid
+
+        ebegin "Starting xendriverdomain"
+
+        start-stop-daemon --start --quiet \
+                --exec /usr/sbin/xl \
+                -- devd --pidfile "${PIDFILE}" $XLDEVD_ARGS
+        eend $? "Failed to start xendriverdomain"
+}
+
+stop() 
+{
+        [ -n "${PIDFILE}" ] || PIDFILE=/var/run/xldevd.pid
+
+        ebegin "Stopping xendriverdomain"
+
+        start-stop-daemon --stop --quiet \
+                --pidfile "${PIDFILE}"
+
+        eend $? "Failed to stop xendriverdomain"
+}


### PR DESCRIPTION
This PR replaces the upstream provided ``xendriverdomain``-init-script with a proper openrc-script.