### PR TITLE
testing/oh-my-zsh: new package

### DIFF
--- a/testing/oh-my-zsh/APKBUILD
+++ b/testing/oh-my-zsh/APKBUILD
@@ -1,0 +1,47 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=oh-my-zsh
+pkgver=20180122
+pkgrel=0
+pkgdesc="A delightful community-driven framework for managing your zsh configuration that includes plugins and themes."
+url="http://ohmyz.sh/"
+arch="noarch"
+license="MIT"
+depends="zsh powerline-extra-symbols"
+makedepends=""
+subpackages="$pkgname-doc"
+options="!check"
+commit="37c2d0ddd751e15d0c87a51e2d9f9849093571dc"
+install="$pkgname.post-install $pkgname.post-upgrade"
+
+source="$pkgname-$pkgver.zip::https://github.com/robbyrussell/$pkgname/archive/$commit.zip"
+
+builddir="$srcdir/"$pkgname-$commit
+
+prepare() {
+	cd "$builddir"
+	sed -i -e "s|\$HOME/.oh-my-zsh|/usr/share/$pkgname|g" templates/zshrc.zsh-template || return 1
+}
+
+package() {
+	cd "$builddir"
+
+	mkdir -p "$pkgdir"/usr/share/oh-my-zsh/
+	chmod 755 $(find . -type d) || return 1
+	mv * "$pkgdir"/usr/share/oh-my-zsh/ || return 1
+}
+
+doc() {
+	cd "$builddir"
+
+	msg "Packaging documentation"
+
+	mkdir -p "$subpkgdir"/usr/share/doc/$pkgname/
+	mv  	"$pkgdir"/usr/share/oh-my-zsh/README.md		"$subpkgdir"/usr/share/doc/$pkgname/ || return 1
+	mv  	"$pkgdir"/usr/share/oh-my-zsh/CONTRIBUTING.md	"$subpkgdir"/usr/share/doc/$pkgname/ || return 1
+	mkdir -p "$subpkgdir"/usr/share/licenses/$pkgname/
+	mv	"$pkgdir"/usr/share/oh-my-zsh/LICENSE.txt	"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
+
+	default_doc || return 1
+}
+sha512sums="51724f26ff7a59a1c9e517677b4a45750326ac4ad9f6b3579ed009253f3d37dedafd92c7d8e921bb456ae6862259173f8c9ea5fa562ee2a1c829b09f8f49dba0  oh-my-zsh-20180122.zip"

--- a/testing/oh-my-zsh/oh-my-zsh.post-install
+++ b/testing/oh-my-zsh/oh-my-zsh.post-install
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "You need to copy the contents of /usr/share/oh-my-zsh/templates/zshrc.zsh-template in your ~/.zshrc.  Then, you should edit it."

--- a/testing/oh-my-zsh/oh-my-zsh.post-upgrade
+++ b/testing/oh-my-zsh/oh-my-zsh.post-upgrade
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "You need to copy the contents of /usr/share/oh-my-zsh/templates/zshrc.zsh-template in your ~/.zshrc.  Then, you should edit it."

--- a/testing/powerline-extra-symbols/APKBUILD
+++ b/testing/powerline-extra-symbols/APKBUILD
@@ -1,0 +1,44 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=powerline-extra-symbols
+pkgver=20171017
+pkgrel=0
+pkgdesc="Extra glyphs for your powerline separators"
+url="https://github.com/ryanoasis/powerline-extra-symbols"
+arch="noarch"
+license="MIT"
+depends="fontconfig"
+makedepends=""
+subpackages="$pkgname-doc"
+options="!check"
+commit="7fa9262caf89c500d6024313d35f0571c90aae79"
+
+source="$pkgname-$pkgver.zip::https://github.com/ryanoasis/$pkgname/archive/$commit.zip"
+
+builddir="$srcdir/"$pkgname-$commit
+
+unpack() {
+	default_unpack || return 1
+}
+
+package() {
+	cd "$builddir"
+
+	mkdir -p "$pkgdir"/usr/share/fonts/$pkgname
+	install -m644 "$builddir"/patched-fonts/*.otf \
+		"$pkgdir"/usr/share/fonts/$pkgname/
+}
+
+doc() {
+	cd "$builddir"
+
+	msg "Packaging documentation"
+
+	mkdir -p "$subpkgdir"/usr/share/doc/$pkgname/
+	mv  	"$builddir"/README.md		"$subpkgdir"/usr/share/doc/$pkgname/ || return 1
+	mkdir -p "$subpkgdir"/usr/share/licenses/$pkgname/
+	mv	"$builddir"/LICENSE		"$subpkgdir"/usr/share/licenses/$pkgname/ || return 1
+
+	default_doc || return 1
+}
+sha512sums="8d0205a843ca2fbe9ba3ab174be2e3d94b132caa60df9b19de49dd23a2d715dccb60198272a55ceb4333fc4441649f5d12426c7aa381254b34149528396fddec  powerline-extra-symbols-20171017.zip"

--- a/testing/powerline-extra-symbols/APKBUILD
+++ b/testing/powerline-extra-symbols/APKBUILD
@@ -25,7 +25,7 @@ package() {
 	cd "$builddir"
 
 	mkdir -p "$pkgdir"/usr/share/fonts/$pkgname
-	install -m644 "$builddir"/patched-fonts/*.otf \
+	install -m644 "$builddir"/PowerlineExtraSymbols.otf \
 		"$pkgdir"/usr/share/fonts/$pkgname/
 }
 


### PR DESCRIPTION
Add powerline-extra-symbols font (https://github.com/ryanoasis/powerline-extra-symbols) as a dependency for oh-my-zsh to properly show arrows for the agnoster theme.

Add oh-my-zsh to allow zsh users to use themes (https://github.com/robbyrussell/oh-my-zsh/wiki/Themes) and plugins (https://github.com/robbyrussell/oh-my-zsh/wiki/Plugins).