### PR TITLE
community/rust: add $pkgname-src submodule for ycmd and racerd code completion support

### DIFF
--- a/community/rust/APKBUILD
+++ b/community/rust/APKBUILD
@@ -6,11 +6,11 @@ pkgname=rust
 pkgver=1.23.0
 _llvmver=4
 _bootver=1.22.0
-pkgrel=0
+pkgrel=1
 pkgdesc="The Rust Programming Language (compiler)"
 url="http://www.rust-lang.org"
 arch="x86_64"
-license="Apache-2.0 BSD ISC MIT"
+license="Apache-2.0 BSD ISC MIT GPL-3.0-or-later GPL-3.0-with-GCC-exception LGPL-3.0 CC-BY-SA-3.0 OFL-1.1"
 
 # gcc is needed at runtime just for linking. Someday rustc might invoke
 # the linker directly, and then we'll only need binutils.
@@ -26,7 +26,7 @@ makedepends="rust>=$_bootver cargo
 	python2 tar zlib-dev"
 
 subpackages="$pkgname-dbg $pkgname-stdlib
-	$pkgname-gdb::noarch $pkgname-lldb::noarch $pkgname-doc"
+	$pkgname-gdb::noarch $pkgname-lldb::noarch $pkgname-doc $pkgname-src"
 source="https://static.rust-lang.org/dist/rustc-$pkgver-src.tar.gz
 	musl-fix-static-linking.patch
 	musl-fix-linux_musl_base.patch
@@ -62,6 +62,9 @@ prepare() {
 
 build() {
 	cd "$builddir"
+
+	#save sources to eliminate compile time cruft
+	cp -a "$builddir"/src "$srcdir"/
 
 	# jemalloc is disabled, because it increases size of statically linked
 	# binaries produced by rustc (stripped hello_world 186 kiB vs. 358 kiB)
@@ -159,6 +162,17 @@ lldb() {
 
 	_mv "$pkgdir"/usr/bin/rust-lldb usr/bin/
 	_mv "$pkgdir"/$_sharedir/etc/lldb_*.py $_sharedir/etc/
+}
+
+src() {
+	pkgdesc="$pkgdesc (source code)"
+	depends="$pkgname"
+
+	mkdir -p "$subpkgdir"/usr/src
+	cd "$subpkgdir"
+
+	mv "$srcdir"/src "$srcdir"/rust
+	_mv "$srcdir"/rust usr/src/
 }
 
 _mv() {


### PR DESCRIPTION
This downloads the source code so that code completion could work properly with ycmd with the rust programming language.