### PR TITLE
testing/rsyslog: add -elasticsearch subpackage

### DIFF
--- a/main/rsyslog/APKBUILD
+++ b/main/rsyslog/APKBUILD
@@ -12,10 +12,10 @@ arch="all"
 license="GPL-3.0 LGPL-3.0"
 options="!check"
 makedepends="zlib-dev gnutls-dev mariadb-dev postgresql-dev net-snmp-dev
-	libnet-dev libgcrypt-dev libestr-dev liblogging-dev
+	libnet-dev libgcrypt-dev libestr-dev liblogging-dev curl-dev
 	libfastjson-dev util-linux-dev py-docutils hiredis-dev linux-headers"
 subpackages="$pkgname-doc $pkgname-mysql $pkgname-pgsql $pkgname-tls
-	$pkgname-snmp $pkgname-hiredis $pkgname-dbg"
+	$pkgname-snmp $pkgname-hiredis $pkgname-elasticsearch $pkgname-dbg"
 source="http://www.rsyslog.com/files/download/$pkgname/$pkgname-$pkgver.tar.gz
 	$pkgname.initd
 	$pkgname.confd
@@ -47,6 +47,7 @@ build() {
 		--enable-gnutls \
 		--enable-snmp \
 		--enable-omhiredis \
+		--enable-elasticsearch \
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man
@@ -102,6 +103,14 @@ snmp() {
 	mkdir -p "$subpkgdir"/usr/lib/rsyslog/
 	mv "$pkgdir"/usr/lib/rsyslog/omsnmp.so \
 		"$subpkgdir"/usr/lib/rsyslog/
+}
+
+elasticsearch() {
+	pkgdesc="rsyslog elasticsearch support"
+
+	mkdir -p "$subpkgdir"/usr/lib/rsyslog/
+	mv "$pkgdir"/usr/lib/rsyslog/omelasticsearch.so \
+		 "$subpkgdir"/usr/lib/rsyslog/
 }
 
 sha512sums="aab888dda8df3ad7ff404767a58539cdc0bb92d0e537b703cf5833555688dd6d8223889b8d70bf8c594339a51831b57df7a65b397d8b40cded608dfb007befe7  rsyslog-8.31.0.tar.gz


### PR DESCRIPTION
Elasticsearch is very popular with rsyslog. This PR provides the
necessary feature to make rsyslog talk directly to it.