### PR TITLE
main/nasm: upgrade to 2.13.02

### DIFF
--- a/main/nasm/APKBUILD
+++ b/main/nasm/APKBUILD
@@ -1,15 +1,16 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nasm
-pkgver=2.13.01
+pkgver=2.13.02
 pkgrel=0
 pkgdesc="80x86 assembler designed for portability and modularity"
 url="http://nasm.sourceforge.net"
 arch="all"
 license="BSD-2"
-source="http://www.nasm.us/pub/nasm/releasebuilds/$pkgver/$pkgname-$pkgver.tar.bz2"
+checkdepends="perl"
 subpackages="$pkgname-doc"
-
+source="http://www.nasm.us/pub/nasm/releasebuilds/$pkgver/$pkgname-$pkgver.tar.bz2"
 builddir="$srcdir"/$pkgname-$pkgver
+
 build () {
 	cd "$builddir"
 	export CFLAGS=
@@ -21,9 +22,14 @@ build () {
 	make
 }
 
+check() {
+	cd "$builddir"
+	make test
+}
+
 package() {
 	cd "$builddir"
 	make INSTALLROOT="$pkgdir" install
 }
 
-sha512sums="3caf1a3bb9c2f406adce1de37afa92fbf7d7f8d2d274baab08b0e9dc6712c09347fc57d04c3962b6820ad303040efe7e3de0b923c3010c8da00051633bf00c5b  nasm-2.13.01.tar.bz2"
+sha512sums="96b8d66fa15a1a6a78fc4ce88029fb406d9904d1e1b65d42b07914c3128d4dc84b4c986a866204a6f25448b0a5eeaa1d0e1147459769765343ddb6ad73edcc0e  nasm-2.13.02.tar.bz2"


### PR DESCRIPTION
The test suite runs but is currently useless. 

It generates the following output and does not fail:
```
cd test && perl -I./perllib -I. performtest.pl --nasm=../nasm *.asm
Can't compare at _file_/bin file stdout
Can't compare at _version/version file stdout
Can't compare at a32offs/unoptimized file a32offs.bin
Can't compare at a32offs/optimized file a32offs.bin
Can't compare at absolute/bin file stdout
Can't compare at addr64x/O0 file stdout
Can't compare at addr64x/O1 file stdout
Can't compare at addr64x/Ox file stdout
Can't compare at align13/unoptimized file stdout
Can't compare at align13/optimized file stdout
Can't compare at align13s/unoptimized file stdout
Can't compare at align13s/optimized file stdout
Can't compare at alonesym-obj/unoptimized file stdout
Can't compare at alonesym-obj/optimized file stdout
Can't compare at andbyte/test file stdout
Can't compare at andbyte/otest file stdout
Can't compare at aoutso/unoptimized file stdout
Can't compare at aoutso/optimized file stdout
Can't compare at aouttest/unoptimized file stdout
Can't compare at aouttest/optimized file stdout
Can't compare at avx/unoptimized file stdout
Can't compare at avx/optimized file stdout
Can't compare at avx005/avx005 file stdout
Can't compare at avx512cd/avx512cd file stdout
Can't compare at avx512er/avx512er file stdout
Can't compare at avx512f/avx512f file stdout
Can't compare at avx512pf/avx512pf file stdout
Can't compare at bcd/optimized file stdout
Can't compare at binexe/unoptimized file stdout
Can't compare at binexe/optimized file stdout
Can't compare at bintest/unoptimized file stdout
Can't compare at bintest/optimized file stdout
Can't compare at br1879590/unoptimized file stdout
Can't compare at br1879590/optimized file stdout
Can't compare at br2003451/optimized file stdout
Can't compare at br2030823/optimized file stdout
Can't compare at br2148476/test file stdout
Can't compare at br2222615/noerror file stdout
Can't compare at br2222615/error file stdout
Can't compare at br2496848/unoptimized file stdout
Can't compare at br2496848/optimized file stdout
Can't compare at br3005117/br3005117 file stdout
Can't compare at br3026808/br3026808 file stdout
Can't compare at br3028880/br3028880 file stdout
Can't compare at br3041451/br3041451 file stdout
Can't compare at br3058845/unoptimized file stdout
Can't compare at br3058845/optimized file stdout
Can't compare at br3066383/br3066383 file stdout
Can't compare at br3109604/unoptimized file stdout
Can't compare at br3109604/optimized file stdout
Can't compare at br3174983/unoptimized file stdout
Can't compare at br3174983/optimized file stdout
Can't compare at br3187743/unoptimized file stdout
Can't compare at br3187743/optimized file stdout
Can't compare at br3189064/unoptimized file stdout
Can't compare at br3189064/optimized file stdout
Can't compare at br3200749/unoptimized file stdout
Can't compare at br3200749/optimized file stdout
Can't compare at br3385573/unoptimized file stdout
Can't compare at br3385573/optimized file stdout
Can't compare at br3392252/br3392252 file stdout
Can't compare at br3392259/br3392259 file stdout
Can't compare at br560575/aout file stderr
Can't compare at br560575/aoutb file stderr
Can't compare at br560575/coff file stderr
Can't compare at br560575/elf32 file stderr
Can't compare at br560575/elf64 file stderr
Can't compare at br560575/as86 file stderr
Can't compare at br560575/win32 file stderr
Can't compare at br560575/win64 file stderr
Can't compare at br560575/rdf file stderr
Can't compare at br560575/ieee file stderr
Can't compare at br560575/macho file stderr
Can't compare at br560873/unoptimized file stdout
Can't compare at br560873/optimized file stdout
Can't compare at br890790/test file stdout
Can't compare at br978756/br978756 file stdout
Can't compare at crc32/test file stdout
Can't compare at elfso/unoptimized file stdout
Can't compare at elfso/optimized file stdout
Can't compare at elif/unoptimized file stdout
Can't compare at elif/optimized file stdout
Can't compare at expimp/O0 file stdout
Can't compare at expimp/O1 file stdout
Can't compare at expimp/Ox file stdout
Can't compare at expimp/error-O0 file stdout
Can't compare at expimp/error-Ox file stdout
Can't compare at far64/test file stdout
Can't compare at float/unoptimized file stdout
Can't compare at float/optimized file stdout
Can't compare at float8/unoptimized file stdout
Can't compare at float8/optimized file stdout
Can't compare at floatb/unoptimized file stdout
Can't compare at floatb/optimized file stdout
Can't compare at floatexp/unoptimized file stdout
Can't compare at floatexp/optimized file stdout
Can't compare at floatize/unoptimized file stdout
Can't compare at floatize/optimized file stdout
Can't compare at floattest/optimized file stdout
Can't compare at fpu/test file stdout
Can't compare at fwdopt/test file stdout
Can't compare at fwdoptpp/error file stdout
Can't compare at fwdoptpp/fatal file stdout
Can't compare at fwdoptpp/warning file stdout
Can't compare at gotoff64/noerr file stdout
Can't compare at gotoff64/err file stdout
Can't compare at ifelse/ifelse file stdout
Can't compare at ifmacro/test file stdout
Can't compare at iftoken/test file stdout
Can't compare at imacro/test file stdout
Can't compare at imm64/imm64-O0 file stdout
Can't compare at imm64/imm64-O1 file stdout
Can't compare at imm64/imm64-Ox file stdout
Can't compare at immwarn/onowarn file stdout
Can't compare at immwarn/owarn file stdout
Can't compare at immwarn/nowarn file stdout
Can't compare at immwarn/warn file stdout
Can't compare at imul/nowarn file stdout
Can't compare at imul/warn file stdout
Can't compare at inctest/test file stdout
Can't compare at insnlbl/test file stdout
Can't compare at invlpga/unoptimized file stdout
Can't compare at invlpga/optimized file stdout
Can't compare at jmp64/test file stdout
Can't compare at lar_lsl/test file stdout
Can't compare at larlsl/test file stdout
Can't compare at lnxhello/aout file stdout
Can't compare at lnxhello/aoutb file stdout
Can't compare at lnxhello/as86 file stdout
Can't compare at lnxhello/elf32 file stdout
Can't compare at local/test file stdout
Can't compare at loopoffs/unoptimized file stdout
Can't compare at loopoffs/optimized file stdout
Can't compare at macro-defaults/warning file stdout
Can't compare at macro-defaults/nonwarning file stdout
Can't compare at mmxsize/unoptimized file stdout
Can't compare at mmxsize/optimized file stdout
Can't compare at movd/optimized file stdout
Can't compare at movimm/unoptimized file stdout
Can't compare at movimm/optimized file stdout
Can't compare at movnti/test file stdout
Can't compare at mpx-64/mpx-64 file stdout
Can't compare at mpx/mpx file stdout
Can't compare at multisection/aout file stdout
Can't compare at multisection/aoutb file stdout
Can't compare at multisection/as86 file stdout
Can't compare at multisection/elf32 file stdout
Can't compare at multisection/elf64 file stdout
Can't compare at multisection/obj file stdout
Can't compare at multisection/rdf file stdout
Can't compare at multisection/win32 file stdout
Can't compare at multisection/win64 file stdout
Can't compare at nasmformat/obj file stdout
Can't compare at nasmformat/bin file stdout
Can't compare at nasmformat/rdf file stdout
Can't compare at newrdwr/test file stdout
Can't compare at nop/unoptimized file stdout
Can't compare at nop/optimized file stdout
Can't compare at nullfile/test file stdout
Can't compare at objtest/unoptimized file stdout
Can't compare at objtest/optimized file stdout
Can't compare at optimization/O0 file stdout
Can't compare at optimization/O1 file stdout
Can't compare at optimization/Ox file stdout
Can't compare at org/elf64 file stdout
Can't compare at org/win64 file stdout
Can't compare at pinsr16/test file stdout
Can't compare at pinsr32/test file stdout
Can't compare at pinsr64/test file stdout
Can't compare at popcnt/test file stdout
Can't compare at ppindirect/test file ppindirect.out
Can't compare at prefix66/test file stdout
Can't compare at pushseg/test file stdout
Can't compare at r13/test file stdout
Can't compare at radix/test file stdout
Can't compare at riprel/unoptimized file stdout
Can't compare at riprel/optimized file stdout
Can't compare at riprel2/unoptimized file stdout
Can't compare at riprel2/optimized file stdout
Can't compare at sha-64/sha-64 file stdout
Can't compare at sha/sha file stdout
Can't compare at smartalign16/test file stdout
Can't compare at smartalign32/test file stdout
Can't compare at smartalign64/test file stdout
Can't compare at struc/test file stdout
Can't compare at test67/unoptimized file stdout
Can't compare at test67/optimized file stdout
Can't compare at testdos/test file stdout
Can't compare at testnos3/test file stdout
Can't compare at uscore/test file stdout
Can't compare at utf/test file stdout
Can't compare at utf/error file stdout
Can't compare at vmread/test file stdout
Can't compare at weirdpaste/preproc file stdout
Can't compare at weirdpaste/bin file stdout
Can't compare at xchg/unoptimized file stdout
Can't compare at xchg/optimized file stdout
Can't compare at xcrypt/test file stdout
Can't compare at zerobyte/test file stdout
```

I found a thread on the nasm forum about the issue but no solution - https://forum.nasm.us/index.php?topic=1875.0