### PR TITLE
main/lxc: fix running systemd based containers under OpenRC / update initd for 2.1 config

### DIFF
--- a/main/lxc/APKBUILD
+++ b/main/lxc/APKBUILD
@@ -21,6 +21,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lvm::noarch lua5.2-lxc:_lua52
 source="https://github.com/lxc/lxc/archive/lxc-$_pkgver.tar.gz
 	version.patch
 	lxc.initd
+	lxc.confd
 	lxc.conf
 
 	download-template-tmpfs.patch
@@ -63,6 +64,7 @@ package() {
 	make DESTDIR="$pkgdir" install
 
 	install -Dm755 "$srcdir"/lxc.initd "$pkgdir"/etc/init.d/lxc
+	install -Dm644 "$srcdir"/lxc.confd "$pkgdir"/etc/conf.d/lxc
 	install -d "$pkgdir"/var/lib/lxc
 
 	# XXX: workaround for https://github.com/lxc/lxc/issues/1095.
@@ -149,6 +151,7 @@ EOF
 
 sha512sums="205d30a8914013f3d31bdcae9786a13b6728ae0d3630f51c644f06e1e96d03631630569a0ce55764ff7b8ee1d1d4d723926fdb2b916396aea212d9c3040b45ab  lxc-2.1.1.tar.gz
 e2ffcbf55447291a8434a4f37255c3a6a119bc4116c75d205006aa2b070bf6be28535cf6107bead14bbf64bf9fa415346ab544bd1c15e1add7d1c6380e6b2def  version.patch
-bd4cb27659cd1b18d97cfb1415f6d57bdbc23fb4504c17b90a51c44f1fac2a4acb1fb731d744fb5211b90fa5988cc9f0e3c257b8b115b9f8522120973bbfe399  lxc.initd
+826bf08f585e74e6a0321399f2b0a9092fe3217520d6eb84e82b662c330ad9fd9966309edc6a4e39f4b1fd30fd842bb8f4f887b56e302e9a22c0d7477c59f8eb  lxc.initd
+fd372ea1786a0c88a6b1b7c852004714734359daf89b60f5831630d34d718dcbd3be5a7dc00ed621c698e165dd5e87e750782ec185bcdde9cd8d55693af26e7e  lxc.confd
 5b83b0323e58bf00bd1e124c265729499cee97559b6fe18482962e3bed50d121b4c7a09f25cbce7b1e18d4234627bc4b4581ba2060e33cd022f105b4429cef01  lxc.conf
 02fd192d137cbb5b6db6959275387d05653f41dad5a5e46ae9b53cacead8cef937733927284658d3f0b910de81f9364c7f0248db990efd88806cf3029264c214  download-template-tmpfs.patch"

--- a/main/lxc/APKBUILD
+++ b/main/lxc/APKBUILD
@@ -5,7 +5,7 @@
 pkgname=lxc
 pkgver=2.1.1
 _pkgver=${pkgver/_rc/.rc}
-pkgrel=0
+pkgrel=1
 pkgdesc="Userspace interface for the Linux kernel containment features"
 url="https://linuxcontainers.org/lxc/"
 arch="all"
@@ -149,6 +149,6 @@ EOF
 
 sha512sums="205d30a8914013f3d31bdcae9786a13b6728ae0d3630f51c644f06e1e96d03631630569a0ce55764ff7b8ee1d1d4d723926fdb2b916396aea212d9c3040b45ab  lxc-2.1.1.tar.gz
 e2ffcbf55447291a8434a4f37255c3a6a119bc4116c75d205006aa2b070bf6be28535cf6107bead14bbf64bf9fa415346ab544bd1c15e1add7d1c6380e6b2def  version.patch
-1037e0b773553aa04b619cec7cfc8fa504af830e58c8211eda367da7e36aeb88f45fca1f955a08fc4fa3f9da660017d5fe7145a326a2064cf15e24d1772d9e27  lxc.initd
+bd4cb27659cd1b18d97cfb1415f6d57bdbc23fb4504c17b90a51c44f1fac2a4acb1fb731d744fb5211b90fa5988cc9f0e3c257b8b115b9f8522120973bbfe399  lxc.initd
 5b83b0323e58bf00bd1e124c265729499cee97559b6fe18482962e3bed50d121b4c7a09f25cbce7b1e18d4234627bc4b4581ba2060e33cd022f105b4429cef01  lxc.conf
 02fd192d137cbb5b6db6959275387d05653f41dad5a5e46ae9b53cacead8cef937733927284658d3f0b910de81f9364c7f0248db990efd88806cf3029264c214  download-template-tmpfs.patch"

--- a/main/lxc/lxc.confd
+++ b/main/lxc/lxc.confd
@@ -1,0 +1,6 @@
+# enable cgroup for systemd based containers
+#systemd_container=ON
+
+# autostart groups (comma separated)
+lxc_group='onboot'
+

--- a/main/lxc/lxc.initd
+++ b/main/lxc/lxc.initd
@@ -3,7 +3,10 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: /var/cvsroot/gentoo-x86/app-emulation/lxc/files/lxc.initd.2,v 1.5 2012/07/21 05:07:15 flameeyes Exp $
 
+description="Linux Containers (LXC)"
+description_reboot="Reboot containers"
 CONTAINER=${SVCNAME#*.}
+: ${lxc_group:=$LXC_GROUP}
 command="/usr/bin/lxc-start"
 pidfile="/var/run/lxc/$CONTAINER.pid"
 extra_started_commands="reboot"
@@ -51,15 +54,36 @@ checkconfig() {
 	fi
 }
 
+systemd_ctr() {
+	# required for lxc-console & services inside systemd containers
+	local cgroup=/sys/fs/cgroup/systemd cmd=$1
+	local mnt_opts='rw,nosuid,nodev,noexec,relatime,none,name=systemd'
+
+	case "$cmd" in
+		 mount) checkpath -d $cgroup
+			if ! mount | grep $cgroup 1>/dev/null; then
+				mount -t cgroup -o $mnt_opts cgroup $cgroup
+			fi
+			;;
+	       unmount) if mount | grep $cgroup 1>/dev/null; then
+				umount $cgroup
+			fi
+			;;
+	esac
+}
+
 _autostart() {
 	ebegin "$1 LXC containers"
 	shift
-	lxc-autostart --group "${LXC_GROUP:-onboot,}" "$@"
+	lxc-autostart --group "$lxc_group" "$@"
 	eend $?
 }
 
 start() {
 	checkconfig || return 1
+	if yesno "$systemd_container"; then
+		systemd_ctr mount
+	fi
 	if [ -z "$CONTAINER" ]; then
 		_autostart "Starting"
 		return
@@ -97,6 +121,8 @@ start() {
 
 stop() {
 	checkconfig || return 1
+	systemd_ctr unmount
+
 	if [ -z "$CONTAINER" ]; then
 		_autostart "Stopping" --shutdown --timeout ${LXC_TIMEOUT:-30}
 		return

--- a/main/lxc/lxc.initd
+++ b/main/lxc/lxc.initd
@@ -43,10 +43,10 @@ checkconfig() {
 	# no need to output anything, the function takes care of that.
 	[ -z "${CONFIGFILE}" ] && return 1
 
-	utsname=$(lxc_get_var lxc.utsname)
+	utsname=$(lxc_get_var lxc.uts.name)
 	if [ "${CONTAINER}" != "${utsname}" ]; then
 	    eerror "You should use the same name for the service and the"
-	    eerror "lxc.utsname. Right now the lxc.utsname is set to ${utsname}"
+	    eerror "lxc.uts.name : Right now the lxc.uts.name is set to : ${utsname}"
 	    return 1
 	fi
 }
@@ -67,7 +67,7 @@ start() {
 
 	rm -f /var/log/lxc/${CONTAINER}.log
 
-	rootpath=$(lxc_get_var lxc.rootfs)
+	rootpath=$(lxc_get_var lxc.rootfs.path)
 	# verify that container is not on tmpfs
 	dev=$(df -P "${rootpath}" | awk '{d=$1}; END {print d}')
 	type=$(awk -v dev="$dev" '$1 == dev {m=$3}; END {print m}' /proc/mounts)


### PR DESCRIPTION
* `systemd` based containers require the `/sys/fs/cgroup/systemd cgroup`
  for `lxc-console` & services inside the containers to work

* `systemd_ctr()` based on recommendations from lxc:

lxc/lxc#1704

* initd use: `lxc.uts.name` & `lxc.rootfs.path`