### PR TITLE
testing/wireguard: version bump

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171221
-_mypkgrel=0
+_ver=0.0.20180118
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="1ede1dcc3eaad54a25e995d956f277eedf272ce0a6915714bd0a947c58f4404d5a9e3ced2a8cb2e80a306e352c23c6a25cbaff533dafd00c923f34575c956b79  WireGuard-0.0.20171221.tar.xz"
+sha512sums="8f90b4a84073e281de17ea1db422c2d97bf97c96aad2177d86485e244a447bf2d5e1c8f74f0bba560949f74c73fb6211cc13949a9b28ede2991a69eeaa9b8bd6  WireGuard-0.0.20180118.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20171221
+pkgver=0.0.20180118
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="1ede1dcc3eaad54a25e995d956f277eedf272ce0a6915714bd0a947c58f4404d5a9e3ced2a8cb2e80a306e352c23c6a25cbaff533dafd00c923f34575c956b79  WireGuard-0.0.20171221.tar.xz"
+sha512sums="8f90b4a84073e281de17ea1db422c2d97bf97c96aad2177d86485e244a447bf2d5e1c8f74f0bba560949f74c73fb6211cc13949a9b28ede2991a69eeaa9b8bd6  WireGuard-0.0.20180118.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20171221
-_mypkgrel=0
+_ver=0.0.20180118
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="1ede1dcc3eaad54a25e995d956f277eedf272ce0a6915714bd0a947c58f4404d5a9e3ced2a8cb2e80a306e352c23c6a25cbaff533dafd00c923f34575c956b79  WireGuard-0.0.20171221.tar.xz"
+sha512sums="8f90b4a84073e281de17ea1db422c2d97bf97c96aad2177d86485e244a447bf2d5e1c8f74f0bba560949f74c73fb6211cc13949a9b28ede2991a69eeaa9b8bd6  WireGuard-0.0.20180118.tar.xz"


### PR DESCRIPTION
* receive: treat packet checking as irrelevant for timers

Small simplification to the state machine, as discussed with Mathias
Hall-Andersen.

* socket: check for null socket before fishing out sport
* wg-quick: ifnames have max len of 15
* tools: plug memleak in config error path

Important bug fixes.

* external-tests: add python implementation

Piotr Lizonczyk has contributed a test vector written in Python.

* poly1305: remove indirect calls

From Samuel Neves, we now are in a better position to mitigate speculative
execution attacks.

* curve25519: modularize implementation
* curve25519: import 32-bit fiat-crypto implementation
* curve25519: import 64-bit hacl-star implementation
* curve25519: resolve symbol clash between fe types
* curve25519: wire up new impls and remove donna
* tools: import new curve25519 implementations
* contrib: keygen-html: update curve25519 implementation

Two of our Curve25519 implementations now use formally verified C. Read this
mailing list post for more information:
https://lists.zx2c4.com/pipermail/wireguard/2018-January/002304.html