### PR TITLE
community/ocaml: add gcc dependency

### DIFF
--- a/community/ocaml/APKBUILD
+++ b/community/ocaml/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Borys Zhukov <mp5@mp5.im>
 pkgname=ocaml
 pkgver=4.04.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Main implementation of the Caml programming language"
 url="http://ocaml.org/"
 arch="all !x86 !armhf !s390x"
 license="LGPL-2.0"
-makedepends="ncurses-dev zlib-dev gdbm-dev"
+makedepends="ncurses-dev zlib-dev gdbm-dev gcc libc-dev"
 depends="ncurses-dev"
 options="textrels"
 subpackages="$pkgname-doc"


### PR DESCRIPTION
Based on this issue: https://bugs.alpinelinux.org/issues/8472

Since ocaml packages use ocamlopt to compile and therefore ocaml is _not_ a run-time dependency [1], I think it is ok the add this dependency.

[1] https://pkgs.alpinelinux.org/package/edge/community/x86_64/unison