### PR TITLE
testing/gearmand: bump to v1.1.18

### DIFF
--- a/testing/gearmand/APKBUILD
+++ b/testing/gearmand/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Aaron Hurt <ahurt@ena.com>
 # Maintainer: Aaron Hurt <ahurt@ena.com>
 pkgname=gearmand
-pkgver=1.1.15
-pkgrel=2
+pkgver=1.1.18
+pkgrel=0
 pkgdesc="A distributed job queue"
 url="http://gearman.org"
 arch="all"
@@ -68,7 +68,7 @@ gearman_libs() {
 	mv "$pkgdir"/usr/lib/libgearman.so* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="c405f5bbecd198d852ccc1a082522a00d1a31dcf8b92f39dc1af78c12926e9d6f13c52e07b8f4ee63354f28928fbe70976ac86301e9f68990246ad6e678578e3  gearmand-1.1.15.tar.gz
+sha512sums="fd2c978775bde19a8f1ffaf720b4c8adfda9859e5f554b247e7edca15fcc684168fb279af6c63e29c0524c8c863a9f3d07ea802e67eec42be793c0487b9beb9a  gearmand-1.1.18.tar.gz
 8d7c7473d8bcc06a6dfcb1975dd5b4992457661c6c2fab5e160f6252222af603003466c26de0c2d241d247ac33bc68f8fae853b7401691f36b2e6c57ff9b65ba  libtest-cmdline.cc.patch
 08a1ce2ef071a33efc5c93de5812f83ee2b96ae604eaedb1d40a998ccb4e88a0f588d846d19623de9b8f98df18639168521763d27f1fb3ca046b4c679d61468b  libhashkit-common.h.patch
 d97dbee95c0b96f0a81e42b730afdb9d129eb83e09be101e1bc2b2cd06a95fe1259265b912bf3850a51c6404e2c5883532a008946dfd46992cb488e1221dae97  gearmand.initd


### PR DESCRIPTION
This package is behind by a couple of releases.