### PR TITLE
community/perl-d*: modernize APKBUILD

### DIFF
--- a/community/perl-data-denter/APKBUILD
+++ b/community/perl-data-denter/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=perl-data-denter
 _pkgreal=Data-Denter
 pkgver=0.15
-pkgrel=0
+pkgrel=1
 pkgdesc="Perl module for Data-Denter"
 url="http://search.cpan.org/dist/Data-Denter/"
 arch="noarch"
@@ -15,26 +15,31 @@ makedepends="perl-dev perl-doc $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/I/IN/INGY/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="819e5c05fb61e90f4c1311286b080405  Data-Denter-0.15.tar.gz"
-sha256sums="3ab4ff9bd49497bfc711dccf8c990aab10470a7bba65a9877632b14d8f5fdb55  Data-Denter-0.15.tar.gz"
 sha512sums="37512f0a7a9f749ceb0d4db210ad25ec812b0ff4a2d955312200251ac7c74fbf1f50930d8475865bc2215e838a00fde73b281ff45569d63931c10d3dc6df6505  Data-Denter-0.15.tar.gz"

--- a/community/perl-data-dump/APKBUILD
+++ b/community/perl-data-dump/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-data-dump
 _pkgreal=Data-Dump
 pkgver=1.23
-pkgrel=0
+pkgrel=1
 pkgdesc="Pretty printing of data structures"
 url="http://search.cpan.org/dist/Data-Dump/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="762c111e525c82ff23d62c90821b26e9  Data-Dump-1.23.tar.gz"
-sha256sums="af53b05ef1387b4cab4427e6789179283e4f0da8cf036e8db516ddb344512b65  Data-Dump-1.23.tar.gz"
 sha512sums="6fd6c23bb6df7f7396219149dbfd23132fc2ea1dd344c32f62fc27a1afeeb28d7ebf2d429184bb6d1189f412e218f9e62a966b49fdd9ad5564e5152d67a02b96  Data-Dump-1.23.tar.gz"

--- a/community/perl-data-dumper/APKBUILD
+++ b/community/perl-data-dumper/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-data-dumper
 _pkgreal=Data-Dumper
 pkgver=2.161
-pkgrel=1
-pkgdesc="unknown"
+pkgrel=2
+pkgdesc="Stringified perl data structures"
 url="http://search.cpan.org/dist/Data-Dumper/"
 arch="all"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages=""
 source="http://search.cpan.org/CPAN/authors/id/S/SM/SMUELLER/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="0c18654f06366c494d5c72801eab9393  Data-Dumper-2.161.tar.gz"
-sha256sums="3aa4ac1b042b3880438165fb2b2139d377564a8e9928ffe689ede5304ee90558  Data-Dumper-2.161.tar.gz"
 sha512sums="9da8ee6912dcc5f63ca6659b323bbafd7db335fb173e6d9dd14745fa93b596c14bf278e4183aef90ca628e6b473da17297b0b3ac49ebec049dd18d1a5e053201  Data-Dumper-2.161.tar.gz"

--- a/community/perl-data-hexdump/APKBUILD
+++ b/community/perl-data-hexdump/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=perl-data-hexdump
 _pkgreal=Data-HexDump
 pkgver=0.02
-pkgrel=0
-pkgdesc="unknown"
+pkgrel=1
+pkgdesc="Hexadecial Dumper"
 url="http://search.cpan.org/dist/Data-HexDump/"
 arch="noarch"
 license="GPL PerlArtistic"
@@ -16,21 +16,28 @@ makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/F/FT/FTASSIN/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
-	make && make test
+	cd "$builddir"
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 

--- a/community/perl-data-optlist/APKBUILD
+++ b/community/perl-data-optlist/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-data-optlist
 _pkgreal=Data-OptList
 pkgver=0.110
-pkgrel=0
-pkgdesc="parse and validate simple name/value option pairs"
+pkgrel=1
+pkgdesc="Parse and validate simple name/value option pairs"
 url="http://search.cpan.org/dist/Data-OptList/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-sub-install perl-params-util perl-test-pod"
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="f9236c9ea5607134ad8a2b3dc901c4c5  Data-OptList-0.110.tar.gz"
-sha256sums="366117cb2966473f2559f2f4575ff6ae69e84c69a0f30a0773e1b51a457ef5c3  Data-OptList-0.110.tar.gz"
 sha512sums="68393958a38f509a71cfba61f6dff8303821918ba29ad8492af0c23cfd4f741c6ce98c4f68ad295f27e166287fc546229c430816f0bdd6009d4f60860c967b76  Data-OptList-0.110.tar.gz"

