### PR TITLE
main/gnupg: enable tofu

### DIFF
--- a/main/gnupg/APKBUILD
+++ b/main/gnupg/APKBUILD
@@ -11,7 +11,8 @@ license="GPL"
 options=""
 depends="pinentry"
 makedepends="gnutls-dev libksba-dev libgcrypt-dev libgpg-error-dev
-	npth-dev zlib-dev libassuan-dev openldap-dev bzip2-dev"
+	npth-dev zlib-dev libassuan-dev openldap-dev bzip2-dev
+	sqlite-dev"
 subpackages="$pkgname-doc"
 source="https://gnupg.org/ftp/gcrypt/$pkgname/$pkgname-$_ver.tar.bz2
 	0001-Include-sys-select.h-for-FD_SETSIZE.patch


### PR DESCRIPTION

When sqlite-dev isn't present tofu gets disabled.