### PR TITLE
testing/wireguard: version bump

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=1
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171111
-_mypkgrel=0
+_ver=0.0.20171127
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="2424c3923555d72a0b5910fc86071b2554934267d4c6521bc40076770984173b2cef55f4276dd4b5a446ea62f7c52424cd89b046f205314cff2919ff7de30e6b  WireGuard-0.0.20171111.tar.xz"
+sha512sums="31fb30f8a8eca96cee43d95b2ca10c05dd7f17f7f5695da6979e0d949735d5488065431529e580a881e3302cf78415c5132e116dc83ba1c40881de8b99627b95  WireGuard-0.0.20171127.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20171111
+pkgver=0.0.20171127
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="2424c3923555d72a0b5910fc86071b2554934267d4c6521bc40076770984173b2cef55f4276dd4b5a446ea62f7c52424cd89b046f205314cff2919ff7de30e6b  WireGuard-0.0.20171111.tar.xz"
+sha512sums="31fb30f8a8eca96cee43d95b2ca10c05dd7f17f7f5695da6979e0d949735d5488065431529e580a881e3302cf78415c5132e116dc83ba1c40881de8b99627b95  WireGuard-0.0.20171127.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171111
-_mypkgrel=0
+_ver=0.0.20171127
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="2424c3923555d72a0b5910fc86071b2554934267d4c6521bc40076770984173b2cef55f4276dd4b5a446ea62f7c52424cd89b046f205314cff2919ff7de30e6b  WireGuard-0.0.20171111.tar.xz"
+sha512sums="31fb30f8a8eca96cee43d95b2ca10c05dd7f17f7f5695da6979e0d949735d5488065431529e580a881e3302cf78415c5132e116dc83ba1c40881de8b99627b95  WireGuard-0.0.20171127.tar.xz"


### PR DESCRIPTION
This is a double bump.

Changes 0.0.20171122:

