### PR TITLE
main/cabextract: modernize and add simple check

### DIFF
--- a/main/cabextract/APKBUILD
+++ b/main/cabextract/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=cabextract
 pkgver=1.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Tool for extracting Microsoft cabinet files"
 url="https://www.cabextract.org.uk/"
 arch="all"
@@ -10,9 +10,10 @@ subpackages="$pkgname-doc"
 makedepends="libmspack-dev"
 source="https://www.cabextract.org.uk/$pkgname-$pkgver.tar.gz"
 
-builddir="$srcdir"/${pkgname}-${pkgver}
-build () {
-	cd $builddir
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -24,8 +25,13 @@ build () {
 	make
 }
 
+check() {
+	cd "$builddir"
+	./cabextract --version > /dev/null
+}
+
 package() {
-	cd $builddir
+	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
 


### PR DESCRIPTION
Add a simple test as upstream doesn't provide a test suite.