### PR TITLE
main/tiny-ec2-bootstrap: new aport

### DIFF
--- a/testing/tiny-ec2-bootstrap/APKBUILD
+++ b/testing/tiny-ec2-bootstrap/APKBUILD
@@ -1,0 +1,28 @@
+# Contributor: Mike Crute <mike@crute.us>
+# Maintainer: Mike Crute <mike@crute.us>
+pkgname=tiny-ec2-bootstrap
+pkgver=1.0.0
+pkgrel=0
+pkgdesc="A tiny EC2 instance bootstrapper that uses instance metadata"
+url="https://github.com/mcrute/tiny-ec2-bootstrap"
+arch="noarch"
+license="MIT"
+options="!check"
+depends=""
+makedepends=""
+install=""
+subpackages=""
+source="https://github.com/mcrute/$pkgname/archive/release-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-release-$pkgver"
+
+build() {
+	cd "$builddir"
+	return 0
+}
+
+package() {
+	cd "$builddir"
+	make install PREFIX=$pkgdir
+}
+
+sha512sums="3075327ad7cf9a2eb26b3c9e98785f542f46ab8ca01125efb6a5bf34fe16a14e346bec0abfe3f09ac99a616eae361f4cbde09f41c65ba5d8fe6fea8c035e2970  release-1.0.0.tar.gz"


### PR DESCRIPTION
This project supports bootstrapping an EC2 instance in a similar manner to Ubuntu's cloud-init but doesn't have any dependencies outside of Busybox, whereas the former pulls in Python and a lot of other libraries.