### PR TITLE
community/perl-[g-h]*: modernize APKBUILD

### DIFF
--- a/community/perl-graph/APKBUILD
+++ b/community/perl-graph/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-graph
 _pkgreal=Graph
 pkgver=0.9704
-pkgrel=0
+pkgrel=1
 pkgdesc="unknown"
 url="http://search.cpan.org/dist/Graph/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/J/JH/JHI/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="1ab4e49420e56eeb1bc81d842aa8f3af  Graph-0.9704.tar.gz"
-sha256sums="325e8eb07be2d09a909e450c13d3a42dcb2a2e96cc3ac780fe4572a0d80b2a25  Graph-0.9704.tar.gz"
 sha512sums="1eed5049577112cc2e41a83f6b3b6a22a08170597b5cb89e2eab6cc68386bfd989d3953d7ceab85bcfbd7d097a6925bd8eb43f48eed1ac07469ea4b2432149da  Graph-0.9704.tar.gz"

--- a/community/perl-graphviz/APKBUILD
+++ b/community/perl-graphviz/APKBUILD
@@ -4,41 +4,46 @@
 pkgname=perl-graphviz
 _pkgreal=GraphViz
 pkgver=2.24
-pkgrel=0
+pkgrel=1
 pkgdesc="Interface to AT&T's GraphViz. Deprecated. See GraphViz2"
 url="http://search.cpan.org/dist/GraphViz/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-libwww perl-file-which perl-xml-twig perl-xml-xpath
 	perl-ipc-run perl-parse-recdescent perl-module-build perl-test2-suite"
-cpanmakedepends="perl-test-pod   "
+cpanmakedepends="perl-test-pod"
 depends="$cpandepends"
 makedepends="perl-dev graphviz $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/R/RS/RSAVAGE/$_pkgreal-$pkgver.tgz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
 
 
-md5sums="b57b32444e73d24cf9c374bf38bad699  GraphViz-2.24.tgz"
-sha256sums="d95efac4cdeedb18283100efe3e00c59c1add524d9ce88c1c8a358359122f5ad  GraphViz-2.24.tgz"
 sha512sums="b37d1303c243a306443d5adf35d597f4e259cedaa7956d80bdb47cba811ce94e63da6b42a23d192fa9da628d999f1c023911f3f956a575aeabe673f77f3f01d9  GraphViz-2.24.tgz"

--- a/community/perl-hash-merge-simple/APKBUILD
+++ b/community/perl-hash-merge-simple/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=perl-hash-merge-simple
 _pkgreal=Hash-Merge-Simple
 pkgver=0.051
-pkgrel=0
+pkgrel=1
 pkgdesc="Recursively merge two or more hashes, simply"
 url="http://search.cpan.org/dist/Hash-Merge-Simple/"
 arch="noarch"
@@ -15,26 +15,31 @@ makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/R/RO/ROKR/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="f47b9b99794b1f958bcfa3e816ff4660  Hash-Merge-Simple-0.051.tar.gz"
-sha256sums="1c56327873d2f04d5722777f044863d968910466997740d55a754071c6287b73  Hash-Merge-Simple-0.051.tar.gz"
 sha512sums="8db850144593632ce8ac8a560dac6670814a9ce3d1091d6aa42ab0eadca4b350671103b1de906d562aeaa0934fd58bd4e557821c5bcd730a10849f8505f65c4c  Hash-Merge-Simple-0.051.tar.gz"

--- a/community/perl-hash-mostutils/APKBUILD
+++ b/community/perl-hash-mostutils/APKBUILD
@@ -3,38 +3,43 @@
 pkgname=perl-hash-mostutils
 _pkgreal=Hash-MostUtils
 pkgver=1.07
-pkgrel=0
+pkgrel=1
 pkgdesc="Pairwise list manipulators"
 url="http://search.cpan.org/dist/Hash-MostUtils/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-provide"
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/B/BE/BELDEN/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="854d195478d801b9e9a4fe68be06d2cd  Hash-MostUtils-1.07.tar.gz"
-sha256sums="3d165b7336d56813316fe38625dab450ae23a86149e191589148fce7899a1b48  Hash-MostUtils-1.07.tar.gz"
 sha512sums="63f0b38a76eac53097c47ea0f998c5b1ddfc8e0888bf9e62ad0c944ee22aca7eca1eaeba07ef284a318f4a03e29bf7bb52b521be994c979352e792ec02ae2eca  Hash-MostUtils-1.07.tar.gz"

--- a/community/perl-http-server-simple-psgi/APKBUILD
+++ b/community/perl-http-server-simple-psgi/APKBUILD
@@ -3,38 +3,43 @@
 pkgname=perl-http-server-simple-psgi
 _pkgreal=HTTP-Server-Simple-PSGI
 pkgver=0.16
-pkgrel=0
+pkgrel=1
 pkgdesc="PSGI handler for HTTP::Server::Simple"
 url="http://search.cpan.org/dist/HTTP-Server-Simple-PSGI/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-http-server-simple"
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/M/MI/MIYAGAWA/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="4ee6f4dee6fbf895b3fb0bb8bb9e5593  HTTP-Server-Simple-PSGI-0.16.tar.gz"
-sha256sums="5f7ccb8453043b97278492a757328116e11e0352f2854a28a9c634e6e9131dba  HTTP-Server-Simple-PSGI-0.16.tar.gz"
 sha512sums="514a61a7d349f02a18b44bd2ef3adbfd457cc61b6ec4eea2e74f1d8f4ffd095b42338552ddf7e9ab2b3ffa79e5c826099665e87c9ca5b08566975101e37b0177  HTTP-Server-Simple-PSGI-0.16.tar.gz"


### PR DESCRIPTION
Changes:
- Move tests to check()
- Remove return 1
- Rename _builddir to builddir
- Add missing default_prepare in prepare()