### PR TITLE
testing/wireguard: version bump

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=1
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171127
-_mypkgrel=1
+_ver=0.0.20171211
+_mypkgrel=2
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="31fb30f8a8eca96cee43d95b2ca10c05dd7f17f7f5695da6979e0d949735d5488065431529e580a881e3302cf78415c5132e116dc83ba1c40881de8b99627b95  WireGuard-0.0.20171127.tar.xz"
+sha512sums="8dfdf09753305e247dbc3a2cb77fcd1abec50dd7c4b1f0643270eea3236c418f9c4daac4215bf99bc6a66c0801b86c1e83ce097cdbf81d6549614f21b6ffbe35  WireGuard-0.0.20171211.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20171127
+pkgver=0.0.20171211
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="31fb30f8a8eca96cee43d95b2ca10c05dd7f17f7f5695da6979e0d949735d5488065431529e580a881e3302cf78415c5132e116dc83ba1c40881de8b99627b95  WireGuard-0.0.20171127.tar.xz"
+sha512sums="8dfdf09753305e247dbc3a2cb77fcd1abec50dd7c4b1f0643270eea3236c418f9c4daac4215bf99bc6a66c0801b86c1e83ce097cdbf81d6549614f21b6ffbe35  WireGuard-0.0.20171211.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171127
-_mypkgrel=1
+_ver=0.0.20171211
+_mypkgrel=2
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="31fb30f8a8eca96cee43d95b2ca10c05dd7f17f7f5695da6979e0d949735d5488065431529e580a881e3302cf78415c5132e116dc83ba1c40881de8b99627b95  WireGuard-0.0.20171127.tar.xz"
+sha512sums="8dfdf09753305e247dbc3a2cb77fcd1abec50dd7c4b1f0643270eea3236c418f9c4daac4215bf99bc6a66c0801b86c1e83ce097cdbf81d6549614f21b6ffbe35  WireGuard-0.0.20171211.tar.xz"


### PR DESCRIPTION
Update to 0.0.20171211:
    
    * curve25519: explictly depend on AS_AVX
    * curve25519: modularize dispatch
    
    It's now much cleaner to see which implementation we're calling, and it will
    be simpler to add more implementations in the future.
    
    * compat: support RAP in assembly
    
    This should fix PaX/Grsecurity support.
    
    * device: do not clear keys during sleep on Android
    
    While we want to clear keys when going to sleep on ordinary Linux, this
    doesn't make sense in the Android world, where phones often sleep but are
    woken up every few milliseconds by the radios to process packets.
    
    * compat: fix 3.10 backport
    
    Important compat fixes for non-x86.
    
    * device: clear last handshake timer on ifdown
    
    When bringing up an interface, we don't want the rate limiting to handshakes
    to apply.
    
    * netlink: rename symbol to avoid clashes
    
    Allows coexistance with horrible Android drivers.
    
    * kernel-tree: jury rig is the more common spelling
    * tools: no need to put this on the stack
    * blake2s-x86_64: fix spacing
    
    Small fixes.
    
    * contrib: keygen-html for generating keys in the browser
    
    This was covered here:
    https://lists.zx2c4.com/pipermail/wireguard/2017-December/002127.html
    
    * tools: remove undocumented unused syntax
    
    Not only did nobody know about this or use it, but the implementation actually
    exposed compiler bugs in Qualcomm's "Snapdragon Clang".
    
    * poly1305: update x86-64 kernel to AVX512F only
    
    From Samuel Neves, this pulls in Andy Polyakov's changes to only require F and
    not VL for the Poly implementation.
    
    * chacha20-arm: fix with clang -fno-integrated-as.
    
    This pulls in David Benjamin's clang fix.
    
    * global: add SPDX tags to all files
    
    From Greg KH, we now have SPDX annotations on all files, matching upstream
    kernel's new approach to file licenses.
    
    * chacha20poly1305: cleaner generic code
    
    This entirely removes the last remains of Martin Willi's ChaCha
    implementation, and now the generic C implementation is extremely small and
    clearly written, while delivering a small performance boost too.
    
    * poly1305: fix avx512f alignment bug
    
    Unlucky people may have had their linkers misalign a constant. This fixes that
    potential.
    
    * chacha20: avx512vl implementation
    
    From Samuel Neves, this imports Andy Polyakov's AVX512VL implementation of
    ChaCha which should have a ~50% performance improvement over AVX2, though it
    is still much slower than our AVX512F implementation.
    
    * chacha20poly1305: wire up avx512vl for skylake-x
    
    Some Skylake machines do not have two FMA units (though others do), so we
    prefer the AVX512VL implementation over the should-be-faster AVX512F
    implementation on those machines. What's needed now is to read the PIROM in
    order to determine at runtime whether the particular Skylake-X machine
    actually has the second FMA unit or not, but until that happens, we just fall
    back to the VL implementation for all Skylake-X.
