### PR TITLE
testing/py-ycm-generator: new aport

### DIFF
--- a/testing/py2-ycm-generator/APKBUILD
+++ b/testing/py2-ycm-generator/APKBUILD
@@ -1,0 +1,65 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=py2-ycm-generator
+_pkgname=${pkgname#py2-*}
+_ghpkgname=YCM-Generator
+pkgver=0_git20160820
+pkgrel=0
+pkgdesc="Generates config files for YouCompleteMe"
+url="https://github.com/rdnetto/YCM-Generator"
+arch="noarch"
+license="GPL-3.0-or-later"
+depends="python2 clang"
+subpackages="$pkgname:py2 $pkgname-vimplugin"
+_gitrev="4d92151f0b29afadacdd3a6c90e5a449afc34bb1"
+source="$pkgname-$pkgver.zip::https://github.com/rdnetto/$_ghpkgname/archive/$_gitrev.zip"
+builddir="$srcdir/"$_ghpkgname-$_gitrev
+options="!check"
+
+_getpythonver() {
+	echo $($1 -c 'import sys; print("%i.%i" '\
+		'% (sys.version_info.major, sys.version_info.minor))')
+}
+
+prepare() {
+	cd "$builddir"
+	local PY_VERSION=$(_getpythonver python2)
+	find . -type d -print0 | xargs -0 chmod 755
+	sed -i -e "s|expand(\"<sfile>:p:h:h\") . \
+\"/config_gen.py\"|\"/usr/lib/python${PY_VERSION}/site-packages/config_gen.py\"|g"\
+		plugin/ycm-generator.vim
+}
+
+package() {
+	install -d "$pkgdir"/usr/share/doc/$_pkgname/
+	install -t "$pkgdir"/usr/share/doc/$_pkgname/ "$builddir"/README.md
+}
+
+py2() {
+        cd "$builddir"
+        local python="python2"
+        pkgdesc="$pkgdesc ${python#python}"
+        depends="$depends $python"
+        install_if="$pkgname=$pkgver-r$pkgrel $python"
+	local PY_VERSION=$(_getpythonver python2)
+	install -d \
+		"$subpkgdir"/usr/lib/python${PY_VERSION}/site-packages/$pkgname\
+		"$subpkgdir"/usr/bin
+	install -t \
+		"$subpkgdir"/usr/lib/python${PY_VERSION}/site-packages/$pkgname\
+		 config_gen.py template.py
+	mv fake-toolchain \
+		"$subpkgdir"/usr/lib/python${PY_VERSION}/site-packages/$pkgname
+	ln -s /usr/lib/python${PY_VERSION}/site-packages/config_gen.py \
+		"$subpkgdir"/usr/bin/config_gen.py
+}
+
+vimplugin() {
+	cd "$builddir"
+	local vimpath="/usr/share/vim/vimfiles"
+	install -d "$subpkgdir"$vimpath/plugin
+	install -t "$subpkgdir"/$vimpath/plugin/ plugin/*
+}
+
+sha512sums="7ad3bfb59517af23697be7f6e033b6b12c52406294a05fd806c40ad1b61c877fc5b588c0ec8367fa83cea932ae51a05560051daaab590f65f277780f0e2faf47  py2-ycm-generator-0_git20160820.zip"


### PR DESCRIPTION
Add vim plugin and .ycm_extra_conf.py generator used for YouCompleteMe, emacs-ycmd, ycmd.  .ycm_extra_conf.py is used to give hints about library include files to expose constants, function signatures, class names, structures used in c/c++ projects.