### PR TITLE
main/jsoncpp: fix build and add check

### DIFF
--- a/main/jsoncpp/APKBUILD
+++ b/main/jsoncpp/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=jsoncpp
 pkgver=1.8.1
-pkgrel=0
+pkgrel=1
 pkgdesc="JSON C++ library"
 url="https://github.com/open-source-parsers/jsoncpp"
 arch="all"
 license="PublicDomain"
-makedepends="scons"
+makedepends="scons python2-dev"
 subpackages="$pkgname-dev"
 source="$pkgname-$pkgver.tar.gz::https://github.com/open-source-parsers/jsoncpp/archive/$pkgver.tar.gz"
 builddir="$srcdir"/jsoncpp-$pkgver
@@ -21,6 +21,12 @@ build() {
 	# build a proper shared lib
 	g++ -o libjsoncpp.so.0.0.0 -shared -Wl,-soname,libjsoncpp.so.0 \
 		buildscons/linux-gcc-*/src/lib_json/*.os -lpthread
+
+}
+
+check() {
+	cd "$builddir"
+	scons check platform=linux-gcc
 }
 
 package() {


### PR DESCRIPTION
Add python2-dev to makedepends as jsoncpp requires python to build.
Also add check() function.