### PR TITLE
testing/font-noto-emoji: Update to 20180102 to support Emoji 5.0

### DIFF
--- a/testing/font-noto-emoji/APKBUILD
+++ b/testing/font-noto-emoji/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Sören Tempel <soeren+alpine@soeren-tempel.net>
 pkgname=font-noto-emoji
-pkgver=20161212
-_commit=f09b63d1ecfe19b93021b0a283f1aa539b7230a9
+pkgver=20180102
+_commit=153e1d4c026c124fbac6ee93e559b5df375f24f5
 pkgrel=0
 pkgdesc="Google Noto emoji fonts"
 url="https://www.google.com/get/noto/"
@@ -10,7 +10,7 @@ arch="noarch"
 license="OFL-1.1"
 depends=""
 depends_dev=""
-makedepends="optipng py-fonttools cairo-dev imagemagick
+makedepends="optipng py-fonttools>=3.15.1 cairo-dev imagemagick
 	py-setuptools bash nototools libpng-dev python2"
 install=""
 subpackages=""
@@ -29,6 +29,4 @@ package() {
 		"$pkgdir"/usr/share/fonts/noto/ || return 1
 }
 
-md5sums="15c81491c0ebd28fc4c386a4d22d4cfd  font-noto-emoji-20161212.tar.gz"
-sha256sums="32926d0483fd7d6ca962876530b9faaae3e49ee05ae5bc417e5f2db2622ba6a5  font-noto-emoji-20161212.tar.gz"
-sha512sums="9600cd6f0747bef5a198f6ab84a191881efdaf936b47719856b3c068254169592685190dce80213c1c0065cae20ca21803d96a92049f3cfc9090322846753ff8  font-noto-emoji-20161212.tar.gz"
+sha512sums="b2da342ccee73e72aac41a59afe0a726acf66cd1314f9582eb890b80ab646a340db14acbf4bd3146de9f30b50f84f38f76ca56369b7ef4b70b3e901e31b72355  font-noto-emoji-20180102.tar.gz"


### PR DESCRIPTION
The older 20161212 only supports up to Emoji 4.0.  This updates it to support Emoji 5.0.

It depends on #3113 and #3112 .

Time it takes to compile:
real	14m 9.18s
user	22m 56.42s
sys	1m 5.36s