### PR TITLE
testing/emacs-site-start: new aport

### DIFF
--- a/testing/emacs-site-start/APKBUILD
+++ b/testing/emacs-site-start/APKBUILD
@@ -1,0 +1,22 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=emacs-site-start
+pkgver=0.1.0
+pkgrel=0
+pkgdesc="Trigger to regenerate /usr/share/emacs/site-lisp/site-start.el to \
+install emacs packages."
+arch="noarch"
+url="https://alpinelinux.org/"
+license="MIT"
+depends="emacs"
+options="!check"
+triggers="$pkgname.trigger=/usr/share/emacs/site-lisp/*"
+source="emacs-site-start.trigger"
+builddir="$srcdir/"$pkgname-$pkgver
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+sha512sums="7e4caa642e02ba3ddbb9990ec15e45a497449e93da455c18bd6e1aa7e3e909ae8aad4325432ed483d6cffd1c467843c6912bec114d927b23fa367b1fffc4b700  emacs-site-start.trigger"

--- a/testing/emacs-site-start/emacs-site-start.trigger
+++ b/testing/emacs-site-start/emacs-site-start.trigger
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "Regenerating /usr/share/emacs/site-lisp/site-start.el"
+echo "" > /usr/share/emacs/site-lisp/site-start.el
+for f in $(ls /usr/share/emacs/site-lisp/*-init-*.el | sort); do
+	f=$(basename $f)
+	echo "Adding $f"
+	echo "(load \"/usr/share/emacs/site-lisp/$f\" nil t)" >> /usr/share/emacs/site-lisp/site-start.el || exit 1
+done
+exit 0


### PR DESCRIPTION
This a trigger to update installed emacs extensions.  All new systemwide emacs plugins should make this a makedepends.

Packages will define an init file in the format of [0-9][0-9]-init-$pkgname.el.  The number indicates the order of execution in increasing order meaning low numbers get init first.  The init file should be placed in /usr/share/emacs/site-lisp/.  The contents of new packages should be placed in /usr/share/emacs/site-lisp/$pkgname.

The trigger will sort the init files and then add them to the site-start.el.  If you delete a emacs package, it will run the trigger and update site-start.el.