### PR TITLE
testing/kea: new aport

### DIFF
--- a/testing/kea-hook-runscript/APKBUILD
+++ b/testing/kea-hook-runscript/APKBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Steve HOLWEG <skytep@gmail.com>
+
+pkgname=kea-hook-runscript
+pkgver=1.1.0
+pkgrel=0
+pkgdesc="This a hook for the Kea DHCP server that allows to run an external script."
+arch="all"
+url="https://github.com/zorun/kea-hook-runscript"
+license="MPL2"
+depends="kea"
+makedepends="kea-dev kea-utils boost-dev"
+install=""
+subpackages=""
+source="$pkgname-$pkgver.tar.gz::https://github.com/zorun/$pkgname/archive/v$pkgver.tar.gz"
+options="!check" # Library and makefile provide no tests
+
+build() {
+	cd "$builddir"
+
+	make
+}
+
+package() {
+	cd "$builddir"
+
+	mkdir -p "${pkgdir}/usr/lib/hooks/"
+
+	install -Dm755 "kea-hook-runscript.so" "${pkgdir}/usr/lib/hooks/kea-hook-runscript.so"
+}
+
+sha512sums="b3b1c8ede6758b596fc03394bbd609aa7971d6b3bd267e2b5dda9c04ff6e9aa048de3d44e93ad287d70320784f1fcd101c03a9e8d12569403540fb49c32eda04  kea-hook-runscript-1.1.0.tar.gz"

