### PR TITLE
community/perl-[i-j]*: modernize APKBUILD

### DIFF
--- a/community/perl-ima-dbi/APKBUILD
+++ b/community/perl-ima-dbi/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-ima-dbi
 _pkgreal=Ima-DBI
 pkgver=0.35
-pkgrel=1
+pkgrel=2
 pkgdesc="unknown"
 url="http://search.cpan.org/dist/Ima-DBI/"
 arch="noarch"
@@ -16,21 +16,28 @@ makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/P/PE/PERRIN/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
-	make && make test
+	cd "$builddir"
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 

--- a/community/perl-import-into/APKBUILD
+++ b/community/perl-import-into/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-import-into
 _pkgreal=Import-Into
 pkgver=1.002005
-pkgrel=0
+pkgrel=1
 pkgdesc="Import packages into other packages"
 url="http://search.cpan.org/dist/Import-Into/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-module-runtime"
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/H/HA/HAARG/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="48bdc7988f5a7d4d06039ccc5c2459e9  Import-Into-1.002005.tar.gz"
-sha256sums="bd9e77a3fb662b40b43b18d3280cd352edf9fad8d94283e518181cc1ce9f0567  Import-Into-1.002005.tar.gz"
 sha512sums="d356307072da18bc40b25f11583018ed416cb87178f080982e14e98e53d42bc1e04aebda56d595e707c05065eaa6ad7a6b059920e8b5b8e1589bfd68e26900fb  Import-Into-1.002005.tar.gz"

--- a/community/perl-ipc-signal/APKBUILD
+++ b/community/perl-ipc-signal/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=perl-ipc-signal
 _pkgreal=IPC-Signal
 pkgver=1.00
-pkgrel=1
+pkgrel=2
 pkgdesc="Perl module provides utility functions dealing with signals"
 url="http://search.cpan.org/dist/IPC-Signal/"
 arch="noarch"
@@ -14,8 +14,9 @@ source="http://search.cpan.org/CPAN/authors/id/R/RO/ROSCH/$_pkgreal-$pkgver.tar.
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
+	default_prepare
+
 	cd "$builddir"
-	default_prepare || return 1
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
@@ -23,17 +24,20 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 	mv "$pkgdir"/usr/share/perl5/vendor_perl/* "$pkgdir"/usr/lib/perl5/vendor_perl
 	rm -fr "$pkgdir"/usr/share/perl5
 }
 
-md5sums="4cebf17fdf1785eaf8c151bf2e8c360a  IPC-Signal-1.00.tar.gz"
-sha256sums="7c21f9c8c2d0c0f0f0f46e77de7c3d879dd562668ddf0525875c38cef2076fd0  IPC-Signal-1.00.tar.gz"
 sha512sums="31ee15a55539546532cb8deb9bd379e0014b526fcd79ac20dc53591391b0fb50b182f6f653837bc230debb1779418316b7ac8e389224ad41a0aa3a380c76f229  IPC-Signal-1.00.tar.gz"

--- a/community/perl-iptables-chainmgr/APKBUILD
+++ b/community/perl-iptables-chainmgr/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-iptables-chainmgr
 _pkgreal=IPTables-ChainMgr
 pkgver=1.6
-pkgrel=0
+pkgrel=1
 pkgdesc="Perl extension for manipulating iptables and ip6tables policies"
 url="http://search.cpan.org/dist/IPTables-ChainMgr/"
 arch="noarch"
@@ -18,6 +18,8 @@ source="http://search.cpan.org/CPAN/authors/id/M/MR/MRASH/$_pkgreal-$pkgver.tar.
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
+	default_prepare
+
 	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
@@ -26,15 +28,18 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="d1e6feb17d85784896f39cc21f730311  IPTables-ChainMgr-1.6.tar.gz"
-sha256sums="958d7961640e9d70f714a72877f7eb32d5a8628591a790a6ccef96f2d84fb8c3  IPTables-ChainMgr-1.6.tar.gz"
 sha512sums="771fab2f2b8383d22f335d34b38a1b2f7deb5a10841ed005609dbe785197eff0c8be4ba4c595495525a341786a0d2173cafeb4ab6aa100582007c77bd2651c09  IPTables-ChainMgr-1.6.tar.gz"

--- a/community/perl-iptables-parse/APKBUILD
+++ b/community/perl-iptables-parse/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-iptables-parse
 _pkgreal=IPTables-Parse
 pkgver=1.6.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Perl extension for parsing iptables and ip6tables firewall rulesets"
 url="http://search.cpan.org/dist/IPTables-Parse/"
 arch="noarch"
@@ -16,26 +16,31 @@ makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/M/MR/MRASH/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="72299f0ab6e10a51837a48d51728a6f7  IPTables-Parse-1.6.1.tar.gz"
-sha256sums="b04a2fe8b021673f2035ac94784bb1c5353a0fd936ab8f093ad23af2b33106e4  IPTables-Parse-1.6.1.tar.gz"
 sha512sums="7638665e34f06771519bc8989ad57b6308c5efb39ecb32f3f6f208d0ece1675f499452f4b4b5b2ddd25109abecbdb5015e4441431defa8688f33f9eb2ad921eb  IPTables-Parse-1.6.1.tar.gz"

--- a/community/perl-json-webtoken/APKBUILD
+++ b/community/perl-json-webtoken/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=perl-json-webtoken
 _pkgname=JSON-WebToken
 pkgver=0.10
-pkgrel=0
+pkgrel=1
 pkgdesc="JSON Web Token (JWT) implementation for Perl"
 url="https://github.com/xaicron/p5-JSON-WebToken"
 arch="noarch"
@@ -17,7 +17,7 @@ source="http://search.cpan.org/CPAN/authors/id/X/XA/XAICRON/$_pkgname-$pkgver.ta
 builddir="$srcdir/$_pkgname-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
 	perl Build.PL --installdirs=vendor || return 1
@@ -26,15 +26,18 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
-	./Build && ./Build test
+	./Build
+}
+
+check() {
+        cd "$builddir"
+        ./Build test
 }
 
 package() {
 	cd "$builddir"
-	./Build install --destdir="$pkgdir" || return 1
+	./Build install --destdir="$pkgdir"
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="a68a0e415493495c5d3c516d854de047  JSON-WebToken-0.10.tar.gz"
-sha256sums="77c182a98528f1714d82afc548d5b3b4dc93e67069128bb9b9413f24cf07248b  JSON-WebToken-0.10.tar.gz"
 sha512sums="ce4acd42814db12fc16c60a8937a4e7d420b0243c3ca26f96a36ee2a2fb4a14f93538340b199fcce9cfbb090d60de5d7e24d5f008a84e1365d7c31f6db9ee312  JSON-WebToken-0.10.tar.gz"


### PR DESCRIPTION
Changes:
- Move tests to check()
- Remove return 1
- rename _builddir to builddir
- add missing default_prepare in prepare()