### PR TITLE
main/perl-date-extract: add missing dependencies and modernize

### DIFF
--- a/main/perl-date-extract/APKBUILD
+++ b/main/perl-date-extract/APKBUILD
@@ -4,38 +4,42 @@
 pkgname=perl-date-extract
 _pkgreal=Date-Extract
 pkgver=0.06
-pkgrel=0
-pkgdesc="extract probable dates from strings"
+pkgrel=1
+pkgdesc="Extract probable dates from strings"
 url="http://search.cpan.org/dist/Date-Extract/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-datetime-format-natural perl-class-data-inheritable perl-test-mocktime"
 cpanmakedepends="   "
 depends="$cpandepends"
-makedepends="perl-dev $cpanmakedepends"
+makedepends="perl-dev perl-module-install $cpanmakedepends"
+checkdepends="perl-file-sharedir"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/A/AL/ALEXMV/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="21fd316d2b6b0a6ab40f381f9e978cdc  Date-Extract-0.06.tar.gz"
-sha256sums="bc7658d5c50c3525ec0efcb55236a5de2d5d4fc06fc147fa3929c8f0953cda2b  Date-Extract-0.06.tar.gz"
 sha512sums="f50bb1e968eab9a5ee5bd1383af1599aabc7af9f9c375e3d366857f1cbf6a6912e8eff99eece2096b09a475c9eb671eeaeb8e4b76c0d865cb452ce8b0a85c448  Date-Extract-0.06.tar.gz"


### PR DESCRIPTION
It needs perl-module-install to build and perl-file-sharedir
to run tests.