### PR TITLE
main/libressl: upgrade to 1.6.3

### DIFF
--- a/main/libressl/APKBUILD
+++ b/main/libressl/APKBUILD
@@ -7,17 +7,14 @@
 #     - CVE-2017-8301
 #
 pkgname=libressl
-pkgver=2.5.5
+pkgver=2.6.3
 _namever=${pkgname}${pkgver%.*}
-pkgrel=4
+pkgrel=0
 pkgdesc="Version of the TLS/crypto stack forked from OpenSSL"
 url="http://www.libressl.org/"
 arch="all"
 license="custom"
-depends=""
-makedepends_build=""
-makedepends_host="linux-headers"
-makedepends="$makedepends_host"
+makedepends="linux-headers"
 replaces="openssl"
 subpackages="$pkgname-dbg $_namever-libcrypto:_libs $_namever-libssl:_libs
 	$_namever-libtls:_libs $pkgname-dev $pkgname-doc"
@@ -36,9 +33,8 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
 }
 
 check() {
@@ -48,12 +44,12 @@ check() {
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 
 dev() {
-	default_dev || return 1
+	default_dev
 	replaces="openssl-dev"
 }
 
@@ -72,5 +68,5 @@ _libs() {
 	fi
 }
 
-sha512sums="3f576e74ddea17bd72e1bfbe0b57b94e1a2a9e6fa56cee50624cd8d18f0a8674273086225669e6ece56e6b859d2376e36e2c140d37acb52d4cd79374c4ba7096  libressl-2.5.5.tar.gz
-07e523ae321b4a6a4afbac7acf4bd30e887b8e18ab2801ca42ba48af130b1cb43d56e70d1039b248c6251623b57c1c638db59105e6fbf4e6175be50d67a0473d  starttls-ldap.patch"
+sha512sums="5c0a0f86ecad1226c2d9a3a8a2e6f412ac0941d402c213ae1d293cd90c6a684198410db8c5250f83b8e2b00968a089afc39e90e053669fc27f82a4eb7c65f5c9  libressl-2.6.3.tar.gz
+9f1628fbc2a697b6570353920d784b161ca0a122047066d8bee15225bad1e5271aa2ed72b145506bcd4ffe58b35da2caf38c4a048db7e014dabd16b5eba44581  starttls-ldap.patch"

--- a/main/libressl/starttls-ldap.patch
+++ b/main/libressl/starttls-ldap.patch
@@ -1,5 +1,5 @@
---- libressl-2.5.5/apps/openssl/s_client.c
-+++ libressl-2.5.5.ldap/apps/openssl/s_client.c
+--- a/apps/openssl/s_client.c
++++ b/apps/openssl/s_client.c
 @@ -56,7 +56,7 @@
   * [including the GNU Public Licence.]
   */
@@ -26,7 +26,7 @@
  	BIO_printf(bio_err, "                 are supported.\n");
  	BIO_printf(bio_err, " -xmpphost host - connect to this virtual host on the xmpp server\n");
  	BIO_printf(bio_err, " -sess_out arg - file to write SSL session to\n");
-@@ -315,7 +316,8 @@
+@@ -284,7 +285,8 @@
  	PROTO_POP3,
  	PROTO_IMAP,
  	PROTO_FTP,
@@ -36,7 +36,7 @@
  };
  
  int
-@@ -575,6 +577,8 @@
+@@ -543,6 +545,8 @@
  				starttls_proto = PROTO_FTP;
  			else if (strcmp(*argv, "xmpp") == 0)
  				starttls_proto = PROTO_XMPP;
@@ -45,7 +45,7 @@
  			else
  				goto bad;
  		}
-@@ -978,6 +982,72 @@
+@@ -934,6 +938,72 @@
  		if (!strstr(sbuf, "<proceed"))
  			goto shut;
  		mbuf[0] = 0;
@@ -118,7 +118,7 @@
  	} else if (proxy != NULL) {
  		BIO_printf(sbio, "CONNECT %s HTTP/1.0\r\n\r\n", connect);
  		mbuf_len = BIO_read(sbio, mbuf, BUFSIZZ);
-@@ -1499,3 +1569,86 @@
+@@ -1437,3 +1507,86 @@
  	return 1;
  }
  


### PR DESCRIPTION
The ABI is 99.90% backwards compatible when the version switched from 2.5.x to 2.6.x series - https://abi-laboratory.pro/tracker/timeline/libressl/