### PR TITLE
community/php7-memcached: upgrade to 3.0.4

### DIFF
--- a/community/php7-memcached/APKBUILD
+++ b/community/php7-memcached/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
 pkgname=php7-memcached
 _pkgreal=memcached
-pkgver=3.0.3
-pkgrel=1
+pkgver=3.0.4
+pkgrel=0
 _phpver=${pkgname#php}
 _phpver=${_phpver%%-*}
 pkgdesc="PHP$_phpver extension for interfacing with memcached via libmemcached library"
@@ -37,4 +37,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$confdir"/20_$_pkgreal.ini
 }
 
-sha512sums="cb24d76f82ce8c1fdd8877bbb46131545bba5011cfff965e3c190b7c0f71f754b47ded6289d3125724d9de781b916971aaadfa0b247c6fe2f51aab77dce61b61  php7-memcached-3.0.3.tgz"
+sha512sums="d0a0f9e99cbcc6829528554551dfacf0d943d54d4be60c9da708de82913a2a0bed7c51d594ae3ecf0c13b56064739f074ce6ada5d7433bdc7e26e8caf9cf5ca2  php7-memcached-3.0.4.tgz"


### PR DESCRIPTION
Adds upcoming php72 compatibility https://pecl.php.net/package-info.php?package=memcached&version=3.0.4

Will be required for https://github.com/alpinelinux/aports/pull/2873