### PR TITLE
main/curl: upgrade to 7.58.0

### DIFF
--- a/main/curl/APKBUILD
+++ b/main/curl/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=curl
-pkgver=7.57.0
+pkgver=7.58.0
 pkgrel=0
 pkgdesc="An URL retrival utility and library"
 url="http://curl.haxx.se"
@@ -11,8 +11,8 @@ arch="all"
 license="MIT"
 depends="ca-certificates"
 makedepends="zlib-dev libressl-dev libssh2-dev groff perl"
-source="http://curl.haxx.se/download/$pkgname-$pkgver.tar.bz2"
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev libcurl"
+source="http://curl.haxx.se/download/$pkgname-$pkgver.tar.bz2"
 
 # secfixes:
 #   7.57.0-r0:
@@ -90,4 +90,4 @@ libcurl() {
 	mv "$pkgdir"/usr/lib "$subpkgdir"/usr
 }
 
-sha512sums="f366d2e931d7aff63bac0e1f760ced32c849252947d522427ba92124566906a7e6bd081b6d1630df36895dda2a00ac4cf1bed1470740693ef47ab90c6a270377  curl-7.57.0.tar.bz2"
+sha512sums="853b945fbfe87e8dcf2186d8cc6609681b9ed3727f9f075bb434d5df07dcccc633fdf30795f6d5956e3355a5cf94a3780e4a3603b08cbd0368e44103de27085b  curl-7.58.0.tar.bz2"


### PR DESCRIPTION
100% backwards compatible - https://abi-laboratory.pro/tracker/objects_report/curl/7.57.0/7.58.0/report.html