### PR TITLE
testing/gdal: enable sqlite support

### DIFF
--- a/testing/gdal/APKBUILD
+++ b/testing/gdal/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Trevor R.H. Clarke <trevor@notcows.com>
 pkgname=gdal
 pkgver=2.2.3
-pkgrel=0
+pkgrel=1
 pkgdesc="A translator library for raster and vector geospatial data formats"
 url="http://gdal.org"
 arch="all"
 license="MIT"
 depends=""
 depends_dev="gdal"
-makedepends="giflib-dev jpeg-dev libjpeg-turbo-dev libpng-dev tiff-dev zlib-dev swig python2-dev curl-dev linux-headers"
+makedepends="giflib-dev jpeg-dev libjpeg-turbo-dev libpng-dev tiff-dev zlib-dev swig python2-dev curl-dev linux-headers sqlite-dev"
 subpackages="$pkgname-dev py-$pkgname:py"
 source="http://download.osgeo.org/$pkgname/$pkgver/$pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Enable SQLite support within GDAL by adding sqlite-dev as a make dependency.