### PR TITLE
testing/powerline-extra-symbols: new aport

### DIFF
--- a/testing/powerline-extra-symbols/APKBUILD
+++ b/testing/powerline-extra-symbols/APKBUILD
@@ -1,0 +1,27 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=powerline-extra-symbols
+pkgver=0_git20171017
+pkgrel=0
+pkgdesc="Extra glyphs for your powerline separators"
+url="https://github.com/ryanoasis/powerline-extra-symbols"
+arch="noarch"
+license="MIT"
+depends="fontconfig"
+subpackages="$pkgname-doc"
+options="!check" # upstream has no unit test
+_gitrev="7fa9262caf89c500d6024313d35f0571c90aae79"
+source="$pkgname-$pkgver.zip::https://github.com/ryanoasis/$pkgname/archive/$_gitrev.zip"
+builddir="$srcdir/"$pkgname-$_gitrev
+
+package() {
+	cd "$builddir"
+	install -d "$pkgdir"/usr/share/fonts/$pkgname \
+		"$pkgdir"/usr/share/doc/$pkgname/
+	install -t "$pkgdir"/usr/share/fonts/$pkgname/ \
+		"$builddir"/PowerlineExtraSymbols.otf
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ "$builddir"/README.md
+}
+
+sha512sums="8d0205a843ca2fbe9ba3ab174be2e3d94b132caa60df9b19de49dd23a2d715dccb60198272a55ceb4333fc4441649f5d12426c7aa381254b34149528396fddec  powerline-extra-symbols-0_git20171017.zip"


### PR DESCRIPTION
This was part of #3135 but split out.

Powerline extra symbols is a font for oh-my-zsh (#3238) to display arrows and certain symbols for the agnoster theme.

For more information see: https://github.com/ryanoasis/powerline-extra-symbols