### PR TITLE
community/perl-[e-f]*: modernize APKBUILD

### DIFF
--- a/community/perl-email-messageid/APKBUILD
+++ b/community/perl-email-messageid/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-email-messageid
 _pkgreal=Email-MessageID
 pkgver=1.406
-pkgrel=0
+pkgrel=1
 pkgdesc="Generate world unique message-ids."
 url="http://search.cpan.org/dist/Email-MessageID/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="e1e235a4a3c64a6c1d07507c7049ff3b  Email-MessageID-1.406.tar.gz"
-sha256sums="ec425ddbf395e0e1ac7c6f95b4933c55c57ac9f1e7514003c7c904ec6cd342b8  Email-MessageID-1.406.tar.gz"
 sha512sums="c36861267a127372076391e5e6458ee19bbdc8d09c3b1ce3131d0cad1a82a6f9b2bc5a29df8bafa2450ea0e5c06993abf98928f2246e694d05875e40b7e36109  Email-MessageID-1.406.tar.gz"

--- a/community/perl-email-mime-encodings/APKBUILD
+++ b/community/perl-email-mime-encodings/APKBUILD
@@ -4,38 +4,41 @@
 pkgname=perl-email-mime-encodings
 _pkgreal=Email-MIME-Encodings
 pkgver=1.315
-pkgrel=0
+pkgrel=1
 pkgdesc="A unified interface to MIME encoding and decoding"
 url="http://search.cpan.org/dist/Email-MIME-Encodings/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="  perl-capture-tiny "
+cpanmakedepends="perl-capture-tiny"
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="0fbe906d7918430750b1ba766cf95151  Email-MIME-Encodings-1.315.tar.gz"
-sha256sums="4c71045507b31ec853dd60152b40e33ba3741779c0f49bb143b50cf8d243ab5c  Email-MIME-Encodings-1.315.tar.gz"
 sha512sums="4cd787e099617b70963c8ef6372e2a16038c61170fdd343aad88a024ecd15c789fd2c8cc19830c3518b6648e428301eed1ae20f496fa97afbdd8bb7f3ae432aa  Email-MIME-Encodings-1.315.tar.gz"

--- a/community/perl-email-simple/APKBUILD
+++ b/community/perl-email-simple/APKBUILD
@@ -4,35 +4,42 @@
 pkgname=perl-email-simple
 _pkgreal=Email-Simple
 pkgver=2.214
-pkgrel=0
+pkgrel=1
 pkgdesc="unknown"
 url="http://search.cpan.org/dist/Email-Simple/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-email-date-format"
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 

--- a/community/perl-encode-eucjpascii/APKBUILD
+++ b/community/perl-encode-eucjpascii/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-encode-eucjpascii
 _pkgreal=Encode-EUCJPASCII
 pkgver=0.03
-pkgrel=2
+pkgrel=3
 pkgdesc="Perl module for Encode-EUCJPASCII"
 url="http://search.cpan.org/dist/Encode-EUCJPASCII/"
 arch="all"
@@ -13,32 +13,35 @@ cpandepends=""
 cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
-subpackages=""
 source="http://search.cpan.org/CPAN/authors/id/N/NE/NEZUMI/$_pkgreal-$pkgver.tar.gz"
+
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	if [ -e Build.PL ]; then
-		perl Build.PL installdirs=vendor || return 1
+		perl Build.PL installdirs=vendor
 	else
