### PR TITLE
main/busybox-initscripts: fix klogd startup

### DIFF
--- a/main/busybox-initscripts/klogd.initd
+++ b/main/busybox-initscripts/klogd.initd
@@ -6,7 +6,7 @@ command_args="${KLOGD_OPTS}"
 pidfile="/var/run/klogd.pid"
 
 depend() {
-	need clock hostname localmount
+	need clock hostname localmount syslog
 	before net
 	keyword -vserver -lxc
 }

--- a/main/busybox-initscripts/syslog.initd
+++ b/main/busybox-initscripts/syslog.initd
@@ -9,6 +9,6 @@ pidfile="/var/run/syslogd.pid"
 start_stop_daemon_args="-g wheel -k 027"
 
 depend() {
-	need clock hostname klogd localmount
+	need clock hostname localmount
 	provide logger
 }

--- a/main/openrc/openrc.post-install
+++ b/main/openrc/openrc.post-install
@@ -26,7 +26,9 @@ for i in etc/rc[SL].d/*; do
 	
 	# add the service to correct "runlevel"
 	case "$svc" in
-		hwclock|modules|sysctl|hostname|keymaps|syslog|bootmisc)
+		syslog|klogd)
+			rc_update $svc sysinit;;
+		hwclock|modules|sysctl|hostname|keymaps|bootmisc)
 			rc_update $svc boot;;
 		*)	rc_update $svc default;;
 	esac


### PR DESCRIPTION
Synopsis
---
`klogd` should depend on `syslog`, as syslog must already be running for klogd to properly utilize it

Expected behavior
---
klogd should write all kernel messages to the syslog daemon, beginning with its startup message (`…kern.notice kernel: klogd started: BusyBox…`) and all kernel early boot messages as seen in `/var/log/dmesg`:

```
# head /var/log/dmesg
[    0.064150] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
[    0.064152] pci_bus 0000:00: root bus resource [mem 0xe0000000-0xfebfffff window]
[    0.064154] pci_bus 0000:00: root bus resource [bus 00-ff]
[    0.064206] pci 0000:00:00.0: [8086:1237] type 00 class 0x060000
[    0.064850] pci 0000:00:01.0: [8086:7000] type 00 class 0x060100
[    0.065965] pci 0000:00:01.1: [8086:7010] type 00 class 0x010180
```


Before patch
---
`/sbin/klogd` starts before `/sbin/syslogd` as the `syslog` service has a startup dependency on the `klogd` service:
```
# cat /etc/init.d/syslog
[...]
depend() {
        need clock hostname klogd localmount
        provide logger
}


# cat /etc/init.d/klogd
[...]
depend() {
        need clock hostname localmount
        before net
        keyword -vserver -lxc
}


# ps aux | grep log
 2120 root       0:00 /sbin/klogd
 2145 root       0:00 /sbin/syslogd -Z
```

Therefore, on my test system, syslog does not receive ~4 seconds worth of kernel messages from klogd, beginning with the klogd startup message and continuing through the kernel's early boot messages:
```
# grep 'kern\.' /var/log/messages
Jan 26 23:57:04 host kern.info kernel: [    4.200892] ip_tables: (C) 2000-2006 Netfilter Core Team
Jan 26 23:57:04 host kern.info kernel: [    4.213438] nf_conntrack version 0.5.0 (16384 buckets, 65536 max)
Jan 26 23:57:04 host kern.info kernel: [    4.301288] NET: Registered protocol family 10
Jan 26 23:57:04 host kern.info kernel: [    5.623007] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
Jan 26 23:57:04 host kern.notice kernel: [    5.627055] Bridge firewalling registered
Jan 26 23:57:04 host kern.info kernel: [    5.682979] Initializing XFRM netlink socket
[...]
```

After patch
---
The daemons start in the correct order:
```
# ps aux | grep log
 1822 root       0:00 /sbin/syslogd -Z
 1847 root       0:00 /sbin/klogd
```
The klogd startup message is logged, as are all messages present in `/var/log/dmesg`:
```
# grep 'kern\.' /var/log/messages
Jan 27 00:33:41 host kern.notice kernel: klogd started: BusyBox v1.27.2 (2017-12-12 10:41:50 GMT)
Jan 27 00:33:41 host kern.info kernel: [    0.063847] pci_bus 0000:00: root bus resource [mem 0x000a0000-0x000bffff window]
Jan 27 00:33:41 host kern.info kernel: [    0.063849] pci_bus 0000:00: root bus resource [mem 0xe0000000-0xfebfffff window]
Jan 27 00:33:41 host kern.info kernel: [    0.063851] pci_bus 0000:00: root bus resource [bus 00-ff]
Jan 27 00:33:41 host kern.debug kernel: [    0.063895] pci 0000:00:00.0: [8086:1237] type 00 class 0x060000
Jan 27 00:33:41 host kern.debug kernel: [    0.064562] pci 0000:00:01.0: [8086:7000] type 00 class 0x060100
[...]
```

Notes
---
- I have added klogd to a runlevel without removing syslog, so that klogd can be selectively disabled without affecting syslog startup.
- If the services are added to the `boot` runlevel klogd can miss some of the earliest messages from the kernel ring buffer, therefore I'm starting them on `sysinit` instead.