### PR TITLE
testing/firefox: Update to 57.0.1

### DIFF
--- a/testing/firefox/APKBUILD
+++ b/testing/firefox/APKBUILD
@@ -10,6 +10,7 @@ url="http://www.firefox.com"
 # limited by rust and cargo
 arch="x86_64"
 license="GPL LGPL MPL"
+options="!check"
 depends=""
 makedepends="
 	alsa-lib-dev

--- a/testing/firefox/APKBUILD
+++ b/testing/firefox/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: William Pitcock <nenolod@dereferenced.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox
-pkgver=57.0
+pkgver=57.0.1
 _pkgver=$pkgver
 _xulver=$pkgver
 pkgrel=1
@@ -219,7 +219,7 @@ __EOF__
 	rm -f "$pkgdir"/${_mozappdirdev}/sdk/lib/libxul.so
 }
 
-sha512sums="bd99ff97a2a6f824e6fbd36fd00193903159e309506b1e6945dcbc43a17a95aaa54a05f32131c56872e8860878ba6063008667955550f03aa8c7084f834d14fc  firefox-57.0.source.tar.xz
+sha512sums="8cbfe0ad2c0f935dbc3a0ac4e855c489c83bf8c4506815dbae6e27f5d6a262ecf19ac82b6e81d52782559834fa14403116ecbf3acc8e3bc56b6c319e68316edd  firefox-57.0.1.source.tar.xz
 0b3f1e4b9fdc868e4738b5c81fd6c6128ce8885b260affcb9a65ff9d164d7232626ce1291aaea70132b3e3124f5e13fef4d39326b8e7173e362a823722a85127  stab.h
 09bc32cf9ee81b9cc6bb58ddbc66e6cc5c344badff8de3435cde5848e5a451e0172153231db85c2385ff05b5d9c20760cb18e4138dfc99060a9e960de2befbd5  fix-fortify-inline.patch
 0fcc647af53a3ce21c2bc36e5631eb0935e7243ebb3ab59b5719542cc54a6ac023a4a857b43b75756efb9ed80c0aecaa94dc5679a3b3792f82e87bf2c1af82e1  disable-hunspell_hooks.patch


### PR DESCRIPTION
This build works fine but it takes a very long time
to build because the rust stuff in version 57 only builds
on 1 core.

Signed-off-by: Leo Unglaub <leo@unglaub.at>