### PR TITLE
main/cmake: upgrade to 3.10.1 and enable system jsoncpp

### DIFF
--- a/main/cmake/APKBUILD
+++ b/main/cmake/APKBUILD
@@ -1,14 +1,14 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cmake
-pkgver=3.9.6
+pkgver=3.10.1
 pkgrel=0
 pkgdesc="CMake is a cross-platform open-source make system"
 url="http://www.cmake.org"
 arch="all"
 license="CMake"
 makedepends="ncurses-dev curl-dev expat-dev zlib-dev bzip2-dev libarchive-dev
-    libuv-dev xz-dev rhash-dev"
+    libuv-dev xz-dev rhash-dev jsoncpp-dev"
 options="!checkroot !check"
 checkdepends="musl-utils file"
 subpackages="$pkgname-doc"
@@ -33,15 +33,12 @@ _parallel_opt() {
 
 build() {
 	cd "$builddir"
-	# jsoncpp needs cmake to build so to avoid recursive build
-	# dependency, we use the bundled version of jsoncpp
 	./bootstrap \
 		--prefix=/usr \
 		--mandir=/share/man \
 		--datadir=/share/$pkgname \
 		--docdir=/share/doc/$pkgname \
 		--system-libs \
-		--no-system-jsoncpp \
 		$(_parallel_opt)
 	make
 }
@@ -56,4 +53,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="9fda2c9ac054ef8fb1bf3885fbdec02c518da89ade220eba06b5502ac3ff300f635ec0922e61f3b2d090644fb743b8f71a04c532ab66b2d890a180cc7da54e6c  cmake-3.9.6.tar.gz"
+sha512sums="14e9a7f01747b369cad3c4e4e83bc777c0c98ce69209456f60d086d2471302f66dc1c1d22fd04e11dcb64de4bfc7dacd9aca70ee0e5f006abd1df79ef642eeed  cmake-3.10.1.tar.gz"


### PR DESCRIPTION
jsoncpp can safely be used a system-libs since jsoncpp uses meson as build system.
See: https://github.com/alpinelinux/aports/commit/3d548530e525db7267fa4f2dcaca4486b3c70bf0