### PR TITLE
community/php7: build with IMAGETYPE_SWC const

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -93,6 +93,7 @@ source="http://php.net/distributions/$_pkgreal-$pkgver.tar.bz2
 	php7-fpm-version-suffix.patch
 	allow-build-recode-and-imap-together.patch
 	fix-tests-devserver.patch
+	ext-standard-image.patch
 	"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
@@ -640,4 +641,5 @@ f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c93976
 d93d3fc015580cf5f75c6cbca4cd980e054b61e1068495da81a7e61f1af2c9ae14f09964c04928ad338142de78e4844aed885b1ad1865282072999fb045c8ad7  fix-asm-constraints-in-aarch64-multiply-macro.patch
 a4c35446745ab0ac806de801f0651fc5d2c98cf60063c3c2d3963a84f1c71ef78e09b7650c08e7231be0fdb93c0c255de38894d7f0e4f4c5a190d17f1a6bc476  php7-fpm-version-suffix.patch
 f8ecae241a90cbc3e98aa4deb3d5d35ef555f51380e29f4e182a8060dffeb84be74f030a14c6b452668471030d78964f52795ca74275db05543ccad20ef1f2cc  allow-build-recode-and-imap-together.patch
-01c3c65f153ea92192f2b2694d93a086ffa67c282fe046f877842942692c25666e4154a09aba6c2161f7f2a3b6595f4d79573e9ee74aec774a95f2f9725846f9  fix-tests-devserver.patch"
+01c3c65f153ea92192f2b2694d93a086ffa67c282fe046f877842942692c25666e4154a09aba6c2161f7f2a3b6595f4d79573e9ee74aec774a95f2f9725846f9  fix-tests-devserver.patch
+d8cf542b2ba946784a47a4c414fc54f665b1425df85f11c13fde019c824898acd9feb64e2b4bc80e3677550e1331159c11dcace82bb14f8c38aca3fd609c7b39  ext-standard-image.patch"

--- a/community/php7/ext-standard-image.patch
+++ b/community/php7/ext-standard-image.patch
@@ -1,0 +1,38 @@
+--- a/ext/standard/image.c
++++ b/ext/standard/image.c
+@@ -34,7 +34,7 @@
+ #include "win32/php_stdint.h"
+ #endif
+ 
+-#if HAVE_ZLIB && !defined(COMPILE_DL_ZLIB)
++#if HAVE_ZLIB
+ #include "zlib.h"
+ #endif
+ 
+@@ -86,7 +86,7 @@
+ 	REGISTER_LONG_CONSTANT("IMAGETYPE_JP2",     IMAGE_FILETYPE_JP2,     CONST_CS | CONST_PERSISTENT);
+ 	REGISTER_LONG_CONSTANT("IMAGETYPE_JPX",     IMAGE_FILETYPE_JPX,     CONST_CS | CONST_PERSISTENT);
+ 	REGISTER_LONG_CONSTANT("IMAGETYPE_JB2",     IMAGE_FILETYPE_JB2,     CONST_CS | CONST_PERSISTENT);
+-#if HAVE_ZLIB && !defined(COMPILE_DL_ZLIB)
++#if HAVE_ZLIB
+ 	REGISTER_LONG_CONSTANT("IMAGETYPE_SWC",     IMAGE_FILETYPE_SWC,     CONST_CS | CONST_PERSISTENT);
+ #endif
+ 	REGISTER_LONG_CONSTANT("IMAGETYPE_IFF",     IMAGE_FILETYPE_IFF,     CONST_CS | CONST_PERSISTENT);
+@@ -195,7 +195,7 @@
+ }
+ /* }}} */
+ 
+-#if HAVE_ZLIB && !defined(COMPILE_DL_ZLIB)
++#if HAVE_ZLIB
+ /* {{{ php_handle_swc
+  */
+ static struct gfxinfo *php_handle_swc(php_stream * stream)
+@@ -1393,7 +1393,7 @@
+ 			result = php_handle_swf(stream);
+ 			break;
+ 		case IMAGE_FILETYPE_SWC:
+-#if HAVE_ZLIB && !defined(COMPILE_DL_ZLIB)
++#if HAVE_ZLIB
+ 			result = php_handle_swc(stream);
+ #else
+ 			php_error_docref(NULL, E_NOTICE, "The image is a compressed SWF file, but you do not have a static version of the zlib extension enabled");


### PR DESCRIPTION
Fix for [redmine-8299](https://bugs.alpinelinux.org/issues/8299).

```
php > echo IMAGETYPE_SWC;
PHP Notice:  Use of undefined constant IMAGETYPE_SWC - assumed 'IMAGETYPE_SWC' in php shell code on line 1
IMAGETYPE_SWC
```