### PR TITLE
opam: Fix missing dependency

### DIFF
--- a/community/opam/APKBUILD
+++ b/community/opam/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Anil Madhavapeddy <anil@recoil.org>
 pkgname=opam
 pkgver=1.2.2
-pkgrel=1
+pkgrel=2
 pkgdesc="OCaml Package Manager"
 url="https://opam.ocaml.org"
 arch="all !x86 !armhf !s390x"  # ocaml not avail on excluded platforms
 license="LGPL-3.0"
-depends="ocaml camlp4 curl tar unzip rsync aspcud"
+depends="ocaml camlp4 curl tar unzip rsync aspcud patch"
 makedepends="$depends_dev"
 install=""
 subpackages=""


### PR DESCRIPTION
Fixes https://bugs.alpinelinux.org/issues/8474

Considering this basic example:
```
FROM alpine:3.7
RUN apk add --no-cache opam build-base m4
RUN opam init -a
RUN opam install -y ocamlfind.1.7.3-1
```

The last command fails because it needs a patch command accepting the --dry-run argument.
However the patch command from busybox doesn't have this option. I believe the "opam" package should depend on "patch" like it does for the "tar", "rsync", "curl", ...

OPAM makes extensive use of the patch command, so virtually no packages works without the ``patch``` package.

Related to https://github.com/ocaml/opam-repository/issues/11241