### PR TITLE
linux-firmware: split up in subpackages

### DIFF
--- a/main/linux-firmware/APKBUILD
+++ b/main/linux-firmware/APKBUILD
@@ -1,17 +1,16 @@
 # Contributor: William Pitcock <nenolod@dereferenced.org>
+# Contributor: Oliver Smith <ollieparanoid@bitmessage.ch>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=linux-firmware
 pkgver=20171227
-pkgrel=0
+pkgrel=1
 pkgdesc="firmware files for linux"
 #url="http://git.kernel.org/?p=linux/kernel/git/dwmw2/linux-firmware.git;a=summary"
 url="http://git.kernel.org/?p=linux/kernel/git/firmware/linux-firmware.git;a=summary"
 arch="all"
 license="custom:multiple"
-depends=
 makedepends=
 install=""
-subpackages=
 replaces="linux-grsec linux-vserver"
 options="!strip !check"
 source="http://dev.alpinelinux.org/archive/$pkgname/$pkgname-${pkgver}.tar.gz
@@ -24,6 +23,22 @@ _giturl="git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.g
 _upload=dev.alpinelinux.org:/archive/$pkgname/
 
 _builddir="$srcdir"/$pkgname-$pkgver
+
+# Put /lib/firmware/* folders in subpackages
+_folders="3com RTL8192E acenic adaptec advansys amd-ucode amdgpu ar3k ath10k
+	ath6k ath9k_htc atmel atusb av7110 bnx2 bnx2x brcm carl9170fw cavium cis cpia2
+	cxgb3 cxgb4 dabusb dsp56k e100 edgeport emi26 emi62 ene-ub6250 ess go7007 i915
+	imx intel isci kaweth keyspan keyspan_pda korg libertas liquidio matrox
+	mellanox moxa mrvl mwl8k mwlwifi myricom netronome nvidia ositech qca qcom qed
+	qlogic r128 radeon rockchip rsi rtl_bt rtl_nic rtlwifi sb16 slicoss sun sxg
+	tehuti ti-connectivity ti-keystone tigon ttusb-budget ueagle-atm vicam vxge yam
+	yamaha"
+subpackages="$pkgname-other"
+depends="linux-firmware-other"
+for i in $_folders; do
+	subpackages="$pkgname-$i:folder $subpackages"
+	depends="$pkgname-$i $depends"
+done
 
 snapshot() {
 	local _date=$(date +%Y%m%d)
@@ -41,14 +56,6 @@ snapshot() {
 	fi
 }
 
-prepare() {
-	return 0
-}
-
-build() {
-	return 0
-}
-
 package() {
 	cd "${_builddir}"
 	make DESTDIR="${pkgdir}" FIRMWAREDIR="/lib/firmware" install
@@ -56,6 +63,35 @@ package() {
 		install -Dm 644 "$srcdir/$i" "$pkgdir/lib/firmware/brcm/$i"
 	done
 	rm -f "${pkgdir}/usr/lib/firmware/{Makefile,README,configure,GPL-3}"
+}
+
+folder() {
+	_folder=${subpkgname##linux-firmware-}
+	pkgdesc="firmware files for linux ($_folder folder)"
+	depends=""
+
+	mkdir -p "$subpkgdir/lib/firmware"
+	mv "$pkgdir/lib/firmware/$_folder" "$subpkgdir/lib/firmware"
+}
+
+other() {
+	# Requires subfolders to be split in subpackages
+	_leftover=""
+	for i in "$pkgdir"/lib/firmware/*; do
+		[ -d "$i" ] && _leftover="$_leftover $(basename $i)"
+	done
+	if [ "$_leftover" != "" ]; then
+		error "Not all subfolders have been moved to subpackages!"
+		error "Fix this by adjusting _folders as follows:"
+		_fixed="$(echo $_folders$_leftover | tr " " "\n" | sort)"
+		echo "_folders=\"$(printf "$_fixed" | tr "\n" " ")\"" | fold -s
+		return 1
+	fi
+
+	# Move /lib/firmware (which doesn't have subfolders now)
+	pkgdesc="firmware files for linux (uncategorized)"
+	depends=""
+	mv "$pkgdir"/lib "$subpkgdir"/
 }
 
 sha512sums="749201c9bb9ea620789f8871d4d52ef5f617b34d59a9db39334edb8fbc86a79d78aa496209d0afc732b64bace78d1a71217b5ec22c9dc3f94c12a80f6acba702  linux-firmware-20171227.tar.gz


### PR DESCRIPTION
This PR splits up the > 250 MB install size linux-firmware package in one package for each `/lib/firmware` subfolder (linux-firmware-liquido (23.7 MB), linux-firmware-netrome (22.0 MB), ...). Files directly in /lib/firmware are now in "linux-firmware-other" (~100 MB), and the "linux-firmware" package depends on all its subpackages for compatibility.

The `other()` function always gets called as last subpackage function, and it checks that all folders in `/lib/firmware` have been moved to subpackages. If that is not the case, it proposes a new `_folders` variable and fails the build:
```
>>> linux-firmware-other*: Running split function other...
>>> ERROR: linux-firmware-other*: Not all subfolders have been moved to subpackages!
>>> ERROR: linux-firmware-other*: Fix this by adjusting _folders as follows:
_folders="3com RTL8192E acenic adaptec advansys amd-ucode amdgpu ar3k ath10k
ath6k ath9k_htc atmel atusb av7110 bnx2 bnx2x brcm carl9170fw cavium cis cpia2
cxgb3 cxgb4 dabusb dsp56k e100 edgeport emi26 emi62 ene-ub6250 ess go7007 i915
imx intel isci kaweth keyspan keyspan_pda korg libertas liquidio matrox
mellanox moxa mrvl mwl8k mwlwifi myricom netronome nvidia ositech qca qcom qed
qlogic r128 radeon rockchip rsi rtl_bt rtl_nic rtlwifi sb16 slicoss sun sxg
tehuti ti-connectivity ti-keystone tigon ttusb-budget ueagle-atm vicam vxge yam
yamaha"
>>> ERROR: linux-firmware-other*: other failed
>>> ERROR: linux-firmware*: prepare_subpackages failed
>>> ERROR: linux-firmware: all failed
```


(See also: <https://lists.alpinelinux.org/alpine-devel/6005.html>)