--- a/testing/kea/APKBUILD
+++ b/testing/kea/APKBUILD
@@ -1,0 +1,157 @@
+# Maintainer: Steve Holweg <skytep@gmail.com>
+# Contributor: Baptiste Jonglez <baptiste--aur@jonglez.org>
+
+pkgname=kea
+pkgver=1.3.0
+pkgrel=0
+pkgdesc="High-performance, extensible DHCP server engine from ISC, supporting both DHCPv4 and DHCPv6"
+arch="all"
+url="http://kea.isc.org"
+license="MPL2"
+depends=""
+makedepends="botan-dev log4cplus-dev boost-dev postgresql-dev mariadb-dev"
+subpackages="$pkgname-doc $pkgname-dev $pkgname-admin:admin:noarch $pkgname-ctrl-agent:ctrlagent $pkgname-dhcp-ddns:dhcpddns $pkgname-dhcp4 $pkgname-dhcp6 $pkgname-keactrl:keactrl:noarch $pkgname-utils"
+
+source="https://ftp.isc.org/isc/kea/${pkgver}/kea-${pkgver}.tar.gz
+				fix-scripts-include-path.patch
+				kea-dhcp4.initd
+				kea-dhcp6.initd
+				kea-dhcp-ddns.initd
+				kea-ctrl-agent.initd"
+
+validpgpkeys="BE0E9748B718253A28BB89FFF1B11BF05CF02E57" # Internet Systems Consortium, Inc. (Signing key, 2017-2018) <codesign@isc.org>
+
+build() {
+	# Complete build for dev and doc
+	cd "$builddir"
+
+	./configure \
+		--with-dhcp-mysql \
+		--with-dhcp-pgsql \
+		--prefix=/usr \
+		--libexecdir=/usr/lib \
+		--sysconfdir=/etc \
+		--localstatedir=/var \
+		--build=$CBUILD \
+		--host=$CHOST
+
+	make
+}
+
+check() {
+	cd "$builddir"
+
+	# Disabled, databases are required for the test to pass
+	#make check
+
+	./src/bin/dhcp4/kea-dhcp4 -v
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="${pkgdir}" install
+}
+
+_common_sub() {
+
+	depends="${pkgname}"
+
+}
+
+admin() {
+	_common_sub
+
+	pkgdesc="$pkgdesc (Databases administration tools)"
+
+	mkdir -p "${subpkgdir}/usr/sbin/"
+	mv "${pkgdir}/usr/sbin/kea-admin" "${subpkgdir}/usr/sbin/kea-admin"
+
+	mkdir -p "${subpkgdir}"/usr/share
+	mv "${pkgdir}/usr/share/kea/" "${subpkgdir}/usr/share"
+}
+
+ctrlagent() {
+	_common_sub
+
+	mkdir -p "${subpkgdir}"/usr/sbin
+	mv "${pkgdir}/usr/sbin/kea-ctrl-agent" "${subpkgdir}/usr/sbin/kea-ctrl-agent"
+
+	mkdir -p "${subpkgdir}/etc/kea"
+	mv "${pkgdir}/etc/kea/kea-ctrl-agent.conf" "${subpkgdir}/etc/kea/kea-ctrl-agent.conf"
+
+	install -Dm755 "${srcdir}/kea-ctrl-agent.initd" "${subpkgdir}/etc/init.d/kea-ctrl-agent.initd"
+}
+
+dhcpddns() {
+	_common_sub
+
+	pkgdesc="$pkgdesc (DDNS Server)"
+
+	mkdir -p ${subpkgdir}/usr/sbin/
+	mv "${pkgdir}/usr/sbin/kea-dhcp-ddns" "${subpkgdir}/usr/sbin/kea-dhcp-ddns"
+
+	mkdir -p ${subpkgdir}/etc/kea/
+	mv "${pkgdir}/etc/kea/kea-dhcp-ddns.conf" "${subpkgdir}/etc/kea/kea-dhcp-ddns.conf"
+
+	install -Dm755 "${srcdir}/kea-dhcp-ddns.initd" "${subpkgdir}/etc/init.d/kea-dhcp-ddns.initd"
+}
+
+dhcp4() {
+	_common_sub
+
+	pkgdesc="$pkgdesc (DHCP4 Server)"
+
+	mkdir -p "${subpkgdir}/usr/sbin/"
+	mv "${pkgdir}/usr/sbin/kea-dhcp4" "${subpkgdir}/usr/sbin/kea-dhcp4"
+
+	mkdir -p "${subpkgdir}/etc/kea/"
+	mv "${pkgdir}/etc/kea/kea-dhcp4.conf" "${subpkgdir}/etc/kea/kea-dhcp4.conf"
+
+	install -Dm755 "${srcdir}/kea-dhcp4.initd" "${subpkgdir}/etc/init.d/kea-dhcp4.initd"
+}
+
+dhcp6() {
+	_common_sub
+
+	pkgdesc="$pkgdesc (DHCP6 Server)"
+
+	mkdir -p ${subpkgdir}/usr/sbin/
+	mv ${pkgdir}/usr/sbin/kea-dhcp6 ${subpkgdir}/usr/sbin/kea-dhcp6
+
+	mkdir -p ${subpkgdir}/etc/kea/
+	mv ${pkgdir}/etc/kea/kea-dhcp6.conf ${subpkgdir}/etc/kea/kea-dhcp6.conf
+
+	install -Dm755 "${srcdir}"/kea-dhcp6.initd "${subpkgdir}"/etc/init.d/kea-dhcp6.initd
+}
+
+keactrl() {
+	_common_sub
+
+	pkgdesc="$pkgdesc (Kea process manager)"
+
+	mkdir -p "${subpkgdir}/usr/sbin/"
+	mv "${pkgdir}/usr/sbin/keactrl" "${subpkgdir}/usr/sbin/keactrl"
+
+	mkdir -p "${subpkgdir}/etc/kea/"
+	mv "${pkgdir}/etc/kea/keactrl.conf" "${subpkgdir}/etc/kea/keactrl.conf"
+}
+
+utils() {
+	_common_sub
+
+	pkgdesc="$pkgdesc (Optional Utils)"
+
+	mkdir -p "${subpkgdir}/usr/sbin/"
+	mv "${pkgdir}/usr/sbin/perfdhcp" "${subpkgdir}/usr/sbin/perfdhcp"
+	mv "${pkgdir}/usr/sbin/kea-lfc" "${subpkgdir}/usr/sbin/kea-lfc"
+
+	mkdir -p "${subpkgdir}/usr/bin/"
+	mv "${pkgdir}/usr/bin/kea-msg-compiler" "${subpkgdir}/usr/bin/kea-msg-compiler"
+}
+
+sha512sums="4708485efe537d9af00b50da9a3f33b740edaf37d9bbfe96f5625e30715349c48ef8a32f5abb8320f00821aea642a5b7ecdbc9f0d323a71b7a07f46f1bed978b  kea-1.3.0.tar.gz
+392e722dc559fdbc3799079f7394df2b1cea9e0259fe4d3d011174241bf10b885e03855c1b50dc3397437ca1217d324881b40948da33a858eb77514b853e3db0  fix-scripts-include-path.patch
+9165141380f723c641411d1394cdeeeac8cf72321012ba0aafa36b64ec171eba996ed6bd1f5460523f7c4b32cb37b368331984bcd19ca82d9c63211fdbb0a36e  kea-dhcp4.initd
+6e7608d2133758bfc80828ef6a072127f25ac9d47cf16c1ca91eca1e5ee8c96a5a7d0e515725a8d9556205e6e70113177b6f7e5c4306385de6266aa5c09ea2d7  kea-dhcp6.initd
+31705accecc50a50c7a01ba700acdc68fb10f776bb583e1c1ae78fb33f8ba9cc66f7e12686f057d9d534a26ca09cbe7879399ee31463b46a78d9f203524357af  kea-dhcp-ddns.initd
+d6b0e14b055abd3aae7f74ea4d32ebb74ffcf87c35f1d3a52407e37574b45262bb0084b1b20f2f08c5bf7388ba23a503689eae6fc90d9096f7f1f6656999bf41  kea-ctrl-agent.initd"

