### PR TITLE
community/perl-[a-b]*: modernize APKBUILD

### DIFF
--- a/community/perl-algorithm-diff/APKBUILD
+++ b/community/perl-algorithm-diff/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-algorithm-diff
 _pkgreal=Algorithm-Diff
 pkgver=1.1903
-pkgrel=0
+pkgrel=1
 pkgdesc="Compute 'intelligent' differences between two files / lists"
 url="http://search.cpan.org/dist/Algorithm-Diff/"
 arch="noarch"
@@ -17,22 +17,27 @@ subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/T/TY/TYEMQ/$_pkgreal-$pkgver.tar.gz"
 
 builddir="$srcdir/$_pkgreal-$pkgver"
+
 prepare() {
+	default_prepare
 	cd "$builddir"
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
 	cd "$builddir"
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="0e8add21a641b8d66436df0c2024bf3b  Algorithm-Diff-1.1903.tar.gz"
-sha256sums="30e84ac4b31d40b66293f7b1221331c5a50561a39d580d85004d9c1fff991751  Algorithm-Diff-1.1903.tar.gz"
 sha512sums="61632be4c19a03ccacaa218ab7cb8bdbc53a4a6030b8173a59c7611056375536788392c1da00ab88f3df9884fc8a67825efc83b70e2e564664d5187021d6b106  Algorithm-Diff-1.1903.tar.gz"

--- a/community/perl-appconfig/APKBUILD
+++ b/community/perl-appconfig/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-appconfig
 _pkgreal=AppConfig
 pkgver=1.71
-pkgrel=0
+pkgrel=1
 pkgdesc="AppConfig is a bundle of Perl5 modules for reading configuration files and parsing command line arguments."
 url="http://search.cpan.org/dist/AppConfig/"
 arch="noarch"
@@ -16,24 +16,28 @@ makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/N/NE/NEILB/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+	cd "$builddir"
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
-	make && make test
+	cd "$builddir"
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="7747d9241561ed5567d5e134b8648707  AppConfig-1.71.tar.gz"
-sha256sums="1177027025ecb09ee64d9f9f255615c04db5e14f7536c344af632032eb887b0f  AppConfig-1.71.tar.gz"
 sha512sums="cbd58601ce0ea6c237e86b8b013cf75e552914263f56b1ab26b8079bff75b28ca2bb35585bfaa187b611afa969767c25494d3ec2a6b3ff5d1aecd2f9ffa8df72  AppConfig-1.71.tar.gz"

--- a/community/perl-autovivification/APKBUILD
+++ b/community/perl-autovivification/APKBUILD
@@ -4,21 +4,22 @@
 pkgname=perl-autovivification
 _pkgreal=autovivification
 pkgver=0.18
-pkgrel=0
+pkgrel=1
 pkgdesc="Lexically disable autovivification."
 url="http://search.cpan.org/dist/autovivification/"
 arch="all"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/V/VP/VPIT/$_pkgreal-$pkgver.tar.gz"
+
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
@@ -28,12 +29,17 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 

--- a/community/perl-business-isbn-data/APKBUILD
+++ b/community/perl-business-isbn-data/APKBUILD
@@ -4,21 +4,22 @@
 pkgname=perl-business-isbn-data
 _pkgreal=Business-ISBN-Data
 pkgver=20140910.003
-pkgrel=0
-pkgdesc="data pack for Business::ISBN"
+pkgrel=1
+pkgdesc="Data pack for Business::ISBN"
 url="http://search.cpan.org/dist/Business-ISBN-Data/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/B/BD/BDFOY/$_pkgreal-$pkgver.tar.gz"
+
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
@@ -28,15 +29,18 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="e45aba8cb0ed856c8633d874a0bf1f5b  Business-ISBN-Data-20140910.003.tar.gz"
-sha256sums="c756048c9b2b76ae5a7b9f1e1f6c59af670ff89b1fa574d4c3d7e4c9659685c9  Business-ISBN-Data-20140910.003.tar.gz"
 sha512sums="90e866e58d242e0de3b097a2df04d26d36eef92366a5fa0b21413065b09ec0e45d5a0cd7c657505975ff58a0b5270cfcec712d3fa5ef60e91c4dec7fe50708ed  Business-ISBN-Data-20140910.003.tar.gz"

--- a/community/perl-business-ismn/APKBUILD
+++ b/community/perl-business-ismn/APKBUILD
@@ -4,21 +4,22 @@
 pkgname=perl-business-ismn
 _pkgreal=Business-ISMN
 pkgver=1.131
-pkgrel=0
+pkgrel=1
 pkgdesc="Work with International Standard Music Numbers"
 url="http://search.cpan.org/dist/Business-ISMN/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-tie-cycle"
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/B/BD/BDFOY/$_pkgreal-$pkgver.tar.gz"
+
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
@@ -28,15 +29,18 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="87e36c8ccc9a9434494a849b7cf2fcc5  Business-ISMN-1.131.tar.gz"
-sha256sums="8fa479a0c6a846dd3aed86811d57266f07270a0d3abff333188976c2483fccf7  Business-ISMN-1.131.tar.gz"
 sha512sums="affe7112ec6901d93a48823c98ea3d646134d8ebb204777119f4bfae49fd0e76772519e07d35392160e2fbc9845dc2c05ce2554ed0614e53c9dc19859ded6cda  Business-ISMN-1.131.tar.gz"

--- a/community/perl-business-issn/APKBUILD
+++ b/community/perl-business-issn/APKBUILD
@@ -4,21 +4,22 @@
 pkgname=perl-business-issn
 _pkgreal=Business-ISSN
 pkgver=1.002
-pkgrel=0
+pkgrel=1
 pkgdesc="Perl extension for International Standard Serial Numbers"
 url="http://search.cpan.org/dist/Business-ISSN/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/B/BD/BDFOY/$_pkgreal-$pkgver.tar.gz"
+
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
@@ -28,15 +29,18 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="c226db6cdb9dfe77d17ad1d540b49f47  Business-ISSN-1.002.tar.gz"
-sha256sums="cb889cae7f2461bb35c3294eaeceb4ee39011974faf7d4dd4effe2c5cc38e5e1  Business-ISSN-1.002.tar.gz"
 sha512sums="c6a2d4ff750071080fc5e6859e0f959bcc14ddc307a28891636d36bbee220de40100148fd96475ad0dd5c0bfac1fdd9f5f47c2d5797c9c1b78c84f0fc811a9a1  Business-ISSN-1.002.tar.gz"


### PR DESCRIPTION
Changes:
- Move tests to check()
- Remove return 1
- Rename _builddir to builddir
- Add missing default_prepare in prepare()