### PR TITLE
community/nodejs-current: upgrade to 9.1.0

### DIFF
--- a/community/nodejs-current/APKBUILD
+++ b/community/nodejs-current/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Jose-Luis Rivas <ghostbar@riseup.net>
 pkgname=nodejs-current
 # The current stable version, i.e. non-LTS.
-pkgver=9.0.0
+pkgver=9.1.0
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - current stable version"
 url="http://nodejs.org/"
@@ -68,5 +68,5 @@ package() {
 	rm "$pkgdir"/usr/bin/npm "$pkgdir"/usr/bin/npx
 }
 
-sha512sums="dbaecaf9aec9efe51df7a4fb7c2c987fd93d2aac8254e520f702e352aa483124e4f047afef13f3db3a4b10284aa39fd9e250fc9d5a441020d3e85c331007d75f  node-v9.0.0.tar.gz
+sha512sums="ed2d28db927e077ebc0bd8ffa87539a6efba1632b81d7fb93fbf2911a28d69354ca592c42bd9be77f860d5693359ec0de1d7077adf2d21194e646fceefcbcdb2  node-v9.1.0.tar.gz
 ba95f21b1e80717ef63941854e7ed412f64a91da068c0dbf0d6d9697333ee266c9f4cd7bf1a01111eeb28aa66adefd8a58cfb3e82debb84b43e35e9dc914dd36  dont-run-gyp-files-for-bundled-deps.patch"


### PR DESCRIPTION
This updates Node.js to v9.1.0