### PR TITLE
allow build to finish after proc_nice test has permission warnings

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -378,7 +378,7 @@ check() {
 	# Ignore it for now and continue build even on test failures.
 	local allow_fail='no'
 	case "$CARCH" in
-		x86 | armhf | aarch64) allow_fail='yes'
+		x86 | armhf | aarch64 | ppc64le) allow_fail='yes'
 	esac
 
 	NO_INTERACTION=1 REPORT_EXIT_STATUS=1 \


### PR DESCRIPTION
2 minor test warnings on tests that issue nice() command with invalid strings/variables. Allow build to continue by adding ppc64le so allow_fail $CARCH list.