### PR TITLE
testing/libfastjson: upgrade to version 0.99.8

### DIFF
--- a/main/libfastjson/APKBUILD
+++ b/main/libfastjson/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Ashley Sommer <ashleysommer@gmail.com>
 # Maintainer: Ashley Sommer <ashleysommer@gmail.com>
 pkgname=libfastjson
-pkgver=0.99.7
+pkgver=0.99.8
 pkgrel=0
 pkgdesc="A fork of the json-c library for rsyslog, optimized for liblognorm processing."
 url="http://www.rsyslog.com/"
@@ -40,4 +40,4 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-sha512sums="d1dd074694c032cd6d10bfa4cd7520932bd4301d28262969e544031258d09ea2f2b8d18ee474ea49b84cb8d97b9dcdef1264f0144027fac38337b248a280e7a6  libfastjson-0.99.7.tar.gz"
+sha512sums="bd68705ab41d360582bb08b1f29be5b16f55d18674f26066cdd36c66a52a571873e013e31dbb0d21ea73684709a63d0f831be9eb12d8c6e9d8eaf5ec71ce6f18  libfastjson-0.99.8.tar.gz"


### PR DESCRIPTION
The new upstream release is a maintenance release without any new
features or otherwise visible changes. However, it contains a number
of important bug fixes. So it would be good to have this available.

see also https://github.com/rsyslog/libfastjson/blob/master/ChangeLog