### PR TITLE
main/gc: upgrade to 7.6.4; modernize

### DIFF
--- a/main/gc/APKBUILD
+++ b/main/gc/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gc
-pkgver=7.6.0
-pkgrel=1
+pkgver=7.6.4
+pkgrel=0
 pkgdesc="A garbage collector for C and C++"
 url="http://hboehm.info/gc/"
 arch="all"
@@ -12,7 +12,6 @@ subpackages="$pkgname-dev $pkgname-doc libgc++:libgccpp"
 source="http://hboehm.info/gc/gc_source/gc-$pkgver.tar.gz
 	fix-boehm-gc.patch
 	"
-
 builddir="$srcdir"/gc-${pkgver%[a-z]}
 
 build() {
@@ -24,14 +23,14 @@ build() {
 		--prefix=/usr \
 		--datadir=/usr/share/doc/gc \
 		--enable-cplusplus \
-		--disable-static \
-		|| return 1
-	make || return 1
+		--disable-static
+
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
 libgccpp() {
@@ -43,8 +42,8 @@ check() {
 	cd "$builddir"
 
 	# two FAILs due to grsecurity
-	make check || return 0
+	make check
 }
 
-sha512sums="511e8c01287b1ee9dbec87f0573377de77038b7af053a3f33afed9b3ffa30e2402d6a9bb0ca4f4b81cd808209b47b5718d498cff3de6632a057fe03fad51fc43  gc-7.6.0.tar.gz
+sha512sums="2c85be3e24b85732b3dc6f08fe98cf1a82b6fb2a22ec73090f80920721c737ef92cee8f0cd7ea7228d686005d164e7da54ce3907c3a1ba5eefa43355a472085e  gc-7.6.4.tar.gz
 6439505931f0d023bf27d6ce0af90d09dc23bb9dd49b561566ec54b2cddc20642be9bd7b41203f643cb6efed3db2f54aef410b436f3acc2351fe4bb0a8791ea4  fix-boehm-gc.patch"


### PR DESCRIPTION
100% backwards compatible - https://abi-laboratory.pro/tracker/timeline/bdwgc/