```
  * chacha20poly1305: fast primitives from Andy Polyakov

  Samuel Neves and I have spent considerable time and headaches porting,
  reworking, and partially rewriting Andy's optimized implementations of
  ChaCha20 and Poly1305. We now support the following:

  On x86_64:
    - Poly1305: integer unit
    - ChaCha20: SSSE3
    - HChaCha20: SSSE3
    - Poly1305: AVX
    - ChaCha20: AVX2
    - Poly1305: AVX2
    - ChaCha20: AVX512
    - Poly1305: AVX512

  On ARM:
    - Poly1305: integer unit
    - ChaCha20: NEON
    - Poly1305: NEON

  On ARM64:
    - Poly1305: integer unit
    - ChaCha20: NEON
    - Poly1305: NEON

  On MIPS64:
    - Poly1305: integer unit

  All others:
    - ChaCha20: generic C
    - Poly1305: generic C

  This is a pretty substantial amount of new handrolled assembly. It will
  perhaps MURDER KITTENS, so please tread lightly with this snapshot and adjust
  expectations accordingly. I'm looking forward to quickly fixing any issues
  folks find while testing.

  Performance-wise, this should see increases all around. The biggest speedups
  will be on ARM and ARM64, but x86_64 and MIPS64 should also see modest speed
  improvements too, especially on Skylake systems supporting AVX512.

  * chacha20poly1305: add more test vectors, some of which are weird

  Test vectors are pretty important, so we added more to catch odd edge cases
  using the following butcher's code:

    from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
    import os

    def encode_blob(blob):
        a = ""
        for i in blob:
            a += "\\x" + hex(i)[2:]
        return a

    enc = [ ]
    dec = [ ]

    def make_vector(plen, adlen):
        key = os.urandom(32)
        nonce = os.urandom(8)
        p = os.urandom(plen)
        ad = os.urandom(adlen)
        c = ChaCha20Poly1305(key).encrypt(nonce=bytes(4) + nonce, data=p, associated_data=ad)

        out = "{\n"
        out += "\t.key\t= \"" + encode_blob(key) + "\",\n"
        out += "\t.nonce\t= \"" + encode_blob(nonce) + "\",\n"
        out += "\t.assoc\t= \"" + encode_blob(ad) + "\",\n"
        out += "\t.alen\t= " + str(len(ad)) + ",\n"
        out += "\t.input\t= \"" + encode_blob(p) + "\",\n"
        out += "\t.ilen\t= " + str(len(p)) + ",\n"
        out += "\t.result\t= \"" + encode_blob(c) + "\"\n"
        out += "}"
        enc.append(out)

        out = "{\n"
        out += "\t.key\t= \"" + encode_blob(key) + "\",\n"
        out += "\t.nonce\t= \"" + encode_blob(nonce) + "\",\n"
        out += "\t.assoc\t= \"" + encode_blob(ad) + "\",\n"
        out += "\t.alen\t= " + str(len(ad)) + ",\n"
        out += "\t.input\t= \"" + encode_blob(c) + "\",\n"
        out += "\t.ilen\t= " + str(len(c)) + ",\n"
        out += "\t.result\t= \"" + encode_blob(p) + "\"\n"
        out += "}"
        dec.append(out)

    make_vector(0, 0)
    make_vector(0, 8)
    make_vector(1, 8)
    make_vector(1, 0)
    make_vector(129, 7)
    make_vector(256, 0)
    make_vector(512, 0)
    make_vector(513, 9)
    make_vector(1024, 16)
    make_vector(1933, 7)
    make_vector(2011, 63)

    print("======== encryption vectors ========")
    print(", ".join(enc))

    print("\n\n\n======== decryption vectors ========")
    print(", ".join(dec))

  * wg-quick: document localhost exception and v6 rule

  Probably a "kill switch" wants this too:
     -m addrtype ! --dst-type LOCAL
  so that basic local services can continue to work.

  * selftest: allowedips: randomized test mutex update
  * allowedips: do not write out of bounds
  * device: uninitialize socket first in destruction
  * tools: tighten up strtoul parsing

  Small fixups.

  * qemu: update kernel
  * qemu: use unprefixed strip when not cross-compiling

  Fedora/Redhat doesn't ship with a prefixed strip, and we don't need
  to use it anyway when we're not cross compiling, so don't.

  * compat: 3.16.50 got proper rt6_get_cookie
  * compat: stable finally backported fix
  * compat: new kernels have netlink fixes
  * compat: fix compilation with PaX

  Usual set of compatibility updates.

  * curve25519-neon: compile in thumb mode

  In thumb mode, it's not possible to use sp as an operand of and, so
  we have to muck around with r3 as a scratch register.

  * socket: only free socket after successful creation of new

  When an interface is down, the socket port can change freely. A socket
  will be allocated when the interface comes up, and if a socket can't be
  allocated, the interface doesn't come up.

  However, a socket port can change while the interface is up. In this
  case, if a new socket with a new port cannot be allocated, it's
  important to keep the interface in a consistent state. The choices are
  either to bring down the interface or to preserve the old socket. This
  patch implements the latter.

  * global: switch from timeval to timespec

  This gets us nanoseconds instead of microseconds, which is better, and
  we can do this pretty much without freaking out existing userspace,
  which doesn't actually make use of the nano/microseconds field. The below
  test program shows that this won't break existing sizes:

    zx2c4@thinkpad ~ $ cat a.c
    void main()
    {
        puts(sizeof(struct timeval) == sizeof(struct timespec) ?
          "success" : "failure");
    }
    zx2c4@thinkpad ~ $ gcc a.c -m64 && ./a.out
    success
    zx2c4@thinkpad ~ $ gcc a.c -m32 && ./a.out
    success
```

Changes 0.0.20171127:

```
  * compat: support timespec64 on old kernels
  * compat: support AVX512BW+VL by lying
  * compat: fix typo and ranges
  * compat: support 4.15's netlink and barrier changes
  * poly1305-avx512: requires AVX512F+VL+BW

  Numerous compat fixes which should keep us supporting 3.10-4.15-rc1.

  * blake2s: AVX512F+VL implementation
  * blake2s: tweak avx512 code
  * blake2s: hmac space optimization

  Another terrific submission from Samuel Neves: we now have an implementation
  of Blake2s using AVX512, which is extremely fast.

  * allowedips: optimize
  * allowedips: simplify
  * chacha20: directly assign constant and initial state

  Small performance tweaks.

  * tools: fix removing preshared keys
  * qemu: use netfilter.org https site
  * qemu: take shared lock for untarring

  Small bug fixes.
```