### PR TITLE
main/grub: move bash-completion data to subpackage and more

### DIFF
--- a/main/grub/APKBUILD
+++ b/main/grub/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=grub
 pkgver=2.02
-pkgrel=3
+pkgrel=4
 pkgdesc="Bootloader with support for Linux, Multiboot and more"
 url="https://www.gnu.org/software/grub/"
 arch="all !s390x"
@@ -13,8 +13,8 @@ makedepends="$depends_dev bison flex linux-headers xz-dev lvm2-dev
 	automake autoconf libtool python2 freetype-dev unifont"
 install=""
 # strip handled by grub Makefiles, abuild strip breaks xen pv-grub
-options="!strip"
-subpackages="$pkgname-dev $pkgname-doc"
+options="!strip !check"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-bash-completion:bashcomp:noarch"
 
 # currently grub only builds on x86*, aarch64 and ppc64le systems
 flavors=""
@@ -56,6 +56,7 @@ _build_flavor() {
 		--target=$CTARGET \
 		--prefix=/usr \
 		--sysconfdir=/etc \
+		--localedir=/usr/share/$pkgname \
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
 		--disable-nls \
@@ -116,8 +117,12 @@ package() {
 	done
 
 	rm -f "$pkgdir"/usr/lib/charset.alias
-	# remove grub-install warning of missing directory
-	mkdir -p "$pkgdir"/usr/share/locale
+}
+
+doc() {
+	default_doc
+	mkdir -p "$subpkgdir"/etc/$pkgname.d
+	mv "$pkgdir"/etc/$pkgname.d/README "$subpkgdir"/etc/$pkgname.d
 }
 
 bios() {
@@ -152,6 +157,15 @@ emu() {
 	depends="$pkgname"
 	mkdir -p $subpkgdir/usr/lib/grub
 	mv $pkgdir/usr/lib/grub/*-emu $subpkgdir/usr/lib/grub/
+}
+
+bashcomp() {
+	depends=""
+	pkgdesc="Bash completions for $pkgname"
+	install_if="$pkgname=$pkgver-r$pkgrel bash-completion"
+	mkdir -p "$subpkgdir"/usr/share/bash-completion/completions
+	mv "$pkgdir"/etc/bash_completion.d/$pkgname "$subpkgdir"/usr/share/bash-completion/completions
+	rmdir "$pkgdir"/etc/bash_completion.d
 }
 
 sha512sums="cc6eb0a42b5c8df2f671cc128ff725afb3ff1f8832a196022e433cf0d3b75decfca2316d0aa5fabea75747d55e88f3d021dd93508563f8ca80fd7b9e7fe1f088  grub-2.02.tar.xz

--- a/main/grub/APKBUILD
+++ b/main/grub/APKBUILD
@@ -120,12 +120,6 @@ package() {
 	rm -f "$pkgdir"/usr/lib/charset.alias
 }
 
-doc() {
-	default_doc
-	mkdir -p "$subpkgdir"/etc/$pkgname.d
-	mv "$pkgdir"/etc/$pkgname.d/README "$subpkgdir"/etc/$pkgname.d
-}
-
 bios() {
 	pkgdesc="$pkgdesc (BIOS version)"
 	depends="$pkgname"

--- a/main/grub/APKBUILD
+++ b/main/grub/APKBUILD
@@ -62,7 +62,8 @@ _build_flavor() {
 		--disable-nls \
 		--disable-werror \
 		$_configure
-	make
+	# Silent build. To pass through TravisCI
+	make > /dev/null
 }
 
 build() {


### PR DESCRIPTION
- move /etc/grub.d/README to -doc subpackage
- point localedir to /usr/share/grub, so we don't need to create /usr/share/locale empty unused directory in package tree and have no abuild warnings about it