### PR TITLE
testing/jgmenu: new aport

### DIFF
--- a/testing/jgmenu/APKBUILD
+++ b/testing/jgmenu/APKBUILD
@@ -1,0 +1,25 @@
+# Contributor: Matthew T Hoare <matthew.t.hoare@gmail.com>
+# Maintainer: Matthew T Hoare <matthew.t.hoare@gmail.com>
+pkgname=jgmenu
+pkgver=0.8
+pkgrel=0
+pkgdesc="Small X11 menu intended to be used with openbox and tint2"
+url="https://www.github.com/johanmalm/jgmenu"
+arch="all"
+license="GPL"
+depends="libx11 cairo pango libxinerama librsvg glib menu-cache python"
+subpackages="${pkgname}-doc"
+source="${pkgname}-${pkgver}.tar.gz::https://www.github.com/johanmalm/jgmenu/archive/v${pkgver}.tar.gz"
+builddir="${srcdir}/${pkgname}-${pkgver}"
+
+build() {
+	cd "$builddir"
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" prefix=/usr install
+}
+
+sha512sums="39ef39e7eee8b2126a07adf1433c3cdda8afe6ce611f1363d0906fe2064f140c179465a757a996731e155b1c87104646a1c5516f4ea6e6238a7941e05b2b967f  jgmenu-0.8.tar.gz"


### PR DESCRIPTION
jgmenu is a small X11 menu that is intended to be used with openbox and tint2 (but can be used with most window managers).

https://github.com/johanmalm/jgmenu