### PR TITLE
testing/kubernetes: update to version 1.8.5

### DIFF
--- a/testing/kubernetes/APKBUILD
+++ b/testing/kubernetes/APKBUILD
@@ -1,24 +1,29 @@
+# Contributor: Mateusz Mikuła <matti@marinelayer.io>
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=kubernetes
-pkgver=1.7.4
+pkgver=1.8.5
 pkgrel=0
 pkgdesc="Container Cluster Manager for Docker"
 url="http://kubernetes.io/"
 arch="x86_64"
 license="APACHE"
-options="!nostrip"
+options="!check !nostrip"
 depends="bash"
-makedepends="go rsync bash linux-headers findutils coreutils"
-source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$pkgver.tar.gz
-no-gnu-grep.patch
-make-e2e_node-run-over-distro-bins.patch
-make-test-cmd-run-over-hyperkube-based-kubectl.patch
-build-with-debug-info.patch
-fix-support-for-ppc64le.patch
-remove-apiserver-add-kube-prefix-for-hyperkube.patch"
+makedepends="bash coreutils findutils go linux-headers rsync"
+source="$pkgname-$pkgver.tar.gz::https://dl.k8s.io/v$pkgver/kubernetes-src.tar.gz
+	no-gnu-grep.patch
+	make-e2e_node-run-over-distro-bins.patch
+	make-test-cmd-run-over-hyperkube-based-kubectl.patch
+	fix-support-for-ppc64le.patch
+	remove-apiserver-add-kube-prefix-for-hyperkube.patch
+	"
+builddir="$srcdir"/build
 
