### PR TITLE
main/darkstat: modernize and add simple check

### DIFF
--- a/main/darkstat/APKBUILD
+++ b/main/darkstat/APKBUILD
@@ -2,44 +2,35 @@
 # Maintainer: ScrumpyJack <scrumpyjack@st.ilet.to>
 pkgname=darkstat
 pkgver=3.0.719
-pkgrel=0
+pkgrel=1
 pkgdesc="Captures network traffic, calculates statistics about usage, and serves reports over HTTP"
 url="https://unix4lyfe.org/darkstat/"
 arch="all"
 license="BSD"
-depends=""
-depends_dev=""
 makedepends="zlib-dev libpcap-dev"
-install=""
 subpackages="$pkgname-doc"
-source="https://unix4lyfe.org/${pkgname}/${pkgname}-${pkgver}.tar.bz2"
+source="https://unix4lyfe.org/$pkgname/$pkgname-$pkgver.tar.bz2"
 
-_builddir="${srcdir}/${pkgname}-${pkgver}"
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
         ./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
+		--prefix=/usr
         make
      }
 
-package() {
-	cd "$_builddir"
-        make DESTDIR=${pkgdir} install
+
+check() {
+	cd "$builddir"
+	./darkstat --help > /dev/null
 }
 
-md5sums="963145de05cb21f4d93a9c244beeaea0  darkstat-3.0.719.tar.bz2"
-sha256sums="aeaf909585f7f43dc032a75328fdb62114e58405b06a92a13c0d3653236dedd7  darkstat-3.0.719.tar.bz2"
+package() {
+	cd "$builddir"
+	make DESTDIR=$pkgdir install
+}
+
 sha512sums="264f6c5f862745fbfb5d125aae5a319369f028fd7be96cfb12775147f528a36b7f5a42bcd6434f2d376933292364641f2ec9cd9bdb1fe105f5a905e331181f98  darkstat-3.0.719.tar.bz2"


### PR DESCRIPTION
Add a simple test as upstream doesn't provide a test suite.