### PR TITLE
testing/fzy: Fix project URL

### DIFF
--- a/testing/fzy/APKBUILD
+++ b/testing/fzy/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Jonathan Neuschäfer <j.neuschaefer@gmx.net>
 pkgname=fzy
 pkgver=0.9
-pkgrel=0
+pkgrel=1
 pkgdesc="A better fuzzy finder"
-url="https://github.com/jhawthorn/"
+url="https://github.com/jhawthorn/$pkgname"
 arch="all"
 license="MIT"
 depends=""


### PR DESCRIPTION
I accidentally used the URL of the author's GitHub user page, instead of
the project page.