### PR TITLE
testing/megatools: revision bump to rebuild

### DIFF
--- a/testing/megatools/APKBUILD
+++ b/testing/megatools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 pkgname=megatools
 pkgver=1.9.98
-pkgrel=0
+pkgrel=1
 pkgdesc="Megatools is a collection of programs for accessing Mega.nz service from a command line of your desktop or server."
 url="https://megatools.megous.com"
 arch="all"


### PR DESCRIPTION
This is currently built against libressl 2.5.
A user in IRC was having issues installing this package on a
system with libressl 2.6.