--- a/testing/kea/fix-scripts-include-path.patch
+++ b/testing/kea/fix-scripts-include-path.patch
@@ -1,0 +1,162 @@
+diff -ru /src/share/database/scripts/mysql/upgrade_1.0_to_2.0.sh.in /src/share/database/scripts/mysql/upgrade_1.0_to_2.0.sh.in
+--- /src/share/database/scripts/mysql/upgrade_1.0_to_2.0.sh.in	2017-08-01 13:03:52.823615380 +0200
++++ /src/share/database/scripts/mysql/upgrade_1.0_to_2.0.sh.in	2017-08-01 13:05:19.092517025 +0200
+@@ -1,12 +1,7 @@
+ #!/bin/sh
+ 
+-# Include utilities. Use installed version if available and
+-# use build version if it isn't.
+-if [ -e @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh ]; then
+-    . @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh
+-else
+-    . @abs_top_builddir@/src/bin/admin/admin-utils.sh
+-fi
++# Include utilities.
++. /usr/share/kea/scripts/admin-utils.sh
+ 
+ VERSION=`mysql_version "$@"`
+ 
+diff -ru /src/share/database/scripts/mysql/upgrade_2.0_to_3.0.sh.in /src/share/database/scripts/mysql/upgrade_2.0_to_3.0.sh.in
+--- /src/share/database/scripts/mysql/upgrade_2.0_to_3.0.sh.in	2017-08-01 13:03:52.823615380 +0200
++++ /src/share/database/scripts/mysql/upgrade_2.0_to_3.0.sh.in	2017-08-01 13:05:27.885738379 +0200
+@@ -1,12 +1,7 @@
+ #!/bin/sh
+ 
+-# Include utilities. Use installed version if available and
+-# use build version if it isn't.
+-if [ -e @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh ]; then
+-    . @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh
+-else
+-    . @abs_top_builddir@/src/bin/admin/admin-utils.sh
+-fi
++# Include utilities.
++. /usr/share/kea/scripts/admin-utils.sh
+ 
+ VERSION=`mysql_version "$@"`
+ 
+diff -ru /src/share/database/scripts/mysql/upgrade_3.0_to_4.0.sh.in /src/share/database/scripts/mysql/upgrade_3.0_to_4.0.sh.in
+--- /src/share/database/scripts/mysql/upgrade_3.0_to_4.0.sh.in	2017-08-01 13:03:52.823615380 +0200
++++ /src/share/database/scripts/mysql/upgrade_3.0_to_4.0.sh.in	2017-08-01 13:11:20.277913463 +0200
+@@ -1,12 +1,7 @@
+ #!/bin/sh
+ 
+-# Include utilities. Use installed version if available and
+-# use build version if it isn't.
+-if [ -e @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh ]; then
+-    . @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh
+-else
+-    . @abs_top_builddir@/src/bin/admin/admin-utils.sh
+-fi
++# Include utilities.
++. /usr/share/kea/scripts/admin-utils.sh
+ 
+ VERSION=`mysql_version "$@"`
+ 
+diff -ru /src/share/database/scripts/mysql/upgrade_4.0_to_4.1.sh.in /src/share/database/scripts/mysql/upgrade_4.0_to_4.1.sh.in
+--- /src/share/database/scripts/mysql/upgrade_4.0_to_4.1.sh.in	2017-08-01 13:03:52.823615380 +0200
++++ /src/share/database/scripts/mysql/upgrade_4.0_to_4.1.sh.in	2017-08-01 13:11:31.137774925 +0200
+@@ -1,12 +1,7 @@
+ #!/bin/sh
+ 
+-# Include utilities. Use installed version if available and
+-# use build version if it isn't.
+-if [ -e @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh ]; then
+-    . @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh
+-else
+-    . @abs_top_builddir@/src/bin/admin/admin-utils.sh
+-fi
++# Include utilities.
++. /usr/share/kea/scripts/admin-utils.sh
+ 
+ VERSION=`mysql_version "$@"`
+ 
+diff -ru /src/share/database/scripts/mysql/upgrade_4.1_to_5.0.sh.in /src/share/database/scripts/mysql/upgrade_4.1_to_5.0.sh.in
+--- /src/share/database/scripts/mysql/upgrade_4.1_to_5.0.sh.in	2017-08-01 13:03:52.823615380 +0200
++++ /src/share/database/scripts/mysql/upgrade_4.1_to_5.0.sh.in	2017-08-01 13:11:37.317696084 +0200
+@@ -1,12 +1,7 @@
+ #!/bin/sh
+ 
+-# Include utilities. Use installed version if available and
+-# use build version if it isn't.
+-if [ -e @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh ]; then
+-    . @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh
+-else
+-    . @abs_top_builddir@/src/bin/admin/admin-utils.sh
+-fi
++# Include utilities.
++. /usr/share/kea/scripts/admin-utils.sh
+ 
+ VERSION=`mysql_version "$@"`
+ 
+diff -ru /src/share/database/scripts/mysql/upgrade_5.0_to_5.1.sh.in /src/share/database/scripts/mysql/upgrade_5.0_to_5.1.sh.in
+--- /src/share/database/scripts/mysql/upgrade_5.0_to_5.1.sh.in	2017-08-01 13:03:52.823615380 +0200
++++ /src/share/database/scripts/mysql/upgrade_5.0_to_5.1.sh.in	2017-08-01 13:11:43.007623495 +0200
+@@ -1,12 +1,7 @@
+ #!/bin/sh
+ 
+-# Include utilities. Use installed version if available and
+-# use build version if it isn't.
+-if [ -e @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh ]; then
+-    . @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh
+-else
+-    . @abs_top_builddir@/src/bin/admin/admin-utils.sh
+-fi
++# Include utilities.
++. /usr/share/kea/scripts/admin-utils.sh
+ 
+ VERSION=`mysql_version "$@"`
+ 
+diff -ru /src/share/database/scripts/pgsql/upgrade_1.0_to_2.0.sh.in /src/share/database/scripts/pgsql/upgrade_1.0_to_2.0.sh.in
+--- /src/share/database/scripts/pgsql/upgrade_1.0_to_2.0.sh.in	2017-08-01 13:03:52.826948671 +0200
++++ /src/share/database/scripts/pgsql/upgrade_1.0_to_2.0.sh.in	2017-08-01 13:04:53.279512387 +0200
+@@ -1,12 +1,7 @@
+ #!/bin/sh
+ 
+-# Include utilities. Use installed version if available and
+-# use build version if it isn't.
+-if [ -e @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh ]; then
+-    . @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh
+-else
+-    . @abs_top_builddir@/src/bin/admin/admin-utils.sh
+-fi
++# Include utilities.
++. /usr/share/kea/scripts/admin-utils.sh
+ 
+ VERSION=`pgsql_version "$@"`
+ 
+diff -ru /src/share/database/scripts/pgsql/upgrade_2.0_to_3.0.sh.in /src/share/database/scripts/pgsql/upgrade_2.0_to_3.0.sh.in
+--- /src/share/database/scripts/pgsql/upgrade_2.0_to_3.0.sh.in	2017-08-01 13:03:52.826948671 +0200
++++ /src/share/database/scripts/pgsql/upgrade_2.0_to_3.0.sh.in	2017-08-01 13:11:52.627500763 +0200
+@@ -1,12 +1,7 @@
+ #!/bin/sh
+ 
+-# Include utilities. Use installed version if available and
+-# use build version if it isn't.
+-if [ -e @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh ]; then
+-    . @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh
+-else
+-    . @abs_top_builddir@/src/bin/admin/admin-utils.sh
+-fi
++# Include utilities.
++. /usr/share/kea/scripts/admin-utils.sh
+ 
+ VERSION=`pgsql_version "$@"`
+ 
+diff -ru /src/share/database/scripts/pgsql/upgrade_3.0_to_3.1.sh.in /src/share/database/scripts/pgsql/upgrade_3.0_to_3.1.sh.in
+--- /src/share/database/scripts/pgsql/upgrade_3.0_to_3.1.sh.in	2017-08-01 13:03:52.826948671 +0200
++++ /src/share/database/scripts/pgsql/upgrade_3.0_to_3.1.sh.in	2017-08-01 13:11:59.840742064 +0200
+@@ -1,12 +1,7 @@
+ #!/bin/sh
+ 
+-# Include utilities. Use installed version if available and
+-# use build version if it isn't.
+-if [ -e @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh ]; then
+-    . @datarootdir@/@PACKAGE_NAME@/scripts/admin-utils.sh
+-else
+-    . @abs_top_builddir@/src/bin/admin/admin-utils.sh
+-fi
++# Include utilities.
++. /usr/share/kea/scripts/admin-utils.sh
+ 
+ VERSION=`pgsql_version "$@"`
+ 

