### PR TITLE
main/git: Fix installation of protocol backends

### DIFF
--- a/main/git/APKBUILD
+++ b/main/git/APKBUILD
@@ -157,7 +157,7 @@ daemon() {
 	mv "$pkgdir"/$_gitcoredir/git-daemon \
 		"$pkgdir"/$_gitcoredir/git-http-backend \
 		"$pkgdir"/$_gitcoredir/git-shell \
-		"$subpkgdir"/$_gitcoredir \
+		"$subpkgdir"/$_gitcoredir
 
 	mv "$pkgdir"/etc "$subpkgdir"/
 }


### PR DESCRIPTION
A trailing backslash lead to a non-properly executed `mv`-command, so all backends (`daemon`, `http-backend`, `shell`) were not available in the package.