### PR TITLE
main/libgcrypt: Upgrade to 1.8.2, change to https

### DIFF
--- a/main/libgcrypt/APKBUILD
+++ b/main/libgcrypt/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libgcrypt
-pkgver=1.8.1
+pkgver=1.8.2
 pkgrel=0
 pkgdesc="general purpose crypto library based on the code used in GnuPG"
 url="http://www.gnupg.org"
@@ -10,7 +10,7 @@ depends=""
 depends_dev="libgpg-error-dev"
 makedepends="$depends_dev texinfo"
 subpackages="$pkgname-dev $pkgname-doc"
-source="ftp://ftp.gnupg.org/gcrypt/libgcrypt/$pkgname-$pkgver.tar.bz2"
+source="https://www.gnupg.org/ftp/gcrypt/libgcrypt/$pkgname-$pkgver.tar.bz2"
 builddir="$srcdir"/$pkgname-$pkgver
 
 build () {
@@ -53,4 +53,4 @@ package() {
 	rm -f ${pkgdir}/usr/share/info/dir
 }
 
-sha512sums="27c9d2fd9cba5afca71d421c9299d6942463975fae0bd10d4ff42cda2d7ea213e6b73c071a40fcf23ff52a93394cc7505ab332f8a4a3321826460e471eda5b4e  libgcrypt-1.8.1.tar.bz2"
+sha512sums="1e8c414f95bf6b50e778102ca7c1b3b1f30d8320826d9fff747a0a098ef85499cdc3e6de736853b9cd4e5dadda35c7c0a291e13643dcac5eaef44f2ddc7a6c09  libgcrypt-1.8.2.tar.bz2"


### PR DESCRIPTION
The download for 1.8.1 currently times out. Change from ftp to https + upgrade to latest version.