### PR TITLE
testing/alttab: new aport

### DIFF
--- a/testing/alttab/APKBUILD
+++ b/testing/alttab/APKBUILD
@@ -1,0 +1,36 @@
+# Contributor: Alexander Kulak <sa-dev@rainbow.by>
+# Maintainer: Alexander Kulak <sa-dev@rainbow.by>
+pkgname=alttab
+pkgver=1.1.0.57
+pkgrel=0
+pkgdesc="X11 window switcher designed for minimalistic window managers or standalone X11 session"
+url="https://github.com/sagb/alttab"
+arch="all"
+license="GPL3+"
+depends="libx11 libxft libxrender libpng fts"
+makedepends="libx11-dev libxft-dev uthash-dev libxrender-dev libpng-dev fts-dev"
+install=""
+subpackages="$pkgname-doc"
+source="${pkgname}-${pkgver}.tar.gz::https://api.github.com/repos/sagb/alttab/tarball/0c14ea2080c5603fbebe9cbca3f198fabb30d2d9"
+builddir="$srcdir/sagb-alttab-0c14ea2"
+options="!check"
+
+build() {
+	cd "$builddir" && \
+	./bootstrap.sh && \
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var && \
+	make
+}
+
+package() {
+	cd "$builddir" && \
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="6dd6cc8b28eb05e5148854304e75de31e5975aff213d70d67d12fa3d935639cde6dd57a032690495f603baeea50a7fa057651b672e4d9aa7d602b4ac8f50b3c6  alttab-1.1.0.57.tar.gz"


### PR DESCRIPTION
`alttab` adds or enhances Alt-Tab feature of lightweight stacking WMs in Alpine, f.e. fluxbox, jwm, twm (aports/main), awesome (aports/community).
I'm upstream author.
After installing `alttab` I've realized that Alpine generally misses png icons for applications, so `alttab` uses icons from window properties only.
Also, `alttab` requires any fontconfig font (configurable, "sans" alias by default). This is always satisfied in "big" linux distributions, but perhaps in Alpine I should describe this dependency explicitly?
