### PR TITLE
testing/wireguard: upgrade to 0.0.20180202

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20180118
-_mypkgrel=1
+_ver=0.0.20180202
+_mypkgrel=2
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="8f90b4a84073e281de17ea1db422c2d97bf97c96aad2177d86485e244a447bf2d5e1c8f74f0bba560949f74c73fb6211cc13949a9b28ede2991a69eeaa9b8bd6  WireGuard-0.0.20180118.tar.xz"
+sha512sums="81eb66b2abe3b3013fc7fbc7f6601808d1676f1fa5e7942d0af09e2ec56e91c396ded2b23eece7c63d1b76f6c3209d93b7cdf06c9d30a59e626d08a604a6780a  WireGuard-0.0.20180202.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180118
+pkgver=0.0.20180202
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="8f90b4a84073e281de17ea1db422c2d97bf97c96aad2177d86485e244a447bf2d5e1c8f74f0bba560949f74c73fb6211cc13949a9b28ede2991a69eeaa9b8bd6  WireGuard-0.0.20180118.tar.xz"
+sha512sums="81eb66b2abe3b3013fc7fbc7f6601808d1676f1fa5e7942d0af09e2ec56e91c396ded2b23eece7c63d1b76f6c3209d93b7cdf06c9d30a59e626d08a604a6780a  WireGuard-0.0.20180202.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20180118
-_mypkgrel=0
+_ver=0.0.20180202
+_mypkgrel=2
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="8f90b4a84073e281de17ea1db422c2d97bf97c96aad2177d86485e244a447bf2d5e1c8f74f0bba560949f74c73fb6211cc13949a9b28ede2991a69eeaa9b8bd6  WireGuard-0.0.20180118.tar.xz"
+sha512sums="81eb66b2abe3b3013fc7fbc7f6601808d1676f1fa5e7942d0af09e2ec56e91c396ded2b23eece7c63d1b76f6c3209d93b7cdf06c9d30a59e626d08a604a6780a  WireGuard-0.0.20180202.tar.xz"


### PR DESCRIPTION
```
== Changes ==

  * curve25519-fiat32: uninline certain functions

  This results in much smaller code size and significanat speed gains on smaller
  hardware.

  * poly1305: add poly-specific self-tests

  Poly is easy to get wrong, so we've added quite a few tests that examine
  certain edge cases and places where other implementations of historically
  failed.

  * tools: dedup secret normalization
  * tools: share curve25519 implementations with kernel
  * contrib: keygen-html: share curve25519 implementation with kernel

  There is now only one place where we ship 25519 code.

  * qemu: disable PIE for compilation
  * qemu: disable AVX-512 in userland
  * qemu: update base versions

  Test suite enhancements.

  * device: let udev know what kind of device we are

  This enables folks to query the device type via udev, which is what systemd's
  networkctl uses.

  * tools: fread doesn't change errno

  This fixes clearing pre-shared keys on old glibc.

  * chacha20poly1305: use existing rol32 function
  * chacha20poly1305: better buffer alignment

  Small enhancements.

  * curve25519: verify that specialized basepoint implementations are correct

  Since some implementations have a specialized function for computing
  basepoints, it's important to do some basic sanity checking with them.

  * curve25519: replace hacl64 with fiat64

  For about 24 hours, fiat64 was faster.

  * curve25519: replace fiat64 with faster hacl64

  Then hacl64 caught up, so we moved back to it.

  * curve25519: break more things with more test cases

  These extra test cases help break the current "rfc7748_precomputed"
  implementation, which we're not using here at the moment, but it is still
  useful to ensure that we don't fall victim to the same bugs.
```