### PR TITLE
main/perl-datetime: upgrade to 1.44 and modernize

### DIFF
--- a/main/perl-datetime/APKBUILD
+++ b/main/perl-datetime/APKBUILD
@@ -3,8 +3,8 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=perl-datetime
 _pkgreal=DateTime
-pkgver=1.39
-pkgrel=1
+pkgver=1.44
+pkgrel=0
 pkgdesc="A date and time object for Perl"
 url="http://search.cpan.org/dist/DateTime/"
 arch="all"
@@ -12,13 +12,13 @@ license="Artistic-2"
 cpandepends="perl-datetime-locale perl-try-tiny perl-dist-checkconflicts perl-params-validationcompiler perl-datetime-timezone perl-namespace-autoclean perl-specio"
 cpanmakedepends="  perl-test-warnings perl-cpan-meta-check perl-test-fatal "
 depends="$cpandepends"
-makedepends="perl-dev $cpanmakedepends"
+makedepends="perl-dev perl-file-sharedir $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/$_pkgreal-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
@@ -28,7 +28,12 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
-	make && make test
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
@@ -37,6 +42,4 @@ package() {
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="4594f4e303fe3e7d80132bfc8a0a6009  DateTime-1.39.tar.gz"
-sha256sums="2d876b624b9c0a18acea9d30495649daf11fb0e01171ef20780072ee97c4a494  DateTime-1.39.tar.gz"
-sha512sums="34ff99a40583a2fefc40bb0ce739dc769371c6716da282e6287eefd2bf8aacfcefb5de7d52509e363ef8404a47649d9c94cdc4f110adda048a0802bd38b5797a  DateTime-1.39.tar.gz"
+sha512sums="a256efc26ad1f2859f3371b70e5edd0d962d2c19c54b746178e3945b1dc665621d09b7ac6be279c7e92b8aa91763c5df2d8ccbca1832ba69ac810feb8533ca71  DateTime-1.44.tar.gz"


### PR DESCRIPTION
version 1.39 is no longer available upstream.