### PR TITLE
main/the_silver_searcher: rebuild with fopencookie support

### DIFF
--- a/main/the_silver_searcher/APKBUILD
+++ b/main/the_silver_searcher/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=the_silver_searcher
 pkgver=2.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A code searching tool similar to ack, with a focus on speed."
 url="https://geoff.greer.fm/ag/"
 arch="all"
@@ -17,7 +17,6 @@ source="https://geoff.greer.fm/ag/releases/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 build () {
 	cd "$builddir"
-	ac_cv_func_fopencookie=no \
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \


### PR DESCRIPTION
fopencookie is now defined in musl.
See commit: bf0205104ba520e7d2fea17704a1cc131551c3d3