### PR TITLE
main/busybox: include patches for CVE-2017-16544, CVE-2017-15874 and CVE-2017-15873

### DIFF
--- a/main/busybox/0013-CVE-2017-16544.patch
+++ b/main/busybox/0013-CVE-2017-16544.patch
@@ -1,0 +1,40 @@
+From c3797d40a1c57352192c6106cc0f435e7d9c11e8 Mon Sep 17 00:00:00 2001
+From: Denys Vlasenko <vda.linux@googlemail.com>
+Date: Tue, 7 Nov 2017 18:09:29 +0100
+Subject: lineedit: do not tab-complete any strings which have control
+ characters
+
+function                                             old     new   delta
+add_match                                             41      68     +27
+
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+---
+ libbb/lineedit.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/libbb/lineedit.c b/libbb/lineedit.c
+index c0e35bb..56e8140 100644
+--- a/libbb/lineedit.c
++++ b/libbb/lineedit.c
+@@ -645,6 +645,18 @@ static void free_tab_completion_data(void)
+ 
+ static void add_match(char *matched)
+ {
++	unsigned char *p = (unsigned char*)matched;
++	while (*p) {
++		/* ESC attack fix: drop any string with control chars */
++		if (*p < ' '
++		 || (!ENABLE_UNICODE_SUPPORT && *p >= 0x7f)
++		 || (ENABLE_UNICODE_SUPPORT && *p == 0x7f)
++		) {
++			free(matched);
++			return;
++		}
++		p++;
++	}
+ 	matches = xrealloc_vector(matches, 4, num_matches);
+ 	matches[num_matches] = matched;
+ 	num_matches++;
+-- 
+cgit v0.12
+

--- a/main/busybox/0014-CVE-2017-15873.patch
+++ b/main/busybox/0014-CVE-2017-15873.patch
@@ -1,0 +1,98 @@
+From 0402cb32df015d9372578e3db27db47b33d5c7b0 Mon Sep 17 00:00:00 2001
+From: Denys Vlasenko <vda.linux@googlemail.com>
+Date: Sun, 22 Oct 2017 18:23:23 +0200
+Subject: bunzip2: fix runCnt overflow from bug 10431
+
+This particular corrupted file can be dealth with by using "unsigned".
+If there will be cases where it genuinely overflows, there is a disabled
+code to deal with that too.
+
+function                                             old     new   delta
+get_next_block                                      1678    1667     -11
+
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+---
+ archival/libarchive/decompress_bunzip2.c | 30 +++++++++++++++++++-----------
+ 1 file changed, 19 insertions(+), 11 deletions(-)
+
+diff --git a/archival/libarchive/decompress_bunzip2.c b/archival/libarchive/decompress_bunzip2.c
+index 7cd18f5..bec89ed 100644
+--- a/archival/libarchive/decompress_bunzip2.c
++++ b/archival/libarchive/decompress_bunzip2.c
+@@ -156,15 +156,15 @@ static unsigned get_bits(bunzip_data *bd, int bits_wanted)
+ static int get_next_block(bunzip_data *bd)
+ {
+ 	struct group_data *hufGroup;
+-	int dbufCount, dbufSize, groupCount, *base, *limit, selector,
+-		i, j, runPos, symCount, symTotal, nSelectors, byteCount[256];
+-	int runCnt = runCnt; /* for compiler */
++	int groupCount, *base, *limit, selector,
++		i, j, symCount, symTotal, nSelectors, byteCount[256];
+ 	uint8_t uc, symToByte[256], mtfSymbol[256], *selectors;
+ 	uint32_t *dbuf;
+ 	unsigned origPtr, t;
++	unsigned dbufCount, runPos;
++	unsigned runCnt = runCnt; /* for compiler */
+ 
+ 	dbuf = bd->dbuf;
+-	dbufSize = bd->dbufSize;
+ 	selectors = bd->selectors;
+ 
+ /* In bbox, we are ok with aborting through setjmp which is set up in start_bunzip */
+@@ -187,7 +187,7 @@ static int get_next_block(bunzip_data *bd)
+ 	   it didn't actually work. */
+ 	if (get_bits(bd, 1)) return RETVAL_OBSOLETE_INPUT;
+ 	origPtr = get_bits(bd, 24);
+-	if ((int)origPtr > dbufSize) return RETVAL_DATA_ERROR;
++	if (origPtr > bd->dbufSize) return RETVAL_DATA_ERROR;
+ 
+ 	/* mapping table: if some byte values are never used (encoding things
+ 	   like ascii text), the compression code removes the gaps to have fewer
+@@ -435,7 +435,14 @@ static int get_next_block(bunzip_data *bd)
+ 			   symbols, but a run of length 0 doesn't mean anything in this
+ 			   context).  Thus space is saved. */
+ 			runCnt += (runPos << nextSym); /* +runPos if RUNA; +2*runPos if RUNB */
+-			if (runPos < dbufSize) runPos <<= 1;
++//The 32-bit overflow of runCnt wasn't yet seen, but probably can happen.
++//This would be the fix (catches too large count way before it can overflow):
++//			if (runCnt > bd->dbufSize) {
++//				dbg("runCnt:%u > dbufSize:%u RETVAL_DATA_ERROR",
++//						runCnt, bd->dbufSize);
++//				return RETVAL_DATA_ERROR;
++//			}
++			if (runPos < bd->dbufSize) runPos <<= 1;
+ 			goto end_of_huffman_loop;
+ 		}
+ 
+@@ -445,14 +452,15 @@ static int get_next_block(bunzip_data *bd)
+ 		   literal used is the one at the head of the mtfSymbol array.) */
+ 		if (runPos != 0) {
+ 			uint8_t tmp_byte;
+-			if (dbufCount + runCnt > dbufSize) {
+-				dbg("dbufCount:%d+runCnt:%d %d > dbufSize:%d RETVAL_DATA_ERROR",
+-						dbufCount, runCnt, dbufCount + runCnt, dbufSize);
++			if (dbufCount + runCnt > bd->dbufSize) {
++				dbg("dbufCount:%u+runCnt:%u %u > dbufSize:%u RETVAL_DATA_ERROR",
++						dbufCount, runCnt, dbufCount + runCnt, bd->dbufSize);
+ 				return RETVAL_DATA_ERROR;
+ 			}
+ 			tmp_byte = symToByte[mtfSymbol[0]];
+ 			byteCount[tmp_byte] += runCnt;
+-			while (--runCnt >= 0) dbuf[dbufCount++] = (uint32_t)tmp_byte;
++			while ((int)--runCnt >= 0)
++				dbuf[dbufCount++] = (uint32_t)tmp_byte;
+ 			runPos = 0;
+ 		}
+ 
+@@ -466,7 +474,7 @@ static int get_next_block(bunzip_data *bd)
+ 		   first symbol in the mtf array, position 0, would have been handled
+ 		   as part of a run above.  Therefore 1 unused mtf position minus
+ 		   2 non-literal nextSym values equals -1.) */
+-		if (dbufCount >= dbufSize) return RETVAL_DATA_ERROR;
++		if (dbufCount >= bd->dbufSize) return RETVAL_DATA_ERROR;
+ 		i = nextSym - 1;
+ 		uc = mtfSymbol[i];
+ 
+-- 
+cgit v0.12
+

