### PR TITLE
testing/efi: add support for 32bit uefi

### DIFF
--- a/testing/efibootmgr/APKBUILD
+++ b/testing/efibootmgr/APKBUILD
@@ -1,11 +1,11 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
-# Maintainer:
+# Maintainer: Lucas Ramage <ramage.lucas@openmailbox.org>
 pkgname=efibootmgr
 pkgver=15
 pkgrel=0
 pkgdesc="Linux user-space application to modify the Intel Extensible Firmware Interface"
 url="https://github.com/rhboot/efibootmgr"
-arch="x86_64 armhf aarch64"
+arch="x86 x86_64 armhf aarch64"
 license="GPL-2.0"
 depends=""
 makedepends="efivar-dev linux-headers popt-dev gettext-dev"

--- a/testing/efivar/APKBUILD
+++ b/testing/efivar/APKBUILD
@@ -1,11 +1,11 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
-# Maintainer:
+# Maintainer: Lucas Ramage <ramage.lucas@openmailbox.org>
 pkgname=efivar
 pkgver=31
 pkgrel=0
 pkgdesc="Tools and library to manipulate EFI variables"
 url="https://github.com/rhboot/efivar"
-arch="x86_64 armhf aarch64"
+arch="x86 x86_64 armhf aarch64"
 license="LGPL-2.1"
 depends=""
 depends_dev=""


### PR DESCRIPTION
testing/efivar: add x86 arch and claim maintainership
testing/efibootmgr: add x86 arch and claim maintainership

https://wiki.alpinelinux.org/wiki/Create_UEFI_boot_USB
Allows for using 32-bit efi for devices like the Asus T100