### PR TITLE
testing/oh-my-zsh: new aport (edited)

### DIFF
--- a/testing/oh-my-zsh/APKBUILD
+++ b/testing/oh-my-zsh/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=oh-my-zsh
+pkgver=0_git20180122
+pkgrel=0
+pkgdesc="A delightful community-driven framework for managing your zsh \
+configuration that includes plugins and themes."
+url="http://ohmyz.sh/"
+arch="noarch"
+license="MIT"
+depends="zsh powerline-extra-symbols"
+subpackages="$pkgname-doc"
+options="!check" # no upstream tests
+_gitrev="37c2d0ddd751e15d0c87a51e2d9f9849093571dc"
+install="$pkgname.post-install $pkgname.post-upgrade"
+source="$pkgname-$pkgver.zip::https://github.com/robbyrussell/$pkgname/archive/$_gitrev.zip
+	install-path.patch"
+builddir="$srcdir/"$pkgname-$_gitrev
+
+package() {
+	cd "$builddir"
+	install -d "$pkgdir"/usr/share/oh-my-zsh/ \
+		"$pkgdir"/usr/share/doc/$pkgname/
+	chmod 755 $(find . -type d)
+	mv * "$pkgdir"/usr/share/oh-my-zsh/
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ \
+		"$pkgdir"/usr/share/oh-my-zsh/README.md
+}
+
+sha512sums="51724f26ff7a59a1c9e517677b4a45750326ac4ad9f6b3579ed009253f3d37dedafd92c7d8e921bb456ae6862259173f8c9ea5fa562ee2a1c829b09f8f49dba0  oh-my-zsh-0_git20180122.zip
+56bcb688489dcf74ba09a2924bd029786273781cf801c990f4ac2ccf53e4d54143f6c59ff49d0fa11189e07f16665ab7329dead0b9853da7bf1480caa419bf15  install-path.patch"

--- a/testing/oh-my-zsh/install-path.patch
+++ b/testing/oh-my-zsh/install-path.patch
@@ -1,0 +1,11 @@
+--- a/templates/zshrc.zsh-template.orig
++++ b/templates/zshrc.zsh-template
+@@ -2,7 +2,7 @@
+ # export PATH=$HOME/bin:/usr/local/bin:$PATH
+ 
+ # Path to your oh-my-zsh installation.
+-export ZSH=$HOME/.oh-my-zsh
++export ZSH=/usr/share/
+ 
+ # Set name of the theme to load. Optionally, if you set this to "random"
+ # it'll load a random theme each time that oh-my-zsh is loaded.

--- a/testing/oh-my-zsh/oh-my-zsh.post-install
+++ b/testing/oh-my-zsh/oh-my-zsh.post-install
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "You need to copy the contents of /usr/share/oh-my-zsh/templates/zshrc.zsh-template in your ~/.zshrc.  Then, you should edit it."

--- a/testing/oh-my-zsh/oh-my-zsh.post-upgrade
+++ b/testing/oh-my-zsh/oh-my-zsh.post-upgrade
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "You need to copy the contents of /usr/share/oh-my-zsh/templates/zshrc.zsh-template in your ~/.zshrc.  Then, you should edit it."


### PR DESCRIPTION
My old fork referencing the pull request to #3135 is not recoverable so this is recreated.  

This package depends on #3237 which is the powerline font.

Added oh-my-zsh to allow zsh users to use themes (https://github.com/robbyrussell/oh-my-zsh/wiki/Themes) and plugins (https://github.com/robbyrussell/oh-my-zsh/wiki/Plugins).