### PR TITLE
main/nodejs: upgrade to 8.9.1

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -5,16 +5,10 @@
 # Contributor: Tadahisa Kamijo <kamijin@live.jp>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 #
-# secfixes:
-#   6.11.1-r0:
-#     - CVE-2017-1000381
-#   6.11.5-r0:
-#     - CVE-2017-14919
-#
 pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
-pkgver=8.9.0
+pkgver=8.9.1
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="http://nodejs.org/"
@@ -99,5 +93,5 @@ npm() {
 	mv "$pkgdir"/usr/lib/node_modules/npm "$subpkgdir"/usr/lib/node_modules/
 }
 
-sha512sums="653de03b94f0a3ce1e62ac707b95165afd2a21af8995842aa6965e8855e5d98718b7fa406c6dff01f03c01c9a6df1005bc0505cc6092a92690663ad44cc36462  node-v8.9.0.tar.gz
+sha512sums="5f4f6fdf472850c4ce5bf0364c8d8dda02bdfa5f519a9ef01c43b2bb97938308c70925b3142425b4d8ef19adbcf8c368c2e1bb8531ae8c3bc922b7e812c6ed5c  node-v8.9.1.tar.gz
 ba95f21b1e80717ef63941854e7ed412f64a91da068c0dbf0d6d9697333ee266c9f4cd7bf1a01111eeb28aa66adefd8a58cfb3e82debb84b43e35e9dc914dd36  dont-run-gyp-files-for-bundled-deps.patch"


### PR DESCRIPTION
This updates Node.js to v8.9.1 LTS