### PR TITLE
Update samba and tevent

### DIFF
--- a/main/samba/APKBUILD
+++ b/main/samba/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=samba
-pkgver=4.7.1
+pkgver=4.7.2
 pkgrel=0
 pkgdesc="Tools to access a server's filespace and printers via SMB"
 url="http://www.samba.org"
@@ -505,7 +505,7 @@ libs() {
 		"$pkgdir"/usr
 }
 
-sha512sums="eaaa494501e0029fab8b0f1789fb28d33104a51b7365ba53741218786a4331f5adc5ea86d65aac1ccd970103c74a99fb875c4ba74460bd8b4597aaefbab18c7c  samba-4.7.1.tar.gz
+sha512sums="dd88fcdd9d0db06a081178bc327eeac11d988cdfff8122c361e94b2f0cfcd8bda714948613592349b1742f8448b6d12ad902730a99fd8229703556abe51eb2fa  samba-4.7.2.tar.gz
 b43809d7ecbf3968f5154c2ded6ed47dae36921f1895ea98bcce50557eb2ad39b736345ffb4214655ed3154c143c20431d248cde828285380bafbf4d2627df9b  uclibc-xattr-create.patch
 62d373dbaee75121a1d73f2c09cdca7239705808ff807b171d1d5a28fd4ffc66bdb52494b62786d7aaba8aeece5c08433b532ca96a28d712452fe9daac8d8d2e  domain.patch
 0d4fd9862191554dc9c724cec0b94fd19afbfd0c4ed619e4c620c075e849cb3f3d44db1e5f119d890da23a3dd0068d9873703f3d86c47b91310521f37356208b  getpwent_r.patch

--- a/main/tevent/APKBUILD
+++ b/main/tevent/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=tevent
-pkgver=0.9.33
+pkgver=0.9.34
 pkgrel=0
 pkgdesc="The tevent library"
 url="http://tevent.samba.org/"
@@ -45,4 +45,4 @@ _py() {
 	mv "$pkgdir"/usr/lib/python* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="3a437957859a556e06f24334301c41a3db1433c1e90d651fa74585a638a36d71369f235a8ab51aa0dd8f9d9bb88ad42f2c3ddeba0b99c4234c63866a8c922b91  tevent-0.9.33.tar.gz"
+sha512sums="29ff88cedc05d9345749ee241f8ab083fc6f98d3975b2739629a3a75a766db6ec42133eeb6c9297315ee0c68ab512c70b8b927d2df5ea61880c673ef33b44183  tevent-0.9.34.tar.gz"


### PR DESCRIPTION
It's important to update tevent first, because samba depends on the new version.