### PR TITLE
testing/kexec-tools: new aport

### DIFF
--- a/testing/kexec-tools/APKBUILD
+++ b/testing/kexec-tools/APKBUILD
@@ -8,7 +8,7 @@ url="https://kernel.org/pub/linux/utils/kernel/kexec/"
 arch="x86_64"
 license="GPL2"
 depends="xz zlib"
-makedepends="zlib-dev xz-dev"
+makedepends="zlib-dev xz-dev linux-headers"
 subpackages="$pkgname-doc"
 source="https://www.kernel.org/pub/linux/utils/kernel/kexec/$pkgname-$pkgver.tar.xz 
 	kexec-tools-2.0.16-fix-config-sub.patch"

--- a/testing/kexec-tools/APKBUILD
+++ b/testing/kexec-tools/APKBUILD
@@ -1,0 +1,38 @@
+# Contributor: Duncan Guthrie <dguthrie@posteo.net>
+# Maintainer: Duncan Guthrie <dguthrie@posteo.net>
+pkgname=kexec-tools
+pkgver=2.0.16
+pkgrel=0
+pkgdesc="Directly boot into a new kernel over a currently running one"
+url="https://kernel.org/pub/linux/utils/kernel/kexec/"
+arch="x86_64"
+license="GPL2"
+depends="xz zlib"
+makedepends="zlib-dev xz-dev"
+subpackages="$pkgname-doc"
+source="https://www.kernel.org/pub/linux/utils/kernel/kexec/$pkgname-$pkgver.tar.xz 
+	kexec-tools-2.0.16-fix-config-sub.patch"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var \
+		--with-zlib \
+		--with-lzma 
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="f2f06e7702fef20c8d7d6aabe1b264e2e2689e5c38cc00dbc2186dd7fa0479edb2dc9e307dd2ad7f03db47015e966e577f11576172604ef01c1bcca471fe2c24  kexec-tools-2.0.16.tar.xz
+3c87540309dceda4c074d5822fd1a5d709ad533baed91dfd77aa64ebfe3850fc099c4b3d2bcc887c81ae53dc5940d17ccf34be25609beb37ed5ef7ed75862d43  kexec-tools-2.0.16-fix-config-sub.patch"

--- a/testing/kexec-tools/APKBUILD
+++ b/testing/kexec-tools/APKBUILD
@@ -13,6 +13,7 @@ subpackages="$pkgname-doc"
 source="https://www.kernel.org/pub/linux/utils/kernel/kexec/$pkgname-$pkgver.tar.xz 
 	kexec-tools-2.0.16-fix-config-sub.patch"
 builddir="$srcdir/$pkgname-$pkgver"
+options="!check"
 
 build() {
 	cd "$builddir"

--- a/testing/kexec-tools/kexec-tools-2.0.16-fix-config-sub.patch
+++ b/testing/kexec-tools/kexec-tools-2.0.16-fix-config-sub.patch
@@ -1,0 +1,10 @@
+--- kexec-tools-2.0.16.old/config/config.sub	2016-12-09 09:42:06.000000000 +0000
++++ kexec-tools-2.0.16/config/config.sub	2017-12-13 19:35:19.248376862 +0000
+@@ -124,6 +124,7 @@
+ case $maybe_os in
+   nto-qnx* | linux-gnu* | linux-android* | linux-dietlibc | linux-newlib* | \
+   linux-uclibc* | uclinux-uclibc* | uclinux-gnu* | kfreebsd*-gnu* | \
++  linux-musl* | \
+   knetbsd*-gnu* | netbsd*-gnu* | \
+   kopensolaris*-gnu* | \
+   storm-chaos* | os2-emx* | rtmk-nova*)


### PR DESCRIPTION
Directly boot into a new kernel over a currently running one
https://kernel.org/pub/linux/utils/kernel/kexec