### PR TITLE
testing/wireguard: version bump

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171211
-_mypkgrel=0
+_ver=0.0.20171221
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="8dfdf09753305e247dbc3a2cb77fcd1abec50dd7c4b1f0643270eea3236c418f9c4daac4215bf99bc6a66c0801b86c1e83ce097cdbf81d6549614f21b6ffbe35  WireGuard-0.0.20171211.tar.xz"
+sha512sums="1ede1dcc3eaad54a25e995d956f277eedf272ce0a6915714bd0a947c58f4404d5a9e3ced2a8cb2e80a306e352c23c6a25cbaff533dafd00c923f34575c956b79  WireGuard-0.0.20171221.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20171211
+pkgver=0.0.20171221
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="8dfdf09753305e247dbc3a2cb77fcd1abec50dd7c4b1f0643270eea3236c418f9c4daac4215bf99bc6a66c0801b86c1e83ce097cdbf81d6549614f21b6ffbe35  WireGuard-0.0.20171211.tar.xz"
+sha512sums="1ede1dcc3eaad54a25e995d956f277eedf272ce0a6915714bd0a947c58f4404d5a9e3ced2a8cb2e80a306e352c23c6a25cbaff533dafd00c923f34575c956b79  WireGuard-0.0.20171221.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171211
-_mypkgrel=0
+_ver=0.0.20171221
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="8dfdf09753305e247dbc3a2cb77fcd1abec50dd7c4b1f0643270eea3236c418f9c4daac4215bf99bc6a66c0801b86c1e83ce097cdbf81d6549614f21b6ffbe35  WireGuard-0.0.20171211.tar.xz"
+sha512sums="1ede1dcc3eaad54a25e995d956f277eedf272ce0a6915714bd0a947c58f4404d5a9e3ced2a8cb2e80a306e352c23c6a25cbaff533dafd00c923f34575c956b79  WireGuard-0.0.20171221.tar.xz"


### PR DESCRIPTION
```

== Changes ==

  * keygen-html: remove prebuilt file
  
  This follows our mailing list discussion.
  
  * wg-quick: add the "Table" config option
  
  In collaboration with Luis Ressel, wg-quick(8) grew an option! We generally
  do not like to add things to wg-quick or allow feature-creep, but this was
  basic enough and mostly involves disabling functionality. Specifically,
  wg-quick now accepts a Table= parameter with these semantics:
  
    ~ Table=auto (default) selects the current behaviour
    ~ Table=off disables creation of routes from allowed ips altogether
    ~ All other values are passed through to "ip route add"'s table option
  
  This should enable people to do basic policy routing. It also matches the
  functionality provided by LEDE/OpenWRT's uci config as well as NixOS's
  networking configuration.
  
  * wg-quick: dumber matching for default routes
  
  Efficiency.
  
  * crypto: compile on UML
  
  UML allows you to compile a Linux Kernel as a standalone ELF binary that runs
  within normal Linux. WireGuard can now be compiled as a normal Linux program,
  runnable on Linux, which is useful for the test suite... and other things.
  
  * compat: kernels < 3.13 modified genl_ops
  
  This fixes a rather important bug with 3.10, 3.11, and 3.12 kernels, where in
  some cases, gcc failed to de-constify a struct that was marked as const when
  it should not have been on on these older kernels, triggering an oops at
  module insertion time.
```