### PR TITLE
community/perl-[l-m]*: modernize APKBUILD

### DIFF
--- a/community/perl-lingua-en-numbers-ordinate/APKBUILD
+++ b/community/perl-lingua-en-numbers-ordinate/APKBUILD
@@ -2,41 +2,33 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=perl-lingua-en-numbers-ordinate
 pkgver=1.04
-pkgrel=0
+pkgrel=1
 pkgdesc="Go from cardinal (53) to ordinal (53rd)"
 url="http://search.cpan.org/dist/Lingua-EN-Numbers-Ordinate"
 arch="noarch"
 license="GPL"
-depends=""
 depends_dev="perl-dev"
 makedepends="$depends_dev"
-install=""
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/N/NE/NEILB/Lingua-EN-Numbers-Ordinate-$pkgver.tar.gz"
 
-_builddir="$srcdir"/Lingua-EN-Numbers-Ordinate-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir/Lingua-EN-Numbers-Ordinate-$pkgver"
 
 build() {
-	cd "$_builddir"
-	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor || return 1
-	make && make test || return 1
+	cd "$builddir"
+	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="8d98839010f7f5cb3b2f593d2e00b505  Lingua-EN-Numbers-Ordinate-1.04.tar.gz"
-sha256sums="26973c2eb43672c3f61ad7d3fef12ef1c64a034da494a0ee0d910c3e0808019f  Lingua-EN-Numbers-Ordinate-1.04.tar.gz"
 sha512sums="f8f5cbfc9ae1d7b4e5e134c8fb089f6ec4ecfd90e0168ece874b007ae8b74936e5aecc38344c036c0845ab7a8c192d07c5a2cdad8f96176c71e89e2e4ae1211e  Lingua-EN-Numbers-Ordinate-1.04.tar.gz"

--- a/community/perl-log-dispatch-config/APKBUILD
+++ b/community/perl-log-dispatch-config/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-log-dispatch-config
 _pkgreal=Log-Dispatch-Config
 pkgver=1.04
-pkgrel=1
+pkgrel=2
 pkgdesc="Perl module for Log-Dispatch-Config"
 url="http://search.cpan.org/dist/Log-Dispatch-Config/"
 arch="noarch"
@@ -16,24 +16,29 @@ makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/M/MI/MIYAGAWA/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
-	make && make test
+	cd "$builddir"
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="ac6f91b838743adb3a47cb09bf8defe5  Log-Dispatch-Config-1.04.tar.gz"
-sha256sums="5a48c583dc87b079bf143a07fa6a73832ff02935617e21578269bc4959130b04  Log-Dispatch-Config-1.04.tar.gz"
 sha512sums="827b767806b206f244955f8f57b7206f84aac75012ec6443fb0c427e0fb0e52cad112cc012bd5c43a1e4a82d9fd49adb7bd024130579754dbe0ad4a2218460ef  Log-Dispatch-Config-1.04.tar.gz"

--- a/community/perl-log-log4perl/APKBUILD
+++ b/community/perl-log-log4perl/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-log-log4perl
 _pkgreal=Log-Log4perl
 pkgver=1.49
-pkgrel=0
+pkgrel=1
 pkgdesc="Log4j implementation for Perl"
 url="http://search.cpan.org/dist/Log-Log4perl/"
 arch="noarch"
@@ -16,27 +16,28 @@ makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/M/MS/MSCHILLI/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
+	default_prepare
+
+	cd "$builddir"
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
-	make && make test
+	cd "$builddir"
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 

--- a/community/perl-mime-construct/APKBUILD
+++ b/community/perl-mime-construct/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=perl-mime-construct
 _pkgreal=mime-construct
 pkgver=1.11
-pkgrel=3
+pkgrel=4
 pkgdesc="Construct and optionally mail MIME messages"
 url="http://search.cpan.org/~rosch/mime-construct/mime-construct"
 arch="noarch"
@@ -17,7 +17,7 @@ builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
 	cd "$builddir"
-	default_prepare || return 1
+	default_prepare
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
@@ -25,14 +25,18 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
-md5sums="73834ea780fbea81b89dbd9b2fb54f58  mime-construct-1.11.tar.gz"
-sha256sums="4cd7bb61b51d41192d1498c1051aa6a4ccd75aeb09b71d2ec706a7084a4a9303  mime-construct-1.11.tar.gz"
+
 sha512sums="1192c5a0cd1c7675aaf4d1570c910672d3c3b6585f33e4781de289e8e1d9530c17b6d48083ad68349b46faa8e03be1dfeef16701b12763adc36bfa4f3b399a5f  mime-construct-1.11.tar.gz"

--- a/community/perl-module-implementation/APKBUILD
+++ b/community/perl-module-implementation/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-module-implementation
 _pkgreal=Module-Implementation
 pkgver=0.09
-pkgrel=0
+pkgrel=1
 pkgdesc="Loads one of several alternate underlying implementations for a module"
 url="http://search.cpan.org/dist/Module-Implementation/"
 arch="noarch"
 license="Artistic-2"
 cpandepends="perl-module-runtime perl-try-tiny perl-test-taint"
-cpanmakedepends="  perl-test-fatal perl-test-requires "
+cpanmakedepends="perl-test-fatal perl-test-requires "
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="52e3fe0ca6b1eff0488d59b7aacc0667  Module-Implementation-0.09.tar.gz"
-sha256sums="c15f1a12f0c2130c9efff3c2e1afe5887b08ccd033bd132186d1e7d5087fd66d  Module-Implementation-0.09.tar.gz"
 sha512sums="049f967ba1bd8a3914968b34006030ae318d99ac629a0f34736f1c2b5392490c30aa0914e777eaefda7f0f58755d2d3363a266b90db59b53fe145ef68e1d953c  Module-Implementation-0.09.tar.gz"

--- a/community/perl-moox-types-mooselike/APKBUILD
+++ b/community/perl-moox-types-mooselike/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=perl-moox-types-mooselike
 _pkgreal=MooX-Types-MooseLike
 pkgver=0.29
-pkgrel=0
-pkgdesc="some Moosish types and a type builder"
+pkgrel=1
+pkgdesc="Some Moosish types and a type builder"
 url="http://search.cpan.org/dist/MooX-Types-MooseLike/"
 arch="noarch"
 license="GPL PerlArtistic"
@@ -16,26 +16,31 @@ makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/M/MA/MATEU/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="0905b92c1b44578e05e7f08fa7adb9ee  MooX-Types-MooseLike-0.29.tar.gz"
-sha256sums="1d3780aa9bea430afbe65aa8c76e718f1045ce788aadda4116f59d3b7a7ad2b4  MooX-Types-MooseLike-0.29.tar.gz"
 sha512sums="69ddd0d663d1ea23dfc7e47ec35192f1951f195f70f788bac47cc93e98d9e888394c07fc39f1740b7c1fd04f8724f2b0dfa14183fe33bceb9f77c1f1d1b8752e  MooX-Types-MooseLike-0.29.tar.gz"


### PR DESCRIPTION
Changes:
- Move tests to check()
- Remove return 1
- rename _builddir to builddir
- add missing default_prepare in prepare()