### PR TITLE
main/sdl2_ttf: add missing make dependency

### DIFF
--- a/main/sdl2_ttf/APKBUILD
+++ b/main/sdl2_ttf/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=sdl2_ttf
 pkgver=2.0.14
-pkgrel=0
+pkgrel=1
 _pkgname=SDL2_ttf
 pkgdesc="A library which allows you to use TrueType fonts in your SDL applications"
 url="http://www.libsdl.org/projects/SDL_ttf/"
@@ -10,8 +10,9 @@ arch="all"
 license="zlib"
 depends=""
 depends_dev="freetype-dev sdl2-dev"
-makedepends="$depends_dev"
+makedepends="$depends_dev mesa-dev"
 subpackages="$pkgname-dev"
+options="!check"  # no test suite
 source="http://www.libsdl.org/projects/SDL_ttf/release/$_pkgname-$pkgver.tar.gz"
 
 builddir="$srcdir"/$_pkgname-$pkgver


### PR DESCRIPTION
Add mesa-dev as a make dependency to fix error:
bin/ld: cannot find -lGL

Also mark as no test suite