### PR TITLE
main/libuv: upgrade to 1.18.0

### DIFF
--- a/main/libuv/APKBUILD
+++ b/main/libuv/APKBUILD
@@ -2,7 +2,7 @@
 # Conttributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libuv
-pkgver=1.17.0
+pkgver=1.18.0
 pkgrel=0
 pkgdesc="Cross-platform asychronous I/O"
 url="http://libuv.org"
@@ -46,5 +46,5 @@ package() {
 		"$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 
-sha512sums="c5cd551e515c106b911df32e47b9f1010973e5831a59693930944fb18b64b8afd25b0f4b865bbf3db44cda38817d7f66eecd27ab9c010500f841f1da973acf50  libuv-v1.17.0.tar.gz
+sha512sums="8a5beccb8f433b4cc22b292419e90fec9bae8253c2173c83582ae2c88244ecde7845b169358ab5ebd769f847b539c6365ebd5ef3f5347ca0aaa7dd1984b0c2d7  libuv-v1.18.0.tar.gz
 478d25c8905cd393b9ced0f1b16e70794a7ef20fb9eb212fd74e50beca3f5a33a6a5267616abecf470426ed3d00efec51df468745ff43c0de05c0ad8234f1eb3  disable-setuid-test.patch"


### PR DESCRIPTION
100% backward compatibility - https://abi-laboratory.pro/tracker/timeline/libuv/