### PR TITLE
testing/zutils: new aport (closes #8382)

### DIFF
--- a/testing/zutils/APKBUILD
+++ b/testing/zutils/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Roberto Oliveira <robertoguimaraes8@gmail.com>
+# Maintainer: Roberto Oliveira <robertoguimaraes8@gmail.com>
+pkgname=zutils
+pkgver=1.6
+pkgrel=0
+pkgdesc="A collection of utilities able to process any combination of compressed and uncompressed files transparently"
+url="http://www.nongnu.org/zutils/zutils.html"
+arch="all"
+license="GPL-2.0"
+depends=""
+makedepends=""
+subpackages="$pkgname-doc"
+source="http://download.savannah.gnu.org/releases/$pkgname/$pkgname-$pkgver.tar.lz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure --prefix=/usr
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="afafd00a61fe28d597add0935c37b1854cff6627faaae20fe6dd1e553458f04b084c6bd2cc72410f239ab5506ba06f84366a73d28d8c7e788a01c14cc4085ecd  zutils-1.6.tar.lz"


### PR DESCRIPTION
Zutils is a collection of utilities able to process any
combination of compressed and uncompressed files transparently.