### PR TITLE
main/nss: upgrade to 3.34.1

### DIFF
--- a/main/nss/APKBUILD
+++ b/main/nss/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nss
-pkgver=3.34
+pkgver=3.34.1
 _ver=${pkgver//./_}
 pkgrel=0
 pkgdesc="Mozilla Network Security Services"
@@ -23,7 +23,7 @@ source="http://ftp.mozilla.org/pub/security/$pkgname/releases/NSS_${pkgver//./_}
 builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	# Respect LDFLAGS
 	sed -i -e 's/\$(MKSHLIB) -o/\$(MKSHLIB) \$(LDFLAGS) -o/g' \
@@ -45,9 +45,9 @@ build() {
 	case "$CARCH" in
 		*64* | s390x) export USE_64=1;;
 	esac
-	make -j 1 -C nss/coreconf || return 1
-	make -j 1 -C nss/lib/dbm || return 1
-	make -j 1 -C nss || return 1
+	make -j 1 -C nss/coreconf
+	make -j 1 -C nss/lib/dbm
+	make -j 1 -C nss
 }
 
 package() {
@@ -75,11 +75,10 @@ package() {
 			-e "s,%NSPR_VERSION%,$pkgver,g" \
 			-e "s,%NSS_VERSION%,$pkgver,g" \
 			-e "s,%NSSUTIL_VERSION%,$pkgver,g" \
-			> "$pkgdir"/usr/lib/pkgconfig/${_pc} \
-			|| return 1
+			> "$pkgdir"/usr/lib/pkgconfig/${_pc}
 	done
-	ln -sf nss.pc "$pkgdir"/usr/lib/pkgconfig/mozilla-nss.pc || return 1
-	chmod 644 "$pkgdir"/usr/lib/pkgconfig/*.pc || return 1
+	ln -sf nss.pc "$pkgdir"/usr/lib/pkgconfig/mozilla-nss.pc
+	chmod 644 "$pkgdir"/usr/lib/pkgconfig/*.pc
 
 	# nss-config
 	sed "$srcdir"/nss-config.in \
@@ -90,29 +89,24 @@ package() {
 		-e "s,@MOD_MAJOR_VERSION@,${NSS_VMAJOR},g" \
 		-e "s,@MOD_MINOR_VERSION@,${NSS_VMINOR},g" \
 		-e "s,@MOD_PATCH_VERSION@,${NSS_VPATCH},g" \
-		> "$pkgdir"/usr/bin/nss-config || return 1
-	chmod 755 "$pkgdir"/usr/bin/nss-config || return 1
+		> "$pkgdir"/usr/bin/nss-config
+	chmod 755 "$pkgdir"/usr/bin/nss-config
 	local minor=${pkgver#*.}
 	minor=${minor%.*}
 	for file in $(find dist/*.OBJ/lib -name "*.so"); do
 		install -m755 $file \
-			"$pkgdir"/usr/lib/${file##*/}.$minor || return 1
+			"$pkgdir"/usr/lib/${file##*/}.$minor
 		ln -s ${file##*/}.$minor "$pkgdir"/usr/lib/${file##*/}
 	done
-	install -m644 dist/*.OBJ/lib/*.a "$pkgdir"/usr/lib/ \
-		|| return 1
-	install -m644 dist/*.OBJ/lib/*.chk "$pkgdir"/usr/lib/ \
-		|| return 1
+	install -m644 dist/*.OBJ/lib/*.a "$pkgdir"/usr/lib/
+	install -m644 dist/*.OBJ/lib/*.chk "$pkgdir"/usr/lib/
 
 	for file in certutil cmsutil crlutil modutil pk12util shlibsign \
 			signtool signver ssltap; do
-		install -m755 dist/*.OBJ/bin/${file} "$pkgdir"/usr/bin/\
-			|| return 1
+		install -m755 dist/*.OBJ/bin/${file} "$pkgdir"/usr/bin/
 	done
-	install -m644 dist/public/nss/*.h "$pkgdir"/usr/include/nss/ \
-		|| return 1
-	install -m644 dist/private/nss/blapi.h dist/private/nss/alghmac.h "$pkgdir"/usr/include/nss/private/ \
-		|| return 1
+	install -m644 dist/public/nss/*.h "$pkgdir"/usr/include/nss/
+	install -m644 dist/private/nss/blapi.h dist/private/nss/alghmac.h "$pkgdir"/usr/include/nss/private/
 }
 
 static() {
@@ -153,7 +147,7 @@ tools() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="72388b596151499850546a68d9a20d82434c59f159564fb7170980f110d43d7026f174f93660d3bb6da79b618fd7d4f1f16246fc80ba568aa555df99ebbaea21  nss-3.34.tar.gz
+sha512sums="6cc4826df4202e865e903a2ed05b49f708a047347b7b4d58f9b83ed097115a128239c4596a033ddeb9ee3fbfe6345a024e11eacb6149bce2d71fbe82c0a41c63  nss-3.34.1.tar.gz
 75dbd648a461940647ff373389cc73bc8ec609139cd46c91bcce866af02be6bcbb0524eb3dfb721fbd5b0bc68c20081ed6f7debf6b24317f2a7ba823e8d3c531  nss.pc.in
 0f2efa8563b11da68669d281b4459289a56f5a3a906eb60382126f3adcfe47420cdcedc6ab57727a3afeeffa2bbb4c750b43bef8b5f343a75c968411dfa30e09  nss-util.pc.in
 09c69d4cc39ec9deebc88696a80d0f15eb2d8c94d9daa234a2adfec941b63805eb4ce7f2e1943857b938bddcaee1beac246a0ec627b71563d9f846e6119a4a15  nss-softokn.pc.in


### PR DESCRIPTION
100% backwards compatible - https://abi-laboratory.pro/tracker/timeline/nss/