### PR TITLE
testing/keepassxc: add aport

### DIFF
--- a/testing/keepassxc/APKBUILD
+++ b/testing/keepassxc/APKBUILD
@@ -1,0 +1,68 @@
+# Contributor: Leonardo Arena <rnalrd@alpinelinux.org>
+# Contributor: August Klein <amatcoder@gmail.com>
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=keepassxc
+pkgver=2.2.4
+pkgrel=0
+pkgdesc="KeePassXC is a cross-platform community-driven port of the Windows application Keepass Password Safe."
+url="https://keepassxc.org/"
+arch="all"
+
+license="GPL-2.0 GPL-3.0 BSD-3-Clause CC0-1.0 LGPL-2.1 LGPL-3.0 Nokia-Qt-exception-1.1 MIT"
+# See COPYING for details for art assets licensing the reason why CC0-1.0, LGPL-2.1, LGPL-3.0 are listed.  It doesn't mean the entire product is CC0 licensed.
+# GPL-2.0 GPL-3.0 are the main licenses
+# BSD-3-Clause applies for the zxcvbn password strength estimator
+# Nokia-Qt-exception-1.1 applies to compressed io streams QtIOCompressor class
+license_build="$license BSL-1.0" # build environment, additional licenses for package maintainer or abuild user
+
+depends=""
+makedepends="cmake qt5-qtbase-dev qt5-qttools-dev libxtst-dev qt5-x11extras-dev libgcrypt-dev libgpg-error-dev argon2-dev zlib-dev"
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/keepassxreboot/$pkgname/archive/$pkgver.tar.gz"
+builddir="$srcdir"/$pkgname-$pkgver
+
+prepare() {
+	cd "$builddir"
+	mkdir build
+	default_prepare
+}
+
+build() {
+	cd "$builddir"/build
+	cmake -DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=/usr/lib \
+		-DCMAKE_BUILD_TYPE=Release ..
+	make
+}
+
+check() {
+	cd "$builddir"/build
+	make test
+}
+
+package() {
+	cd "$builddir"/build
+	make DESTDIR="$pkgdir" install
+}
+
+doc() {
+	cd "$builddir"
+
+	msg "Packaging documentation and licenses"
+
+	mkdir -p "$subpkgdir"/usr/share/doc/$pkgname/
+	mv "$builddir"/CHANGELOG	"$subpkgdir"/usr/share/doc/$pkgname/ || return 1
+	mv "$builddir"/README.md	"$subpkgdir"/usr/share/doc/$pkgname/ || return 1
+
+	mkdir -p "$subpkgdir"/usr/share/licenses/$pkgname/
+	#mv "$builddir"/LICENSE.BOOST-1.0		"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1 #not shipped out
+	mv "$builddir"/LICENSE.BSD			"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
+	mv "$builddir"/LICENSE.GPL-3			"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
+	mv "$builddir"/LICENSE.NOKIA-LGPL-EXCEPTION	"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
+	mv "$builddir"/LICENSE.CC0			"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
+	mv "$builddir"/LICENSE.LGPL-2.1			"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
+	mv "$builddir"/LICENSE.GPL-2			"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
+	mv "$builddir"/LICENSE.LGPL-3			"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
+}
+sha512sums="f3308138d63b65a8b384a52f4723507be921d7bbf19031724886fcd12266bf2683326f5531c8f665b0e98ff63cd97251694199ef748191e59a5a8cceb3710025  keepassxc-2.2.4.tar.gz"

--- a/testing/keepassxc/APKBUILD
+++ b/testing/keepassxc/APKBUILD
@@ -64,5 +64,6 @@ doc() {
 	mv "$builddir"/LICENSE.LGPL-2.1			"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
 	mv "$builddir"/LICENSE.GPL-2			"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
 	mv "$builddir"/LICENSE.LGPL-3			"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
+	mv "$builddir"/COPYING				"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
 }
 sha512sums="f3308138d63b65a8b384a52f4723507be921d7bbf19031724886fcd12266bf2683326f5531c8f665b0e98ff63cd97251694199ef748191e59a5a8cceb3710025  keepassxc-2.2.4.tar.gz"


### PR DESCRIPTION
This is the forked version of the keychain password manager KeePassX with additional features and continued development.  Additional details can be found at https://keepassxc.org/ .

KeePassX latest release was 2.0.3 in Sep 2016.  KeePassXC latest release is 2.2.4 in Dec 2017.