### PR TITLE
main/imagemagick:  upgrade to 7.0.7.10

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
-pkgver=7.0.7.8
+pkgver=7.0.7.10
 _abiver=7
 _pkgver=${pkgver%.*}-${pkgver##*.}
 pkgrel=0
@@ -10,11 +10,11 @@ pkgdesc="A collection of tools and libraries for many image formats"
 url="http://www.imagemagick.org/"
 arch="all"
 license="custom"
-depends=""
 options="libtool"
 makedepends="zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev fontconfig-dev
 	perl-dev ghostscript-dev libwebp-dev libtool tiff-dev lcms2-dev
 	libwebp-dev libxml2-dev librsvg-dev"
+checkdepends="freetype fontconfig ghostscript ghostscript-fonts lcms2"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-c++:_cxx $pkgname-libs"
 source="http://www.imagemagick.org/download/releases/ImageMagick-$_pkgver.tar.xz"
 builddir="$srcdir/ImageMagick-${_pkgver}"
@@ -48,6 +48,11 @@ build() {
 	make
 }
 
+check() {
+	cd "$builddir"
+	make check
+}
+
 package() {
 	cd "$builddir"
 	make -j1 DESTDIR="$pkgdir" install
@@ -72,4 +77,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="77547f8a0f667b7519f9282d7c2a51ad0f3d07fc29d612f633182eddb78cd8062239e1b738ad2c8090424631b8298ba559c495ade5e52900875b8d7a85d6401a  ImageMagick-7.0.7-8.tar.xz"
+sha512sums="8cd9cb6b63bf3af490e596d35ad9d75cd7e9f573385ab58eb5a1a009b4d37997079ae59c07c669496b942f6b3a61076db0a8f42903d5aecf3aa0e286bc6ea683  ImageMagick-7.0.7-10.tar.xz"


### PR DESCRIPTION
ABI is 100% backwards compatible https://abi-laboratory.pro/tracker/timeline/imagemagick/