--- a/main/busybox/0015-CVE-2017-15874.patch
+++ b/main/busybox/0015-CVE-2017-15874.patch
@@ -1,0 +1,31 @@
+From 9ac42c500586fa5f10a1f6d22c3f797df11b1f6b Mon Sep 17 00:00:00 2001
+From: Denys Vlasenko <vda.linux@googlemail.com>
+Date: Fri, 27 Oct 2017 15:37:03 +0200
+Subject: unlzma: fix SEGV, closes 10436
+
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+---
+ archival/libarchive/decompress_unlzma.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/archival/libarchive/decompress_unlzma.c b/archival/libarchive/decompress_unlzma.c
+index a904087..be43424 100644
+--- a/archival/libarchive/decompress_unlzma.c
++++ b/archival/libarchive/decompress_unlzma.c
+@@ -450,8 +450,12 @@ unpack_lzma_stream(transformer_state_t *xstate)
+  IF_NOT_FEATURE_LZMA_FAST(string:)
+ 			do {
+ 				uint32_t pos = buffer_pos - rep0;
+-				if ((int32_t)pos < 0)
++				if ((int32_t)pos < 0) {
+ 					pos += header.dict_size;
++					/* bug 10436 has an example file where this triggers: */
++					if ((int32_t)pos < 0)
++						goto bad;
++				}
+ 				previous_byte = buffer[pos];
+  IF_NOT_FEATURE_LZMA_FAST(one_byte2:)
+ 				buffer[buffer_pos++] = previous_byte;
+-- 
+cgit v0.12
+

--- a/main/busybox/APKBUILD
+++ b/main/busybox/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=busybox
 pkgver=1.27.2
-pkgrel=3
+pkgrel=4
 pkgdesc="Size optimized toolbox of many common UNIX utilities"
 url=http://busybox.net
 arch="all"
@@ -33,6 +33,10 @@ source="http://busybox.net/downloads/$pkgname-$pkgver.tar.bz2
 	0010-udhcpc-Don-t-background-if-n-is-given.patch
 	0011-testsuite-fix-cpio-tests.patch
 	0012-microcom-segfault.patch
+	
+	0013-CVE-2017-16544.patch
+	0014-CVE-2017-15873.patch
+	0015-CVE-2017-15874.patch
 
 	top-buffer-overflow.patch
 
@@ -185,6 +189,9 @@ d1c375184f806f7550bac5c82ab5471bdb8085d845172c973724b22af05ab3759b3ce982e088b4c4
 9b5143d0be615b1604d82007628d59a62721f1e61a63cca7a4ffa5e60fa8da102bfc21fa20cc35c2f5a0a24bc8013598f8eff5888f9d0f3bcfa796343b5f5a91  0010-udhcpc-Don-t-background-if-n-is-given.patch
 f4e00eb13fda752df13f300a7ed9b1320ca9f573c4309247f292c8710464d7be8740148f42e4aff16312335eadabce5a629dce4af58334b9199faf2fd658e4f9  0011-testsuite-fix-cpio-tests.patch
 a09a64b3bce8048c58a68dcd2dd9e63c911009c06195d6bb4e5aecfb5700e479c25b34635c60899127975fae32275ad51846ee75f840d612e00668ce9aba8322  0012-microcom-segfault.patch
+74620e589e863f63ad3fed1e37405e385648789d59e8914074f94b2d279728ad54cd497073ff7afe2aac1bca81150fa1b396034206358599281f15fb2dd079d5  0013-CVE-2017-16544.patch
+8a9f314c7d08d349957549c59d306d1b608f147e27719a290d421cce288c11adb8593034a6d722688ae3c5dc60a5180f7aa948213987cd5b188340558607cbcb  0014-CVE-2017-15873.patch
+93b3188fe3397899a625c203bcc03ddedadb96cceeb38ecad3ad3395d75fdfa7e1ba7cfc34eb8ebc7c70165ae967da474735247bf114398bea00440e90b1bef7  0015-CVE-2017-15874.patch
 524e858b52cb31fb8d24e8c7f18606fff349aeab6a14da9cca3902641f6127980daed73c53586c6e8b41eecda06cdb29c40ff1dde2dc82a318c2649680458921  top-buffer-overflow.patch
 a9b1403c844c51934637215307dd9e2adb9458921047acff0d86dcf229b6e0027f4b2c6cdaa25a58407aad9d098fb5685d58eb5ff8d2aa3de4912cdea21fe54c  acpid.logrotate
 02102f0764ffbec86e97ccab99b3a1e55ffa5b25aa2cdc1fe270d5b575610bdb50568574c7cbd05aba91b13151f84f536b44320c180051cbd77cf258e4fc89a4  busyboxconfig


### PR DESCRIPTION
I have created an automated tool at https://github.com/Xe/cve-2017-16544 that will test busybox's ash implementation for this bug.

All CVE's listed in the title are fixed by their upstream patches.