### PR TITLE
community/docker: upgrade to 17.12.0

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=docker
-pkgver=17.10.0
+pkgver=17.12.0
 _ver=${pkgver/_/-}-ce
 pkgrel=0
 _gitcommit=v$_ver
@@ -22,8 +22,8 @@ install="$pkgname.pre-install"
 # VNDR_COMMIT=9909bb2b8a0b7ea464527b376dc50389c90df587
 # GOMETALINTER_COMMIT=bfcc1d6942136fd86eb6f1a6fb328de8398fbd80
 
-_runc_ver=0351df1c5a66838d0c392b4ac4cf9450de844e2d
-_containerd_ver=06b9cb35161009dcb7123345749fef02f7cea8e0
+_runc_ver=b2567b37d7b75eb4cf325b77297b140ea686ce8f
+_containerd_ver=89623f28b87a6004d4b785663257362d1658a729
 _tini_ver=949e6facb77383876aeff8a6944dde66b3089574
 _libnetwork_ver=7b2b1feb1de4817d522cc372af149ff48d25028e
 
@@ -96,12 +96,10 @@ build() {
 	# containerd
 	msg "building containerd"
 	cd "$_containerd_builddir"
+	# Vendor dir only works if it's part of a package in the src dir. Easiest solution is to make it a src dir iself
+	mv vendor src
 	mkdir -p src/github.com/containerd/
 	ln -s "$_containerd_builddir" src/github.com/containerd/containerd
-	##### Workaround for v17.10.0 unreachable vendor dir
-	mkdir -p vendor/src/
-	mv vendor/g* vendor/src
-	#####
 	GOPATH="$PWD" LDFLAGS="" make GIT_COMMIT="$_containerd_ver"
 
 	# libnetwork (docker-proxy)
@@ -240,9 +238,9 @@ vim() {
 	done
 }
 
-sha512sums="4ec5dae379ecda36b9af7066432507947142631efea471cd7f447677f9db1fe1522fe81ef68b28d3e63b5e759535a1c518ce1ef71f4de0e9dd32c957c682098c  docker-17.10.0.tar.gz
-bad4643ce37dbba168cc3b0820cf7dc8166ff2d7970de519f86ca09123b59999174dd98b7bc550b714dc8235732923e0090031c789deb603f310e042a39f1d76  runc-0351df1c5a66838d0c392b4ac4cf9450de844e2d.tar.gz
-c749bda691197ec8a7603db9ad92f2800a3f065143430a660333b7862518deb4c158a1c1fd01671dff438b40988d4a64d8f06bab05496b8728c6e2f57cd7da0a  containerd-06b9cb35161009dcb7123345749fef02f7cea8e0.tar.gz
+sha512sums="7381bddf4b2538b2b76229d962925eee74a38ddbb18a6f988ccff2a2ce0ef334148ea76d9697e89acc6c9018cb6f785b59c27450dfb930ead01fa5684c6a90b1  docker-17.12.0.tar.gz
+a5bf97ce284317e03e63ee0e39228d77848fcde2f6322de06eebc2536978b5d87fd8c3fbccb2e74ef8c80fbaa28f3d0b24074cb9fde01e268593332aacd57695  runc-b2567b37d7b75eb4cf325b77297b140ea686ce8f.tar.gz
+6eae5e213c3016a49bf923184708a404aca6f7c2aa0b8ce12f4a52cd405d81670783d95696faa83d7dcc3a29ef130fcb145d61c98dccf443ff30b6a2e7463342  containerd-89623f28b87a6004d4b785663257362d1658a729.tar.gz
 673ea638fa5c560d8238d7c1d88f114430f9d8efe701804bfe30044d0c059a688cbf6b62922be50834e16ee055ef6cf015f6232f76f0d942768f9e84e95496cd  libnetwork-7b2b1feb1de4817d522cc372af149ff48d25028e.tar.gz
 b6c1454f734662adf2fdedcb75cb7cdc82f4cf5b4c41fadf6891a670fa26d49b789034f4af8bf920b9e1ff1c3536123637ade9471f4ae2c1ef6c534e839b9f27  tini-949e6facb77383876aeff8a6944dde66b3089574.tar.gz
 54d570901f6f1e329883e3d348ed7370e9f68b73a01b72195bed3d37508cc82e82f6c6893f798c058da00e40ff2262baaa1514d274174a3f83508e1186c7a3c4  go-md2man-1.0.7.tar.gz


### PR DESCRIPTION
I had to make some adjustments to get it to build for 17.12.0. The easiest solution was to just move `vendor/` to `src/`, and put the symlink there.

According to `go help gopath`, the vendor directory is only consulted in the src dir, usually as part of another package, but it does not find the packages through the symlink to the source itself.