### PR TITLE
main/gnumeric: add py-libxml2 as makedepends

### DIFF
--- a/main/gnumeric/APKBUILD
+++ b/main/gnumeric/APKBUILD
@@ -1,15 +1,14 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gnumeric
 pkgver=1.12.35
-pkgrel=1
+pkgrel=2
 pkgdesc="A GNOME Spreadsheet Program"
 url="http://www.gnome.org/projects/gnumeric/"
 arch="all"
 license="GPL"
 makedepends="gtk+3.0-dev intltool desktop-file-utils goffice-dev rarian
 	python2-dev py-gobject3-dev libxslt-dev bison flex itstool
-	libxml2-utils
-	autoconf automake libtool"
+	libxml2-utils py-libxml2 autoconf automake libtool"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 source="https://download.gnome.org/sources/$pkgname/${pkver%.*}/$pkgname-$pkgver.tar.xz
 	unbreak-build-by-skipping-cs.patch


### PR DESCRIPTION
Add py-libxml2 to fix build error:
File "/usr/bin/itstool", line 27, in <module>
import libxml2
ImportError: No module named libxml2