### PR TITLE
testing/capnproto-c++: new aport

### DIFF
--- a/testing/capnproto-c++/APKBUILD
+++ b/testing/capnproto-c++/APKBUILD
@@ -1,0 +1,38 @@
+# Contributor: Florian Larysch <fl@n621.de>
+# Maintainer: Florian Larysch <fl@n621.de>
+pkgname=capnproto-c++
+pkgver=0.6.1
+pkgrel=0
+pkgdesc="Cap'n Proto serialization/RPC system"
+url="https://capnproto.org"
+arch="all"
+license="MIT"
+depends=""
+makedepends="linux-headers"
+subpackages="$pkgname-dev"
+source="$pkgname-$pkgver.tar.gz::https://capnproto.org/$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var
+	make
+}
+
+check() {
+	cd "$builddir"
+
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+sha512sums="cd35aec18175b28149cf39ccbf360f8023d2762d04c0d6fdfbd7789ca26eac6228dfec6a414f48ff78aec4aad4c3d9d5f143a6a59dd86c16f653fc538e64b58e  capnproto-c++-0.6.1.tar.gz"


### PR DESCRIPTION
Cap'n Proto is a binary serialization framework in the spirit of Google
Protobuf.

Signed-off-by: Florian Larysch <fl@n621.de>