### PR TITLE
main/portaudio: upgrade to 190600.20161030

### DIFF
--- a/main/portaudio/APKBUILD
+++ b/main/portaudio/APKBUILD
@@ -2,61 +2,67 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=portaudio
-pkgver=19
-pkgrel=1
+pkgver=190600.20161030
+pkgrel=0
 pkgdesc="Cross platform, open-source, audio I/O library"
 url="http://www.portaudio.com/"
 arch="all"
 license="MIT"
-depends=
-depends_dev="alsa-lib-dev"
-makedepends="$depends_dev
-	jack-dev
-	linux-headers autoconf automake libtool"
-install=""
+options="!check" # No unit tests, requires hardware to execute tests
+makedepends="alsa-lib-dev jack-dev linux-headers autoconf automake libtool"
+checkdepends="jack alsa-lib"
 subpackages="$pkgname-dev"
-source="http://www.portaudio.com/archives/pa_stable_v19_20140130.tgz
+source="http://www.portaudio.com/archives/pa_stable_v${pkgver/./_}.tgz
 	portaudio-pkgconfig-alsa.patch
 	portaudio-audacity.patch
 	"
+builddir="$srcdir"/portaudio
 
-_builddir="$srcdir"/portaudio
 prepare() {
-	local i
-	cd "$_builddir"
-	update_config_sub || return 1
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-	autoreconf -vif || return 1
+	cd "$builddir"
+	update_config_sub
+	default_prepare
+	autoreconf -vif
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
 		--disable-static \
 		--with-jack \
-		--with-alsa \
-		|| return 1
-	make || return 1
+		--with-alsa 
+	make
+}
+
+check() {
+	cd "$builddir"/bin
+	local t1
+	for t1 in pa_devs pa_fuzz pa_minlat paex_pink paex_read_write_wire paex_record \
+		paex_saw paex_sine paex_write_sine paex_write_sine_nonint paqa_devs paqa_errs \
+		paqa_latency patest1; do
+		msg "$t1":
+		./"$t1"
+	done
+
+	local t2
+	for t2 in buffer callbackstop clip dither hang in_overflow latency leftright \
+		longsine many maxsines mono multi_sine out_underflow prime ringmix sine8 \
+		sine_channelmaps sine_formats sine_srate sine_time start_stop stop stop_playout \
+		toomanysines two_rates underflow wire; do
+		msg patest_"$t2":
+		./patest_"$t2"
+	done
+
 }
 
 package() {
-	cd "$_builddir"
-	make -j1 DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
 }
 
-md5sums="7f220406902af9dca009668e198cbd23  pa_stable_v19_20140130.tgz
-be4a9f727516af217ff41903ffea4291  portaudio-pkgconfig-alsa.patch
-1fdd7d60815651feab22c42434f228d4  portaudio-audacity.patch"
-sha256sums="8fe024a5f0681e112c6979808f684c3516061cc51d3acc0b726af98fc96c8d57  pa_stable_v19_20140130.tgz
-146a5e59dccf165215c70de5766f29e6b652c2a6ed9d490e33baec5c10da6b33  portaudio-pkgconfig-alsa.patch
-78f12532fd60be85e0f9bc1a788a8f26d13a78598db12850f9fe0aac2face5ed  portaudio-audacity.patch"
-sha512sums="078adfdc2cec7fbd4019837eee65f8411b873b51064dfd7334e1c55118c26ea1fb68cb22e46ee69adb69c78d026b00a7ed973c40632e7d79703e12669a62ee3e  pa_stable_v19_20140130.tgz
+sha512sums="7ec692cbd8c23878b029fad9d9fd63a021f57e60c4921f602995a2fca070c29f17a280c7f2da5966c4aad29d28434538452f4c822eacf3a60af59a6dc8e9704c  pa_stable_v190600_20161030.tgz
 d58e7f8717f9d451535546e16939a959f63ccdd21bcbbc8e08efde2722382b068603bae6d93449476b206c85160d8084d39b39748b4fb43ab2b6eaee704ba1f8  portaudio-pkgconfig-alsa.patch
-86d14e1e984671593a9afdb5ec45bc944bd87610f32f8dde34f770eba067ff4a229400c3c0af403c32114c26ab43e5d81bcc70c742b0f6df864fd5ed3adf74af  portaudio-audacity.patch"
+e5a83dedadd8d66d24efc5062f339b2518dd707ccb856235f2beb6bb0f78a61b5439b708e52a64a62a02b5e55f97eaa8644b5f057b582d542730a42a5b731571  portaudio-audacity.patch"

--- a/main/portaudio/portaudio-audacity.patch
+++ b/main/portaudio/portaudio-audacity.patch
@@ -1,6 +1,5 @@
-diff -wruN portaudio/include/pa_unix_oss.h portaudio-v19/include/pa_unix_oss.h
---- portaudio/include/pa_unix_oss.h	1969-12-31 18:00:00.000000000 -0600
-+++ portaudio-v19/include/pa_unix_oss.h	2012-12-14 22:34:14.290247100 -0600
+--- a/include/pa_unix_oss.h
++++ b/include/pa_unix_oss.h
 @@ -0,0 +1,52 @@
 +#ifndef PA_UNIX_OSS_H
 +#define PA_UNIX_OSS_H
