### PR TITLE
main/cutter: modernize and mark no test

### DIFF
--- a/main/cutter/APKBUILD
+++ b/main/cutter/APKBUILD
@@ -2,42 +2,27 @@
 # Maintainer: Michael Mason <ms13sp@gmail.com>
 pkgname=cutter
 pkgver=1.04
-pkgrel=0
+pkgrel=1
 pkgdesc="A program that allows firewall administrators to abort TCP/IP connections"
 url="http://www.digitage.co.uk/digitage/software/linux-security/cutter"
 arch="all"
 license="GPL-2.0"
-depends=""
 makedepends="linux-headers"
-install=""
-subpackages=""
+options="!check"
 source="http://www.digitage.co.uk/digitage/files/cutter/$pkgname-$pkgver.tgz
 	musl-fix.patch"
 
-_builddir="$srcdir"/$pkgname-$pkgver
-
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-	cd "$_builddir"
-	make || return 1
+	cd "$builddir"
+	make
 }
 
 package() {
-	cd "$_builddir"
-	install -m755 -D $pkgname "$pkgdir"/usr/sbin/$pkgname || return 1
+	cd "$builddir"
+	install -m755 -D $pkgname "$pkgdir"/usr/sbin/$pkgname
 }
 
-md5sums="0efbf3c62ab0bdba39b083ad023914de  cutter-1.04.tgz
-dca1d7b39deb52edfd353bc8a7eb1d34  musl-fix.patch"
-sha256sums="1b336c69eb3393f6ca118a529773014c41126ac6dabd04b77151daa1c2f01180  cutter-1.04.tgz
-66baab0636e605a935199785bb916219c24e0673c682289ff04a44d061a3e1fb  musl-fix.patch"
 sha512sums="79c17ec8c17e696a79aa8b11fda347f2e6929eb35f9a37da450acf6aff7ab9471e13eaef24708f90f3f0c2791fade2eb944443b98df3d3ae4eef0c408abc7b3a  cutter-1.04.tgz
 815ffcfbae6865443b49390f1c5dc583243009150271804468aad00102b136ac2e6abe565efa18d15f4411690444ca6fdd1184a8b31e61f5a62115f87f6d53dc  musl-fix.patch"


### PR DESCRIPTION
Upstream does not provide a test suite and to run cutter you need
to run it as root, so no way to add a simple check like --help.