### PR TITLE
community/neovim: ignore st terminfo cursor shape

### DIFF
--- a/community/neovim/APKBUILD
+++ b/community/neovim/APKBUILD
@@ -10,9 +10,10 @@
 #     - CVE-2017-6350
 
 # TODO: Try to trim the base package to include only common syntax files etc.
+# NOTE: ignore-st-cursor-shape.patch will be in neovim 0.2.3
 pkgname=neovim
 pkgver=0.2.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Vim-fork focused on extensibility and agility"
 url="https://neovim.io"
 arch="all !s390x" # needs luajit
@@ -22,6 +23,7 @@ makedepends="cmake gettext-dev gperf libtermkey-dev libuv-dev libvterm-dev
 	lua5.1-lpeg lua5.1-mpack luajit-dev msgpack-c-dev unibilium-dev"
 subpackages="$pkgname-lang $pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/neovim/$pkgname/archive/v$pkgver.tar.gz
+	ignore-st-cursor-shape.patch
 	nodoc.txt"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -64,4 +66,5 @@ doc() {
 }
 
 sha512sums="5609defe86ac98356f1b9ae9adc6049bb4df920a9a2ae3104f761d52d4dd54cbc84d2596231595dd9b0aa97201fef2121e6c5c86a19267ab6b871dbf4b568209  neovim-0.2.2.tar.gz
+46663e6d71a0cbd501fc62c97940e9e8438190080eea442fd060ae4b60ac6f8d656578df83f26a3210ced90db034038c8da0746b7161a6636a4d9275860be716  ignore-st-cursor-shape.patch
 72ab288f53acddc088c567aafe8c5afa6835325fab7879e782d1d62f87a662f3a6bac123c450debbae1b32336cc60b2830b429838ee3dfcc7524773b5069f4f0  nodoc.txt"

--- a/community/neovim/ignore-st-cursor-shape.patch
+++ b/community/neovim/ignore-st-cursor-shape.patch
@@ -1,0 +1,20 @@
+diff -ruN a/src/nvim/tui/tui.c b/src/nvim/tui/tui.c
+--- a/src/nvim/tui/tui.c	2018-02-09 18:00:57.112018546 +0100
++++ b/src/nvim/tui/tui.c	2018-02-09 18:03:44.232783880 +0100
+@@ -1444,7 +1444,7 @@
+   // Some terminals can not currently be trusted to report if they support
+   // DECSCUSR or not. So we need to have a blacklist for when we should not
+   // trust the reported features.
+-  if (!((vte_version != 0 && vte_version < 3900) || konsole)) {
++  if (!(st || (vte_version != 0 && vte_version < 3900) || konsole)) {
+     // Dickey ncurses terminfo has included the Ss and Se capabilities,
+     // pioneered by tmux, since 2011-07-14. So adding them to terminal types,
+     // that do actually have such control sequences but lack the correct
+@@ -1464,6 +1464,7 @@
+         || tmux       // per tmux manual page
+         // https://lists.gnu.org/archive/html/screen-devel/2013-03/msg00000.html
+         || screen
++        || st         // #7641
+         || rxvt       // per command.C
+         // per analysis of VT100Terminal.m
+         || iterm || iterm_pretending_xterm


### PR DESCRIPTION
Fixes a crash that started to appear with the ncurses 6.0_p20171125-r0 update.

It would be nice if this could be backported to 3.7 since it fixes a crash.

Fixes: https://bugs.alpinelinux.org/issues/8469