### PR TITLE
main/mc: fix build

### DIFF
--- a/main/mc/APKBUILD
+++ b/main/mc/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mc
 pkgver=4.8.19
-pkgrel=0
+pkgrel=1
 pkgdesc="A filemanager/shell that emulates Norton Commander"
 url="http://www.midnight-commander.org"
 arch="all"
@@ -11,7 +11,9 @@ depends=""
 subpackages="$pkgname-doc $pkgname-lang"
 makedepends="e2fsprogs-dev glib-dev pcre-dev ncurses-dev libssh2-dev"
 source="http://www.midnight-commander.org/downloads/$pkgname-$pkgver.tar.bz2
-	alpine_syntax.patch"
+	alpine_syntax.patch
+	tty_init-unify-curses-initialization.patch"
+
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -36,6 +38,11 @@ build() {
 		--without-x \
 		|| return 1
 	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
@@ -63,4 +70,5 @@ lang() {
 }
 
 sha512sums="eecf39b3f043cad1f47aabcd25a0e672e7bbf406944f457521e0ff5db344f01cdc8572bb45b2507a54469ff1130c457a90f62eb7d5e6191f9c7d4f35a4b46a2e  mc-4.8.19.tar.bz2
-aee89eaacaafcdfe2ceb2eb7b7dcf08d669dbaffcb76f4c1613498017096c33068b7bf9d06e6f7d0685c9928cebaa932ab78b3a68f3b2de59b512022b3944e8d  alpine_syntax.patch"
+aee89eaacaafcdfe2ceb2eb7b7dcf08d669dbaffcb76f4c1613498017096c33068b7bf9d06e6f7d0685c9928cebaa932ab78b3a68f3b2de59b512022b3944e8d  alpine_syntax.patch
+ca89e39c4c501464b6980f7956ec606def6cc4d12865d3826c0bd59a4b59144a5105cd95131854e4b42a39cbee4f4ecfca673746005b077e32d0e688b0b8e9f8  tty_init-unify-curses-initialization.patch"

--- a/main/mc/tty_init-unify-curses-initialization.patch
+++ b/main/mc/tty_init-unify-curses-initialization.patch
@@ -1,0 +1,61 @@
+From 4d46a108629beb66a293672db7b44f863b6598ba Mon Sep 17 00:00:00 2001
+From: Thomas Dickey <dickey@his.com>
+Date: Fri, 14 Apr 2017 14:06:13 +0300
+Subject: [PATCH] Ticket #3697: (tty_init): unify curses initialization
+
+...for various curses implementations.
+
+Signed-off-by: Andrew Borodin <aborodin@vmail.ru>
+---
+ lib/tty/tty-ncurses.c | 26 +++++++++-----------------
+ 1 file changed, 9 insertions(+), 17 deletions(-)
+
+diff --git a/lib/tty/tty-ncurses.c b/lib/tty/tty-ncurses.c
+index a7a11f368..8e69b39f6 100644
+--- a/lib/tty/tty-ncurses.c
++++ b/lib/tty/tty-ncurses.c
+@@ -179,6 +179,8 @@ mc_tty_normalize_lines_char (const char *ch)
+ void
+ tty_init (gboolean mouse_enable, gboolean is_xterm)
+ {
++    struct termios mode;
++
+     initscr ();
+ 
+ #ifdef HAVE_ESCDELAY
+@@ -194,25 +196,15 @@ tty_init (gboolean mouse_enable, gboolean is_xterm)
+     ESCDELAY = 200;
+ #endif /* HAVE_ESCDELAY */
+ 
+-#ifdef NCURSES_VERSION
++    tcgetattr (STDIN_FILENO, &mode);
+     /* use Ctrl-g to generate SIGINT */
+-    cur_term->Nttyb.c_cc[VINTR] = CTRL ('g');   /* ^g */
++    mode.c_cc[VINTR] = CTRL ('g');  /* ^g */
+     /* disable SIGQUIT to allow use Ctrl-\ key */
+-    cur_term->Nttyb.c_cc[VQUIT] = NULL_VALUE;
+-    tcsetattr (cur_term->Filedes, TCSANOW, &cur_term->Nttyb);
+-#else
+-    /* other curses implementation (bsd curses, ...) */
+-    {
+-        struct termios mode;
+-
+-        tcgetattr (STDIN_FILENO, &mode);
+-        /* use Ctrl-g to generate SIGINT */
+-        mode.c_cc[VINTR] = CTRL ('g');  /* ^g */
+-        /* disable SIGQUIT to allow use Ctrl-\ key */
+-        mode.c_cc[VQUIT] = NULL_VALUE;
+-        tcsetattr (STDIN_FILENO, TCSANOW, &mode);
+-    }
+-#endif /* NCURSES_VERSION */
++    mode.c_cc[VQUIT] = NULL_VALUE;
++    tcsetattr (STDIN_FILENO, TCSANOW, &mode);
++
++    /* curses remembers the "in-program" modes after this call */
++    def_prog_mode ();
+ 
+     tty_start_interrupt_key ();
+ 
+-- 
+2.15.0
+


### PR DESCRIPTION
Patch backported from upstream and it fixes error when calling ncurses API:
tty-ncurses.c:199:13: error: dereferencing pointer to incomplete type 'TERMINAL {aka struct term}'
cur_term->Nttyb.c_cc[VINTR] = CTRL ('g');   /* ^g */

Also add check() function