### PR TITLE
community/docker-registry: security upgrade to 2.6.2

### DIFF
--- a/community/docker-registry/APKBUILD
+++ b/community/docker-registry/APKBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Christian Kampka <christian@kampka.net>
 
 pkgname=docker-registry
-pkgver=2.6.1
-pkgrel=3
+pkgver=2.6.2
+pkgrel=0
 pkgdesc="An implementation of the Docker Registry HTTP API V2 for use with docker 1.6+"
 url="https://github.com/docker/distribution"
 arch="x86 x86_64 ppc64le"
@@ -64,6 +64,6 @@ package() {
 		"$pkgdir"/var/lib/$pkgname
 }
 
-sha512sums="a2175cb5ab049599e1bdae7026dc84e14b79883eca3ceaafda54497a1743103f125f65fa3922c003363dd86aa1422f539aff8b17746b9768968fef757e931c36  docker-registry-2.6.1.tar.gz
+sha512sums="a091db2e15d7c1dc8cd39a40de5bb63cc1ead68e95dfaf6b3735a789adb87f146c03eff81f700e0059e5f6ffc43e6c3dd3358503697882cb080b991629f82c60  docker-registry-2.6.2.tar.gz
 96100a4de311afa19d293a3b8a63105e1fcdf49258aa8b1752befd389e6b4a2b1f70711341ea011b450d4468bd37dbd07a393ffab3b9aa1b2213cf0fdd915904  docker-registry.initd
 5a38f4d3f0ee5cd00c0a5ced744eb5b29b839da5921adea26c5de3eb88b6b2626a7ba29b1ab931e5f8fbfafbed8c94cb972a58737ec0c0a69cf515c32139e387  config-example.patch"


### PR DESCRIPTION
CVE-2017-1146 https://github.com/docker/distribution/releases/tag/v2.6.2