### PR TITLE
testing/dnsdist: new aport

### DIFF
--- a/testing/dnsdist/APKBUILD
+++ b/testing/dnsdist/APKBUILD
@@ -1,0 +1,54 @@
+# Contributor: Vince Mele <vmele@inoc.com>
+# Maintainer: Vince Mele <vmele@inoc.com>
+pkgname=dnsdist
+pkgver=1.2.0
+pkgrel=0
+pkgdesc="dnsdist is a highly DNS-, DoS-, and abuse-aware loadbalancer."
+url="https://dnsdist.org"
+arch="x86_64"
+license="GPL2"
+depends="boost luajit libedit libsodium protobuf net-snmp re2"
+makedepends="boost-dev luajit-dev libedit-dev libsodium-dev protobuf-dev net-snmp-dev re2-dev"
+install=""
+subpackages="$pkgname-doc"
+source="https://downloads.powerdns.com/releases/dnsdist-$pkgver.tar.bz2"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+
+	LIBSODIUM_CFLAGS=$CFLAGS \
+	LIBSODIUM_LIBS=-lsodium \
+	LIBEDIT_CFLAGS=$CFLAGS \
+	LIBEDIT_LIBS=-ledit \
+	PROTOBUF_CFLAGS=$CFLAGS \
+	PROTOBUF_LIBS=-lprotobuf \
+	RE2_CFLAGS=$CFLAGS \
+	RE2_LIBS="-lre2" \
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--enable-dnscrypt \
+		--enable-libsodium \
+		--enable-re2 \
+		--with-protobuf \
+		--with-boost=/usr/include \
+		--with-net-snmp \
+		--with-luajit
+	make
+}
+
+check(){
+	cd "$builddir"
+	make check-local
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="93f8c5f18462d3291c973a690f6ac2b3c5791d9947bee83d9250b503b7526de365bdcb530f3b082e51ae168a9129e77d5558af7cc3b9d2e98a585af53783c237  dnsdist-1.2.0.tar.bz2"


### PR DESCRIPTION
testing/dnsdist: new aport

https://dnsdist.org
dnsdist is a highly DNS-, DoS-, and abuse-aware loadbalancer.