### PR TITLE
community/exim: fix CVE-2017-16943, some cleanups

### DIFF
--- a/community/exim/APKBUILD
+++ b/community/exim/APKBUILD
@@ -6,15 +6,15 @@
 # Maintainer: Jesse Young <jlyo@jlyo.org>
 pkgname=exim
 pkgver=4.89
-pkgrel=6
+pkgrel=7
 pkgdesc="A Message Transfer Agent"
 url="http://www.exim.org/"
 arch="all"
 license="GPL2"
 options="!check suid"
 depends="ca-certificates"
-pkgusers="exim"
-pkggroups="exim"
+pkgusers="$pkgname"
+pkggroups="$pkgname mail"
 makedepends="bash gawk perl $depends_dev db-dev pcre-dev libressl-dev libspf2-dev mariadb-dev
 	postgresql-dev sqlite-dev libidn-dev linux-headers"
 install="exim.pre-install"
@@ -22,6 +22,7 @@ subpackages="$pkgname-cdb $pkgname-dbmdb $pkgname-dnsdb $pkgname-sqlite $pkgname
 	$pkgname-utils $pkgname-scripts::noarch $pkgname-doc"
 source="ftp://ftp.exim.org/pub/exim/exim4/$pkgname-$pkgver.tar.xz
 	CVE-2017-1000369.patch
+	CVE-2017-16943.patch
 	exim.Makefile
 	exim.confd
 	exim.initd
@@ -32,12 +33,14 @@ builddir="$srcdir/$pkgname-$pkgver"
 # secfixes:
 #   4.89-r5:
 #   - CVE-2017-1000369
+#   4.89-r7:
+#   - CVE-2017-16943
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
-	cp "$srcdir"/$pkgname.Makefile Local/Makefile || return 1
+	cp "$srcdir"/$pkgname.Makefile Local/Makefile
 	sed -i \
 		-e 's/-lnsl//g' \
 		-e 's/^HAVE_ICONV.*$//' \
