### PR TITLE
testing/emacs-ycmd: new aport

### DIFF
--- a/testing/emacs-ycmd/50-init-emacs-ycmd.el
+++ b/testing/emacs-ycmd/50-init-emacs-ycmd.el
@@ -1,0 +1,39 @@
+(add-to-list 'load-path "/usr/share/emacs/site-lisp/emacs-ycmd/")
+
+(setq debug-on-error t)
+
+(add-to-list 'load-path "/usr/share/emacs/site-lisp/emacs-ycmd/contrib")
+(require 'ycmd-next-error)
+
+(set-variable 'ycmd-server-command '("python3" "/usr/lib/python3.6/site-packages/ycmd/ycmd"))
+(set-variable 'ycmd-global-config "/usr/lib/python3.6/site-packages/ycmd/.ycm_extra_conf.py")
+(set-variable 'ycmd-gocode-binary-path "/usr/lib/python3.6/site-packages/ycmd/third_party/gocode/gocode")
+(set-variable 'ycmd-godef-binary-path "/usr/lib/python3.6/site-packages/ycmd/third_party/godef/godef")
+(set-variable 'ycmd-rust-src-path "/usr/src/rust")
+(set-variable 'ycmd-racerd-binary-path "/usr/lib/python3.6/site-packages/ycmd/third_party/racerd/target/release/racerd")
+(set-variable 'ycmd-python-binary-path "/usr/bin/python3")
+
+(require 'ycmd)
+(add-hook 'after-init-hook #'global-ycmd-mode)
+
+(defun ycmd-setup-completion-at-point-function ()
+  "Setup \`completion-at-point-functions' for \`ycmd-mode'."
+  (add-hook 'completion-at-point-functions
+            #'ycmd-complete-at-point nil :local))
+
+(add-hook 'ycmd-mode #'ycmd-setup-completion-at-point-function)
+
+(when (require 'company nil t)
+  (add-hook 'after-init-hook 'global-company-mode))
+(when (require 'elpy nil t)
+(elpy-enable))
+
+(require 'company-ycmd)
+(company-ycmd-setup)
+(add-hook 'after-init-hook 'global-company-mode)
+
+(require 'flycheck-ycmd)
+(flycheck-ycmd-setup)
+
+(require 'ycmd-eldoc)
+(add-hook 'ycmd-mode-hook 'ycmd-eldoc-setup)

--- a/testing/emacs-ycmd/APKBUILD
+++ b/testing/emacs-ycmd/APKBUILD
@@ -1,0 +1,77 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=emacs-ycmd
+pkgver=1.3_git20180218
+pkgrel=0
+pkgdesc="Emacs client for ycmd, the code completion system."
+url="https://github.com/abingham/emacs-ycmd"
+arch="noarch"
+license="MIT Apache-2.0 GPL-3.0-or-later BSD-3-Clause"
+checkdepends="cask nodejs go python2 py3-jedi clang-dev typescript"
+depends="py3-ycmd emacs"
+_gitrev="a35a2ddd911da6d3a926bdef2614a2898055a5e2"
+_initfile="50-init-$pkgname.el"
+source="$pkgname-$pkgver.zip::https://github.com/abingham/$pkgname/archive/$_gitrev.zip
+	fix-runner.patch
+	add-test-settings.patch
+	use-python3.patch
+	$pkgname
+	$_initfile"
+builddir="$srcdir/"$pkgname-$_gitrev
+subpackages="$pkgname-doc"
+
+build() {
+	local c
+	for c in $(find . -name "Cask") ; do
+		cd "$(dirname $c)"
+		cask --dev install
+	done
+	cask build
+}
+
+package() {
+	cd "$builddir"
+	install -d "$pkgdir"/usr/share/emacs/site-lisp/$pkgname \
+		"$pkgdir"/usr/share/doc/$pkgname/ "$pkgdir"/usr/bin
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/$pkgname/ *.el *.elc
+	cp -a contrib .cask "$pkgdir"/usr/share/emacs/site-lisp/$pkgname/
+	install -t "$pkgdir"/usr/share/emacs/site-lisp/ "$srcdir"/$_initfile
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ README.md CHANGES.md
+	install -t "$pkgdir"/usr/bin "$srcdir"/$pkgname
+}
+
+_getpythonver(){
+        echo $($1 -c 'import sys; print("%i.%i" % '\
+		'(sys.version_info.major, sys.version_info.minor))')
+}
+
+check() {
+	cd "$builddir"
+	dirs=""
+	local elpa
+	for elpa in $(find $builddir/ -name "elpa" -type d) ; do
+		for d in $(ls -d $elpa/* | sort) ; do
+			dirs="$dirs:$d"
+		done
+	done
+	local pv=$(_getpythonver python3)
+	local pydirs=
+	for pd in \
+		$(ls -d /usr/lib/python${pv}/site-packages/ycmd/third_party/* \
+			| sort) ; do
+		pydirs="$pydirs:$pd"
+	done
+	export PYTHONPATH="/usr/lib/python${pv}/site-packages/jedi\
+		:$pydirs:$PYTHONPATH"
+	export EMACSLOADPATH="$dirs:$EMACSLOADPATH"
+	make YCMDPATH="/usr/lib/python${pv}/site-packages/ycmd/ycmd/" \
+		REQUEST_BACKEND=curl test
+}
+
+sha512sums="5544e9666c8c9231c6b809e0d9aa8d90eb04a2a9d7bbd65e40abfdc3b9ba3740a5f2c98825b4357adee01963304a8ca854429052d66b5a126060178d265e5dbe  emacs-ycmd-1.3_git20180218.zip
+bc0d46199681aa1408706ad3bcd238b19e7b246fd4f7c8a9d926366ad9417f966a140e639cb6d76d538eb84a2a6b23f57e0b4518d14e11228fb23488b82436fa  fix-runner.patch
+c87ce579d92e0a537eb94194a60bacc229b4f661441aeb7f4dfe55e2dd922c5795ead84a2829ec29189aed77cf8e700f8f05cef1702e5bccf48a99e27708ffc6  add-test-settings.patch
+280c2f02e197b369caf72c5750a1b1506913a693c8cf9736190fc732dda8b77f231736adfc83d0fbaea203cb2c0ee993c167b4ad6efa937e2c555da85597d600  use-python3.patch
+92089137588d0becdfab12f4108d86688b5e18e62930c997bcf808a80adcd7bf181acf617502f34f683cc7e8076b84287db130147775b4914d1bad7380745053  emacs-ycmd
+041de8a5959da1dbe9710ac2f733efe6261c51ce5520ada88983d1567a8d138bff4ec256b379062b3bc6da9ce3bf50a32b1e50a3be28b756394f6662f2f922bb  50-init-emacs-ycmd.el"

--- a/testing/emacs-ycmd/add-test-settings.patch
+++ b/testing/emacs-ycmd/add-test-settings.patch
@@ -1,0 +1,15 @@
+--- a/test/ycmd-test.el.orig
++++ b/test/ycmd-test.el
+@@ -49,6 +49,12 @@
+ 
+ ;;; Code:
+ 
++(set-variable 'ycmd-server-command '("python3" "/usr/lib/python3.6/site-packages/ycmd/ycmd"))
++(set-variable 'ycmd-gocode-binary-path "/usr/lib/python3.6/site-packages/ycmd/third_party/gocode/gocode")
++(set-variable 'ycmd-godef-binary-path "/usr/lib/python3.6/site-packages/ycmd/third_party/godef/godef")
++(set-variable 'ycmd-rust-src-path "/usr/src/rust")
++(set-variable 'ycmd-racerd-binary-path "/usr/lib/python3.6/site-packages/ycmd/third_party/racerd/target/release/racerd")
++(set-variable 'ycmd-python-binary-path "/usr/bin/python3")
+ 
+ (require 'let-alist)
+ (require 'ert)

--- a/testing/emacs-ycmd/emacs-ycmd
+++ b/testing/emacs-ycmd/emacs-ycmd
@@ -1,0 +1,15 @@
+#!/bin/sh
+dirs=""
+for elpa in $(find /usr/share/emacs/site-lisp/emacs-ycmd/ -name "elpa" -type d) ; do
+	for d in $(ls -d $elpa/* | sort) ; do
+		dirs="$dirs:$d"
+	done
+done
+local pv=$(python3 -c 'import sys; print("%i.%i" % (sys.version_info.major, sys.version_info.minor))')
+local pydirs=
+for pd in $(ls -d /usr/lib/python${pv}/site-packages/ycmd/third_party/* | sort) ; do
+	pydirs="$pydirs:$pd"
+done
+export PYTHONPATH="/usr/lib/python${pv}/site-packages/jedi:$pydirs:$PYTHONPATH"
+export EMACSLOADPATH="$dirs:$EMACSLOADPATH"
+emacs $@

--- a/testing/emacs-ycmd/fix-runner.patch
+++ b/testing/emacs-ycmd/fix-runner.patch
@@ -1,0 +1,11 @@
+--- a/test/run.el.orig
++++ b/test/run.el
+@@ -24,6 +24,8 @@
+ 
+ ;;; Code:
+ 
++(setq load-file-rep-suffixes '(""))
++
+ (defun ycmd-runs-this-script-p ()
+   t)
+ 

--- a/testing/emacs-ycmd/use-python3.patch
+++ b/testing/emacs-ycmd/use-python3.patch
@@ -1,0 +1,11 @@
+--- a/test/run.el.orig
++++ b/test/run.el
+@@ -39,7 +39,7 @@
+   (let* ((load-prefer-newer t)
+          (source-directory (locate-dominating-file ycmd-runner-file "Cask"))
+          (pkg-rel-dir (format ".cask/%s/elpa" emacs-version))
+-         (python-path (executable-find "python")))
++         (python-path (executable-find "python3")))
+     (unless python-path
+       (error "Python not found"))
+     (setq package-user-dir (expand-file-name pkg-rel-dir source-directory))


### PR DESCRIPTION
This package add code completion, variable spell checking, trivial code correction support for emacs using ycmd code completion server. It depends on #3161 , #3159  .

The check dependencies requires the following packages but not merged yet:
* typescript - #3466
* py-jedi - #3425 (py-ycmd has version requirements for this one)
* cask - #3459