### PR TITLE
testing/request-el: new package

### DIFF
--- a/testing/request-el/50-init-request-el.el
+++ b/testing/request-el/50-init-request-el.el
@@ -1,0 +1,1 @@
+(add-to-list 'load-path "/usr/share/emacs/site-lisp/request-el/")

--- a/testing/request-el/APKBUILD
+++ b/testing/request-el/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=request-el
+_pkgname=emacs-request
+pkgver=0.3.0
+pkgrel=0
+pkgdesc="Request.el -- Easy HTTP request for Emacs Lisp"
+url="https://github.com/tkf/emacs-request"
+arch="noarch"
+license="GPL-3.0-or-later"
+depends="emacs deferred-el"
+makedepends="emacs-site-start"
+subpackages="$pkgname-doc"
+options="!check"
+source="$pkgname-$pkgver.tar.gz::https://github.com/tkf/$_pkgname/archive/v$pkgver.tar.gz
+	50-init-request-el.el"
+builddir="$srcdir/"$_pkgname-$pkgver
+_initfile="50-init-$pkgname.el"
+
+package() {
+	cd "$builddir"
+
+	install -d "$pkgdir"/usr/share/emacs/site-lisp/$pkgname "$pkgdir"/usr/share/emacs/site-lisp/ "$pkgdir"/usr/share/doc/$pkgname/ "$pkgdir"/usr/share/licenses/$pkgname/
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/$pkgname/ *.el
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/ "$srcdir"/$_initfile
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ README.rst
+	install -t "$pkgdir"/usr/share/licenses/$pkgname/ COPYING
+}
+
+sha512sums="9146ddaf66a2b56270530f5663b384e754175b18f9a0b01466c52bc7466ac1b18156f60529da2bdd941fb92d3e12736de526fdbb8bd131a74900b55d0708e7e3  request-el-0.3.0.tar.gz
+c2cd442d473839e09c68200afd76918da5f10176e4096dc6d260e013423fe569daa457b666843b7d1c676a7c92b95d76a37226c566405c11d504621d5360f374  50-init-request-el.el"


### PR DESCRIPTION
Adding dependency for emacs-ycmd. It requires #3161 .

request.el is for http request for emacs.  More information can be found at https://github.com/tkf/emacs-request .  ycmd uses http as a IPC communication with client plugins.