### PR TITLE
community/nodejs-current: Update to 9.2.0

### DIFF
--- a/community/nodejs-current/APKBUILD
+++ b/community/nodejs-current/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Jose-Luis Rivas <ghostbar@riseup.net>
 pkgname=nodejs-current
 # The current stable version, i.e. non-LTS.
-pkgver=9.1.0
+pkgver=9.2.0
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - current stable version"
 url="https://nodejs.org/"
@@ -68,5 +68,5 @@ package() {
 	rm "$pkgdir"/usr/bin/npm "$pkgdir"/usr/bin/npx
 }
 
-sha512sums="ed2d28db927e077ebc0bd8ffa87539a6efba1632b81d7fb93fbf2911a28d69354ca592c42bd9be77f860d5693359ec0de1d7077adf2d21194e646fceefcbcdb2  node-v9.1.0.tar.gz
+sha512sums="8cdea451616ff0cb44a34cda96ddca816636652cb3259ee4d2be13d9a4c724e5492a070374949a12b5ddc3c2473cd33a311985c5502c6de578b85b0b5f3ab873  node-v9.2.0.tar.gz
 ba95f21b1e80717ef63941854e7ed412f64a91da068c0dbf0d6d9697333ee266c9f4cd7bf1a01111eeb28aa66adefd8a58cfb3e82debb84b43e35e9dc914dd36  dont-run-gyp-files-for-bundled-deps.patch"


### PR DESCRIPTION
This adds the pkgver and sha512sum for nodejs-v9.2.0