### PR TITLE
testing/font-comic-neue: new aport

### DIFF
--- a/testing/font-comic-neue/APKBUILD
+++ b/testing/font-comic-neue/APKBUILD
@@ -1,0 +1,28 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=font-comic-neue
+_pkgname=comicneue
+pkgver=2.4
+pkgrel=0
+pkgdesc="Comic Neue is a font that fixes the shortcomings of Comic Sans"
+url="http://comicneue.com/"
+arch="noarch"
+license="OFL-1.1"
+depends="fontconfig"
+_gitrev="216e1cca320e7e7886c9523f9afbb7972eb7a9f2"
+source="$_pkgname-$pkgver.tar.gz::https://github.com/crozynski/$_pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+subpackages="$pkgname-doc"
+options="!check" # data files no tests distributed
+
+package() {
+	cd "$builddir"
+	install -d "$pkgdir/usr/share/fonts/$_pkgname" \
+		"$pkgdir"/usr/share/doc/$_pkgname/
+	install -t "$pkgdir"/usr/share/fonts/$_pkgname OTF/*.otf
+	install -t "$pkgdir"/usr/share/doc/$_pkgname/ FONTLOG.txt \
+		Booklet-ComicNeue.pdf README.md
+}
+
+sha512sums="400934ecc951877456ffd1de6118d794b73b08bce438abdbeb4cec67c652338a785948ccc3d83acec8bd7c3d0c51102bccca9f2d15fac31b73378f8a3ed2e98a  comicneue-2.4.tar.gz"


### PR DESCRIPTION
This is a free alternative to Comic Sans installed from msttcorefonts-installer package.

More details can be found at: 
http://comicneue.com/
https://github.com/crozynski/comicneue
License: OFL-1.1