### PR TITLE
main/libwebsockets: upgrade to 2.4.1

### DIFF
--- a/community/ttyd/APKBUILD
+++ b/community/ttyd/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=ttyd
 pkgver=1.3.3
-pkgrel=3
+pkgrel=4
 pkgdesc="Share your terminal over the web"
 url="https://tsl0922.github.io/ttyd"
 arch="all"

--- a/main/libwebsockets/APKBUILD
+++ b/main/libwebsockets/APKBUILD
@@ -1,12 +1,13 @@
 # Contributor: V.Krishn <vkrishn4@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libwebsockets
-pkgver=2.4.0
-pkgrel=1
+pkgver=2.4.1
+pkgrel=0
 pkgdesc="C library for lightweight websocket clients and servers"
 url="http://libwebsockets.org"
 arch="all"
 license="LGPL2+"
+options="!check"
 makedepends="cmake zlib-dev libressl-dev"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-test:_test"
 source="$pkgname-$pkgver.tar.gz::https://github.com/warmcat/$pkgname/archive/v$pkgver.tar.gz"
@@ -21,6 +22,13 @@ build() {
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_VERBOSE_MAKEFILE=TRUE
 	make
+}
+
+# TODO: Use test subpkg to validate
+check() {
+	cd "$builddir"
+
+	make check
 }
 
 package() {
@@ -38,4 +46,4 @@ _test() {
 	mv "$pkgdir"/usr/share "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="89ccc24b44e4f38f3b3918634dc5f2be78be1ea9fc1748064c8a54adae026c410bfc743caf9bbd304c312e34e624f5f8fb101d7b36052af9b94dbf309625ec0a  libwebsockets-2.4.0.tar.gz"
+sha512sums="a5f6a3388517d6f46183dfd1e625475ac1d4d509690e431a581d6ca927078fa50ac9a0787b4305fe088c694af1809335020bfc083a4d4d98585143f13ff61c75  libwebsockets-2.4.1.tar.gz"

--- a/main/mosquitto/APKBUILD
+++ b/main/mosquitto/APKBUILD
@@ -1,20 +1,22 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mosquitto
 pkgver=1.4.14
-pkgrel=3
+pkgrel=4
 pkgdesc="An Open Source MQTT v3.1 Broker"
 url="http://mosquitto.org/"
 arch="all"
 license="BSD"
-depends=""
-depends_dev=""
-makedepends="$depends_dev libressl-dev c-ares-dev util-linux-dev
-	libwebsockets-dev"
+replaces="mosquitto-utils"
 install="$pkgname.pre-install"
+# "abuild -r" then test/mosq_test.py can't start subprocess "$srcdir/src/mosquitto"
+# "abuild check" will run subprocess and execute the tests without any issues.
+options="!check"
+makedepends="libressl-dev c-ares-dev util-linux-dev libwebsockets-dev libxslt"
+checkdepends="python2"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-libs++:_pp
 	$pkgname-libs $pkgname-clients"
-replaces="mosquitto-utils"
 source="http://mosquitto.org/files/source/$pkgname-$pkgver.tar.gz
+	test_broker_makefile.patch
 	libressl.patch
 	config.patch
 	mosquitto.initd"
@@ -27,7 +29,7 @@ builddir="$srcdir/$pkgname-$pkgver"
 #     - CVE-2017-7650
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	# dont strip
 	sed -i -e "s|(INSTALL) -s|(INSTALL)|g" \
@@ -44,18 +46,24 @@ build() {
 		WITH_SRV=yes \
 		WITH_TLS_PSK=no \
 		WITH_ADNS=no \
-		prefix=/usr || return 1
+		prefix=/usr
+}
+
+check() {
+	cd "$builddir"
+
+	make test
 }
 
 package() {
 	cd "$builddir"
 
-	make prefix=/usr DESTDIR="$pkgdir" install || return 1
+	make prefix=/usr DESTDIR="$pkgdir" install
 
 	mv "$pkgdir"/etc/mosquitto/mosquitto.conf.example \
-		"$pkgdir"/etc/mosquitto/mosquitto.conf || return 1
+		"$pkgdir"/etc/mosquitto/mosquitto.conf
 	sed -i -e 's/#log_dest stderr/log_dest syslog/' \
-		"$pkgdir"/etc/mosquitto/mosquitto.conf || return 1
+		"$pkgdir"/etc/mosquitto/mosquitto.conf
 
 	install -Dm755 "$srcdir"/mosquitto.initd "$pkgdir"/etc/init.d/mosquitto
 }
@@ -77,6 +85,7 @@ clients() {
 }
 
 sha512sums="dc75a971354f87deeb79f32435acfae9bc561a1a24a75ee4940a35176ff91758071930d2105d8dee2a090e07527dbfaa5692bece67e03cc87e8b4b8b46f846c2  mosquitto-1.4.14.tar.gz
+b4c5c4d513c58b24aa5dec11fc3c644d18cc447eed099de77ea518ce1a70f84854b03f242d756462e46067872a89f0c2c49728ff2424a31dc9cac93c5c1e332b  test_broker_makefile.patch
 53859b628f965b77f6e47910c0ceba2f2737b815131ed800dc64a80419e434d25b5ba0938ae645882e9aa5d475d4940c7d35cc6d56f54bc4937a66b32d7db4ad  libressl.patch
 d5442373ae6ae8bc83eee59b425fbd76e80f905b9fd2bd2ed2a37a7e156fe95a9cf477c9c4dac0975c5fd90e70884de6fb8a16aefcd37b239199d5deae50b7d2  config.patch
 16f96d8f7f3a8b06e2b2e04d42d7e0d89a931b52277fc017e4802f7a3bc85aff4dd290b1a0c40382ea8f5568d0ceb7319c031d9be916f346d805231a002b0433  mosquitto.initd"

--- a/main/mosquitto/test_broker_makefile.patch
+++ b/main/mosquitto/test_broker_makefile.patch
@@ -1,0 +1,14 @@
+# https://github.com/eclipse/mosquitto/issues/636
+--- a/test/broker/Makefile
++++ b/test/broker/Makefile
+@@ -89,8 +89,10 @@
+ 	./08-ssl-connect-identity.py
+ 	./08-ssl-connect-no-identity.py
+ 	./08-ssl-bridge.py
++ifeq ($(WITH_TLS_PSK),yes)
+ 	./08-tls-psk-pub.py
+ 	./08-tls-psk-bridge.py
++endif
+ endif
+ 
+ 09 :


### PR DESCRIPTION
70.4% backward compatibility - https://abi-laboratory.pro/tracker/timeline/libwebsockets/