### PR TITLE
main/bash-completion: fix conflict with util-linux-bash-completion

### DIFF
--- a/main/bash-completion/APKBUILD
+++ b/main/bash-completion/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Lucas Ramage <ramage.lucas@openmailbox.org>
 pkgname=bash-completion
 pkgver=2.7
-pkgrel=2
+pkgrel=3
 pkgdesc="Command-line tab-completion for bash"
 url="https://github.com/scop/bash-completion"
 arch="noarch"
@@ -29,6 +29,7 @@ _conflicting="
 	ncal
 	newgrp
 	renice
+	rfkill
 	rtcwake
 	su
 	nmcli


### PR DESCRIPTION
Both packages provide `/usr/share/bash-completion/completions/rfkill`,
and conflict.

Upstream for bash-completion has [fixed][0] the issue already, but that's
not yet part of any release.

Add rfkill to the list of conflicting completions untill the next
bash-completion release.

[0]:https://github.com/scop/bash-completion/commit/d962f3a3be2b5c3811e546890c99b19694c2a08e