### PR TITLE
testing/font-fantasque-sans: new aport

### DIFF
--- a/testing/font-fantasque-sans/APKBUILD
+++ b/testing/font-fantasque-sans/APKBUILD
@@ -1,0 +1,78 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=font-fantasque-sans
+_pkgname=fantasque-sans
+pkgver=1.7.2
+pkgrel=0
+pkgdesc="A font family with a great monospaced variant for programmers."
+url="https://github.com/belluzj/fantasque-sans"
+arch="noarch"
+license="OFL-1.1"
+depends="fontconfig"
+makedepends="fontconfig"
+source="$_pkgname-$pkgver-normal.tar.gz::https://github.com/belluzj/fantasque-sans/releases/download/v$pkgver/FantasqueSansMono-Normal.tar.gz
+        $_pkgname-$pkgver-noloopk.tar.gz::https://github.com/belluzj/fantasque-sans/releases/download/v$pkgver/FantasqueSansMono-NoLoopK.tar.gz
+	$_pkgname-$pkgver-largelineheight.tar.gz::https://github.com/belluzj/fantasque-sans/releases/download/v$pkgver/FantasqueSansMono-LargeLineHeight.tar.gz
+	$_pkgname-$pkgver-largelineheightnoloopk.tar.gz::https://github.com/belluzj/fantasque-sans/releases/download/v$pkgver/FantasqueSansMono-LargeLineHeight-NoLoopK.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+subpackages="$pkgname-doc $pkgname-normal $pkgname-noloopk \
+	$pkgname-largelineheight $pkgname-largelineheightnoloopk"
+options="!check" # data files only no tests are distributed
+
+unpack() {
+	default_unpack
+	mkdir -p "$builddir"
+	cd "$builddir"
+	mkdir normal noloopk largelineheight largelineheightnoloopk
+	tar -xvf "$srcdir"/$_pkgname-$pkgver-normal.tar.gz -C normal
+	tar -xvf "$srcdir"/$_pkgname-$pkgver-noloopk.tar.gz -C noloopk
+	tar -xvf "$srcdir"/$_pkgname-$pkgver-largelineheight.tar.gz \
+		-C largelineheight
+	tar -xvf "$srcdir"/$_pkgname-$pkgver-largelineheightnoloopk.tar.gz \
+		-C largelineheightnoloopk
+}
+
+_variantgenerator() {
+	install -d "$subpkgdir/usr/share/fonts/$_pkgname"
+	pkgdesc="$pkgdesc ($2)"
+	install -t "$subpkgdir"/usr/share/fonts/$_pkgname \
+		"$builddir"/$1/OTF/*.otf
+}
+
+package() {
+	cd "$builddir"/normal
+	install -d "$pkgdir/usr/share/fonts/$_pkgname" \
+		"$pkgdir"/usr/share/doc/$_pkgname/
+	install -t "$pkgdir"/usr/share/doc/$_pkgname/ CHANGELOG.md README.md
+}
+
+normal() {
+	#they use the same name for the variants
+	depends="$depends !$pkgname-noloopk !$pkgname-largelineheight \
+		!$pkgname-largelineheightnoloopk"
+	_variantgenerator "normal" "Normal"
+}
+
+noloopk() {
+	depends="$depends !$pkgname-normal !$pkgname-largelineheight \
+		!$pkgname-largelineheightnoloopk"
+	_variantgenerator "noloopk" "NoLoopK"
+}
+
+largelineheight() {
+	depends="$depends !$pkgname-normal !$pkgname-noloopk \
+		!$pkgname-largelineheightnoloopk"
+	_variantgenerator "largelineheight" "LargeLineHeight"
+}
+
+largelineheightnoloopk() {
+	depends="$depends !$pkgname-normal !$pkgname-noloopk \
+		!$pkgname-largelineheight"
+	_variantgenerator "largelineheightnoloopk" "LargeLineHeight-NoLoopK"
+}
+
+sha512sums="f854de5a5e0464d7f69b484c4ae0f59cfdcaa65d357b9935eda1df8cb90781f78c6b6ab0a96ac5099a6464a52de14cf26630d3db5dad8228e86e44033b32c228  fantasque-sans-1.7.2-normal.tar.gz
+07fdb568b25f8d8d8b34c1d9573a37821b301de3733dd72664c9c04c61499d72fb5bf6be3afeb4fbd40c81b6b9cddfaaa2efc2a29d61ff57804e9ccda86d1828  fantasque-sans-1.7.2-noloopk.tar.gz
+eca787c4d6436ccfae10da8cb7894a6ea9ada4013334914c3419fd81c26cac249ac7ae05b6be945ad67ce8aae131de4bc7af33de9dff0dde716206997bf8086f  fantasque-sans-1.7.2-largelineheight.tar.gz
+4c6e5238e8b84cf3f2164191416557718b6bb60d650efa8a13039ef90a39a685fb4417ca5901a87f17182ec23105ea5928d123d2a413120146d69a564d92a168  fantasque-sans-1.7.2-largelineheightnoloopk.tar.gz"


### PR DESCRIPTION
This is a Comic Sans monospace font for programmers.

The subpackages are mutually exclusive because they use the same font name.

More info: https://github.com/belluzj/fantasque-sans
License: OFL-1.1