--- a/community/perl-date-simple/APKBUILD
+++ b/community/perl-date-simple/APKBUILD
@@ -4,13 +4,13 @@
 pkgname=perl-date-simple
 _pkgreal=Date-Simple
 pkgver=3.03
-pkgrel=2
-pkgdesc="unknown"
+pkgrel=3
+pkgdesc="A perl simple date object"
 url="http://search.cpan.org/dist/Date-Simple/"
 arch="all"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
@@ -18,7 +18,7 @@ source="http://search.cpan.org/CPAN/authors/id/I/IZ/IZUT/$_pkgreal-$pkgver.tar.g
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
@@ -28,15 +28,18 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="436049dc2c7dfd8423d8bcc807248b31  Date-Simple-3.03.tar.gz"
-sha256sums="29a1926314ce1681a312d6155c29590c771ddacf91b7485873ce449ef209dd04  Date-Simple-3.03.tar.gz"
 sha512sums="3e64a0ba224427e688a45945860fd5e876e6ca5b01298e744e257981ed84d933ab14c9ab8d5b74316c031ffa9821afd9563270109cba20a5939f14af2dde8668  Date-Simple-3.03.tar.gz"

--- a/community/perl-datetime-calendar-julian/APKBUILD
+++ b/community/perl-datetime-calendar-julian/APKBUILD
@@ -4,13 +4,13 @@
 pkgname=perl-datetime-calendar-julian
 _pkgreal=DateTime-Calendar-Julian
 pkgver=0.04
-pkgrel=0
+pkgrel=1
 pkgdesc="DateTime object in the Julian calendar"
 url="http://search.cpan.org/dist/DateTime-Calendar-Julian/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-datetime"
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
@@ -18,7 +18,7 @@ source="http://search.cpan.org/CPAN/authors/id/P/PI/PIJLL/$_pkgreal-$pkgver.tar.
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
@@ -28,15 +28,18 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="de688324eb33a27449ac2a5bfe1453a0  DateTime-Calendar-Julian-0.04.tar.gz"
-sha256sums="bb5968ad18bcd0772d2c311cd2deb23b777475ea05aa1099688247cd27a5000e  DateTime-Calendar-Julian-0.04.tar.gz"
 sha512sums="e822d57dabbf76dcca9dc1eb097cef9c15579aeb1782a51eb3dd01d47eda0aef2aa92096df67602297a24c387445f6eb381bb3eedfe33486990844f3c96b4960  DateTime-Calendar-Julian-0.04.tar.gz"

--- a/community/perl-datetime-format-builder/APKBUILD
+++ b/community/perl-datetime-format-builder/APKBUILD
@@ -4,13 +4,13 @@
 pkgname=perl-datetime-format-builder
 _pkgreal=DateTime-Format-Builder
 pkgver=0.81
