### PR TITLE
main/perl-mailtools: point sources to new url

### DIFF
--- a/main/perl-mailtools/APKBUILD
+++ b/main/perl-mailtools/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-mailtools
 _pkgreal=MailTools
 pkgver=2.18
-pkgrel=1
+pkgrel=2
 pkgdesc="Various e-mail related modules"
 url="http://search.cpan.org/dist/MailTools/"
 arch="noarch"
@@ -16,25 +16,29 @@ provides="perl-mail-tools=$pkgver"
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
-source="http://search.cpan.org/CPAN/authors/id/M/MA/MARKOV/$_pkgreal-$pkgver.tar.gz"
+source="http://cpan.metacpan.org/authors/id/M/MA/MARKOV/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
-
+builddir="$srcdir/$_pkgreal-$pkgver"
 prepare() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 


### PR DESCRIPTION
the source tarball for this package seems to no longer exist at the old
location. the url has been updated to point to the correct location.

I tested building this on my desktop, which is running edge.
the checksums didn't change, so we know this is still the original source file.
it might be a good idea to backport this to 3.6. 