### PR TITLE
testing/dash-el: new package

### DIFF
--- a/testing/dash-el/50-init-dash-el.el
+++ b/testing/dash-el/50-init-dash-el.el
@@ -1,0 +1,1 @@
+(add-to-list 'load-path "/usr/share/emacs/site-lisp/dash-el/")

--- a/testing/dash-el/APKBUILD
+++ b/testing/dash-el/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=dash-el
+_pkgname=dash.el
+pkgver=2.13.0
+pkgrel=0
+pkgdesc="A modern list library for Emacs"
+url="https://github.com/magnars/dash.el"
+arch="noarch"
+license="GPL-3.0-or-later"
+depends="emacs"
+makedepends="emacs-site-start emacs"
+options="check"
+source="$pkgname-$pkgver.tar.gz::https://github.com/magnars/$_pkgname/archive/$pkgver.tar.gz
+	50-init-dash-el.el"
+builddir="$srcdir/"$_pkgname-$pkgver
+_initfile="50-init-$pkgname.el"
+subpackages="$pkgname-doc"
+
+package() {
+	cd "$builddir"
+	install -d "$pkgdir"/usr/share/emacs/site-lisp/$pkgname "$pkgdir"/usr/share/doc/$pkgname/
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/$pkgname/ *.el
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/ "$srcdir"/$_initfile
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
+}
+
+check() {
+	cd "$builddir"
+	./run-tests.sh	
+}
+
+sha512sums="59969e3df1b258a1bae76904e5abaf64c5143de9b8994a04799dad3a317c6ccc1dcd19b99a337a23bce0e46cfb6bc90bf8c6b0e6a532946b4f0ec188d331b559  dash-el-2.13.0.tar.gz
+e5ed32180cc9b4afbc27fa03add9c1711261b202740450546881db8e0cb695719d0bd53de06bf9c1ad1620006192344ddb08de33c66f6ac8a21a4c83637f9659  50-init-dash-el.el"

--- a/testing/dash-el/APKBUILD
+++ b/testing/dash-el/APKBUILD
@@ -10,11 +10,10 @@ arch="noarch"
 license="GPL-3.0-or-later"
 depends="emacs"
 makedepends="emacs-site-start emacs"
-options="check"
-source="$pkgname-$pkgver.tar.gz::https://github.com/magnars/$_pkgname/archive/$pkgver.tar.gz
-	50-init-dash-el.el"
-builddir="$srcdir/"$_pkgname-$pkgver
 _initfile="50-init-$pkgname.el"
+source="$pkgname-$pkgver.tar.gz::https://github.com/magnars/$_pkgname/archive/$pkgver.tar.gz
+	$_initfile"
+builddir="$srcdir/"$_pkgname-$pkgver
 subpackages="$pkgname-doc"
 
 package() {


### PR DESCRIPTION
Adding dependency for emacs-ycmd.  It requires #3161 .

dash.el is a list (data structure) library used in emacs programs.  More information can be found at https://github.com/magnars/dash.el .