### PR TITLE
main/gvfs: Update to 1.33.92

### DIFF
--- a/main/gvfs/APKBUILD
+++ b/main/gvfs/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gvfs
-pkgver=1.33.3
+pkgver=1.33.92
 pkgrel=0
 pkgdesc="Backends for the gio framework in GLib"
 url="http://ftp.gnome.org/pub/gnome/sources/gvfs/${pkgver%.*}/"
@@ -144,4 +144,4 @@ dav() {
 #	pkgdesc="AFC support for gvfs"
 #}
 
-sha512sums="96b273b2390f1f0f9434e8a2ee55b2f48e90515084fb118c6031ec21a25724ffe571025127b446321e2906edfffcf101ec8b390023ee9b2659a46df2f4f75376  gvfs-1.33.3.tar.xz"
+sha512sums="d0898f74eb4a66afc1a41684123052623f8a1faf1cd1544b3431aa37787f0bed59d2a4c2078e99aabaff55a7bbcf0344992ac4fe4b9d4df7acc9a9e46c416ef9  gvfs-1.33.92.tar.xz"

--- a/main/gvfs/APKBUILD
+++ b/main/gvfs/APKBUILD
@@ -8,6 +8,7 @@ url="http://ftp.gnome.org/pub/gnome/sources/gvfs/${pkgver%.*}/"
 arch="all"
 license="GPL"
 depends=""
+options="!check"
 triggers="$pkgname.trigger=/usr/lib/gvfs"
 makedepends="intltool fuse-dev libgudev-dev expat-dev samba-dev
 	libsoup-dev avahi-dev libarchive-dev udisks2-dev libgphoto2-dev


### PR DESCRIPTION
The package jumps to the very high number .92 without
any versions before. There is no reason for it, but the
build itself works fine.

Signed-off-by: Leo Unglaub <leo@unglaub.at>