### PR TITLE
main/libogg: Update to 1.3.3

### DIFF
--- a/main/libogg/APKBUILD
+++ b/main/libogg/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Mika Havela <mika.havela@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libogg
-pkgver=1.3.2
+pkgver=1.3.3
 pkgrel=1
 pkgdesc="Ogg bitstream and framing library"
 url="http://xiph.org/ogg/"
@@ -36,6 +36,4 @@ package() {
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 
-md5sums="b72e1a1dbadff3248e4ed62a4177e937  libogg-1.3.2.tar.gz"
-sha256sums="e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692  libogg-1.3.2.tar.gz"
-sha512sums="4a659bfa2851cdb7db6b852fa744ea594426e657cb74b9b0153f9c8b88e5cc836f1f7749d8e279248ffa7c550f25ef36eb68c379d5cf45e63f6b1be780de65fa  libogg-1.3.2.tar.gz"
+sha512sums="16f9cbc7f5b77c1719d80e666995ad825a3d4b6facfa51e3df3b1a9678cca7dc3c4f6ee15096c394c97ed5e67fced1aaedacc563cddfe4e0c748dd39940b099e  libogg-1.3.3.tar.gz"

--- a/main/libogg/APKBUILD
+++ b/main/libogg/APKBUILD
@@ -7,6 +7,7 @@ pkgdesc="Ogg bitstream and framing library"
 url="http://xiph.org/ogg/"
 arch="all"
 license="BSD"
+options="!check"
 depends=
 subpackages="$pkgname-doc $pkgname-dev"
 source="http://downloads.xiph.org/releases/ogg/$pkgname-$pkgver.tar.gz

--- a/main/libogg/APKBUILD
+++ b/main/libogg/APKBUILD
@@ -8,10 +8,8 @@ url="http://xiph.org/ogg/"
 arch="all"
 license="BSD"
 options="!check"
-depends=
 subpackages="$pkgname-doc $pkgname-dev"
-source="http://downloads.xiph.org/releases/ogg/$pkgname-$pkgver.tar.gz
-	"
+source="http://downloads.xiph.org/releases/ogg/$pkgname-$pkgver.tar.gz"
 
 _builddir="$srcdir/$pkgname-$pkgver"
 


### PR DESCRIPTION
This commit also updates all checksums to sha512 and
removed old entries.

Signed-off-by: Leo Unglaub <leo@unglaub.at>