### PR TITLE
testing/nim: fix coroutines

### DIFF
--- a/testing/nim/APKBUILD
+++ b/testing/nim/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 #
-# WARNING: Coroutines does not work and there may be more breakages!
+# WARNING: There may be breakages!
 pkgname=nim
 pkgver=0.17.0
 pkgrel=0
@@ -14,7 +14,8 @@ subpackages="$pkgname-doc nimsuggest niminst"
 source="https://nim-lang.org/download/$pkgname-$pkgver.tar.xz
 	$pkgname-csources-$pkgver.tar.gz::https://github.com/nim-lang/csources/archive/v$pkgver.tar.gz
 	niminst-fix-paths.patch
-	nim-config-fix-paths.patch"
+	nim-config-fix-paths.patch
+	nim-config-fix-coro.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # Don't run tests on armhf, it'd take eternity...
@@ -80,4 +81,5 @@ niminst() {
 sha512sums="90d709b39746fac5582b9df69d3eb9e3b7a39563a98f7a3002f00716b936e4e0d2be47d8b877878318692e6e2b85c08077dfcc20d9059573a1967402c244894b  nim-0.17.0.tar.xz
 fbf64d347e25da48d5237eef35209774f0e542975465c5d2cd98878f10ea0ab62ad1404758131543b8cf634afabc90d85e9e59dec96eae9bb60fffb88d204d92  nim-csources-0.17.0.tar.gz
 4ab36c5d8772567ba09b536e3dd91ddcf253892056751318ccbfce7ac24f0a646bfcd94f5dadc823c9a8394bea9614fede20c1805638052ebdbe7b5bafba4f05  niminst-fix-paths.patch
-813eb4cb93b0e9f12cb7666bef65c583390008ec09bc850f43f621688dc809bc51c105898095a8ef6316fbef49ac657a7abc75d74ad7b8cb3919c8f1a721af02  nim-config-fix-paths.patch"
+813eb4cb93b0e9f12cb7666bef65c583390008ec09bc850f43f621688dc809bc51c105898095a8ef6316fbef49ac657a7abc75d74ad7b8cb3919c8f1a721af02  nim-config-fix-paths.patch
+bc1158d06a7ea667a0fb48b054fc3e1c5e2026260443ffa4b3958f65ea2899b72b8365b77906ebe7b33500c6442405fdc9177767001a0d9a70c67b7689fbcd36  nim-config-fix-coro.patch"

--- a/testing/nim/nim-config-fix-coro.patch
+++ b/testing/nim/nim-config-fix-coro.patch
@@ -1,0 +1,11 @@
+diff -ruN a/config/nim.cfg b/config/nim.cfg
+--- a/config/nim.cfg	2018-01-06 22:48:43.920598426 +0100
++++ b/config/nim.cfg	2018-01-06 22:49:43.620979479 +0100
+@@ -9,6 +9,7 @@
+ #  gcc.path %= "$CC_PATH"
+ 
+ cc = gcc
++define:nimCoroutinesSetjmp
+ 
+ # additional options always passed to the compiler:
+ --parallel_build: "0" # 0 to auto-detect number of processors


### PR DESCRIPTION
Fix coroutines by using setjmp instead of ucontext (which musl doesn't support, because it deprecated)