-		PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor || return 1
+		PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 	fi
 }
 
 build() {
 	cd "$builddir"
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="5daa65f55b7c2050bb0713d9e95f239d  Encode-EUCJPASCII-0.03.tar.gz"
-sha256sums="f998d34d55fd9c82cf910786a0448d1edfa60bf68e2c2306724ca67c629de861  Encode-EUCJPASCII-0.03.tar.gz"
 sha512sums="0d7a06e1f5eaa20451ef360ef78372cb0ecf0c9a525efed5db0b55b0fc98b47c87eff4f9be069bdd7be50156f8edfc0cb9a257e9efd5a33130cc745dca12b7d8  Encode-EUCJPASCII-0.03.tar.gz"

--- a/community/perl-encode-jis2k/APKBUILD
+++ b/community/perl-encode-jis2k/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-encode-jis2k
 _pkgreal=Encode-JIS2K
 pkgver=0.03
-pkgrel=2
+pkgrel=3
 pkgdesc="Perl module for Encode-JIS2K"
 url="http://search.cpan.org/dist/Encode-JIS2K/"
 arch="all"
@@ -13,33 +13,35 @@ cpandepends=""
 cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
-subpackages=""
 source="http://search.cpan.org/CPAN/authors/id/D/DA/DANKOGAI/$_pkgreal-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	if [ -e Build.PL ]; then
-		perl Build.PL installdirs=vendor || return 1
+		perl Build.PL installdirs=vendor
 	else
-		PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor || return 1
+		PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 	fi
 }
 
 build() {
 	cd "$builddir"
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
 
-md5sums="60539471aa408a2b793cd45a6ce651db  Encode-JIS2K-0.03.tar.gz"
-sha256sums="1ec84d72db39deb4dad6fca95acfcc21033f45a24d347c20f9a1a696896c35cc  Encode-JIS2K-0.03.tar.gz"
 sha512sums="93d73a84e394faf8411d158ead0bc398ff1935ba14e35c64992d9fc8c2aa4ce1a71b5f46dbb1a765d3b160b19a9216bec68d42c8be1940d271dde418a62db4ec  Encode-JIS2K-0.03.tar.gz"

--- a/community/perl-extutils-depends/APKBUILD
+++ b/community/perl-extutils-depends/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-extutils-depends
 _pkgreal=ExtUtils-Depends
 pkgver=0.405
-pkgrel=0
+pkgrel=1
 pkgdesc="unknown"
 url="http://search.cpan.org/dist/ExtUtils-Depends/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/X/XA/XAOC/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="caefbca2f173d0cea3f5ac26b6c08a2c  ExtUtils-Depends-0.405.tar.gz"
-sha256sums="8ad6401ad7559b03ceda1fe4b191c95f417bdec7c542a984761a4656715a8a2c  ExtUtils-Depends-0.405.tar.gz"
 sha512sums="b9983ad763ff0cb81c899bc24f3152f13c69e608304b6e4446bd07b9b13d039650f3f87544c0bdd29c67246ea2973f04a1ce0fccbffb566fe89fdbe0bb03f11b  ExtUtils-Depends-0.405.tar.gz"

--- a/community/perl-extutils-libbuilder/APKBUILD
+++ b/community/perl-extutils-libbuilder/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-extutils-libbuilder
 _pkgreal=ExtUtils-LibBuilder
 pkgver=0.08
-pkgrel=0
+pkgrel=1
 pkgdesc="Perl module for ExtUtils-LibBuilder"
 url="http://search.cpan.org/dist/ExtUtils-LibBuilder/"
 arch="noarch"
@@ -18,28 +18,32 @@ source="http://search.cpan.org/CPAN/authors/id/A/AM/AMBS/$_pkgreal-$pkgver.tar.g
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
+
 	cd "$builddir"
 	if [ -e Build.PL ]; then
-		perl Build.PL installdirs=vendor || return 1
+		perl Build.PL installdirs=vendor
 	else
-		PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor || return 1
+		PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 	fi
 }
 
 build() {
 	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	./Build && perl ./Build test
+	./Build
+}
+
+check() {
+        cd "$builddir"
+        ./Build test
 }
 
 package() {
 	cd "$builddir"
-	./Build install destdir="$pkgdir" || return 1
+	./Build install destdir="$pkgdir"
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
 
-md5sums="8ffe9e9a3c2f916f40dc4f6aed237d33  ExtUtils-LibBuilder-0.08.tar.gz"
-sha256sums="c51171e06de53039f0bca1d97a6471ec37941ff59e8a3d1cb170ebdd2573b5d2  ExtUtils-LibBuilder-0.08.tar.gz"
 sha512sums="c9cb95ff9ce3d30163e3e6e76adc03e164bddcef1fa58a068f6fc41e4be7289f06712457fba341244e6d37ec5976912920d44ac02ff6c9a2cde368b102e5133e  ExtUtils-LibBuilder-0.08.tar.gz"

--- a/community/perl-file-basedir/APKBUILD
+++ b/community/perl-file-basedir/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-file-basedir
 _pkgreal=File-BaseDir
 pkgver=0.07
-pkgrel=0
+pkgrel=1
 pkgdesc="Use the Freedesktop.org base directory specification"
 url="http://search.cpan.org/dist/File-BaseDir/"
 arch="noarch"
@@ -16,26 +16,31 @@ makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/K/KI/KIMRYAN/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	perl Build.PL installdirs=vendor || return 1
+	perl Build.PL installdirs=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	./Build && ./Build test
+	./Build
+}
+
+check() {
+	cd "$builddir"
+	./Build test
 }
 
 package() {
-	cd "$_builddir"
-	./Build install destdir="$pkgdir" || return 1
+	cd "$builddir"
+	./Build install destdir="$pkgdir"
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="5d10401970d209049c8491d2906c3e13  File-BaseDir-0.07.tar.gz"
-sha256sums="120a57ef78535e13e1465717b4056aff4ce69af1e31c67c65d1177a52169082b  File-BaseDir-0.07.tar.gz"
 sha512sums="782ed883f37aeb28c4c71a10108865b2cc152c2a7a6015f84cf775be452493a3f599182d213a934e48bd64ffc74369bea61ad89f26f8b7b0c2f94504f107b35d  File-BaseDir-0.07.tar.gz"

--- a/community/perl-file-find-rule/APKBUILD
+++ b/community/perl-file-find-rule/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-file-find-rule
 _pkgreal=File-Find-Rule
 pkgver=0.34
-pkgrel=0
+pkgrel=1
 pkgdesc="unknown"
 url="http://search.cpan.org/dist/File-Find-Rule/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-text-glob perl-number-compare"
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/R/RC/RCLAMP/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="a7aa9ad4d8ee87b2a77b8e3722768712  File-Find-Rule-0.34.tar.gz"
-sha256sums="7e6f16cc33eb1f29ff25bee51d513f4b8a84947bbfa18edb2d3cc40a2d64cafe  File-Find-Rule-0.34.tar.gz"
 sha512sums="97328a86578942d214f7ac530cc88fc84dc7ef2018db06b8c0c58907a4045e90c9c97d1848ed4f16838bd8ca591aca4fa9f24649c81fd8dfe9efe7a2f9f2722c  File-Find-Rule-0.34.tar.gz"

--- a/community/perl-file-readbackwards/APKBUILD
+++ b/community/perl-file-readbackwards/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-file-readbackwards
 _pkgreal=File-ReadBackwards
 pkgver=1.05
-pkgrel=2
-pkgdesc="reading a file backwards"
+pkgrel=3
+pkgdesc="Reading a file backwards"
 url="http://search.cpan.org/dist/File-ReadBackwards/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/U/UR/URI/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test || return 1
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="613d9d02de6c1d86d5fa5b8816a6b214  File-ReadBackwards-1.05.tar.gz"
-sha256sums="82b261af87507cc3e7e66899c457104ebc8d1c09fb85c53f67c1f90f70f18d6e  File-ReadBackwards-1.05.tar.gz"
 sha512sums="8e1eeeda0acfdc0b9e1f5234cac37348890fb962e5edd395804d6cf9ab2c221217e2714025303493cafde7ce77721e6c09b2b53825dadb978fafe68f6d7b8c20  File-ReadBackwards-1.05.tar.gz"

--- a/community/perl-functional-utility/APKBUILD
+++ b/community/perl-functional-utility/APKBUILD
@@ -3,38 +3,43 @@
 pkgname=perl-functional-utility
 _pkgreal=Functional-Utility
 pkgver=1.02
-pkgrel=0
-pkgdesc="helper tools for light-weight functional programming."
+pkgrel=1
+pkgdesc="Helper tools for light-weight functional programming."
 url="http://search.cpan.org/dist/Functional-Utility/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/B/BE/BELDEN/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="75fc2f5cb6d23d5412fe4ff3a6d54f85  Functional-Utility-1.02.tar.gz"
-sha256sums="1ee089bc0d522bfd6a530eec815233ecb81778f8a576b9733430dc9c4e734104  Functional-Utility-1.02.tar.gz"
 sha512sums="bd6945baeef8b35466238c655ec8e7384e087ebfdc565119dc142987feb5affc6c0a85a879f47ff1508f7e0db705ca5a3f9a08d6b09164fa432b4b7c34b04ed1  Functional-Utility-1.02.tar.gz"


### PR DESCRIPTION
Changes:
- Move tests to check()
- Remove return 1
- Rename _builddir to builddir
- Add missing default_prepare in prepare()