### PR TITLE
main/xf86-input-libinput: add missing make dependency

### DIFF
--- a/main/xf86-input-libinput/APKBUILD
+++ b/main/xf86-input-libinput/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-input-libinput
 pkgver=0.26.0
-pkgrel=0
+pkgrel=1
 pkgdesc="X.Org input driver based on libinput"
 url="http://xorg.freedesktop.org/"
 arch="all"
 license="MIT"
 depends=""
 depends_dev="libinput-dev xorg-server-dev"
-makedepends="$depends_dev resourceproto scrnsaverproto"
+makedepends="$depends_dev resourceproto scrnsaverproto eudev-dev"
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 builddir="$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Add eudev-dev as a make dependency to fix build error:
libinput.h:34:21: fatal error: libudev.h: No such file or directory