### PR TITLE
testing/ycmd: new aport

### DIFF
--- a/testing/py-ycmd/APKBUILD
+++ b/testing/py-ycmd/APKBUILD
@@ -1,0 +1,457 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=py-ycmd
+_pkgname=ycmd
+pkgver=31_git20180224
+pkgrel=0
+pkgdesc="A code-completion & code-comprehension server"
+url="https://github.com/Valloric/ycmd"
+arch="all"
+_e_java=
+_e_c=
+_e_go=
+_e_js=
+_e_cs=
+_e_rust=
+_e_typescript=
+_arch_makedepends=
+_arch_configure=
+case "$CARCH" in
+	aarch64*|ppc64le|arm*|s390x|x86|x86_64)
+		_e_java=1
+		_e_c=1
+		_e_go=1
+		_e_js=1
+		_arch_makedepends="clang-dev clang-libs go nodejs nodejs-npm"
+		_arch_configure="$_arch_configure --system-libclang --clang-completer "
+		_arch_configure+="--go-completer --js-completer --java-completer" ;;
+esac
+case "$CARCH" in
+	x86|x86_64)
+		_e_cs=1
+		_arch_makedepends="$_arch_makedepends mono-dev"
+		_arch_configure="$_arch_configure --cs-completer" ;;
+esac
+case "$CARCH" in
+	x86_64)
+		_e_rust=1
+		_e_typescript=1
+		_arch_makedepends="$_arch_makedepends rust cargo"
+		_arch_configure="$_arch_configure --rust-completer" ;;
+esac
+license="GPL-3.0-or-later Apache-2.0 MIT Python-2.0 GPL-2.1-or-later MPL-2.0 "
+license+="BSD-3-Clause BSD-2-Clause ZPL-2.1 ISC MS-PL EPL-1.0 CPL-1.0 W3C Apache-1.1 "
+license+="MPL-1.1 Plexus ICU custom"
+checkdepends="py-pyhamcrest py-webtest py-flake8 py-enum34 py-pycodestyle py-nose "
+checkdepends+="py-mock py-psutil py-nose-exclude py-requests py-urllib3 py-future "
+checkdepends+="py2-unittest2 !py2-bottle !py3-bottle openjdk8 typescript py-jedi"
+makedepends="python2-dev python3-dev py-setuptools py3-setuptools cmake "
+makedepends+="$_arch_makedepends"
+_gitrev="f260d2e1fcddd33fb319abfd277fe169108750e3"
+_jedipkgname="JediHTTP"
+_jedi_gitrev="d283a73f26cdf36069ef99353a072184f794e4d7"
+_omnisharppkgname="omnisharp-server"
+_omnisharp_gitrev="e1902915c6790bcec00b8d551199c8a3537d33c9"
+_bottlepkgname="bottle"
+_bottle_gitrev="7423aa0f64e381507d1e06a6bcab48888baf9a7b"
+_frozendictpkgname="python-frozendict"
+_frozendict_gitrev="b27053e4d11f5891319fd29eda561c130ba3112a"
+_gocodepkgname="gocode"
+_gocode_gitrev="843b7a63f621bb441274849d58671870adf1a5ce"
+_godefpkgname="godef"
+_godef_gitrev="da0b40ecd9d74d280b1fd88555405312d1c14780"
+_futurepkgname="python-future"
+_future_gitrev="6b8341c0412ddf8081151692e9034986a6f867bc"
+_racerdpkgname="racerd"
+_racerd_gitrev="29cd4c6fd2a9301e49931c2e065b2e10c4b587e4"
+_requestspkgname="requests"
+_requests_gitrev="1108058626450b863d154bb74d669754b480caa4"
+_waitresspkgname="waitress"
+_waitress_gitrev="7bb27bb66322fc564e14005d29cb6fddd76a0ab6"
+_nrefactorypkgname="NRefactory"
+_nrefactory_gitrev="3f78bdbedb78cc3e3023bdfbeda016de194acffd"
+_cecilpkgname="cecil"
+_cecil_gitrev="4770957a006b34d35c7c85fbfe80e57de1ade1f9"
+source="$pkgname-$pkgver.zip::https://github.com/Valloric/$_pkgname/archive/${_gitrev}.zip
+	$pkgname-$pkgver-JediHTTP.zip::https://github.com/vheon/$_jedipkgname/archive/$_jedi_gitrev.zip
+	$pkgname-$pkgver-omnisharp-server.zip::https://github.com/OmniSharp/$_omnisharppkgname/archive/$_omnisharp_gitrev.zip
+	$pkgname-$pkgver-bottle.zip::https://github.com/bottlepy/$_bottlepkgname/archive/$_bottle_gitrev.zip
+	$pkgname-$pkgver-python-frozendict.zip::https://github.com/slezica/$_frozendictpkgname/archive/$_frozendict_gitrev.zip
+	$pkgname-$pkgver-gocode.zip::https://github.com/nsf/$_gocodepkgname/archive/$_gocode_gitrev.zip
+	$pkgname-$pkgver-godef.zip::https://github.com/Manishearth/$_godefpkgname/archive/$_godef_gitrev.zip
+	$pkgname-$pkgver-python-future.zip::https://github.com/PythonCharmers/$_futurepkgname/archive/$_future_gitrev.zip
+	$pkgname-$pkgver-racerd.zip::https://github.com/jwilm/$_racerdpkgname/archive/$_racerd_gitrev.zip
+	$pkgname-$pkgver-requests.zip::https://github.com/requests/$_requestspkgname/archive/$_requests_gitrev.zip
+	$pkgname-$pkgver-waitress.zip::https://github.com/Pylons/$_waitresspkgname/archive/$_waitress_gitrev.zip
+	$pkgname-$pkgver-nrefactory.zip::https://github.com/icsharpcode/$_nrefactorypkgname/archive/$_nrefactory_gitrev.zip
+	$pkgname-$pkgver-cecil.zip::https://github.com/jbevain/$_cecilpkgname/archive/$_cecil_gitrev.zip
+	fix-max-line-length.patch
+	prepare-shutdown_test.patch
+	README.Alpine"
+builddir="$srcdir/"$_pkgname-$_gitrev
+subpackages="py2-$_pkgname:_py2 py3-$_pkgname:_py3 $pkgname-doc"
+
+unpack() {
+	default_unpack
+	mv $_jedipkgname-$_jedi_gitrev/* $builddir/third_party/$_jedipkgname/
+	mv $_omnisharppkgname-$_omnisharp_gitrev/* $builddir/third_party/OmniSharpServer/
+	mv $_bottlepkgname-$_bottle_gitrev/* $builddir/third_party/$_bottlepkgname/
+	mv $_frozendictpkgname-$_frozendict_gitrev/* $builddir/third_party/frozendict/
+	mv $_gocodepkgname-$_gocode_gitrev/* $builddir/third_party/$_gocodepkgname/
+	mv $_godefpkgname-$_godef_gitrev/* $builddir/third_party/$_godefpkgname/
+	mv $_futurepkgname-$_future_gitrev/* $builddir/third_party/$_futurepkgname/
+	mv $_racerdpkgname-$_racerd_gitrev/* $builddir/third_party/$_racerdpkgname/
+	mv $_requestspkgname-$_requests_gitrev/* $builddir/third_party/$_requestspkgname/
+	mv $_waitresspkgname-$_waitress_gitrev/* $builddir/third_party/$_waitresspkgname/
+	mv $_nrefactorypkgname-$_nrefactory_gitrev/* \
+		$builddir/third_party/OmniSharpServer/$_nrefactorypkgname/
+	mv $_cecilpkgname-$_cecil_gitrev/* \
+		$builddir/third_party/OmniSharpServer/$_cecilpkgname/
+}
+
+_getpythonver(){
+	echo $($1 -c 'import sys; print("%i.%i" % (sys.version_info.major, sys.version_info.minor))')
+}
+
+_pybuild() {
+	local python="$1"
+	cp -a "$builddir" "${builddir}_$python"
+	cd "${builddir}_$python"
+	#[[ "$python" == "python3" ]] && sed -i -e "s|python3|python|g" cpp/ycm/CMakeLists.txt
+	sed -i -e "s|EXTERNAL_LIBCLANG_PATH \${TEMP}|EXTERNAL_LIBCLANG_PATH \
+$(ls /usr/lib/libclang.so.*)|g" cpp/ycm/CMakeLists.txt
+	find "$srcdir" -type d -print0 | xargs -0 chmod 755
+	$python ./build.py $_arch_configure
+}
+
+build() {
+	_pybuild python2
+	_pybuild python3
+}
+
+package() {
+	install -d "$pkgdir"/usr/share/doc/$pkgname
+	install -t "$pkgdir"/usr/share/doc/$pkgname "$srcdir"/README.Alpine
+}
+
+_mkcp() {
+	local dest="$1"
+	shift
+	install -d "$dest"
+	cp -a $@ "$dest"
+}
+
+_jsdoc() {
+	local pyver="$1"
+	local cmd="$2"
+	local pattern="$3"
+	local spndir="$subpkgdir"/usr/lib/python$pyver/site-packages/$_pkgname
+	local docndir="$pkgdir"/usr/share/doc/$pkgname
+	node_modules=$(find third_party/tern_runtime/node_modules -iname "$pattern" \
+			| cut -d'/' -f4)
+	for m in ${node_modules}; do
+		if [[ "$cmd" == "mv" ]]; then
+			_mkcp "$docndir"/third_party/tern_runtime/node_modules/$m \
+			"$spndir"/third_party/tern_runtime/node_modules/$m/\
+$(basename $(find third_party/tern_runtime/node_modules/$m -iname "$pattern"))
+		fi
+		if [[ "$cmd" == "rm" ]]; then
+			rm "$spndir"/third_party/tern_runtime/node_modules/$m/\
+$(basename $(find third_party/tern_runtime/node_modules/$m -iname "$pattern"))
+		fi
+	done
+}
+
+_javadoc() {
+	local module="$1"
+	local pnamever
+	pnamever=$(basename \
+$(ls -d third_party/eclipse.jdt.ls/target/repository/plugins/$module* | head -n 1))
+	_mkcp "$pkgdir"/usr/share/licenses/$pkgname/third_party/eclipse.jdt.ls/$pnamever \
+	third_party/eclipse.jdt.ls/target/repository/plugins/$pnamever/about_files/*
+}
+
+_reflect() {
+	local destbase="$1"
+	shift
+	local srcbase="$1"
+	shift
+	for f in $@; do
+		install -d "$destbase"/$(dirname $f)
+		install -t "$destbase"/$(dirname $f)/ "$srcbase"/$f
+	done
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"  ## remove if arch isn't noarch
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+	local _builddir="${builddir}_$python"
+	cd "$_builddir"
+	local pyver=$(_getpythonver $python)
+	local spndir="$subpkgdir"/usr/lib/python$pyver/site-packages/$_pkgname
+	local docndir="$pkgdir"/usr/share/doc/$pkgname
+
+	_mkcp  "$spndir"/third_party/ \
+		third_party/JediHTTP/ \
+		third_party/bottle/ \
+		third_party/frozendict/ \
+		third_party/python-future/ \
+		third_party/requests/ \
+		third_party/waitress/
+	[[ -n "$_e_java" && "$_e_java" == "1" ]] \
+		&& cp -a third_party/eclipse.jdt.ls/ "$spndir"/third_party/
+	[[ -n "$_e_js" && "$_e_js" == "1" ]] \
+		&& _mkcp "$spndir"/third_party/ third_party/tern_runtime/
+	[[ -n "$_e_cs" && "$_e_cs" == "1" ]] \
+		&& _mkcp "$spndir"/third_party/OmniSharpServer/OmniSharp/bin/ \
+		third_party/OmniSharpServer/OmniSharp/bin/Release/
+	[[ -n "$_e_go" && "$_e_go" == "1" ]] \
+		&& _mkcp "$spndir"/third_party/gocode/ third_party/gocode/gocode \
+		&& _mkcp "$spndir"/third_party/godef/ third_party/godef/godef
+	[[ -n "$_e_rust" && "$_e_rust" == "1" ]] \
+		&& _mkcp "$spndir"/third_party/racerd/target/release \
+			third_party/racerd/target/release/racerd
+	local libclanglibs=
+	[[ -n "$_e_c" && "$_e_c" == "1" ]]       && libclanglibs="libclang.so.*"
+	_mkcp "$spndir"/ ycmd ycm_core.so CORE_VERSION clang_includes $libclanglibs \
+		cpp PYTHON_USED_DURING_BUILDING
+	rm -rf  "$spndir"/ycmd/tests \
+		"$spndir"/third_party/python-future/tests/ \
+		"$spndir"/third_party/waitress/waitress/tests \
+		"$spndir"/third_party/JediHTTP/jedihttp/tests \
+		"$spndir"/third_party/python-future/src/future/tests \
+		"$spndir"/third_party/python-future/src/past/tests \
+		"$spndir"/third_party/tern_runtime/node_modules/tern/bin/test \
+		"$spndir"/cpp/ycm/tests/gmock/msvc \
+		"$spndir"/cpp/ycm/tests/gmock/gtest/msvc/ \
+		"$spndir"/cpp/ycm/tests/gmock/gtest/xcode \
+		"$spndir"/cpp/ycm/tests/gmock/gtest/m4/ \
+		"$spndir"/cpp/ycm/tests/gmock/gtest/codegear/ \
+		"$spndir"/third_party/python-future/pytest.ini \
+		"$spndir"/third_party/python-future/discover_tests.py \
+		"$spndir"/third_party/python-future/check_rst.sh \
+	"$spndir"/third_party/tern_runtime/node_modules/tern/bin/update_authors.sh \
+		"$spndir"/third_party/waitress/rtd.txt \
+		"$spndir"/third_party/requests/requirements.txt \
+		"$spndir"/third_party/python-future/requirements_py26.txt \
+		"$spndir"/third_party/python-future/TESTING.txt \
+		"$spndir"/third_party/JediHTTP/test_requirements.txt \
+	"$spndir"/third_party/tern_runtime/node_modules/readable-stream/GOVERNANCE.md \
+		"$spndir"/cpp/ycm/benchmarks/benchmark/LICENSE \
+		"$spndir"/cpp/ycm/tests/gmock/LICENSE \
+		"$spndir"/cpp/ycm/tests/gmock/scripts/generator/LICENSE \
+		"$spndir"/cpp/ycm/tests/gmock/gtest/LICENSE \
+		"$spndir"/third_party/JediHTTP/LICENSE \
+		"$spndir"/third_party/JediHTTP/NOTICE \
+		"$spndir"/third_party/bottle/LICENSE \
+		"$spndir"/third_party/frozendict/LICENSE.txt \
+		"$spndir"/third_party/python-future/LICENSE.txt \
+		"$spndir"/third_party/requests/LICENSE \
+		"$spndir"/third_party/requests/NOTICE \
+		"$spndir"/third_party/waitress/COPYRIGHT.txt \
+		"$spndir"/third_party/waitress/LICENSE.txt
+	local findpat=
+	[[ -n "$_e_js" && "$_e_js" == "1" ]] && findpat='-o -iname "test.js"'
+	find "$subpkgdir" -type f \
+		-iname "MANIFEST.in" \
+		-o -iname "test.py" \
+		-o -iname "*.cmake" \
+		-o -iname "Makefile" \
+		-o -iname "configure.ac" \
+		-o -iname "Makefile.am" \
+		-o -iname "setup.py" \
+		-o -iname "setup.cfg" \
+		-o -iname "*\.yml" \
+		-o -iname "CMakeLists.txt" \
+		-o -iname "tox.ini" \
+		-o -iname "test_requests.py" \
+		$findpat \
+		-o \( -name "\.*" -a ! -name ".ycm_extra_conf.py" \) \
+		-print0 | xargs -0 rm -rf
+	find "$subpkgdir" -type d \
+		-iname "__pycache__" \
+		-o -iname "docs" \
+		-o -iname "doc" \
+		-o -iname "travis" \
+		-o -iname "test" \
+		-print0 | xargs -0 rm -rf
+	[[ -n "$_e_js" && "$_e_js" == "1" ]] \
+&& _mkcp "$srcdir/"$pkgname-doc/usr/share/licenses/$pkgname/third_party/tern_runtime/\
+node_modules/tern/doc \
+	"$spndir"/third_party/tern_runtime/node_modules/tern/doc/manual.txt \
+	"$spndir"/third_party/tern_runtime/node_modules/tern/doc/BACKERS.txt
+	_reflect "$docndir" "$spndir"/ \
+		/cpp/ycm/benchmarks/benchmark/CONTRIBUTORS \
+		/cpp/ycm/benchmarks/benchmark/AUTHORS \
+		/cpp/ycm/tests/gmock/README \
+		/cpp/ycm/tests/gmock/CONTRIBUTORS \
+		/cpp/ycm/tests/gmock/CHANGES \
+		/cpp/ycm/tests/gmock/scripts/generator/README \
+		/cpp/ycm/tests/gmock/scripts/generator/README.cppclean \
+		/cpp/ycm/tests/gmock/gtest/README \
+		/cpp/ycm/tests/gmock/gtest/CONTRIBUTORS \
+		/cpp/ycm/tests/gmock/gtest/CHANGES \
+		/third_party/JediHTTP/README.md \
+		/third_party/bottle/AUTHORS \
+		/third_party/bottle/README.rst \
+		/third_party/frozendict/README.md \
+		/third_party/frozendict/README.txt \
+		/third_party/python-future/README.rst \
+		/third_party/requests/AUTHORS.rst \
+		/third_party/requests/CONTRIBUTING.md \
+		/third_party/requests/HISTORY.rst \
+		/third_party/requests/README.rst \
+		/third_party/requests/requests/packages/README.rst \
+		/third_party/bottle/plugins/werkzeug/README \
+		/third_party/bottle/plugins/sqlite/README \
+		/third_party/waitress/CHANGES.txt \
+		/third_party/waitress/CONTRIBUTORS.txt \
+		/third_party/waitress/README.rst \
+		/third_party/waitress/TODO.txt
+	[[ -z "$_e_cs" && "$_e_cs" == "1" ]] \
+		&& _mkcp "$docndir"/third_party/OmniSharpServer \
+			third_party/OmniSharpServer/README.md \
+		&& _mkcp "$docndir"/third_party/OmniSharpServer/cecil \
+			third_party/OmniSharpServer/cecil/NOTES.txt
+	[[ -n "$_e_go" && "$_e_go" == "1" ]] \
+		&& _mkcp "$docndir"/third_party/gocode/ \
+			third_party/gocode/README.md \
+		&& _mkcp "$docndir"/third_party/godef/ \
+			third_party/godef/README
+	[[ -n "$_e_rust" && "$_e_rust" == "1" ]] \
+		&& _mkcp "$docndir"/third_party/racerd	\
+			third_party/racerd/README.md
+	_mkcp "$docndir"/ 	README.md
+	_mkcp "$docndir"/docs 	docs/*
+
+	if [[ -n "$_e_java" && "$_e_java" == "1" ]]; then
+		plugins="$_builddir"/third_party/eclipse.jdt.ls/target/repository/plugins/
+		cd "$plugins"
+		for f in $(find $plugins -name "*.jar"); do
+			d=$(basename $f | sed -e "s|\.jar||g")
+			mkdir -p $d
+			unzip $f -d $d
+		done
+
+		cd "$_builddir"/
+		_javadoc "com.ibm.icu.base"
+		_javadoc "org.eclipse.m2e.archetype.common"
+		_javadoc "org.junit"
+		for d in $dirs; do
+docs=$(find "$_builddir"/third_party/eclipse.jdt.ls/target/repository/plugins/$d/ \
+				-type f -iname "*README*")
+			for doc in $docs; do
+_mkcp "$subpkgdir"/usr/share/doc/$pkgname/third_party/eclipse.jdt.ls/$d "$doc"
+			done
+		done
+	fi
+
+	if [[ -n "$_e_js" && "$_e_js" == "1" ]]; then
+		cd "$spndir"/
+		_jsdoc "$pyver" "rm" "*COPYRIGHT*"
+		_jsdoc "$pyver" "rm" "*NOTICE*"
+		_jsdoc "$pyver" "mv" "README*"
+		_jsdoc "$pyver" "mv" "AUTHORS*"
+		_jsdoc "$pyver" "mv" "CONTRIBUTING*"
+		_jsdoc "$pyver" "mv" "HISTORY*"
+		_jsdoc "$pyver" "mv" "CHANGE*"
+		_jsdoc "$pyver" "mv" "NEWS.txt"
+	fi
+
+	cd "$spndir"/
+	ln -s cpp/ycm/.ycm_extra_conf.py .ycm_extra_conf.py
+}
+
+_py3() {
+	_py python3
+}
+
+_py2() {
+	_py python2
+}
+
+_check() {
+	local python="$1"
+	local _builddir="${builddir}_$python"
+	cd "$_builddir"
+	local completers="python"
+	if [[ -n "$_e_cs"   && "$_e_cs" == "1" ]]; then
+		completers="$completers cs"
+	else
+		sed -i -r -e ':a' -e 'N' -e '$!ba' \
+		-e "s|'cs'[,]?\n                  ||g" ./ycmd/tests/shutdown_test.py
+	fi
+	if [[ -n "$_e_c"    && "$_e_c" == "1" ]]; then
+		completers="$completers cfamily"
+	else
+ 		sed -i -r -e ':a' -e 'N' -e '$!ba' \
+		-e "s|'cfamily'[,]?\n                  ||g" ./ycmd/tests/shutdown_test.py
+	fi
+	if [[ -n "$_e_go"   && "$_e_go" == "1" ]]; then
+		completers="$completers go"
+	else
+		sed -i -r -e ':a' -e 'N' -e '$!ba' \
+		-e "s|'go'[,]?\n                  ||g" ./ycmd/tests/shutdown_test.py
+	fi
+	if [[ -n "$_e_js"   && "$_e_js" == "1" ]]; then
+		completers="$completers javascript"
+	else
+		sed -i -r -e ':a' -e 'N' -e '$!ba' \
+		-e "s|'javascript'[,]?\n                  ||g" \
+			./ycmd/tests/shutdown_test.py
+	fi
+	if [[ -n "$_e_java" && "$_e_java" == "1" ]]; then
+		completers="$completers java"
+	else
+		sed -i -r -e ':a' -e 'N' -e '$!ba' \
+		-e "s|'java'[,]?\n                  ||g" ./ycmd/tests/shutdown_test.py
+	fi
+	if [[ -n "$_e_rust" && "$_e_rust" == "1" ]]; then
+		completers="$completers rust"
+	else
+		sed -i -r -e ':a' -e 'N' -e '$!ba' \
+		-e "s|'rust'[,]?\n||g" ./ycmd/tests/shutdown_test.py
+	fi
+	if [[ -n "$_e_typescript" && "$_e_typescript" == "1" ]]; then
+		completers="$completers typescript"
+	else
+		sed -i -r -e ':a' -e 'N' -e '$!ba' \
+		-e "s|'typescript'[,]?\n                  ||g" \
+			./ycmd/tests/shutdown_test.py
+	fi
+	export JAVA_HOME="/usr/lib/jvm/java-1.8-openjdk/"
+	mkdir -p "$_builddir/ycmd/tests/testdata/python-future/some/path" \
+		"$_builddir/ycmd/tests/testdata/python-future/another/path"
+	echo "print('hello world')" > \
+		"$_builddir"/ycmd/tests/testdata/python-future/standard_library/os.py
+	echo "print('hello world')" > \
+		"$_builddir"/ycmd/tests/testdata/python-future/virtualenv_library/os.py
+	ln -s third_party/python-future/src \
+		ycmd/tests/testdata/python-future/standard_library/site-packages
+	mkdir -p "$_builddir/third_party/eclipse.jdt.ls"
+	$python run_tests.py --skip-build --completers $completers
+}
+
+check() {
+	_check python2
+	_check python3
+}
+
+sha512sums="77a09f0ccde7a3a2f0bcae8be31d16609bc001ac0020b9b1d5da9c6f1a6eb0720440f2d83090a83822f14e00df581e8de89be19213d0f82dbc1179e9363e0b6e  py-ycmd-31_git20180224.zip
+d41271be087ca8fdb31ee06a2674e32532f3f4157143841cee66ee7024e0b57f4e5917b3a700eaf5bd76a02844928bc2bafe18b05fefd4a2882eb07bb801b6f3  py-ycmd-31_git20180224-JediHTTP.zip
+24872e1160058da910e53a0db5caebca697d27dbc60a77094d3658f98fa0652e99734f34f3961f5ef00c4d11df3556bcbc0359e34f19112b932ce88e590a8b7e  py-ycmd-31_git20180224-omnisharp-server.zip
+25b98ee5c3e4eb7d24bc5ec9497628ebdc8435b0e6b2940117c14f57420e87eba73d3460a3af6b47aff341bdd7ddd254aed0e38b6979a8d3e1f35a0b2c134f20  py-ycmd-31_git20180224-bottle.zip
+9206786953b93afb4256e2969bb35e28444033bfac920f2965afecefcea6024017cb087cf1eae041446304cc5c3d3a819ca85da3bfbc3fffa19f8615eaf75fd4  py-ycmd-31_git20180224-python-frozendict.zip
+61541f0808280fa3cad876e0eb33563b9254e71c01aa22eafc71dd80b90f0c8c93f1ba7b04b06e68c6dfcaef273b44ce2ef7485c9a21184fe4ce22e2c9652b2f  py-ycmd-31_git20180224-gocode.zip
+1354ca2580859f4380dce3c330d40d2797477c3ff70570259385eea2d154da05c7d50962882e959ab91e2ee2e9747cdcce6c6e3584812be287098c28d3145eb6  py-ycmd-31_git20180224-godef.zip
+22ca4e5cdb53a2f2cb0f5559cef6ed6fcbb8d681aa906c9c036b938acdfe8c2b7702fa48c4783d45cf0c5287e62f2bf4963b7e6f2a5a099f6162b4ded80625c6  py-ycmd-31_git20180224-python-future.zip
+975e51e624f854b1336a2b6f29cc5c38540afe2829e0ce9896b5c0f0398125e5c63270fd1ad824b3c8356470b6fd8ed4b661857ea790b72c8af209ce8e2e358e  py-ycmd-31_git20180224-racerd.zip
+5d63d0a9b44387ab358f6f610120a0763b5a491fe801f81e9689a1af6b0d92b8e0e3a2107402ee52872bf2feedb983232ded21fa08191e965bd3c5ab946dced5  py-ycmd-31_git20180224-requests.zip
+238b43104f703c020d19f96c31bf65d7fc2bb5b916fc41bf035c9251ad08a86068d2e767bfbcad551416627b5f5800c0ad9b96b3e7e3d19dc8d2625050f0890b  py-ycmd-31_git20180224-waitress.zip
+c75009e4432e667333ed4c0eafaff9ff200ecfc383cd6a490aaeef52101a2b2fa4bc406ea8bff845714ca6f271ee760d4e4f9d61125865ff6774a2edec0d1383  py-ycmd-31_git20180224-nrefactory.zip
+57679c04b8c1393dd3cfeece0b43a4da0c3e5b2d557cc0f2a825e1970b1de711058d99b3ea04574e5b76e57fde0e149eb956dedac8311e14b96f206b35f54a0d  py-ycmd-31_git20180224-cecil.zip
+562765d51f3700f5083d27655bf4691bc1e5bfe40c03175722b503be15b60a3713cd175887b0c3465872bf8f2c58cec49f6dfdc5f17134c8cb8bae241970d07f  fix-max-line-length.patch
+7513031667bf2d926fc2ab96b5e505f5d187cfeae340878dcd12a5e769a33f08488aebc7d9116876f882f3bf13c3ca632fda4f4ce6767da9d2cbf103bcbeed93  prepare-shutdown_test.patch
+2373808cb55646956fd4d35f7ab09101ff3d6841f676cef39979fadbd474e4a08ed98943e42f373f2c18d240836cfac0ebf017fcb913eb68f8b1e4dd4a70a244  README.Alpine"

--- a/testing/py-ycmd/README.Alpine
+++ b/testing/py-ycmd/README.Alpine
@@ -1,0 +1,20 @@
+You need to `sudo apk add rust-src` in order to have the Rust completer work properly.
+
+You need to `sudo apk add py-jedi` in order to have the Python completer to work properly.
+
+You need to either `sudo apk add bear ycm-generator` to generate a compile_commands.json (to detect compilation flags) and generate a .ycm_extra_conf.py 
+(includes header location) respectively per project and set your ycm_global_ycm_extra_conf in order to have the C family completers to work properly, 
+or you need to set your ycm_global_ycm_extra_conf to point to /usr/lib/python3.6/site-packages/ycmd/.ycm_extra_conf.py to use a more generic but less 
+predictive code completion.
+
+You need to `sudo apk add compdb` for Ninja build system support to generate a compile_commands.json file.
+
+You need to `sudo apk add clang-dev` for C / C++ / Objective C / Objective C++ support.
+
+You need to `sudo apk add go` for Go support.
+
+You need to `sudo apk add nodejs` for NodeJs support.
+
+You need to `sudo apk add openjdk8` for Java support.
+
+You need to `sudo apk add typescript` for TypeScript support.

--- a/testing/py-ycmd/fix-max-line-length.patch
+++ b/testing/py-ycmd/fix-max-line-length.patch
@@ -1,0 +1,11 @@
+--- a/run_tests.py.orig
++++ b/run_tests.py
+@@ -42,7 +42,7 @@
+ def RunFlake8():
+   print( 'Running flake8' )
+   subprocess.check_call( [
+-    sys.executable, '-m', 'flake8', p.join( DIR_OF_THIS_SCRIPT, 'ycmd' )
++    sys.executable, '-m', 'flake8', '--max-line-length', '100', '--exclude', 'testdata', p.join( DIR_OF_THIS_SCRIPT, 'ycmd' )
+   ] )
+ 
+ 

--- a/testing/py-ycmd/prepare-shutdown_test.patch
+++ b/testing/py-ycmd/prepare-shutdown_test.patch
@@ -1,0 +1,38 @@
+--- a/ycmd/tests/shutdown_test.py.orig
++++ b/ycmd/tests/shutdown_test.py
+@@ -53,13 +53,15 @@
+   def FromHandlerWithSubservers_test( self ):
+     self.Start()
+ 
+-    filetypes = [ 'cs',
++    filetypes = [
++                  'cs',
+                   'go',
+                   'java',
+                   'javascript',
+                   'python',
+                   'typescript',
+-                  'rust' ]
++                  'rust'
++                ]
+     for filetype in filetypes:
+       self.StartSubserverForFiletype( filetype )
+     self.AssertServersAreRunning()
+@@ -84,13 +86,15 @@
+   def FromWatchdogWithSubservers_test( self ):
+     self.Start( idle_suicide_seconds = 5, check_interval_seconds = 1 )
+ 
+-    filetypes = [ 'cs',
++    filetypes = [
++                  'cs',
+                   'go',
+                   'java',
+                   'javascript',
+                   'python',
+                   'typescript',
+-                  'rust' ]
++                  'rust'
++                ]
+     for filetype in filetypes:
+       self.StartSubserverForFiletype( filetype )
+     self.AssertServersAreRunning()


### PR DESCRIPTION
This is a code completion server used for YouCompleteMe used in vim and emacs-ycmd.  It provides IntelliSense, code correction, documentation to open source text editors that the big IDE editors have.  Languages supported C, C++, C#, Objective C, Python, JavaScript (Node.JS), Rust, Go, Java.  TypeScript support enabled.

rust-src ( #3174 ) is an optional dependency that never gets pulled but up to the user to decide if they want rust support. Already merged.

For Python code completion support, you must pull the py-jedi ( #3425 ) package.

For Java (and maybe Ruby) support you need openjdk8.

Check dependencies not merged but required for Travis CI to evaluate:
* py-pyhamchrest ( #3475 ).
* py-jedi ( #3425  )
* py2-configparser ( #3467 ) -- this was not listed in checkdepends because it gets indirectly pulled by py-flake8
* typescript ( #3466 )