@@ -54,10 +53,11 @@ diff -wruN portaudio/include/pa_unix_oss.h portaudio-v19/include/pa_unix_oss.h
 +#endif
 +
 +#endif
-diff -wruN portaudio/include/portaudio.h portaudio-v19/include/portaudio.h
---- portaudio/include/portaudio.h	2012-08-31 19:10:13.000000000 -0500
-+++ portaudio-v19/include/portaudio.h	2012-12-14 22:34:14.368247200 -0600
-@@ -1146,6 +1146,15 @@
+
+
+--- a/include/portaudio.h
++++ b/include/portaudio.h
+@@ -1197,6 +1197,15 @@
  signed long Pa_GetStreamWriteAvailable( PaStream* stream );
  
  
@@ -71,12 +71,11 @@ diff -wruN portaudio/include/portaudio.h portaudio-v19/include/portaudio.h
 +
 +
  /* Miscellaneous utilities */
+
  
- 
-diff -wruN portaudio/src/common/pa_front.c portaudio-v19/src/common/pa_front.c
---- portaudio/src/common/pa_front.c	2012-12-04 12:39:48.000000000 -0600
-+++ portaudio-v19/src/common/pa_front.c	2012-12-14 09:44:34.604344800 -0600
-@@ -1216,8 +1216,10 @@
+--- a/src/common/pa_front.c
++++ b/src/common/pa_front.c
+@@ -1257,8 +1257,10 @@
                                    hostApiInputParametersPtr, hostApiOutputParametersPtr,
                                    sampleRate, framesPerBuffer, streamFlags, streamCallback, userData );
  
@@ -88,7 +87,7 @@ diff -wruN portaudio/src/common/pa_front.c portaudio-v19/src/common/pa_front.c
  
  
      PA_LOGAPI(("Pa_OpenStream returned:\n" ));
-@@ -1729,6 +1731,32 @@
+@@ -1770,6 +1772,32 @@
      return result;
  }
  
@@ -121,9 +120,10 @@ diff -wruN portaudio/src/common/pa_front.c portaudio-v19/src/common/pa_front.c
  
  PaError Pa_GetSampleSize( PaSampleFormat format )
  {
-diff -wruN portaudio/src/common/pa_stream.c portaudio-v19/src/common/pa_stream.c
---- portaudio/src/common/pa_stream.c	2008-02-15 01:50:33.000000000 -0600
-+++ portaudio-v19/src/common/pa_stream.c	2012-12-14 09:44:34.607345000 -0600
+
+
+--- a/src/common/pa_stream.c
++++ b/src/common/pa_stream.c
 @@ -93,6 +93,8 @@
      streamRepresentation->streamInfo.inputLatency = 0.;
      streamRepresentation->streamInfo.outputLatency = 0.;
@@ -132,22 +132,20 @@ diff -wruN portaudio/src/common/pa_stream.c portaudio-v19/src/common/pa_stream.c
 +    streamRepresentation->hostApiType = 0;
  }
  
- 
-diff -wruN portaudio/src/common/pa_stream.h portaudio-v19/src/common/pa_stream.h
---- portaudio/src/common/pa_stream.h	2008-02-15 01:50:33.000000000 -0600
-+++ portaudio-v19/src/common/pa_stream.h	2012-12-14 09:44:34.610345200 -0600
+
+--- a/src/common/pa_stream.h
++++ b/src/common/pa_stream.h
 @@ -152,6 +152,7 @@
      PaStreamFinishedCallback *streamFinishedCallback;
      void *userData;
      PaStreamInfo streamInfo;
 +    PaHostApiTypeId hostApiType;
  } PaUtilStreamRepresentation;
- 
- 
-diff -wruN portaudio/src/hostapi/oss/pa_unix_oss.c portaudio-v19/src/hostapi/oss/pa_unix_oss.c
---- portaudio/src/hostapi/oss/pa_unix_oss.c	2011-05-02 12:07:11.000000000 -0500
-+++ portaudio-v19/src/hostapi/oss/pa_unix_oss.c	2012-12-14 09:44:34.625346000 -0600
-@@ -2028,3 +2028,26 @@
+
+
+--- a/src/hostapi/oss/pa_unix_oss.c
++++ b/src/hostapi/oss/pa_unix_oss.c
+@@ -2043,3 +2043,26 @@
  #endif
  }
  
@@ -174,10 +172,11 @@ diff -wruN portaudio/src/hostapi/oss/pa_unix_oss.c portaudio-v19/src/hostapi/oss
 +
 +   return NULL;
 +}
-diff -up portaudio/configure.in~ portaudio/configure.in
---- portaudio/configure.in~	2013-04-07 12:20:18.000000000 +0200
-+++ portaudio/configure.in	2013-05-04 15:14:14.356191153 +0200
-@@ -387,7 +387,7 @@ case "${host_os}" in
+
+
+--- a/configure.in
++++ b/configure.in
+@@ -402,7 +402,7 @@
             DLL_LIBS="$DLL_LIBS -lasound"
             LIBS="$LIBS -lasound"
             OTHER_OBJS="$OTHER_OBJS src/hostapi/alsa/pa_linux_alsa.o"


### PR DESCRIPTION
ABI is 97.50% backwards compatible https://abi-laboratory.pro/tracker/timeline/portaudio/