### PR TITLE
testing/ecs-cli: new aport

### DIFF
--- a/testing/ecs-cli/APKBUILD
+++ b/testing/ecs-cli/APKBUILD
@@ -1,0 +1,21 @@
+# Contributor: rsteube <rsteube@users.noreply.github.com>
+# Maintainer: rsteube <rsteube@users.noreply.github.com>
+pkgname=ecs-cli
+pkgver=1.2.1
+pkgrel=0
+pkgdesc="A custom Amazon ECS CLI that eases up the cluster setup process."
+url="https://github.com/aws/amazon-ecs-cli"
+arch="x86_64"
+license="Apache-2.0"
+depends=""
+depends_dev=""
+makedepends=""
+install=""
+subpackages=""
+source="https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-v$pkgver"
+
+package() {
+	install -Dm755 "$srcdir/ecs-cli-linux-amd64-v$pkgver" "$pkgdir"/usr/bin/ecs-cli
+}
+
+md5sums="bde271020ad54de3bde4a9f258dae509  ecs-cli-linux-amd64-v$pkgver"


### PR DESCRIPTION
Added command line interface for Amazon Elastic Container Service.