-builddir="$srcdir"/$pkgname-$pkgver
+unpack() {
+	mkdir -p $builddir
+	tar -xf $srcdir/$pkgname-$pkgver.tar.gz -C $builddir
+}
 
 build() {
 	cd "$builddir"
@@ -44,11 +49,9 @@ package() {
 	install -d $pkgdir/var/lib/kubelet
 }
 
-
-sha512sums="78404f7e6cfa6a4b599bf76373d59c799040c42ad8ce8abf259f2468eeaa07cb31514e32bd6577985087bebafe50da0baf3d0e7e9e0958a9f6250c6dade450f9  kubernetes-1.7.4.tar.gz
-18dadb171ba860f382d5185b88ec6a1338c322ffead133f2ab27c9bf0a2363ef4c7b94ead5a95c0d77539144e818ccc5fc864c642382d1f1974787b191a8a6ce  no-gnu-grep.patch
+sha512sums="fbf3ebb130b735ce6b31cf666b0c3914380c1117d4efece75b6b269016d552777862f70267d9bc5e3feeddd7e15107881e6f99c100bfd3b0d9bbef1325f645ea  kubernetes-1.8.5.tar.gz
+bf83357a169ecdabffdbefa0e9b24e01fbd99f289e846d34506ae3d32c599c6f9b8acac9a96cb587177eb62f48f0530088280cd1aa425c780daa1c6087e4d730  no-gnu-grep.patch
 06e3e8626b70077eb693da9c53dca3bc566aea4590a27c5dd3997b6d34abec5bf5d749b7be94b60b83361884c29b3a6dbb56c40b18c008b19e7cbd6e0d5c87e6  make-e2e_node-run-over-distro-bins.patch
 07ecfbdb005250c65360a7357aeaacd1b342658c6685d37c0ea6b4740e4aebebc0213f74a81926bc0a6262161602d53f0c6cb6f19c5ecfb3be90c9372dc3cccd  make-test-cmd-run-over-hyperkube-based-kubectl.patch
-9f1a86529893aca8a3c757bf61e7f0bd0c6c92ccc94f48ddc583374cf92d3961f4f98a3a6c2c87c29ebeaae04a95ccdd8435d1e1eebdd82eff9c0827e810fbe6  build-with-debug-info.patch
 ff043b723edc644a8270a471bfb45b400a4547a9dd70b28c5c27dc041d956da2d1da36422694b35ac589a7ca651de44c7346d3d63fd36ec570bab7325a6fd73b  fix-support-for-ppc64le.patch
 469a93156ea5919fa77e54a0a142bf44a899d841bdf180a78ab5fd751891b18d675bd6b807f04da85fc7962c43e2f840a4587c3145e7829878089a3b17ec187e  remove-apiserver-add-kube-prefix-for-hyperkube.patch"

--- a/testing/kubernetes/no-gnu-grep.patch
+++ b/testing/kubernetes/no-gnu-grep.patch
@@ -1,8 +1,6 @@
-diff --git a/build/root/Makefile.generated_files b/build/root/Makefile.generated_files
-index 45287dc..8617f49 100644
---- a/build/root/Makefile.generated_files
-+++ b/build/root/Makefile.generated_files
-@@ -155,7 +155,7 @@ $(foreach dir, $(ALL_GO_DIRS), $(eval           \
+--- kubernetes-1.8.4/build/root/Makefile.generated_files.orig
++++ kubernetes-1.8.4/build/root/Makefile.generated_files
+@@ -155,7 +155,7 @@
  # is what the .stamp file represents.
  $(foreach dir, $(ALL_GO_DIRS),  \
      $(META_DIR)/$(dir)/$(GOFILES_META)):
@@ -10,8 +8,8 @@ index 45287dc..8617f49 100644
 +	FILES=$$(ls $</*.go | grep -v $(GENERATED_FILE_PREFIX));  \
  	mkdir -p $(@D);                                           \
  	echo "gofiles__$< := $$(echo $${FILES})" >$@.tmp;         \
- 	cmp -s $@.tmp $@ || touch $@.stamp;                       \
-@@ -181,7 +181,7 @@ ifeq ($(DBG_MAKEFILE),1)
+ 	if ! cmp -s $@.tmp $@; then                               \
+@@ -187,7 +187,7 @@
  endif
  ALL_K8S_TAG_FILES := $(shell                             \
      find $(ALL_GO_DIRS) -maxdepth 1 -type f -name \*.go  \
@@ -20,7 +18,7 @@ index 45287dc..8617f49 100644
  )
  
  #
-@@ -208,7 +208,7 @@ ifeq ($(DBG_MAKEFILE),1)
+@@ -214,7 +214,7 @@
      $(warning ***** finding all +k8s:deepcopy-gen tags)
  endif
  DEEPCOPY_DIRS := $(shell                                             \
@@ -29,16 +27,16 @@ index 45287dc..8617f49 100644
          | xargs -n1 dirname                                          \
          | LC_ALL=C sort -u                                           \
  )
-@@ -275,7 +275,7 @@ $(META_DIR)/$(DEEPCOPY_GEN).mk:
+@@ -289,7 +289,7 @@
  	 ./hack/run-in-gopath.sh go list                                      \
  	     -f '{{.ImportPath}}{{"\n"}}{{range .Deps}}{{.}}{{"\n"}}{{end}}'  \
- 	     ./cmd/libs/go2idl/deepcopy-gen                                   \
+ 	     ./vendor/k8s.io/code-generator/cmd/deepcopy-gen                  \
 -	     | grep --color=never "^$(PRJ_SRC_PATH)/"                         \
 +	     | grep "^$(PRJ_SRC_PATH)/"                         \
  	     | xargs ./hack/run-in-gopath.sh go list                          \
  	         -f '{{$$d := .Dir}}{{$$d}}{{"\n"}}{{range .GoFiles}}{{$$d}}/{{.}}{{"\n"}}{{end}}'  \
  	     | paste -sd' ' -                                                 \
-@@ -332,7 +332,7 @@ ifeq ($(DBG_MAKEFILE),1)
+@@ -352,7 +352,7 @@
      $(warning ***** finding all +k8s:defaulter-gen tags)
  endif
  DEFAULTER_DIRS := $(shell                                            \
@@ -47,16 +45,16 @@ index 45287dc..8617f49 100644
          | xargs -n1 dirname                                          \
          | LC_ALL=C sort -u                                           \
  )
-@@ -425,7 +425,7 @@ $(META_DIR)/$(DEFAULTER_GEN).mk:
+@@ -453,7 +453,7 @@
  	 ./hack/run-in-gopath.sh go list                                      \
  	     -f '{{.ImportPath}}{{"\n"}}{{range .Deps}}{{.}}{{"\n"}}{{end}}'  \
- 	     ./cmd/libs/go2idl/defaulter-gen                                  \
+ 	     ./vendor/k8s.io/code-generator/cmd/defaulter-gen                 \
 -	     | grep --color=never "^$(PRJ_SRC_PATH)/"                         \
 +	     | grep "^$(PRJ_SRC_PATH)/"                         \
  	     | xargs ./hack/run-in-gopath.sh go list                          \
  	         -f '{{$$d := .Dir}}{{$$d}}{{"\n"}}{{range .GoFiles}}{{$$d}}/{{.}}{{"\n"}}{{end}}'  \
  	     | paste -sd' ' -                                                 \
-@@ -472,7 +472,7 @@ ifeq ($(DBG_MAKEFILE),1)
+@@ -506,7 +506,7 @@
      $(warning ***** finding all +k8s:openapi-gen tags)
  endif
  OPENAPI_DIRS := $(shell                                             \
@@ -65,16 +63,16 @@ index 45287dc..8617f49 100644
          | xargs -n1 dirname                                         \
          | LC_ALL=C sort -u                                          \
  )
-@@ -523,7 +523,7 @@ $(META_DIR)/$(OPENAPI_GEN).mk:
+@@ -557,7 +557,7 @@
  	 ./hack/run-in-gopath.sh go list                                      \
  	     -f '{{.ImportPath}}{{"\n"}}{{range .Deps}}{{.}}{{"\n"}}{{end}}'  \
- 	     ./cmd/libs/go2idl/openapi-gen                                    \
+ 	     ./vendor/k8s.io/code-generator/cmd/openapi-gen                   \
 -	     | grep --color=never "^$(PRJ_SRC_PATH)/"                         \
 +	     | grep "^$(PRJ_SRC_PATH)/"                         \
  	     | xargs ./hack/run-in-gopath.sh go list                          \
  	         -f '{{$$d := .Dir}}{{$$d}}{{"\n"}}{{range .GoFiles}}{{$$d}}/{{.}}{{"\n"}}{{end}}'  \
  	     | paste -sd' ' -                                                 \
-@@ -581,7 +581,7 @@ ifeq ($(DBG_MAKEFILE),1)
+@@ -621,7 +621,7 @@
      $(warning ***** finding all +k8s:conversion-gen tags)
  endif
  CONVERSION_DIRS := $(shell                                              \
@@ -83,19 +81,19 @@ index 45287dc..8617f49 100644
          | cut -f1 -d:                                                   \
          | xargs -n1 dirname                                             \
          | LC_ALL=C sort -u                                              \
-@@ -639,7 +639,7 @@ $(foreach dir, $(CONVERSION_DIRS), $(eval           \
+@@ -683,7 +683,7 @@
  # is what the .stamp file represents.
  $(foreach dir, $(CONVERSION_DIRS),  \
      $(META_DIR)/$(dir)/$(CONVERSIONS_META)):
 -	TAGS=$$(grep --color=never -h '^// *+k8s:conversion-gen=' $</*.go   \
 +	TAGS=$$(grep -h '^// *+k8s:conversion-gen=' $</*.go   \
  	    | cut -f2- -d=                                                  \
- 	    | sed 's|$(PRJ_SRC_PATH)/||');                                  \
- 	mkdir -p $(@D);                                                     \
-@@ -717,7 +717,7 @@ $(META_DIR)/$(CONVERSION_GEN).mk:
+ 	    | sed 's|$(PRJ_SRC_PATH)/||'                                    \
+ 	    | sed 's|^k8s.io/|vendor/k8s.io/|');                            \
+@@ -771,7 +771,7 @@
  	 ./hack/run-in-gopath.sh go list                                      \
  	     -f '{{.ImportPath}}{{"\n"}}{{range .Deps}}{{.}}{{"\n"}}{{end}}'  \
- 	     ./cmd/libs/go2idl/conversion-gen                                 \
+ 	     ./vendor/k8s.io/code-generator/cmd/conversion-gen                \
 -	     | grep --color=never "^$(PRJ_SRC_PATH)/"                         \
 +	     | grep "^$(PRJ_SRC_PATH)/"                         \
  	     | xargs ./hack/run-in-gopath.sh go list                          \


### PR DESCRIPTION
Changed source download location because release 1.8.4 on GitHub [is broken](https://github.com/kubernetes/kubernetes/issues/56346).

I don't see the need for `build-with-debug-info.patch` so I removed it from `source` but left patch untouched in case it will be required in the future.