### PR TITLE
main/mkinitfs: skip apk hooks

### DIFF
--- a/main/mkinitfs/0001-skip-hooks-on-diskless-install.patch
+++ b/main/mkinitfs/0001-skip-hooks-on-diskless-install.patch
@@ -1,0 +1,30 @@
+From 0bd97e8aef5208bc92c3e72049f7fea198a90bd1 Mon Sep 17 00:00:00 2001
+From: Henrik Riomar <henrik.riomar@gmail.com>
+Date: Mon, 8 Jan 2018 16:37:44 +0100
+Subject: [PATCH] skip hooks on diskless install
+
+We can not run hooks before musl and busybox is installed.
+
+Use the new flag --initramfs-diskless-boot in order to skip hooks.
+This flag also implies --initdb and the relevant --force flags for
+initramfs diskless boot.
+---
+ initramfs-init.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/initramfs-init.in b/initramfs-init.in
+index f3a3ee5..7c78c58 100755
+--- a/initramfs-init.in
++++ b/initramfs-init.in
+@@ -598,7 +598,7 @@ if [ "$KOPT_chart" = yes ]; then
+ 	pkgs="$pkgs acct"
+ fi
+ 
+-apkflags="--initdb --progress --force"
++apkflags="--initramfs-diskless-boot --progress"
+ if [ -z "$ALPINE_REPO" ]; then
+ 	apkflags="$apkflags --no-network"
+ else
+-- 
+2.15.0
+

--- a/main/mkinitfs/APKBUILD
+++ b/main/mkinitfs/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=mkinitfs
 pkgver=3.2.0
 _ver=${pkgver%_git*}
-pkgrel=0
+pkgrel=1
 pkgdesc="Tool to generate initramfs images for Alpine"
 url="https://git.alpinelinux.org/cgit/mkinitfs"
 arch="all"
@@ -10,10 +10,11 @@ license="GPL2"
 makedepends_build=""
 makedepends_host="busybox kmod-dev util-linux-dev cryptsetup-dev linux-headers"
 makedepends="$makedepends_build $makedepends_host"
-depends="busybox apk-tools>=2.0 lddtree>=1.25"
+depends="busybox apk-tools>=2.8.2 lddtree>=1.25"
 install="$pkgname.pre-upgrade $pkgname.post-install $pkgname.post-upgrade"
 triggers="$pkgname.trigger=/usr/share/kernel/*"
 source="http://dev.alpinelinux.org/archive/$pkgname/$pkgname-$_ver.tar.xz
+	0001-skip-hooks-on-diskless-install.patch
 	"
 builddir="$srcdir/$pkgname-$_ver"
 
@@ -27,4 +28,5 @@ package() {
 	make install DESTDIR="$pkgdir"
 }
 
-sha512sums="906bfbce677d4ece9c9fea7b2a529121740bc9d96ea011be083303cc5c56162f09271b0a673e9e335234ccf2f293109bda1eda333698a95357d0772c86f498af  mkinitfs-3.2.0.tar.xz"
+sha512sums="906bfbce677d4ece9c9fea7b2a529121740bc9d96ea011be083303cc5c56162f09271b0a673e9e335234ccf2f293109bda1eda333698a95357d0772c86f498af  mkinitfs-3.2.0.tar.xz
+f5c9b21e53c663dac1b8f33f929dbe067492f0dc1bd5ef5310ef531033f31fc3fa0b6de6dce03cecaf90b8ed47b278d0f1f7c64dbbeede7621c895ee3ea79864  0001-skip-hooks-on-diskless-install.patch"


### PR DESCRIPTION
Skip pre/post apk hooks on diskless initramfs installation.

(cherry picked from commit 8c9aa20b2f1445d63a2923145fffca1b40f1470a)