### PR TITLE
main/imagemagick: upgrade to 7.0.7.22; check fix

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
-pkgver=7.0.7.21
+pkgver=7.0.7.22
 _abiver=7
 _pkgver=${pkgver%.*}-${pkgver##*.}
 pkgrel=0
@@ -26,6 +26,11 @@ build() {
 		's:DOCUMENTATION_PATH="${DATA_DIR}/doc/${DOCUMENTATION_RELATIVE_PATH}":DOCUMENTATION_PATH="/usr/share/doc/imagemagick":g' \
 		configure
 
+	local _openmp=""
+	case "$CARCH" in
+		s390x) _openmp="--disable-openmp"
+	esac
+
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -34,6 +39,7 @@ build() {
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--disable-static \
+		$_openmp \
 		--with-threads \
 		--without-x \
 		--with-tiff \
@@ -77,4 +83,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="1bbdeb1a67f2057f2c17cee4d0cdd5d9d5304f961b4a5e45c05ac797e941cda9eb73795c273c9b2fd4f3ec6a84e84570c6c91f667a8ae0fbd6c3e1e2b6bb54ce  ImageMagick-7.0.7-21.tar.xz"
+sha512sums="3a5bcceb8469c743738d71db670ea60e30fdb4c1bacc5719832828d97d52c256366ce3a4d80aace1466109ac42b9bb6ca8b5c53f939c043eac2d1c816961d772  ImageMagick-7.0.7-22.tar.xz"


### PR DESCRIPTION
 Revert removal of s390x disable openmp flag.

100% backwards compatiable - https://abi-laboratory.pro/tracker/timeline/imagemagick/

I am not sure that the change from custom to Apache license in a previous commit is correct:
https://www.imagemagick.org/script/license.php