### PR TITLE
main/libressl: upgrade to 2.6.4; modernize

### DIFF
--- a/main/libressl/APKBUILD
+++ b/main/libressl/APKBUILD
@@ -7,7 +7,7 @@
 #     - CVE-2017-8301
 #
 pkgname=libressl
-pkgver=2.6.3
+pkgver=2.6.4
 _namever=${pkgname}${pkgver%.*}
 pkgrel=0
 pkgdesc="Version of the TLS/crypto stack forked from OpenSSL"
@@ -45,9 +45,8 @@ build() {
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		|| return 1
-	make || return 1
+		--localstatedir=/var
+	make
 }
 
 check() {
@@ -57,12 +56,13 @@ check() {
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 
 dev() {
-	default_dev || return 1
+	default_dev
 	replaces="openssl-dev"
 }
 
@@ -81,6 +81,6 @@ _libs() {
 	fi
 }
 
-sha512sums="5c0a0f86ecad1226c2d9a3a8a2e6f412ac0941d402c213ae1d293cd90c6a684198410db8c5250f83b8e2b00968a089afc39e90e053669fc27f82a4eb7c65f5c9  libressl-2.6.3.tar.gz
-07e523ae321b4a6a4afbac7acf4bd30e887b8e18ab2801ca42ba48af130b1cb43d56e70d1039b248c6251623b57c1c638db59105e6fbf4e6175be50d67a0473d  starttls-ldap.patch
+sha512sums="181761da573ff392aaee17dd3dde416d7cbb299ab3e07b49c97e279ceb3f619e78d1dc9ec4c59b0af024f0a8270ff31fe37f8282d0392be34c3143c9647cd246  libressl-2.6.4.tar.gz
+9f1628fbc2a697b6570353920d784b161ca0a122047066d8bee15225bad1e5271aa2ed72b145506bcd4ffe58b35da2caf38c4a048db7e014dabd16b5eba44581  starttls-ldap.patch
 ef8150843f5aae577a859198439673591764fb3ab1da03436607328962f084356fd7f793484c3ad5f2294bd9e8dad15644c311b0da811acbc83eed4b71c0145a  ssl-libcompat.patch"

--- a/main/libressl/starttls-ldap.patch
+++ b/main/libressl/starttls-ldap.patch
@@ -1,5 +1,5 @@
---- libressl-2.5.5/apps/openssl/s_client.c
-+++ libressl-2.5.5.ldap/apps/openssl/s_client.c
+--- a/apps/openssl/s_client.c
++++ b/apps/openssl/s_client.c
 @@ -56,7 +56,7 @@
   * [including the GNU Public Licence.]
   */
@@ -26,7 +26,7 @@
  	BIO_printf(bio_err, "                 are supported.\n");
  	BIO_printf(bio_err, " -xmpphost host - connect to this virtual host on the xmpp server\n");
  	BIO_printf(bio_err, " -sess_out arg - file to write SSL session to\n");
-@@ -315,7 +316,8 @@
+@@ -284,7 +285,8 @@
  	PROTO_POP3,
  	PROTO_IMAP,
  	PROTO_FTP,
@@ -36,7 +36,7 @@
  };
  
  int
-@@ -575,6 +577,8 @@
+@@ -543,6 +545,8 @@
  				starttls_proto = PROTO_FTP;
  			else if (strcmp(*argv, "xmpp") == 0)
  				starttls_proto = PROTO_XMPP;
@@ -45,7 +45,7 @@
  			else
  				goto bad;
  		}
-@@ -978,6 +982,72 @@
+@@ -934,6 +938,72 @@
  		if (!strstr(sbuf, "<proceed"))
  			goto shut;
  		mbuf[0] = 0;
@@ -118,7 +118,7 @@
  	} else if (proxy != NULL) {
  		BIO_printf(sbio, "CONNECT %s HTTP/1.0\r\n\r\n", connect);
  		mbuf_len = BIO_read(sbio, mbuf, BUFSIZZ);
-@@ -1499,3 +1569,86 @@
+@@ -1437,3 +1507,86 @@
  	return 1;
  }
  


### PR DESCRIPTION
100% backwards compatible - https://abi-laboratory.pro/tracker/timeline/libressl/