### PR TITLE
testing/f-el: new package

### DIFF
--- a/testing/f-el/50-init-f-el.el
+++ b/testing/f-el/50-init-f-el.el
@@ -1,0 +1,1 @@
+(add-to-list 'load-path "/usr/share/emacs/site-lisp/f-el/")

--- a/testing/f-el/APKBUILD
+++ b/testing/f-el/APKBUILD
@@ -1,0 +1,29 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=f-el
+_pkgname=f.el
+pkgver=0.20.0
+pkgrel=0
+pkgdesc="Modern API for working with files and directories in Emacs"
+url="https://github.com/rejeep/f.el"
+arch="noarch"
+license="GPL-3.0-or-later"
+depends="emacs s-el"
+makedepends="emacs-site-start"
+options="!check"
+source="$pkgname-$pkgver.tar.gz::https://github.com/rejeep/$_pkgname/archive/v$pkgver.tar.gz
+	50-init-f-el.el"
+builddir="$srcdir/"$_pkgname-$pkgver
+_initfile="50-init-$pkgname.el"
+
+package() {
+	cd "$builddir"
+
+	install -d "$pkgdir"/usr/share/emacs/site-lisp/$pkgname "$pkgdir"/usr/share/doc/$pkgname/
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/$pkgname/ *.el
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/ "$srcdir"/$_initfile
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
+}
+
+sha512sums="0c44e63cd527a37bd5582d5a2a4cb2269d179930d7f41b378b9100ad5bb4518291b02197b1d55e1bf603bb5b1c12181b982d9b9a3f8fbd48860f6e86ea36c03e  f-el-0.20.0.tar.gz
+180313f80fe1c5e9d28b687601734b3ca28d4a174dd23b2f58aefe7fc04397741e4270ab4f921d0887ee2358189cd3e33e4c95d7fe70298f7b7ced77976da1bc  50-init-f-el.el"


### PR DESCRIPTION
Add dependency for emacs-ycmd.  It requires #3161 .

f.el is a package for working with files and directories in emacs.  More information can be found at https://github.com/rejeep/f.el .