### PR TITLE
testing/s-el: new package

### DIFF
--- a/testing/s-el/50-init-s-el.el
+++ b/testing/s-el/50-init-s-el.el
@@ -1,0 +1,1 @@
+(add-to-list 'load-path "/usr/share/emacs/site-lisp/s-el/")

--- a/testing/s-el/APKBUILD
+++ b/testing/s-el/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=s-el
+_pkgname=s.el
+pkgver=1.12.0
+pkgrel=0
+pkgdesc="The long lost Emacs string manipulation library."
+url="https://github.com/magnars/s.el"
+arch="noarch"
+license="GPL-3.0-or-later"
+depends="emacs"
+checkdepends="emacs"
+makedepends="emacs-site-start"
+source="$pkgname-$pkgver.tar.gz::https://github.com/magnars/$_pkgname/archive/$pkgver.tar.gz
+	50-init-s-el.el"
+builddir="$srcdir/"$_pkgname-$pkgver
+_initfile="50-init-$pkgname.el"
+subpackages="$pkgname-doc"
+
+package() {
+	cd "$builddir"
+	install -d "$pkgdir"/usr/share/emacs/site-lisp/$pkgname "$pkgdir"/usr/share/emacs/site-lisp/ "$pkgdir"/usr/share/doc/$pkgname/
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/$pkgname/ *.el
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/ "$srcdir"/$_initfile
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
+}
+
+check() {
+	cd "$builddir"
+	./run-tests.sh
+}
+
+sha512sums="036369011295dfde7567ae8bd479be9635de479e8821c3fe117a6c3827bc83492bb91e6ac64d4b20b061da95690f5585ed58f116a2b8c877dceee22153c8c990  s-el-1.12.0.tar.gz
+a4ba7ed6a30c0432ce7dc779057a729d4c98a94d03f3a09632eae47e62320d3488e31c2b64e674fa059aa08def9f09e0a7260c3472ef06e5d40b73563349463b  50-init-s-el.el"


### PR DESCRIPTION
Adding dependency package for emacs-ycmd.  It requires #3161 .

s.el is a string manipulation library for emacs.  More info can be found at https://github.com/magnars/s.el .