### PR TITLE
 main/aspell-ru: fix package version, modernize apkbuild

### DIFF
--- a/main/aspell-ru/APKBUILD
+++ b/main/aspell-ru/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=aspell-ru
 pkgver=0.99f7.1
-pkgrel=2
+pkgrel=0
 pkgdesc="Russian dictionary for aspell"
 _pkgname=aspell6-ru
 _pkgver=0.99f7-1

--- a/main/aspell-ru/APKBUILD
+++ b/main/aspell-ru/APKBUILD
@@ -1,27 +1,29 @@
+# Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=aspell-ru
-pkgver=0.99f7
-pkgrel=1
+pkgver=0.99f7.1
+pkgrel=2
 pkgdesc="Russian dictionary for aspell"
+_pkgname=aspell6-ru
+_pkgver=0.99f7-1
 url="http://aspell.net/"
 arch="noarch"
 license="GPL2"
+options="!check"
 depends=""
 makedepends="aspell-dev"
-source="ftp://ftp.gnu.org/gnu/aspell/dict/ru/aspell6-ru-$pkgver-1.tar.bz2"
+source="ftp://ftp.gnu.org/gnu/aspell/dict/ru/$_pkgname-$_pkgver.tar.bz2"
+builddir="$srcdir/$_pkgname-$_pkgver"
 
-_builddir="$srcdir"/aspell6-ru-$pkgver-1
 build () {
-	cd "$_builddir"
-	./configure || return 1
-	make || return 1
+	cd "$builddir"
+	./configure
+	make
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 
-md5sums="c4c98eaa5e77ad3adccbc5c96cb57cb3  aspell6-ru-0.99f7-1.tar.bz2"
-sha256sums="5c29b6ccce57bc3f7c4fb0510d330446b9c769e59c92bdfede27333808b6e646  aspell6-ru-0.99f7-1.tar.bz2"
 sha512sums="789fe15f5502b54008a41f2afb5635dcb7bb0a36e61b300ee48b2429c339793f5c4808d6063f13f1f8455ce251912433890e7d01ca59d8b0924ecd2987ceb430  aspell6-ru-0.99f7-1.tar.bz2"


### PR DESCRIPTION
- fixed pkgver because https://repology.org thinks it's obsolete
- it have no test suite, so added !check

- fixed pkgrel because version bump.
