### PR TITLE
main/libmaxminddb: upgrade to 1.3.1

### DIFF
--- a/main/libmaxminddb/APKBUILD
+++ b/main/libmaxminddb/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=libmaxminddb
-pkgver=1.2.1
+pkgver=1.3.1
 pkgrel=0
 pkgdesc="Maxmind GeoIP2 database library"
 url="https://github.com/maxmind/libmaxminddb"
@@ -43,6 +43,6 @@ package() {
 	install -m755 -D "$srcdir"/libmaxminddb.confd "$pkgdir"/etc/conf.d/libmaxminddb
 }
 
-sha512sums="c77e2714c30dbd9d83a755d7e4d24016534510f4cc7213fe9549d610bf79aaeb28f761a9fb769270d9043b1baab537c5a4b3a9994b525d48f395fe94c104b5b3  libmaxminddb-1.2.1.tar.gz
+sha512sums="c13a18483caf720808d6a02baf8abe48c3aa4dd38ddc7ddd79b5d95d686600e19bb4b2242da08623f5d363a5be4b7636f7fcb59a5a7c9df9ab5a359ecd30b293  libmaxminddb-1.3.1.tar.gz
 1feb1f2dd57991d729b6f9d29834f43d7405038cdbdfb0113a0e8f8f951a74c5e40651f9d241460f110acdd300196cf580b370e6cec56985cca797ba5610e622  libmaxminddb.cron
 5f8dc6dad84cb1d188504a22470acf89542755c0bb3a78e4d3ae4e5bfa49fe64a7d2ee17441084db2710115463d39361df060a74b3a48fc4d8fc5e802afd2099  libmaxminddb.confd"


### PR DESCRIPTION
100% backwards compatibility - https://abi-laboratory.pro/tracker/timeline/libmaxminddb/