### PR TITLE
testing/eigen: Add signature file

### DIFF
--- a/testing/eigen/APKBUILD
+++ b/testing/eigen/APKBUILD
@@ -27,6 +27,7 @@ package() {
         mkdir -p "$pkgdir"/usr/include/eigen3
         cp -r "$builddir"/Eigen "$pkgdir"/usr/include/eigen3
         cp -r "$builddir"/unsupported "$pkgdir"/usr/include/eigen3
+        cp "$builddir"/signature_of_eigen3_matrix_library "$pkgdir"/usr/include/eigen3
 }
 
 sha512sums="4077a5c3b95e3573774ccd3fe6c7233cb4b83db2358c19b43ea796925bd0201451d8632bddc5d68b1b57bbf67c5473a8908926eed065a745689a2acec9711d5c  eigen-3.3.4.tar.gz"


### PR DESCRIPTION
The Eigen 3 library can be found automatically by build systems like CMake.  All of those systems look for a directory containing the file `signature_of_eigen3_matrix_library`.  Without this file auto-discovery will fail.