### PR TITLE
main/libmicrohttpd: upgrade to 0.9.57

### DIFF
--- a/main/libmicrohttpd/APKBUILD
+++ b/main/libmicrohttpd/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libmicrohttpd
-pkgver=0.9.55
+pkgver=0.9.57
 pkgrel=0
 pkgdesc="a small C library that is supposed to make it easy to run an HTTP server as part of another application."
 url="https://www.gnu.org/software/libmicrohttpd/"
@@ -37,4 +37,4 @@ package() {
 		"$pkgdir"/usr/include/platform.h
 }
 
-sha512sums="b410e7253d7c98c40b5e8b8dcd1f93bcbb05c88717190e8dae73073d36465e8e5cfa53c6c5098de60051a5ec64dc423fd94f4b06537d8146b744aa99f5a0b173  libmicrohttpd-0.9.55.tar.gz"
+sha512sums="996a59b1bc950320f21df095d3e24e1e6a6e4204095eb84e7dc5e5ed296b1dbe553459b227ba6cc93f60721f1975f778ece8c7c1c10e9168d030fba46675eed3  libmicrohttpd-0.9.57.tar.gz"


### PR DESCRIPTION
100% backward
compatibility - https://abi-laboratory.pro/tracker/timeline/libmicrohttpd/