### PR TITLE
main/audit: fix prefix, allow make check on s390x

### DIFF
--- a/main/audit/APKBUILD
+++ b/main/audit/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Tycho Andersen <tycho@docker.com>
 pkgname=audit
 pkgver=2.8.2
-pkgrel=0
+pkgrel=1
 pkgdesc="User space tools for 2.6 kernel auditing"
 url="http://people.redhat.com/sgrubb/audit/"
 arch="all"
@@ -16,11 +16,6 @@ source="http://people.redhat.com/sgrubb/audit/audit-$pkgver.tar.gz
 
 builddir="$srcdir/audit-$pkgver"
 
-# FIXME: check on s390x
-if [ "$CARCH" = "s390x" ]; then
-	options="!check"
-fi
-
 build() {
 	if [ "$CARCH" = "ppc64le" ]; then
 		WITHOUT="--without-python3 --without-python"
@@ -30,7 +25,7 @@ build() {
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/ \
+		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
@@ -56,8 +51,8 @@ package() {
 
 static() {
 	pkgdesc="Static libaudit libraries"
-	mkdir -p "$subpkgdir"/lib/
-	mv "$pkgdir"/lib/*.a "$subpkgdir"/lib/
+	mkdir -p "$subpkgdir"/usr/lib/
+	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib/
 }
 
 sha512sums="888ebf5e8e9d285b82d87377fc8836886d7a8b089c1be4091420a77a0250c9baf09aebb7a6330ff5043fb35f51eb6baf8d4491e26da7ad0811f0087e395b5012  audit-2.8.2.tar.gz


### PR DESCRIPTION
prefix was set to /, now set to /usr
make check is okay on s390x