### PR TITLE
main/xen: add basic xen-pci rc script

### DIFF
--- a/main/xen/APKBUILD
+++ b/main/xen/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=xen
 pkgver=4.10.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Xen hypervisor"
 url="http://www.xen.org/"
 arch="x86_64 armhf aarch64"
@@ -183,6 +183,8 @@ source="https://downloads.xenproject.org/release/$pkgname/$pkgver/$pkgname-$pkgv
 	xenqemu.confd
 	xenqemu.initd
 	xendriverdomain.initd
+	xen-pci.initd
+	xen-pci.confd
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver
@@ -434,4 +436,6 @@ c7c0eecd5f454d903b57a710902da27dcb2c6b200f88d4eadfab33a447be6b41454109d482aab849
 ab2105c75cfe01768aecd5bcbb56269d63666e8a44e42b6a83aee87df6c84ee2f9ab249171c21b2e09f8fec2cae8318f6e87d160989398a3e7dd68db8d52c426  xen-consoles.logrotate
 bdbe15c924071cdc2d0f23e53ba8e3f837d4b5369bfb218abd3405f9bef25d105269aaf0784baeb69c073a5786b8c82ffdfd414e86874da34293cfdc2c497928  xenqemu.confd
 8475119369409efb8ad930c7735cd3d782191d18fab4fc322a51120c395162ff88e381182876036d1078afd30079dbf3f94a3568689e9b52ba235adead4b97d3  xenqemu.initd
-85afec835a374aac3d307b3226eee7a08a676b1daac7e39bb7463d564ef72438dc27dd188a871cfd031e80c6992b756951f26bdca0d445e07eab6dba5245de46  xendriverdomain.initd"
+85afec835a374aac3d307b3226eee7a08a676b1daac7e39bb7463d564ef72438dc27dd188a871cfd031e80c6992b756951f26bdca0d445e07eab6dba5245de46  xendriverdomain.initd
+a46337bebce24337f00adbe08095b9f5128c1f440e2033329e5ace9fd817a31fb772d75c0ecc7cc06f34b1522ebf8b21874ee4d0881a0f29851b1c1235f29cf3  xen-pci.initd
+2db5fa6edeeb028236460029b976a849f22b3a15d3929acc3911dc41f365b471c2b815eb111639bc230a69528b1571f3c2e9e8e1e81a6679e55387e39355aa99  xen-pci.confd"

--- a/main/xen/xen-pci.confd
+++ b/main/xen/xen-pci.confd
@@ -1,0 +1,4 @@
+# /etc/conf.d/xen-pci
+
+# PCI devices that will be used by domUs
+DEVICES=""

--- a/main/xen/xen-pci.initd
+++ b/main/xen/xen-pci.initd
@@ -1,0 +1,38 @@
+#!/sbin/openrc-run
+
+extra_commands="status"
+
+depend() {
+        need xenstored
+        after xend xenconsoled
+        before xendomains
+}
+
+is_running() {
+        false
+}
+
+start() {
+        if [ "${DEVICES}" != "" ]; then
+                attached=$(xl pci-assignable-list)
+                for x in ${DEVICES}; do
+                        if echo "$attached" | grep -qsw "$x"; then
+                          echo "PCI device $x already added - skipping"
+                        else
+                          echo "Adding PCI device $x to Xen"
+                          xl pci-assignable-add $x
+                        fi
+                done
+        else
+                echo "DEVICES in /etc/conf.d/xen-pci is empty"
+        fi
+}
+
+stop() {
+	# do nothing devices may be in use
+	true
+}
+
+status() {
+        true
+}


### PR DESCRIPTION
Adds a basic xen-pci release OpenRC script that will run before
xendomains and release PCI devices from dom0, so they can
be pci "passthroughed" to e.g. network or storage domain domUs.