### PR TITLE
main/tmux: rebuild because of ncurses update

### DIFF
--- a/main/tmux/APKBUILD
+++ b/main/tmux/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=tmux
 pkgver=2.6
-pkgrel=0
+pkgrel=1
 pkgdesc="Tool to control multiple terminals from a single terminal"
 url="https://tmux.github.io/"
 arch="all"


### PR DESCRIPTION
after updating to 6.0_p20171125-r0 tmux crashes without rebuild
(starting vim)