### PR TITLE
main/x265: upgrade to 2.6

### DIFF
--- a/community/xpra/APKBUILD
+++ b/community/xpra/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=xpra
 pkgver=2.1.3
-pkgrel=0
+pkgrel=1
 pkgdesc="Xpra is 'screen for X' & allows you to run X programs, usually on a remote host over SSH or encrypted tcp"
 url="http://xpra.org"
 # !armhf: fails to build

--- a/main/ffmpeg/APKBUILD
+++ b/main/ffmpeg/APKBUILD
@@ -4,16 +4,18 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=ffmpeg
 pkgver=3.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Complete and free Internet live audio and video broadcasting solution for Linux/Unix"
 url="http://ffmpeg.org/"
 arch="all"
 license="GPL"
+options="!check" # tests/data/hls-lists.append.m3u8 fails
 subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
 makedepends="gnutls-dev lame-dev libvorbis-dev xvidcore-dev zlib-dev libvdpau-dev
 	imlib2-dev x264-dev libtheora-dev coreutils bzip2-dev perl-dev libvpx-dev
 	libvpx-dev sdl2-dev libxfixes-dev libva-dev alsa-lib-dev rtmpdump-dev
 	v4l-utils-dev yasm opus-dev x265-dev"
+checkdepends="rsync"
 source="http://ffmpeg.org/releases/ffmpeg-$pkgver.tar.xz
 	0001-libavutil-clean-up-unused-FF_SYMVER-macro.patch
 	"
@@ -73,6 +75,16 @@ build() {
 	make
 	${CC:-gcc} -o tools/qt-faststart $CFLAGS tools/qt-faststart.c
 	make doc/ffmpeg.1 doc/ffplay.1 doc/ffserver.1
+}
+
+# https://ffmpeg.org/fate.html
+check() {
+	cd "$builddir"
+	./configure \
+		--samples=fate-suite/
+	make fate-rsync
+	make fate-list
+	make fate
 }
 
 package() {

--- a/main/gst-plugins-bad/APKBUILD
+++ b/main/gst-plugins-bad/APKBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gst-plugins-bad
 pkgver=1.12.3
-pkgrel=2
+pkgrel=3
 pkgdesc="GStreamer bad plugins"
 url="https://gstreamer.freedesktop.org/"
 arch="all"
 license="LGPL GPL"
 depends=""
 replaces="gst-plugins-bad1"
-subpackages="$pkgname-lang $pkgname-dev $pkgname-doc"
+options="!check" # most fail because: XDG_RUNTIME_DIR not set in the env.
 makedepends="
 	alsa-lib-dev
 	bluez-dev
@@ -18,6 +18,7 @@ makedepends="
 	faad2-dev
 	flite-dev
 	glib-dev
+	glu-dev
 	gsm-dev
 	gst-plugins-base-dev
 	gstreamer-dev
@@ -40,6 +41,8 @@ makedepends="
 	x265-dev
 	xvidcore-dev
 	"
+checkdepends="orc-compiler"
+subpackages="$pkgname-lang $pkgname-dev $pkgname-doc"
 source="https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-$pkgver.tar.xz"
 ldpath="/usr/lib/gstreamer-.0"
 builddir="$srcdir"/gst-plugins-bad-$pkgver
@@ -56,18 +59,23 @@ build() {
 		--enable-experimental \
 		--disable-fatal-warnings \
 		--with-package-name="GStreamer Bad Plugins (Alpine Linux)" \
-		--with-package-origin="http://alpinelinux.org/" \
-		|| return 1
-	make || return 1
+		--with-package-origin="http://alpinelinux.org/"
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
 doc() {
 	default_doc
 	replaces="${pkgname}1-doc"
 }
+
 sha512sums="6df47381de3a2f4286d047c1e7de2c76dd4312c9806636e2012717282cde0f3e5b2d0ffa910c564c8e122b19363e842b663cce1eda7ae95a05d63d1dbbd52661  gst-plugins-bad-1.12.3.tar.xz"

--- a/main/x265/APKBUILD
+++ b/main/x265/APKBUILD
@@ -1,16 +1,16 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=x265
-pkgver=2.5
+pkgver=2.6
 pkgrel=0
 pkgdesc="Open Source H265/HEVC video encoder"
-url="https://bitbucket.org/multicoreware/x265"
+url="http://x265.org"
 arch="all"
 license="GPL"
-makedepends="cmake yasm"
+makedepends="cmake yasm" # 2.6+ will use nasm instead of yasm
 subpackages="$pkgname-dev"
 source="$pkgname-$pkgver.tar.gz::https://bitbucket.org/multicoreware/$pkgname/downloads/${pkgname}_${pkgver}.tar.gz"
-builddir="$srcdir/${pkgname}_$pkgver"
+builddir="$srcdir/${pkgname}_v$pkgver"
 
 build() {
 	cd "$builddir"/build/linux
@@ -31,10 +31,16 @@ build() {
 	make
 }
 
+check() {
+	cd "$builddir"/build/linux
+
+	./x265 --version
+}
+
 package() {
 	cd "$builddir"/build/linux
 
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="f39b0b06a9f6ab9ab19fcdc1cba1578ace433e22dc8ec3f549ec3e5eeaaf40d17de6c7d419c12c16717ae795c45d953ef34a2fc9376d7e83eb7e9e74ab19ec93  x265-2.5.tar.gz"
+sha512sums="35c3716313e3dfd1555dd725b60f2b3b00a615d8b8d8267439722b52021d47e34eebf94b837b92a92d40c7ffab7b3198d6391365d62672b257c0a87d1db8a736  x265-2.6.tar.gz"


### PR DESCRIPTION
89.1% backward compatibility - https://abi-laboratory.pro/tracker/timeline/x265/