### PR TITLE
community/elasticsearch: upgrade to 6.1.0

### DIFF
--- a/community/elasticsearch/APKBUILD
+++ b/community/elasticsearch/APKBUILD
@@ -1,13 +1,13 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=elasticsearch
-pkgver=5.6.3
+pkgver=6.1.0
 pkgrel=0
 pkgdesc="Open Source, Distributed, RESTful Search Engine"
 url="https://www.elastic.co/products/elasticsearch"
 arch="x86 x86_64"
 license="ASL-2.0"
-depends="java-jna-native>=4.1 openjdk8-jre"
+depends="java-jna-native>=4.1 openjdk8-jre bash"
 makedepends=""
 install="$pkgname.pre-install"
 subpackages="$pkgname-doc"
@@ -19,15 +19,20 @@ source="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$pkgv
 builddir="$srcdir/$pkgname-$pkgver"
 
 default_module=transport-netty4
-_modules="lang-mustache
-	  reindex
-	  ingest-common
-	  lang-expression
-	  lang-groovy
-	  percolator
-	  aggs-matrix-stats
-	  lang-painless
-	  transport-netty3"
+_modules="
+	aggs-matrix-stats
+	analysis-common
+	ingest-common
+	lang-expression
+	lang-mustache
+	lang-painless
+	mapper-extras
+	parent-join
+	percolator
+	reindex
+	repository-url
+	tribe
+	"
 for _mod in $_modules; do
 	subpackages="$subpackages $pkgname-$_mod:_${_mod//-/_}"
 	eval "_${_mod//-/_}() { _builtin_module $_mod; }"
@@ -89,7 +94,7 @@ _builtin_module() {
 	install -m644 -t "$destdir" "$builddir"/modules/$name/*
 }
 
-sha512sums="ee57d010e196eb25e5296fe95ab2de5e503d4d66f7eec8c8f6ac2ff9ddbc1a8dc1514202d705e291ee49d3e04650b597a9afc5f92f179b8faa5e2fe3c662f33e  elasticsearch-5.6.3.tar.gz
+sha512sums="ba4829c7bb422b42bdc480797521399d9b39c6fd9bb2597585f8fdb0a261e8e11bd8e98b3df562b7320b2775643be9918b043d818caa79b0a6403c9c0657774e  elasticsearch-6.1.0.tar.gz
 dc916861497d4a589d6b3ab70d90ff9970e4d57003ed82d08c5f90dec337f995dcabf2556b7a27ade926e846ad435392f7845acfe9280dce17b4c172d85328ae  elasticsearch.initd
 2ab1baf1b5c8782f3f371ba221aadd3e841abc62175f0b1ddcfc68d711e2370465124e076f8cc2e549c25a1da9db8c90172b2f410bd6bbe4153f0e831620b6ba  elasticsearch.confd
 6de81485cdc059afef58382862e4155482463fde0b604aaa8dbe904c778b841467c4a383a5e54acd09e3436f1fb7be9923e001fb77bd3d7894e113a5e0f4036b  README.alpine"


### PR DESCRIPTION
* also adds `bash` as a depends as the script that starts `ES` requires it.