### PR TITLE
testing/kakoune: upgrade to baf3d82b3412b9aa0b98febf114baf7f16439994

### DIFF
--- a/testing/kakoune/APKBUILD
+++ b/testing/kakoune/APKBUILD
@@ -1,13 +1,13 @@
 # Maintainer: Jakub Skrzypnik <j.skrzypnik@openmailbox.org>
-_commit="7fabda2e45d095757d59efc125086e2e8c079735"
+_commit="baf3d82b3412b9aa0b98febf114baf7f16439994"
 pkgname=kakoune
-pkgver=0_git20170501
+pkgver=0_git20171229
 pkgrel=0
 pkgdesc="Code editor heavily inspired by Vim, but with less keystrokes"
 url="http://kakoune.org"
 arch="all"
 license="Unlicense"
-makedepends="ncurses-dev boost-dev asciidoc"
+makedepends="ncurses-dev asciidoc"
 subpackages="$pkgname-doc"
 source="https://github.com/mawww/kakoune/archive/${_commit}.zip"
 
@@ -22,6 +22,4 @@ package() {
 	make PREFIX="/usr" DESTDIR="$pkgdir/" debug=no install || return 1
 }
 
-md5sums="0a9aa94f2db1425f82e2294c5a76099a  7fabda2e45d095757d59efc125086e2e8c079735.zip"
-sha256sums="52180fb02c8a4fe9fb9a6f942daa98d0d54e59900f5e41c73e818ad34b6430d8  7fabda2e45d095757d59efc125086e2e8c079735.zip"
-sha512sums="f155653496c2e2b8e213819e595f0593f255fe8902c9e0beb8bd519c4395e7735ddde8df49721c64ea6c7322f40e35d7c24abe440d9b8f0ffd86b7e012ea0c7e  7fabda2e45d095757d59efc125086e2e8c079735.zip"
+sha512sums="76b2db08630706b134f1688ae258a64552bc8b0c426a845c83e5abdc0413902675f9c1150ae1e2ed272ca3ac6f271bedd1ce75137267c1f0d2ab0a80c11472ca  baf3d82b3412b9aa0b98febf114baf7f16439994.zip"


### PR DESCRIPTION
The dependency on boost was dropped.