### PR TITLE
linux-firmware: lowercase subpackages / use local

### DIFF
--- a/main/linux-firmware/APKBUILD
+++ b/main/linux-firmware/APKBUILD
@@ -25,12 +25,12 @@ _upload=dev.alpinelinux.org:/archive/$pkgname/
 _builddir="$srcdir"/$pkgname-$pkgver
 
 # Put /lib/firmware/* folders in subpackages
-_folders="3com RTL8192E acenic adaptec advansys amd-ucode amdgpu ar3k ath10k
-	ath6k ath9k_htc atmel atusb av7110 bnx2 bnx2x brcm carl9170fw cavium cis cpia2
-	cxgb3 cxgb4 dabusb dsp56k e100 edgeport emi26 emi62 ene-ub6250 ess go7007 i915
-	imx intel isci kaweth keyspan keyspan_pda korg libertas liquidio matrox
-	mellanox moxa mrvl mwl8k mwlwifi myricom netronome nvidia ositech qca qcom qed
-	qlogic r128 radeon rockchip rsi rtl_bt rtl_nic rtlwifi sb16 slicoss sun sxg
+_folders="3com acenic adaptec advansys amd-ucode amdgpu ar3k ath10k ath6k
+	ath9k_htc atmel atusb av7110 bnx2 bnx2x brcm carl9170fw cavium cis cpia2 cxgb3
+	cxgb4 dabusb dsp56k e100 edgeport emi26 emi62 ene-ub6250 ess go7007 i915 imx
+	intel isci kaweth keyspan keyspan_pda korg libertas liquidio matrox mellanox
+	moxa mrvl mwl8k mwlwifi myricom netronome nvidia ositech qca qcom qed qlogic
+	r128 radeon rockchip rsi rtl8192e rtl_bt rtl_nic rtlwifi sb16 slicoss sun sxg
 	tehuti ti-connectivity ti-keystone tigon ttusb-budget ueagle-atm vicam vxge yam
 	yamaha"
 subpackages="$pkgname-other"
@@ -66,25 +66,29 @@ package() {
 }
 
 folder() {
-	_folder=${subpkgname##linux-firmware-}
+	local folder=${subpkgname##linux-firmware-}
 	pkgdesc="firmware files for linux ($_folder folder)"
 	depends=""
 
+	# Move /lib/firmware/$folder (case insensitive)
 	mkdir -p "$subpkgdir/lib/firmware"
-	mv "$pkgdir/lib/firmware/$_folder" "$subpkgdir/lib/firmware"
+	mv "$(find "$pkgdir/lib/firmware" -iname "$folder" -type d)" \
+		"$subpkgdir/lib/firmware"
 }
 
 other() {
 	# Requires subfolders to be split in subpackages
-	_leftover=""
+	local leftover=""
+	local i
 	for i in "$pkgdir"/lib/firmware/*; do
-		[ -d "$i" ] && _leftover="$_leftover $(basename $i)"
+		[ -d "$i" ] && leftover="$leftover $(basename $i)"
 	done
-	if [ "$_leftover" != "" ]; then
+	if [ "$leftover" != "" ]; then
+		local fixed
 		error "Not all subfolders have been moved to subpackages!"
 		error "Fix this by adjusting _folders as follows:"
-		_fixed="$(echo $_folders$_leftover | tr " " "\n" | sort)"
-		echo "_folders=\"$(printf "$_fixed" | tr "\n" " ")\"" | fold -s
+		fixed="$(echo $_folders$leftover | tr " " "\n" | tr '[A-Z]' '[a-z]' | sort)"
+		echo "_folders=\"$(printf "$fixed" | tr "\n" " ")\"" | fold -s
 		return 1
 	fi
 


### PR DESCRIPTION
* Always use lowercase subpackage names (no more linux-firmware-RTL8192E, thanks to Timo Teras for [pointing it out](https://lists.alpinelinux.org/alpine-devel/6016.html))
* Use `local` for local variables (thanks to @jirutka for [pointing it out](https://github.com/alpinelinux/aports/commit/133ebbcf836126748f910e9225050545bda77875#r26737067))