### PR TITLE
main/sdl2: re-add directfb support

### DIFF
--- a/main/sdl2/APKBUILD
+++ b/main/sdl2/APKBUILD
@@ -2,13 +2,13 @@
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=sdl2
 pkgver=2.0.7
-pkgrel=0
+pkgrel=1
 pkgdesc="A development library designed to provide low level access to audio, keyboard, mouse, joystick and graphics"
 url="http://www.libsdl.org"
 arch="all"
 license="zlib"
 depends=""
-makedepends="alsa-lib-dev libxcursor-dev libxrandr-dev libxrender-dev mesa-dev
+makedepends="alsa-lib-dev directfb-dev libxcursor-dev libxrandr-dev libxrender-dev mesa-dev
 	libxscrnsaver-dev libxi-dev libx11-dev libxext-dev libusb-dev libxkbcommon-dev"
 subpackages="$pkgname-dev"
 source="https://www.libsdl.org/release/SDL2-$pkgver.tar.gz"
@@ -16,6 +16,8 @@ builddir="$srcdir/SDL2-$pkgver"
 
 build() {
 	cd "$builddir"
+	# NOTE: Please do not remove the --enable-video-directfb flag.
+	# Some apps, used for booting Alpine derivatives, require this to function!
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -26,8 +28,13 @@ build() {
 		--disable-esd \
 		--disable-nas \
 		--disable-rpath \
-		--with-x
+		--with-x \
+		--enable-video-directfb
 	make
+}
+
+check() {
+    [ "$($builddir/sdl2-config --version)" == "$pkgver" ]
 }
 
 package() {


### PR DESCRIPTION
This re-adds directfb support, which is required by a program we use in pmOS for unlocking rootfs/LUKS on boot.

This also adds a simple check to the package, since no test suite exists for this app.