### PR TITLE
main/cairo: enable color emoji support 

### DIFF
--- a/main/cairo/APKBUILD
+++ b/main/cairo/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cairo
 pkgver=1.14.10
-pkgrel=0
+pkgrel=1
 pkgdesc="A vector graphics library"
 url="http://cairographics.org/"
 arch="all"
@@ -16,6 +16,7 @@ _ultver="2016-04-23"
 source="http://cairographics.org/releases/$pkgname-$pkgver.tar.xz
 	fontconfig-ultimate-$_ultver.tar.gz::https://github.com/bohoomil/fontconfig-ultimate/archive/$_ultver.tar.gz
 	musl-stacksize.patch
+	cairo-1.14.6-colored-emojis.patch
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -74,4 +75,5 @@ tools() {
 
 sha512sums="a381d97e6046da0012eb5595118efb95ff02e3e84310682e458b503ebf22d6b2663bcc1391980768bb9cd02ae809b8df2e11d6200b48745dc5ec824c342b5852  cairo-1.14.10.tar.xz
 d8185f4ec74f44c4746acf7e79bba7ff7ffd9d35bdabeb25e10b4e12825942d910931aa857f1645e5c8185bcb40a1f1ffe1e7e647428e9ea66618b2aec52fac3  fontconfig-ultimate-2016-04-23.tar.gz
-86f26fe41deb5e14f553c999090d1ec1d92a534fa7984112c9a7f1d6c6a8f1b7bb735947e8ec3f26e817f56410efe8cc46c5e682f6a278d49b40a683513740e0  musl-stacksize.patch"
+86f26fe41deb5e14f553c999090d1ec1d92a534fa7984112c9a7f1d6c6a8f1b7bb735947e8ec3f26e817f56410efe8cc46c5e682f6a278d49b40a683513740e0  musl-stacksize.patch
+d178d413f0e258c7970340bea6e2fcaf8d9c6cfed3d831c29dcbd7b1a782e0b8c9106fca0d2d4beb6939a8993cc2554464b6fb4df888a736f8083cde226a41c6  cairo-1.14.6-colored-emojis.patch"

--- a/main/cairo/cairo-1.14.6-colored-emojis.patch
+++ b/main/cairo/cairo-1.14.6-colored-emojis.patch
@@ -1,0 +1,13 @@
+diff -urp cairo-1.14.6.orig/src/cairo-ft-font.c cairo-1.14.6/src/cairo-ft-font.c
+--- cairo-1.14.6.orig/src/cairo-ft-font.c	2016-12-05 15:58:48.292450747 -0800
++++ cairo-1.14.6/src/cairo-ft-font.c	2016-12-05 16:00:16.972824582 -0800
+@@ -2260,7 +2260,7 @@ _cairo_ft_scaled_glyph_init (void			*abs
+      * Moreover, none of our backends and compositors currently support
+      * color glyphs.  As such, this is currently disabled.
+      */
+-    /* load_flags |= FT_LOAD_COLOR; */
++     load_flags |= FT_LOAD_COLOR;
+ #endif
+ 
+     error = FT_Load_Glyph (face,
+


### PR DESCRIPTION
This patch allows for xfce4-terminal to display color emojis on the command line and Chromium to properly display font-noto-emoji.  It may require all packages that depend on cairo be rebuilt.

We can enable it now (for 1.14.10) or wait for 1.15.8.

https://www.phoronix.com/scan.php?page=news_item&px=Cairo-1.15.8-Colored-Emoji