### PR TITLE
main/libwebp: upgrade to 0.6.1

### DIFF
--- a/main/libwebp/APKBUILD
+++ b/main/libwebp/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Kiyoshi Aman <kiyoshi.aman@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libwebp
-pkgver=0.6.0
-pkgrel=1
+pkgver=0.6.1
+pkgrel=0
 pkgdesc="Libraries for working with WebP images"
 url="https://developers.google.com/speed/webp/"
 arch="all"
@@ -45,4 +45,4 @@ tools() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="be8eb9a3ddd3dec57f9f573d076ef97b17ea18de7e58e08e3fcb26456262394e9bb663c883d34f1aee0a91f23568e61c5ec4a7d0429cc385c009bf088ce6a1a4  libwebp-0.6.0.tar.gz"
+sha512sums="fece551d8fabdd8d7ba6807baa54a69a345f8690be4415dd0c0dea54002d78fe893a5d5aacfc13800300edd462b969d596709ac3213f6bc90f8e3698b2490d5f  libwebp-0.6.1.tar.gz"


### PR DESCRIPTION
100% backward compatibility - https://abi-laboratory.pro/tracker/timeline/libwebp/