-pkgrel=0
+pkgrel=1
 pkgdesc="Create DateTime parser classes and objects."
 url="http://search.cpan.org/dist/DateTime-Format-Builder/"
 arch="noarch"
 license="Artistic-2.0"
 cpandepends="perl-datetime-format-strptime perl-datetime perl-class-factory-util perl-params-validate"
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
@@ -18,7 +18,7 @@ source="http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/$_pkgreal-$pkgver.ta
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
@@ -28,15 +28,18 @@ prepare() {
 build() {
 	cd "$builddir"
 	export CFLAGS=$(perl -MConfig -E 'say $Config{ccflags}')
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="21d950a9425c0173d6191697bf9dc4dc  DateTime-Format-Builder-0.81.tar.gz"
-sha256sums="7cd58a8cb53bf698407cc992f89e4d49bf3dc55baf4f3f00f1def63a0fff33ef  DateTime-Format-Builder-0.81.tar.gz"
 sha512sums="617cf72e900d9bb17fd5c3cfbfa1874bf1c34de144514ea4cabd7b66eb682696b9c9501e66db1073da59c5e8278e6878b893876a1a7f11a9c011dbae44ebdd57  DateTime-Format-Builder-0.81.tar.gz"

--- a/community/perl-dbix-contextualfetch/APKBUILD
+++ b/community/perl-dbix-contextualfetch/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-dbix-contextualfetch
 _pkgreal=DBIx-ContextualFetch
 pkgver=1.03
-pkgrel=0
+pkgrel=1
 pkgdesc="Add contextual fetches to DBI"
 url="http://search.cpan.org/dist/DBIx-ContextualFetch/"
 arch="noarch"
@@ -16,21 +16,26 @@ makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/T/TM/TMTM/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	cd "$builddir"
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
-	make && make test
+	cd "$builddir"
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 

--- a/community/perl-devel-hide/APKBUILD
+++ b/community/perl-devel-hide/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=perl-devel-hide
 _pkgreal=Devel-Hide
 pkgver=0.0009
-pkgrel=0
+pkgrel=1
 pkgdesc="Forces the unavailability of specified Perl modules (for testing)"
 url="http://search.cpan.org/dist/Devel-Hide/"
 arch="noarch"
@@ -15,26 +15,29 @@ makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/F/FE/FERREIRA/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="ca2ed6a23b0a3af29962986761fc1171  Devel-Hide-0.0009.tar.gz"
-sha256sums="71dec40b9e53cd2dc98301ea4a64e1a95b71aa414f9b0d6d28c56c54f8fa16de  Devel-Hide-0.0009.tar.gz"
 sha512sums="c1cceb186de73f22132b2b9a16f75389b33b675aaa50c5095615f6f7c22fd0bad9edaf1d66d1cfbec6d536c93583b17a512bcae73310ac6a854e0c98c2ff6a9c  Devel-Hide-0.0009.tar.gz"

--- a/community/perl-digest-perl-md5/APKBUILD
+++ b/community/perl-digest-perl-md5/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-digest-perl-md5
 _pkgreal=Digest-Perl-MD5
 pkgver=1.9
-pkgrel=0
+pkgrel=1
 pkgdesc="Perl Implementation of Rivest's MD5 algorithm"
 url="http://search.cpan.org/dist/Digest-Perl-MD5/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/D/DE/DELTA/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="41f1160e11ce0d99021fc8d6c725fa3d  Digest-Perl-MD5-1.9.tar.gz"
-sha256sums="7100cba1710f45fb0e907d8b1a7bd8caef35c64acd31d7f225aff5affeecd9b1  Digest-Perl-MD5-1.9.tar.gz"
 sha512sums="015a1f046b85b5b89c1b44073d60116d483332cd667cb7230222df9651b7da837a532991e91848ff0b65f171b8870c2c4bda651da4ca54ea75d062ba6a55b525  Digest-Perl-MD5-1.9.tar.gz"

--- a/community/perl-dir-self/APKBUILD
+++ b/community/perl-dir-self/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-dir-self
 _pkgreal=Dir-Self
 pkgver=0.11
-pkgrel=0
+pkgrel=1
 pkgdesc="a __DIR__ constant for the directory your source file is in"
 url="http://search.cpan.org/dist/Dir-Self/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
-cpanmakedepends="   "
+cpanmakedepends=""
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/M/MA/MAUKE/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="e484446c3aa042737c0b7cbd0fb2f904  Dir-Self-0.11.tar.gz"
-sha256sums="e251a51abc7d9ba3e708f73c2aa208e09d47a0c528d6254710fa78cc8d6885b5  Dir-Self-0.11.tar.gz"
 sha512sums="c2795149e74c71037fab8c3149e85e11d4ee77dbb54f85d07e49c39504b3ba910a5ded32831adf36915b302abc4ced386dcd51b6dfbaef46e069c803793e8efc  Dir-Self-0.11.tar.gz"

--- a/community/perl-dist-checkconflicts/APKBUILD
+++ b/community/perl-dist-checkconflicts/APKBUILD
@@ -4,38 +4,43 @@
 pkgname=perl-dist-checkconflicts
 _pkgreal=Dist-CheckConflicts
 pkgver=0.11
-pkgrel=0
-pkgdesc="declare version conflicts for your dist"
+pkgrel=1
+pkgdesc="Declare version conflicts for your dist"
 url="http://search.cpan.org/dist/Dist-CheckConflicts/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends="perl-list-moreutils perl-module-runtime"
-cpanmakedepends="  perl-test-fatal "
+cpanmakedepends="perl-test-fatal"
 depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/D/DO/DOY/$_pkgreal-$pkgver.tar.gz"
 
-_builddir="$srcdir/$_pkgreal-$pkgver"
+builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
-	cd "$_builddir"
+	default_prepare
+
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor
 }
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	export CFLAGS=`perl -MConfig -E 'say $Config{ccflags}'`
-	make && make test
+	make
+}
+
+check() {
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="c8725a92b9169708b0f63036812070f2  Dist-CheckConflicts-0.11.tar.gz"
-sha256sums="ea844b9686c94d666d9d444321d764490b2cde2f985c4165b4c2c77665caedc4  Dist-CheckConflicts-0.11.tar.gz"
 sha512sums="6c3f8546c1c7904bbc2a3c1135d145cbff95997c3032e9129afc98bdd98578dd9219af444f357dd8e9b1f08442a2fdd9d6f7fe8768f8ef165e71570f5ae246ad  Dist-CheckConflicts-0.11.tar.gz"


### PR DESCRIPTION
Changes:
- Move tests to check()
- Remove return 1
- Rename _builddir to builddir
- Add missing default_prepare in prepare()
- Remove old checksums