### PR TITLE
testing/haxe: update to 3.4.5

### DIFF
--- a/testing/haxe/APKBUILD
+++ b/testing/haxe/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jon Ong <jonongjs@rottenmage.com>
 # Maintainer: Andy Li <andy@onthewings.net>
 pkgname=haxe
-pkgver=3.4.4
+pkgver=3.4.5
 _versuffix=
 pkgrel=1
 pkgdesc="Cross-platform toolkit and programming language"
@@ -47,7 +47,7 @@ package() {
 	install -Dm 644 extra/LICENSE.txt "$pkgdir"/usr/share/licenses/$pkgname/LICENSE.txt
 	install -Dm 644 "$srcdir/haxe.sh" "$pkgdir/etc/profile.d/haxe.sh"
 }
-sha512sums="e6f3dc4659ff785b8ffbe2fcc4fcee75afe66b848e1423f4e63cec383d2f99d54332d9f0812eb3b1931847f2429c4dbc64caedbf9afca750598292ce34f5522a  haxe-3.4.4.tar.gz
+sha512sums="1df0a011752c93fd6bc659da0d03f328a011acdb27d6fd37512342f74a4836c52a60a72525caa86b79ac14b1dd1b93872955e3f640d1e175811a2ce2066be515  haxe-3.4.5.tar.gz
 711a58dae9311a2614467a04b294c6b0b3064849d4840f98d24c152a49abf856c79567aa810c59701e76d42db43359c04ae29a8b5d0404132b5cd107ae6b58e1  haxelib.tar.gz
 a09864fa5b00210695f9d1d5f6b4c4f0a5f37ec7c5020671e32185e0f205e46535103673eaa1a585627e7aebc4b64185414c6cd4dd59f12bfda2191d372be3b5  ocamllibs.tar.gz
 c756571769bcdb0d7040b44b3d486e445c56a01a8d23d26f668be19b8d147e9f324166f004872d04e912f329e45ad821672a0a365df4ba27fb1dc22bb34130a3  haxe.sh"


### PR DESCRIPTION
Haxe 3.4.5 is a bugfix/improvement release. Changelog can be found at https://github.com/HaxeFoundation/haxe/blob/3.4.5/extra/CHANGES.txt#L1-L16