### PR TITLE
testing/gdal: Support PostgreSQL and SQLite drivers

### DIFF
--- a/testing/gdal/APKBUILD
+++ b/testing/gdal/APKBUILD
@@ -9,8 +9,30 @@ arch="all"
 license="MIT"
 depends=""
 depends_dev="gdal"
-makedepends="giflib-dev jpeg-dev libjpeg-turbo-dev libpng-dev tiff-dev zlib-dev swig python2-dev curl-dev linux-headers"
-subpackages="$pkgname-dev py-$pkgname:py"
+
+makedepends="
+	curl-dev
+	giflib-dev
+	jpeg-dev
+	libjpeg-turbo-dev
+	libpng-dev
+	linux-headers
+	postgresql-dev
+	python2-dev
+	sqlite-dev
+	swig
+	tiff-dev
+	zlib-dev
+"
+
+subpackages="
+	$pkgname-dev
+	py-$pkgname:py
+"
+
+# TODO: https://trac.osgeo.org/gdal/wiki/TestingNotes
+options="!check"
+
 source="http://download.osgeo.org/$pkgname/$pkgver/$pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -42,4 +64,16 @@ py() {
 	install -d "$subpkgdir"/usr/bin
 	install -m755 scripts/*.py "$subpkgdir"/usr/bin/
 }
+
+check() {
+	cd "$builddir"
+	apps/gdal-config --version | grep "$pkgver"
+
+	# confirms MBTiles support
+	apps/gdal_translate --formats | grep "MBTiles -raster- (rw+v)"
+
+	# confirms PostgreSQL/PostGIS support
+	apps/ogr2ogr --formats | grep "PostgreSQL -vector- (rw+): PostgreSQL/PostGIS"
+}
+
 sha512sums="205c1723e2c5d7c1c5b6bb0a92e880db80eae5944da8f00705e7acc58a664474f7d3eb6e2783a1cd6eef7c6b43c76f94c75d109f43805438e8f0560b2f4843cf  gdal-2.2.3.tar.xz"


### PR DESCRIPTION
Enable support for the following drivers:

- PostgreSQL
- SQLite