### PR TITLE
testing/bear: new aport

### DIFF
--- a/testing/bear/APKBUILD
+++ b/testing/bear/APKBUILD
@@ -1,0 +1,43 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=bear
+_pkgname=Bear
+pkgver=2.3.11
+pkgrel=0
+pkgdesc="Build EAR - Bear is a tool that generates a compilation database for \
+clang tooling."
+url="https://github.com/rizsotto/Bear"
+arch="all"
+license="GPL-3.0"
+checkdepends="py3-lit py3-coverage python2 python3 bash"
+makedepends="cmake"
+source="$pkgname-$pkgver.tar.gz::https://github.com/rizsotto/$_pkgname/archive/$pkgver.tar.gz"
+builddir="$srcdir/"$_pkgname-$pkgver
+subpackages="$pkgname-doc"
+
+build() {
+	cd "$builddir"
+	cmake . -DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DBUILD_DOCUMENTATION=on \
+		-DBUILD_TESTING=off
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+	install -d "$pkgdir"/usr/share/doc/$pkgname/
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ README.md ChangeLog.md
+}
+
+check() {
+	cd "$builddir"
+	export PATH="$(echo "$PATH" | \
+		sed -r -e 's|/usr/lib/ccache/bin[/]?||g'):$builddir/bear:$PATH"
+	chmod +x bear/bear
+	lit -v test
+}
+
+sha512sums="820688f4e9beb8f878eb9d48ded22221edb9c3ad8ac20bfdee109acdae088bfdb73cdaa1846b9e4b41a45d598752aa6c974c1733507377e15ffe3607d72aa837  bear-2.3.11.tar.gz"


### PR DESCRIPTION
Add a compile_commands.json generator for ycmd that hints how to compile the source code file for c/c++/objc so that ycmd's FixIt feature works.