--- a/testing/kea/kea-ctrl-agent.initd
+++ b/testing/kea/kea-ctrl-agent.initd
@@ -1,0 +1,12 @@
+#!/sbin/openrc-run
+  
+name="kea-ctrl-agent"
+command="/usr/sbin/kea-ctrl-agent"
+command_args="-c /etc/kea/kea-ctrl-agent.conf"
+command_background="yes"
+pidfile="/run/kea-ctrl-agent.pid"
+
+depend() {
+	need net
+	after firewall
+}

--- a/testing/kea/kea-dhcp-ddns.initd
+++ b/testing/kea/kea-dhcp-ddns.initd
@@ -1,0 +1,12 @@
+#!/sbin/openrc-run
+  
+name="kea-dhcp-ddns"
+command="/usr/sbin/kea-dhcp-ddns"
+command_args="-c /etc/kea/kea-dhcp-ddns.conf"
+command_background="yes"
+pidfile="/run/kea-dhcp-ddns.pid"
+
+depend() {
+	need net
+	after firewall
+}

--- a/testing/kea/kea-dhcp4.initd
+++ b/testing/kea/kea-dhcp4.initd
@@ -1,0 +1,12 @@
+#!/sbin/openrc-run
+  
+name="kea-dhcp4"
+command="/usr/sbin/kea-dhcp4"
+command_args="-c /etc/kea/kea-dhcp4.conf"
+command_background="yes"
+pidfile="/run/kea-dhcp4.pid"
+
+depend() {
+	need net
+	after firewall
+}

--- a/testing/kea/kea-dhcp6.initd
+++ b/testing/kea/kea-dhcp6.initd
@@ -1,0 +1,12 @@
+#!/sbin/openrc-run
+  
+name="kea-dhcp6"
+command="/usr/sbin/kea-dhcp6"
+command_args="-c /etc/kea/kea-dhcp6.conf"
+command_background="yes"
+pidfile="/run/kea-dhcp6.pid"
+
+depend() {
+	need net
+	after firewall
+}


### PR DESCRIPTION
testing/kea: new aport
http://kea.isc.org
High-performance, extensible DHCP server engine from ISC, supporting both DHCPv4 and DHCPv6

testing/kea-hook-runscript: new aport
https://github.com/zorun/kea-hook-runscript
This a hook for the Kea DHCP server that allows to run an external script.