### PR TITLE
main/php5: security upgrade to 5.6.33

### DIFF
--- a/community/php5/APKBUILD
+++ b/community/php5/APKBUILD
@@ -3,8 +3,8 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
-pkgver=5.6.32
-pkgrel=2
+pkgver=5.6.33
+pkgrel=0
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
 arch="all"
@@ -125,6 +125,9 @@ _confdir=/etc/$pkgname
 _peardir=/usr/share/pear
 
 # secfixes:
+#   5.6.33-r0:
+#     - CVE-2018-5711
+#     - CVE-2018-5712
 #   5.6.31-r0:
 #     - CVE-2017-9224
 #     - CVE-2017-9226
@@ -505,7 +508,7 @@ pdo_dblib()	{ _mv_ext pdo_dblib "$pkgname-pdo freetds"; }
 wddx()		{ _mv_ext wddx; }
 opcache()	{ _mv_ext opcache; }
 
-sha512sums="d3f53a9c14e05726ec80785ee2db482d73cfd9bfca751041150da63e5e9273a2ea9a0027d3d9c80434ae8c1f93e7a4556b050969c271e696a841ec785efbeedc  php-5.6.32.tar.bz2
+sha512sums="d57d87bf5ceb4b8b72908dc9d4236533697ba7055c25bdd299b35ff42b9d0258020241953a6f2c448929742c73fb2e3c67aa630c556af8fccbbe312ec51f1576  php-5.6.33.tar.bz2
 f7d922cab98617ef910b4c14974e768c85e60424cd1b216f688b34b2d823b642a5b896463008c134ce47c150f9407f5c438823b7e7bc89b3fb440cd3e97b9d7e  php-fpm.initd
 d1dd6a5764e18414476aaaa109efcc568696ac17a61a1afdf7d0621d3e38c5be717a81ee4d11d28963f11e76879af7d3806970e651061f8c4abffb03c4bd5af4  php5-module.conf
 f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c939768584f3e4edbe52e8bd6103fb6777462326a9d94e8ab1f505  php-install-pear-xml.patch


### PR DESCRIPTION
- CVE-2018-5711
- CVE-2018-5712

Ref http://php.net/archive/2018.php#id2018-01-04-4