### PR TITLE
testing/wireguard: version bump

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171101
-_mypkgrel=0
+_ver=0.0.20171111
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="c3a394256cf3cc2dce75dcb299f54969f74d4076a351b61972f10fb3e69191756c0c32552a5acc7e0cd5919c248f12035e6a33f15e43fdad64c6cf1230511ee3  WireGuard-0.0.20171101.tar.xz"
+sha512sums="2424c3923555d72a0b5910fc86071b2554934267d4c6521bc40076770984173b2cef55f4276dd4b5a446ea62f7c52424cd89b046f205314cff2919ff7de30e6b  WireGuard-0.0.20171111.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20171101
+pkgver=0.0.20171111
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="c3a394256cf3cc2dce75dcb299f54969f74d4076a351b61972f10fb3e69191756c0c32552a5acc7e0cd5919c248f12035e6a33f15e43fdad64c6cf1230511ee3  WireGuard-0.0.20171101.tar.xz"
+sha512sums="2424c3923555d72a0b5910fc86071b2554934267d4c6521bc40076770984173b2cef55f4276dd4b5a446ea62f7c52424cd89b046f205314cff2919ff7de30e6b  WireGuard-0.0.20171111.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,7 +8,7 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171101
+_ver=0.0.20171111
 _mypkgrel=1
 _toolsrel=0
 _name=wireguard
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="c3a394256cf3cc2dce75dcb299f54969f74d4076a351b61972f10fb3e69191756c0c32552a5acc7e0cd5919c248f12035e6a33f15e43fdad64c6cf1230511ee3  WireGuard-0.0.20171101.tar.xz"
+sha512sums="2424c3923555d72a0b5910fc86071b2554934267d4c6521bc40076770984173b2cef55f4276dd4b5a446ea62f7c52424cd89b046f205314cff2919ff7de30e6b  WireGuard-0.0.20171111.tar.xz"


### PR DESCRIPTION
Changes:

```

  * Kconfig: remove trailing whitespace
  * allowedips: rename from routingtable
  * tools: remove ioctl cruft
  * global: revert checkpatch.pl changes
  
  Cleanliness.
  
  * device: please lockdep
  * device: wait for all peers to be freed before destroying
  
  These make the various checkers happy.
  
  * netlink: plug memory leak
  * qemu: check for memory leaks
  
  There was a small memory leak on the netlink configuration layer that's now
  been fixed.
  
  * receive: hoist fpu outside of receive loop
  
  Should be a small speedup on x86_64.
  
  * qemu: more debugging
  * qemu: bump kernel version
  
  Significantly more debugging checkers have been turned on.
  
  * wg-quick: stat the correct enclosing folder of config file
  * wg-quick: allow for tabs in keys
  
  Minor fixups for wg-quick(8).
  
  * compat: 4.4.0 has strange ECN function
  
  Nobody actually runs base 4.4.0, but this is more correct anyway.
  
  * netlink: make sure we reserve space for NLMSG_DONE
  
  A rather important change - due to an upstream kernel bug, that's existed
  since the advent of netlink itself, sometimes wg(8) failed to receive valid
  data back from kernelspace, resulting in "ENOBUFS" when trying to dump all
  peers. This patch works around it while we wait for upstream to commit the
  fix.
  
  * curve25519: reject deriving from NULL private keys
  * tools: allow for NULL keys everywhere
  
  A null 25519 private point isn't a valid point (prior to normalization), which
  is why we use it as the "unsetting" value. Conversely, however, except for
  psk, we should be using the existence of it in the netlink message being an
  indication of whether or not it's set, for the tools.
```