@@ -46,14 +49,14 @@ prepare() {
 
 build() {
 	cd "$builddir"
-	make makefile || return 1
-	make -j1 || return 1
+	make makefile
+	make -j1
 }
 
 package() {
 	cd "$builddir"
 	install -m750 -D -g mail -d "$pkgdir"/etc/mail
-	make DESTDIR="$pkgdir" INSTALL_ARG="-no_symlink -no_chown exim" install || return 1
+	make DESTDIR="$pkgdir" INSTALL_ARG="-no_symlink -no_chown exim" install
 	install -D -m644 doc/exim.8 "$pkgdir"/usr/share/man/man8/exim.8
 	cd "$pkgdir"/usr/sbin
 	mv exim-${pkgver%.*}* exim
@@ -69,26 +72,29 @@ package() {
 		-e 's~# av_scanner = clamd:/tmp/clamd~# av_scanner = clamd:/run/clamav/clamd.sock~' \
 		-e '/# spamd_address = 127.0.0.1 783/a# spamd_address = 127.0.0.1 11333 variant=rspamd' \
 		"$pkgdir"/etc/$pkgname/$pkgname.conf
+	# Create subdirs for logs and extensions
+	install -dm750 -o $pkgname -g mail "$pkgdir"/var/log/$pkgname
+	mkdir -p "$pkgdir"/usr/lib/$pkgname
 }
 
 scripts() {
-	pkgdesc="exim scripts"
-	depends="exim perl"
+	pkgdesc="EXIM scripts"
+	depends="$pkgname perl"
 	cd "$builddir"
 	make	DESTDIR="$subpkgdir" \
 		INSTALL_ARG="exicyclog exim_checkaccess eximstats exiqgrep exigrep exinext exiqsumm exipick exiwhat convert4r3 convert4r4" \
-		install || return 1
+		install
 	rm -fr "$subpkgdir"/etc
 }
 
 utils() {
-	pkgdesc="exim utils"
-	depends="exim"
+	pkgdesc="EXIM utils"
+	depends="$pkgname"
 	cd "$builddir"
 	make	DESTDIR="$subpkgdir" \
 		INSTALL_ARG="exim_dbmbuild exim_dumpdb exim_tidydb exim_fixdb exim_lock" \
-		install || return 1
-	install -m755 "$srcdir"/exim.gencert "$subpkgdir"/usr/sbin/exim_gencert || return 1
+		install
+	install -m755 "$srcdir"/exim.gencert "$subpkgdir"/usr/sbin/exim_gencert
 	rm -fr "$subpkgdir"/etc
 }
 
@@ -107,8 +113,9 @@ dnsdb() { _mv_ext dnsdb; }
 
 sha512sums="ce5faef3847a5baf1b4fec1ffe46ce7efaafb24e63bcc52a61f38e8312a88eccaa816c3947ba428bef3eed38b1e91e606f6ed07bc0a3e14c6a6ed0ecb41eb9fa  exim-4.89.tar.xz
 cffe895974e9f570e2f60583206e0c2865e9ca400636e5ed2117c531fc62b03753f41286565ee253c11610e61589275cb5235b34cae052b5dcc6e5c37fbc7ece  CVE-2017-1000369.patch
+2821077669f2b5bea4ed99ba9549b4952fa85a9b97b4211efe90c3002e05ee14867d58ed3cd749b693dc0413d49781717c863ab9a5368ba0f07678419efbdabf  CVE-2017-16943.patch
 e9524d3a2cc230b4ecb3b098f53247121b9582fc7807b1549c5a3fd54bb416b837c4e09476f2e01dca03d590a968c40bf90d4b6a9f8a4abad082fdec91916a0f  exim.Makefile
 bb6f5ead067af19ace661cc92bcd428da97570aedd1f9dc5b61a34e7e3fb3e028be6c96d51df73353bdfcaf69a3ee053fb03d245f868d63ebf518aa96ec82d66  exim.confd
-8d0c594c5e3834ddd3a7743c025caf3f5c04f6ac17e25f2278e7a36b726150f0f8e36a1c76cd1a4b454edcb163181ee05ea40a6b61a0e9172c600e4808ccc80f  exim.initd
+3769e74a54566362bcdf57c45fbf7d130d7a7529fbc40befce431eef0387df117c71a5b57779c507e30d5b125913b5f26c9d16b17995521a1d94997be6dc3e02  exim.initd
 28e748693a6a72d9943fa9c342ff041fe650fa6977f468dee127e845e6c2a91872ce33fb6f5698838906bde3ed92de7a91cdb0349cedc40b806261867e8c06cb  exim.logrotate
 abdaf749ed3947a75b997caa300bf9f27ef82760f1854aa4521a9ac0f322f1655b65a375bc7a709259daea88bf93cfab5289997fa8e376fac9a3477f09bab642  exim.gencert"

--- a/community/exim/CVE-2017-16943.patch
+++ b/community/exim/CVE-2017-16943.patch
@@ -1,0 +1,35 @@
+From: Jeremy Harris <jgh146exb@wizmail.org>
+Date: Fri, 24 Nov 2017 20:22:33 +0000 (+0000)
+Subject: Avoid release of store if there have been later allocations.  Bug 2199
+X-Git-Url: https://git.exim.org/exim.git/commitdiff_plain/4e6ae6235c68de243b1c2419027472d7659aa2b4
+
+Avoid release of store if there have been later allocations.  Bug 2199
+---
+
+diff --git a/src/src/receive.c b/src/src/receive.c
+index e7e518a..d9b5001 100644
+--- a/src/receive.c
++++ b/src/receive.c
+@@ -1810,8 +1810,8 @@ for (;;)
+   (and sometimes lunatic messages can have ones that are 100s of K long) we
+   call store_release() for strings that have been copied - if the string is at
+   the start of a block (and therefore the only thing in it, because we aren't
+-  doing any other gets), the block gets freed. We can only do this because we
+-  know there are no other calls to store_get() going on. */
++  doing any other gets), the block gets freed. We can only do this release if
++  there were no allocations since the once that we want to free. */
+ 
+   if (ptr >= header_size - 4)
+     {
+@@ -1820,9 +1820,10 @@ for (;;)
+     header_size *= 2;
+     if (!store_extend(next->text, oldsize, header_size))
+       {
++      BOOL release_ok = store_last_get[store_pool] == next->text;
+       uschar *newtext = store_get(header_size);
+       memcpy(newtext, next->text, ptr);
+-      store_release(next->text);
++      if (release_ok) store_release(next->text);
+       next->text = newtext;
+       }
+     }

--- a/community/exim/exim.initd
+++ b/community/exim/exim.initd
@@ -16,8 +16,6 @@ depend() {
 
 start_pre() {
 	ebegin
-	checkpath -d -o exim:mail -m750 "/var/log/exim"
-	checkpath -d -o exim:mail -m750 "/usr/lib/exim"
 	$command -bV >/dev/null 2>>${startuplog:-/dev/null}
 	eend $?
 }


### PR DESCRIPTION
CVE-2017-16943 fix: https://bugs.exim.org/show_bug.cgi?id=2199

remove all "return 1"

create directories for logs and extensions at package time and remove
this creation from init script