### PR TITLE
testing/rakudo: new aport

### DIFF
--- a/testing/moarvm/APKBUILD
+++ b/testing/moarvm/APKBUILD
@@ -1,0 +1,54 @@
+# Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
+# Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
+pkgname=moarvm
+pkgver=2018.01
+pkgrel=0
+pkgdesc="A VM for NQP And Rakudo Perl 6"
+url="http://moarvm.org/"
+arch="all"
+license="Artistic-2.0"
+depends=""
+makedepends="perl gcc musl-dev make"
+install=""
+subpackages="$pkgname-dev $pkgname-doc"
+source="${pkgname}-${pkgver}.tar.gz::http://moarvm.org/releases/MoarVM-$pkgver.tar.gz"
+builddir="$srcdir"/MoarVM-"$pkgver"
+
+build() {
+	cd "$builddir"
+        unset CPPFLAGS CFLAGS
+        perl Configure.pl --prefix=/usr
+        make
+}
+
+check() {
+        cd "$builddir"
+        LD_LIBRARY_PATH=. ./moar --version
+}
+
+package() {
+	cd "$builddir"
+        install -Dm755 moar "$pkgdir"/usr/bin/moar
+        install -Dm755 libmoar.so "$pkgdir"/usr/lib/libmoar.so
+}
+
+dev() {
+      cd "$builddir"
+      make DESTDIR="$builddir"/install install
+      for file in $(find install/usr/include/ -type f); do
+          install -Dm644 ${file} "$subpkgdir"/usr/include/moar/${file#install/usr/include}
+      done
+      for file in $(find install/usr/share/nqp -type f); do
+          install -Dm644 ${file} "$subpkgdir"/usr/share/nqp/${file#install/usr/share/nqp}
+      done
+      install -Dm644 install/usr/share/pkgconfig/moar.pc "$subpkgdir"/usr/share/pkgconfig/moar.pc
+}
+
+doc() {
+      cd "$builddir"
+      mkdir -p "$subpkgdir"/usr/share/doc/"$pkgname"
+      for file in Artistic2.txt CREDITS LICENSE MANIFEST README.markdown VERSION docs; do
+          cp -r $file "$subpkgdir"/usr/share/doc/"$pkgname"
+      done
+}
+sha512sums="2e558c92562096596992e6e0070092481e5a5d25ac3047110d023536deebc9a4db21d9844ecf3b7c0ae5cc6fa529cc48d9a8e98cdc2f5e23a8effc37b7509ef9  moarvm-2018.01.tar.gz"

--- a/testing/nqp/APKBUILD
+++ b/testing/nqp/APKBUILD
@@ -1,0 +1,50 @@
+# Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
+# Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
+pkgname=nqp
+pkgver=2018.01
+pkgrel=0
+pkgdesc="Not Quite Perl"
+url="https://github.com/perl6/nqp"
+arch="all"
+options="!archcheck" # Arch dependencies are embedded
+license="Artistic-2.0"
+depends="moarvm"
+makedepends="perl-utils gcc musl-dev make moarvm-dev"
+install=""
+subpackages="$pkgname-doc $pkgname-examples"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/perl6/nqp/archive/${pkgver}.tar.gz"
+builddir="$srcdir"/"$pkgname"-"$pkgver"
+
+build() {
+	cd "$builddir"
+        perl Configure.pl --prefix=/usr --backends=moar
+        make
+}
+
+check() {
+        cd "$builddir"
+        make test
+}
+
+package() {
+	cd "$builddir"
+        make DESTDIR="$pkgdir" install
+}
+
+doc() {
+	cd "$builddir"
+	mkdir -p "$subpkgdir"/usr/share/doc/"$pkgname"
+	for file in CREDITS LICENSE README.pod VERSION docs; do
+                cp -r $file "$subpkgdir"/usr/share/doc/"$pkgname"
+        done
+}
+
+examples() {
+	cd "$builddir"
+        mkdir -p "$subpkgdir"/usr/share/doc/"$pkgname"
+        for file in examples; do
+                cp -r $file "$subpkgdir"/usr/share/doc/"$pkgname"
+        done
+}
+
+sha512sums="d7cba1c41858550e90a2b939eb70153fb25394fca0928a7e4692a9dcfcb9dd15d1e7d6d2e420d78f4dcae966b08e58ba59dc1fb5da4f802e14d27fb637a9bb97  nqp-2018.01.tar.gz"

--- a/testing/rakudo/APKBUILD
+++ b/testing/rakudo/APKBUILD
@@ -1,0 +1,55 @@
+# Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
+# Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
+pkgname=rakudo
+pkgver=2018.01
+pkgrel=0
+pkgdesc="A compiler for the Perl 6 programming language"
+url="http://rakudo.org/"
+arch="all"
+license="Artistic-2.0"
+depends="nqp"
+makedepends="perl-utils gcc g++ musl-dev make moarvm-dev"
+install=""
+subpackages="$pkgname-dev $pkgname-doc"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/rakudo/rakudo/archive/$pkgver.tar.gz"
+builddir="$srcdir"/rakudo-"$pkgver"
+
+build() {
+        cd "$builddir"
+        perl Configure.pl --prefix=/usr --backends=moar
+        make M_INCPATH=/usr/include/moar
+        make DESTDIR=install install
+}
+
+check() {
+        cd "$builddir"
+        make test
+}
+
+package() {
+	cd "$builddir"
+        install -Dm755 install/usr/bin/perl6 "$pkgdir"/usr/bin/perl6
+        for file in $(find install/usr/share -type f); do
+          install -Dm644 ${file} "$pkgdir"/usr/share/${file#install/usr/share}
+        done
+}
+
+dev() {
+        cd "$builddir"
+        install -Dm755 perl6-debug-m "$subpkgdir"/usr/bin/perl6-debug-m
+        install -Dm755 perl6-gdb-m "$subpkgdir"/usr/bin/perl6-gdb-m
+        install -Dm755 perl6-lldb-m "$subpkgdir"/usr/bin/perl6-lldb-m
+        install -Dm755 perl6-m "$subpkgdir"/usr/bin/perl6-m
+        install -Dm755 perl6-valgrind-m "$subpkgdir"/usr/bin/perl6-valgrind-m
+        install -Dm755 tools/install-dist.pl "$subpkgdir"/usr/share/perl6/bin/install-dist.pl
+}
+
+doc() {
+      cd "$builddir"
+      mkdir -p "$subpkgdir"/usr/share/doc/"$pkgname"
+      for file in CONTRIBUTING.md CREDITS INSTALL.txt LICENSE README.md VERSION docs; do
+          cp -r $file "$subpkgdir"/usr/share/doc/"$pkgname"
+      done
+}
+
+sha512sums="1849cfac7df5f03c504c307bdf8a6b25e1bf2a01d3ef85863e50b1205936b63791ced4195f027893f2f5f8f579ca6c69730c7571027d4ec035c6ca559dd0de52  rakudo-2018.01.tar.gz"


### PR DESCRIPTION
Supersedes PR https://github.com/alpinelinux/aports/pull/3042

Updated to latest release, 2018.01.

Adding 3 new aports: MoarVM, NQP, and Rakudo. Rakudo is dependent on NQP which is dependent on MoarVM, so they need to go together.
