### PR TITLE
testing/firefox:  Add H.264 support with FFmpeg to fix YouTube live video

### DIFF
--- a/testing/firefox/APKBUILD
+++ b/testing/firefox/APKBUILD
@@ -4,7 +4,7 @@ pkgname=firefox
 pkgver=57.0.3
 _pkgver=$pkgver
 _xulver=$pkgver
-pkgrel=1
+pkgrel=2
 pkgdesc="Firefox web browser"
 url="http://www.firefox.com"
 # limited by rust and cargo
@@ -20,6 +20,7 @@ makedepends="
 	cargo
 	clang-dev
 	dbus-glib-dev
+	ffmpeg-dev
 	gconf-dev
 	gtk+2.0-dev
 	gtk+3.0-dev
@@ -92,6 +93,13 @@ prepare() {
 	cp "$srcdir"/stab.h toolkit/crashreporter/google-breakpad/src/
 	# https://bugzilla.mozilla.org/show_bug.cgi?id=1341234
 	echo "ac_add_options BINDGEN_CFLAGS='-I/usr/include/nspr -I/usr/include/pixman-1'" >>.mozconfig
+
+	grep -l -r -e "use std::ascii::AsciiExt;" "${srcdir}/firefox-$pkgver/servo/components/style/"
+	for f in $(grep -l -r -e "use std::ascii::AsciiExt;" "${srcdir}/firefox-$pkgver/servo/components/style/"); do
+		msg "Patching $f"
+		sed -i -e 's|#[allow(unused_imports)] use std::ascii::AsciiExt;|use std::ascii::AsciiExt;|g' \
+			-e 's|use std::ascii::AsciiExt;|#[allow(unused_imports)] use std::ascii::AsciiExt;|g' "${f}" || return 1
+	done
 }
 
 build() {
@@ -130,6 +138,7 @@ build() {
 		--enable-system-ffi \
 		--enable-system-hunspell \
 		--enable-system-sqlite \
+		--enable-ffmpeg \
 		\
 		--with-pthreads \
 		--with-system-bz2 \

--- a/testing/firefox/APKBUILD
+++ b/testing/firefox/APKBUILD
@@ -94,7 +94,6 @@ prepare() {
 	# https://bugzilla.mozilla.org/show_bug.cgi?id=1341234
 	echo "ac_add_options BINDGEN_CFLAGS='-I/usr/include/nspr -I/usr/include/pixman-1'" >>.mozconfig
 
-	grep -l -r -e "use std::ascii::AsciiExt;" "${srcdir}/firefox-$pkgver/servo/components/style/"
 	for f in $(grep -l -r -e "use std::ascii::AsciiExt;" "${srcdir}/firefox-$pkgver/servo/components/style/"); do
 		msg "Patching $f"
 		sed -i -e 's|#[allow(unused_imports)] use std::ascii::AsciiExt;|use std::ascii::AsciiExt;|g' \


### PR DESCRIPTION
This is to allow for users to play YouTube live video and some Internet radio stations

firefox=57.0.3-r1 cannot play YouTube video and some Internet stations because of the missing FFMpeg dependency.  I decided just keep it in the same package.  If the person doesn't want H.264 support or do not like the FFmpeg (for reasons mentioned below), they could delete ffmpeg-dev, ffmpeg-libs.

The alternative would be to have 3 or 2 separate mutually exclusive packages (testing/firefox [without ffmpeg], testing/firefox-h264ffm, testing/firefox-h264va, or just testing/firefox-264 [with ffmpeg].  The incentives for separate packages is to reduce the attack vectors.  For 2017, FFmpeg had 47 CVEs with 4 code execution CVEs and libav had 24 CVEs with 0 code execution CVEs according to CVE Details (www.cvedetails.com).  

For licensing of H.264, we should make it link to it at build time but dispose of the ffmpeg-lib and ffmpeg-dev package.  It is listed under makedepends.

Before 478 HTML5 score
html5te.st/00c7333b3b03b892

After 481 HTML5 score
html5te.st/4cad413b3c5a7517

As with the use std::ascii::AsciiExt; patching, the build process errored out for a warning of it being unused.