### PR TITLE
testing/rsyslog: remove libee requirement

### DIFF
--- a/main/rsyslog/APKBUILD
+++ b/main/rsyslog/APKBUILD
@@ -12,7 +12,7 @@ arch="all"
 license="GPL-3.0 LGPL-3.0"
 options="!check"
 makedepends="zlib-dev gnutls-dev mariadb-dev postgresql-dev net-snmp-dev
-	libnet-dev libgcrypt-dev libee-dev libestr-dev liblogging-dev
+	libnet-dev libgcrypt-dev libestr-dev liblogging-dev
 	libfastjson-dev util-linux-dev py-docutils hiredis-dev linux-headers"
 subpackages="$pkgname-doc $pkgname-mysql $pkgname-pgsql $pkgname-tls
 	$pkgname-snmp $pkgname-hiredis $pkgname-dbg"


### PR DESCRIPTION
rsyslog does not require libee for quite a while now. This PR removes
the requirement.