### PR TITLE
testing/popup-el: new package

### DIFF
--- a/testing/popup-el/50-init-popup-el.el
+++ b/testing/popup-el/50-init-popup-el.el
@@ -1,0 +1,1 @@
+(add-to-list 'load-path "/usr/share/emacs/site-lisp/popup-el/")

--- a/testing/popup-el/APKBUILD
+++ b/testing/popup-el/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=popup-el
+pkgver=0.5.3
+pkgrel=0
+pkgdesc="Visual Popup Interface Library for Emacs"
+url="https://github.com/auto-complete/popup-el"
+arch="noarch"
+license="GPL-3.0-or-later"
+depends="emacs"
+checkdepends="cask"
+makedepends="emacs-site-start"
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/auto-complete/$pkgname/archive/v$pkgver.tar.gz
+	50-init-popup-el.el"
+builddir="$srcdir/"$pkgname-$pkgver
+_initfile="50-init-$pkgname.el"
+
+package() {
+	cd "$builddir"
+	install -d "$pkgdir"/usr/share/emacs/site-lisp/$pkgname "$pkgdir"/usr/share/doc/$pkgname/
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/$pkgname/ *.el
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/ "$srcdir"/$_initfile
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
+}
+
+check() {
+	cd "$builddir"
+	cask exec emacs -batch -Q -l tests/run-test.el
+}
+
+sha512sums="ad67e5d1e4d969151359a54759ae74b2f1107b25b56e7bcedf15995ff6bc0188916fcf5af64ee6ee2b5046e831ebb49c521724e224d7ddb473d3229f3094f5d5  popup-el-0.5.3.tar.gz
+7d341d83a068335967217e5ecff15f6a070f7e609b51dc48301a911c54e899ea07ccd0672f10b6ee5679d79238a145c3d52c31b9db77798205d74a2c49b05ee0  50-init-popup-el.el"


### PR DESCRIPTION
Adding dependency for emacs-ycmd.  It requires #3161 .

This is required for popup UI widget capability for menus in emacs-ycmd and other emacs programs.  More information can be found at https://github.com/auto-complete/popup-el .