### PR TITLE
main/gdb: remove double definition of pt_regs structure during gdbser…

### DIFF
--- a/main/gdb/APKBUILD
+++ b/main/gdb/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gdb
 pkgver=8.0.1
-pkgrel=5
+pkgrel=6
 pkgdesc="The GNU Debugger"
 url="https://www.sourceware.org/gdb/"
 arch="all"
@@ -13,7 +13,8 @@ options="!check"
 subpackages="$pkgname-doc"
 source="https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.xz
 	s390x-use-elf-gdb_fpregset_t.patch
-	ppc-musl.patch"
+	ppc-musl.patch
+	ppc-ptregs.patch"
 
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -60,4 +61,5 @@ package() {
 
 sha512sums="5eb328910033f0918058be2f92caebf1e8dfc6caa3c730d99d621627e53de3c1b43761c2f683d53555893253c2f06768cbf56cdea051a3d291ffb6cfae87b5e1  gdb-8.0.1.tar.xz
 c3872eb51b3a42c5a33f8b7542c37fab7b0548560202e5eda740a2176cdfadff9bf73c6d26bceb225829dcb509c823acae2ccc796237ac97ebe552b82582bdf5  s390x-use-elf-gdb_fpregset_t.patch
-04911f87904b62dd7662435f9182b20485afb29ddb3d6398a9d31fef13495f7b70639c77fdae3a40e2775e270d7cd40d0cfd7ddf832372b506808d33c8301e01  ppc-musl.patch"
+04911f87904b62dd7662435f9182b20485afb29ddb3d6398a9d31fef13495f7b70639c77fdae3a40e2775e270d7cd40d0cfd7ddf832372b506808d33c8301e01  ppc-musl.patch
+b75e1c1ee503a1948a7d5b8d90427b5c7d38ded69978056cee0adca222771a5c95ed1ac73127fcae7b795ea94296344eee5fca47e4cd04b418c164a756fb0933  ppc-ptregs.patch"

--- a/main/gdb/ppc-ptregs.patch
+++ b/main/gdb/ppc-ptregs.patch
@@ -1,0 +1,10 @@
+--- a/gdb/gdbserver/linux-ppc-low.c
++++ b/gdb/gdbserver/linux-ppc-low.c
+@@ -21,7 +21,6 @@
+ #include "linux-low.h"
+ 
+ #include <elf.h>
+-#include <asm/ptrace.h>
+ 
+ #include "nat/ppc-linux.h"
+ #include "linux-ppc-tdesc.h"


### PR DESCRIPTION
now that gdbserver is enabled as part of gdb APKBUILD need to remove double declaration of pt_regs structure