### PR TITLE
testing/deferred-el: new package

### DIFF
--- a/testing/deferred-el/50-init-deferred-el.el
+++ b/testing/deferred-el/50-init-deferred-el.el
@@ -1,0 +1,1 @@
+(add-to-list 'load-path "/usr/share/emacs/site-lisp/deferred-el/")

--- a/testing/deferred-el/APKBUILD
+++ b/testing/deferred-el/APKBUILD
@@ -1,0 +1,29 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=deferred-el
+_pkgname=emacs-deferred
+pkgver=0.5.1
+pkgrel=0
+pkgdesc="Simple asynchronous functions for emacs lisp"
+url="https://github.com/kiwanami/emacs-deferred"
+arch="noarch"
+license="GPL-3.0-or-later"
+depends="emacs"
+makedepends="emacs-site-start"
+options="!check"
+source="$pkgname-$pkgver.tar.gz::https://github.com/kiwanami/$_pkgname/archive/v$pkgver.tar.gz
+	50-init-deferred-el.el"
+builddir="$srcdir/"$_pkgname-$pkgver
+_initfile="50-init-$pkgname.el"
+
+package() {
+	cd "$builddir"
+
+	install -d "$pkgdir"/usr/share/emacs/site-lisp/$pkgname "$pkgdir"/usr/share/doc/$pkgname/
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/$pkgname/ *.el
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/ "$srcdir"/$_initfile
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ README.markdown README.ja.markdown README-concurrent.markdown README-concurrent.ja.markdown
+}
+
+sha512sums="357890f73917c7929cbb79f71a26901ac24abe9ea532181b730deee8eba97709b41c360904e2a2a8028ee1295e7ae845da5c702c74256a450f3d144080960a2b  deferred-el-0.5.1.tar.gz
+e1f901a2dc3817b1b7dfce66b5f57c1f42e70d06aafd169e8011bf30e9a3dde939b4d94bfe3cbb89c6b95b9c9b69894dc30d1a4cf9c8d4e68b306d63a9fd9b5f  50-init-deferred-el.el"


### PR DESCRIPTION
Adding emacs-ycmd dependency.  It requires #3161 .

deferred.el is a asynchronous task programming package used for emacs programming.  More information can be found at https://github.com/kiwanami/emacs-deferred .