### PR TITLE
nginx do not delete /run/nginx diretory.

### DIFF
--- a/main/nginx/APKBUILD
+++ b/main/nginx/APKBUILD
@@ -233,7 +233,7 @@ package() {
 	# Remove archaic charset maps.
 	rm ./etc/$pkgname/koi-* ./etc/$pkgname/win-utf
 
-	rm -rf ./run ./etc/$pkgname/*.default
+	rm -rf ./etc/$pkgname/*.default
 }
 
 vim() {


### PR DESCRIPTION
nginx pid file will write into /run/nginx/nginx.pid.
so,  we do not delete "run" directory  in the APKBUILD file.

Error Info: 
[root@35b983e1c496.docker.airdb.io srv]# nginx 
[root@35b983e1c496.docker.airdb.io srv]# nginx: [emerg] open() "/run/nginx/nginx.pid" failed (2: No such file or directory)



