### PR TITLE
main/mkinitfs: skip apk hooks

### DIFF
--- a/main/mkinitfs/0003-skip-hooks-on-diskless-install.patch
+++ b/main/mkinitfs/0003-skip-hooks-on-diskless-install.patch
@@ -1,0 +1,30 @@
+From 0bd97e8aef5208bc92c3e72049f7fea198a90bd1 Mon Sep 17 00:00:00 2001
+From: Henrik Riomar <henrik.riomar@gmail.com>
+Date: Mon, 8 Jan 2018 16:37:44 +0100
+Subject: [PATCH] skip hooks on diskless install
+
+We can not run hooks before musl and busybox is installed.
+
+Use the new flag --initramfs-diskless-boot in order to skip hooks.
+This flag also implies --initdb and the relevant --force flags for
+initramfs diskless boot.
+---
+ initramfs-init.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/initramfs-init.in b/initramfs-init.in
+index f3a3ee5..7c78c58 100755
+--- a/initramfs-init.in
++++ b/initramfs-init.in
+@@ -598,7 +598,7 @@ if [ "$KOPT_chart" = yes ]; then
+ 	pkgs="$pkgs acct"
+ fi
+ 
+-apkflags="--initdb --progress --force"
++apkflags="--initramfs-diskless-boot --progress"
+ if [ -z "$ALPINE_REPO" ]; then
+ 	apkflags="$apkflags --no-network"
+ else
+-- 
+2.15.0
+

--- a/main/mkinitfs/APKBUILD
+++ b/main/mkinitfs/APKBUILD
@@ -2,18 +2,19 @@
 pkgname=mkinitfs
 pkgver=3.1.0
 _ver=${pkgver%_git*}
-pkgrel=3
+pkgrel=4
 pkgdesc="Tool to generate initramfs images for Alpine"
 url="http://git.alpinelinux.org/cgit/mkinitfs"
 makedepends_build=""
 makedepends_host="kmod-dev util-linux-dev cryptsetup-dev linux-headers"
 makedepends="$makedepends_build $makedepends_host"
-depends="busybox apk-tools>=2.0 lddtree>=1.25"
+depends="busybox apk-tools>=2.7.5 lddtree>=1.25"
 install="$pkgname.pre-upgrade $pkgname.post-install $pkgname.post-upgrade"
 triggers="$pkgname.trigger=/usr/share/kernel/*"
 source="http://dev.alpinelinux.org/archive/$pkgname/$pkgname-$_ver.tar.xz
 	0001-features-ext4-needs-crc32.patch
 	0002-fix-booting-from-btrfs-raid.patch
+	0003-skip-hooks-on-diskless-install.patch
 	"
 arch="all"
 license="GPL2"
@@ -31,4 +32,5 @@ package() {
 
 sha512sums="ec80702c6b41cb7898679377bef949cc1079b006c2dcc760c801f60a411eb1d3b3fd34ae2088b0bd3779202953466bce6efd62253d93dda32a8bca9bcd8942fc  mkinitfs-3.1.0.tar.xz
 e66961014d5d68c6e5a529f365f2d8d17fb0c10892b4a61d0c7838ae01ed11f1749912badd902af3a9b5452de72647dd007dda1653c4b0fcd9a6b95e7bf834b9  0001-features-ext4-needs-crc32.patch
-97c3864596059e134529fa395b05eca556c7d90005716716e67895f021e6f1fe33b2f1d85f1145048e092aae595da0bff5578caa23863224042982dabb7b7993  0002-fix-booting-from-btrfs-raid.patch"
+97c3864596059e134529fa395b05eca556c7d90005716716e67895f021e6f1fe33b2f1d85f1145048e092aae595da0bff5578caa23863224042982dabb7b7993  0002-fix-booting-from-btrfs-raid.patch
+f5c9b21e53c663dac1b8f33f929dbe067492f0dc1bd5ef5310ef531033f31fc3fa0b6de6dce03cecaf90b8ed47b278d0f1f7c64dbbeede7621c895ee3ea79864  0003-skip-hooks-on-diskless-install.patch"


### PR DESCRIPTION
Skip pre/post apk hooks on diskless initramfs installation.

(cherry picked from commit 8c9aa20b2f1445d63a2923145fffca1b40f1470a)