### PR TITLE
community/roundcubemail: fetch jsdeps

### DIFF
--- a/community/roundcubemail/APKBUILD
+++ b/community/roundcubemail/APKBUILD
@@ -3,17 +3,18 @@
 _php=php7
 pkgname=roundcubemail
 pkgver=1.3.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A PHP web-based mail client"
 url="http://www.roundcube.net"
 arch="noarch"
-license="GPL-3.0-or-later"
+license="GPL-3.0-or-later LGPL-3.0-or-later MIT"
 install="$pkgname.post-upgrade"
 depends="${_php} ${_php}-imap ${_php}-xml ${_php}-json ${_php}-dom
 	${_php}-exif ${_php}-pear-net_idna2 ${_php}-pear-mail_mime
 	${_php}-pear-net_smtp ${_php}-pear-auth_sasl ${_php}-openssl
 	${_php}-session ${_php}-mbstring ${_php}-iconv ${_php}-intl
 	"
+builddepends="curl file php7-pear unzip"
 options="!check"
 subpackages="$pkgname-installer $pkgname-doc"
 source="https://github.com/roundcube/$pkgname/releases/download/$pkgver/${pkgname}-$pkgver.tar.gz
@@ -28,10 +29,17 @@ builddir="$srcdir"/roundcubemail-$pkgver
 
 prepare() {
 	cd "$builddir"
+
+	# fetch jsdeps and updatecss must be done before patching
+	export PHP_LIBDIR=".:/usr/share/php7:/usr/share/php7/PEAR"
+	php7 -d include_path="$PHP_LIBDIR" -f ./bin/install-jsdeps.sh
+	php7 -d include_path="$PHP_LIBDIR" -f ./bin/updatecss.sh
+
 	default_prepare
 
 	# fix permissions
 	find . -type f -print | xargs chmod a-x
+	find . -type d -print | xargs chmod go-w
 	# remove .htaccess
 	find . -name \.htaccess -print | xargs rm -f
 
@@ -43,11 +51,16 @@ prepare() {
 
 	# cleanup
 	sed -i 's/\r//' SQL/mssql.initial.sql
+	find . -type f -name \*.git\* -print | xargs -r rm -f
 	rm -rf logs temp
 }
 
 build() {
-	return 0
+	cd "$builddir"
+
+	export PHP_LIBDIR=".:/usr/share/php7:/usr/share/php7/PEAR"
+	php7 -d include_path="$PHP_LIBDIR" -f ./bin/jsshrink.sh
+	php7 -d include_path="$PHP_LIBDIR" -f ./bin/cssshrink.sh
 }
 
 package() {

--- a/community/roundcubemail/roundcubemail.post-upgrade
+++ b/community/roundcubemail/roundcubemail.post-upgrade
@@ -41,7 +41,7 @@ fi
 
 # display info about upgrade
 echo "*" >&2
-echo -e "* Please read /usr/share/doc/roundcube/UPGRADE\n\
+echo -e "* Please read /usr/share/doc/roundcube/UPGRADING\n\
 * in roundcubemail-doc package for schema or config update" >&2
 echo "*" >&2
 exit 0


### PR DESCRIPTION
From 1.3.x and forward jsdeps need to be fetched

https://github.com/roundcube/roundcubemail/wiki/Build-from-source#3-install-javascript-dependencies