### PR TITLE
testing/rcm: new aport

### DIFF
--- a/testing/rcm/APKBUILD
+++ b/testing/rcm/APKBUILD
@@ -1,0 +1,27 @@
+# Contributor: Hiroshi Kajisha <kajisha@gmail.com>
+# Maintainer: Hiroshi Kajisha <kajisha@gmail.com>
+pkgname=rcm
+pkgver=1.3.1
+pkgrel=0
+pkgdesc="rc file (dotfile) management"
+url="https://github.com/thoughtbot/rcm"
+arch="noarch"
+license="BSD-3-Clause"
+makedepends="autoconf automake ruby-mustache"
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/thoughtbot/$pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	./autogen.sh
+	./configure --prefix=/usr
+	make -j1
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="14ea8597efde30d286d2c020ff40cc3c2b61e57e50d20693f9402958284e3e709bf94706cc9c1ca74f5be9b0f5d8969ec21cd1e69efc553286bbf101ede03bd9  rcm-1.3.1.tar.gz"


### PR DESCRIPTION
https://github.com/thoughtbot/rcm
rc file (dotfile) management