### PR TITLE
community/postsrsd: Support setting listen address

### DIFF
--- a/community/postsrsd/20-set-socket-listen-address.patch
+++ b/community/postsrsd/20-set-socket-listen-address.patch
@@ -1,3 +1,11 @@
+This commit is taken from the official postsrsd repositry and can be
+found at: https://github.com/roehling/postsrsd/commit/fc2ba94684c99f771ea35f37b29009ba5ec0edb3
+It adds the ability to set the socket listen address for the daemon, thus enabling support to run it within a separate container than postfix.
+
+---
+ postsrsd.c | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
 diff --git a/postsrsd.c b/postsrsd.c
 index 5a8bd1c..adf65d3 100644
 --- a/postsrsd.c

--- a/community/postsrsd/20-set-socket-listen-address.patch
+++ b/community/postsrsd/20-set-socket-listen-address.patch
@@ -1,0 +1,72 @@
+diff --git a/postsrsd.c b/postsrsd.c
+index 5a8bd1c..adf65d3 100644
+--- a/postsrsd.c
++++ b/postsrsd.c
+@@ -48,7 +48,7 @@
+ 
+ static char *self = NULL;
+ 
+-static size_t bind_service (const char *service, int family, int* socks, size_t max_socks)
++static size_t bind_service (const char *listen_addr, const char *service, int family, int* socks, size_t max_socks)
+ {
+   struct addrinfo *addr, *it;
+   struct addrinfo hints;
+@@ -60,7 +60,7 @@ static size_t bind_service (const char *service, int family, int* socks, size_t
+   hints.ai_family = family;
+   hints.ai_socktype = SOCK_STREAM;
+ 
+-  err = getaddrinfo(NULL, service, &hints, &addr);
++  err = getaddrinfo(listen_addr, service, &hints, &addr);
+   if (err != 0) {
+     fprintf(stderr, "%s: bind_service(%s): %s\n", self, service, gai_strerror(err));
+     return count;
+@@ -219,6 +219,7 @@ static void show_help ()
+     "   -s<file>       read secrets from file (required)\n"
+     "   -d<domain>     set domain name for rewrite (required)\n"
+     "   -a<char>       set first separator character which can be one of: -=+ (default: =)\n"
++    "   -l<addr>       set socket listen address (default: 127.0.0.1)\n"
+     "   -f<port>       set port for the forward SRS lookup (default: 10001)\n"
+     "   -r<port>       set port for the reverse SRS lookup (default: 10002)\n"
+     "   -p<pidfile>    write process ID to pidfile (default: none)\n"
+@@ -243,7 +244,7 @@ int main (int argc, char **argv)
+ {
+   int opt, timeout = 1800, family = AF_UNSPEC;
+   int daemonize = FALSE;
+-  char *forward_service = NULL, *reverse_service = NULL,
++  char *listen_addr = NULL, *forward_service = NULL, *reverse_service = NULL,
+        *user = NULL, *domain = NULL, *chroot_dir = NULL;
+   char separator = '=';
+   char *secret_file = NULL, *pid_file = NULL;
+@@ -264,7 +265,7 @@ int main (int argc, char **argv)
+   tmp = strrchr(argv[0], '/');
+   if (tmp) self = strdup(tmp + 1); else self = strdup(argv[0]);
+ 
+-  while ((opt = getopt(argc, argv, "46d:a:f:r:s:u:t:p:c:X::Dhev")) != -1) {
++  while ((opt = getopt(argc, argv, "46d:a:l:f:r:s:u:t:p:c:X::Dhev")) != -1) {
+     switch (opt) {
+       case '?':
+         return EXIT_FAILURE;
+@@ -280,6 +281,9 @@ int main (int argc, char **argv)
+       case 'a':
+         separator = *optarg;
+         break;
++      case 'l':
++        listen_addr = strdup(optarg);
++        break;
+       case 'f':
+         forward_service = strdup(optarg);
+         break;
+@@ -404,11 +408,11 @@ int main (int argc, char **argv)
+     return EXIT_FAILURE;
+   }
+   /* Bind ports. May require privileges if the config specifies ports below 1024 */
+-  sc = bind_service(forward_service, family, &sockets[socket_count], 4 - socket_count);
++  sc = bind_service(listen_addr, forward_service, family, &sockets[socket_count], 4 - socket_count);
+   if (sc == 0) return EXIT_FAILURE;
+   while (sc-- > 0) handler[socket_count++] = handle_forward;
+   free (forward_service);
+-  sc = bind_service(reverse_service, family, &sockets[socket_count], 4 - socket_count);
++  sc = bind_service(listen_addr, reverse_service, family, &sockets[socket_count], 4 - socket_count);
+   if (sc == 0) return EXIT_FAILURE;
+   while (sc-- > 0) handler[socket_count++] = handle_reverse;
+   free (reverse_service);

--- a/community/postsrsd/APKBUILD
+++ b/community/postsrsd/APKBUILD
@@ -27,7 +27,7 @@ build() {
 	cmake .. -DCMAKE_INSTALL_PREFIX=/usr/ \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DGENERATE_SRS_SECRET=OFF \
-		-DCONFIG_DIR=/etc/postsrsd || return 1
+		-DCONFIG_DIR=/etc/postsrsd
 	make all
 }
 
@@ -42,14 +42,6 @@ package() {
 	install -Dm0755 "$srcdir/postsrsd.initd" "$pkgdir/etc/init.d/postsrsd"
 }
 
-md5sums="cb6e13a06d6bbd7d383efb9bbf0867ce  postsrsd-1.4.tar.gz
-a4104dbe7c6bc88de6a1fa29ee82e531  10-fix-defaults.patch
-bf9a65dcd4ca8b3404d71af3617208f0  20-set-socket-listen-address.patch
-575d5c5563def2aabdd752abc54b5e45  postsrsd.initd"
-sha256sums="f3230d57c36ba4688cc3beb90fbb0f199a06381e4df2edbc4ef541a9e8a574ff  postsrsd-1.4.tar.gz
-4e8093e8a90f499402f17ea9be253c499f47218bc7918d58825f6a1e2daa2543  10-fix-defaults.patch
-2e26e7299ec51a2932090676337db61f57a56dfe5a3c968440ae46100ff443ab  20-set-socket-listen-address.patch
-e59e9193998041023f6ef2740fd8ddaa2903d2a88f39e14f638c5ca2ce023b3b  postsrsd.initd"
 sha512sums="e5b9d2091d562030dd8d35117a3c5fb7d99c0613120fc90f74be57af5e88a3fe0ce73a5ce702708047ae37f70c6aedb4a0df018dccbe480048ccb6ed4debbcef  postsrsd-1.4.tar.gz
 bdafd3921fac6af21cf099ac63fd06692dca37366e197b23aaedd3cf748652bcc5b54cf545b24c7e6cb48d266233a29e9184481af99aa8d58a80e512d326c788  10-fix-defaults.patch
 3d8327845cc7a3c8e721b291d8b834d257f89899fb8a9c8a627fe90ea7ef1bfa2e46fcfd208f0aca9d112642087795e203b01e877d9dab3de1ea9c8e3213851b  20-set-socket-listen-address.patch

--- a/community/postsrsd/APKBUILD
+++ b/community/postsrsd/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Kevin Daudt <ops@ikke.info>
 pkgname=postsrsd
 pkgver=1.4
-pkgrel=0
+pkgrel=1
 pkgdesc="Postfix Sender Rewriting Scheme daemon"
 url="https://github.com/roehling/postsrsd"
 arch="all"
@@ -14,6 +14,7 @@ install="$pkgname.pre-install"
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/roehling/postsrsd/archive/$pkgver.tar.gz
 	10-fix-defaults.patch
+	20-set-socket-listen-address.patch
 	postsrsd.initd"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -43,10 +44,13 @@ package() {
 
 md5sums="cb6e13a06d6bbd7d383efb9bbf0867ce  postsrsd-1.4.tar.gz
 a4104dbe7c6bc88de6a1fa29ee82e531  10-fix-defaults.patch
+bf9a65dcd4ca8b3404d71af3617208f0  20-set-socket-listen-address.patch
 575d5c5563def2aabdd752abc54b5e45  postsrsd.initd"
 sha256sums="f3230d57c36ba4688cc3beb90fbb0f199a06381e4df2edbc4ef541a9e8a574ff  postsrsd-1.4.tar.gz
 4e8093e8a90f499402f17ea9be253c499f47218bc7918d58825f6a1e2daa2543  10-fix-defaults.patch
+2e26e7299ec51a2932090676337db61f57a56dfe5a3c968440ae46100ff443ab  20-set-socket-listen-address.patch
 e59e9193998041023f6ef2740fd8ddaa2903d2a88f39e14f638c5ca2ce023b3b  postsrsd.initd"
 sha512sums="e5b9d2091d562030dd8d35117a3c5fb7d99c0613120fc90f74be57af5e88a3fe0ce73a5ce702708047ae37f70c6aedb4a0df018dccbe480048ccb6ed4debbcef  postsrsd-1.4.tar.gz
 bdafd3921fac6af21cf099ac63fd06692dca37366e197b23aaedd3cf748652bcc5b54cf545b24c7e6cb48d266233a29e9184481af99aa8d58a80e512d326c788  10-fix-defaults.patch
+3d8327845cc7a3c8e721b291d8b834d257f89899fb8a9c8a627fe90ea7ef1bfa2e46fcfd208f0aca9d112642087795e203b01e877d9dab3de1ea9c8e3213851b  20-set-socket-listen-address.patch
 bec690156e60a10286f92470420e2caccd0cd8fd5707fefddeb768b36a4697b9651acd707c7de08a99832a8b27a0328560501fb1376fe39bc27f5fbe4dca7797  postsrsd.initd"


### PR DESCRIPTION
This patch addes support for specifying the socket listening address
using the "-l" startup argument.
Original commit found at:
https://github.com/roehling/postsrsd/commit/fc2ba94684c99f771ea35f37b29009ba5ec0edb3