### PR TITLE
main/autoconf: backport patch for runstatedir support

### DIFF
--- a/main/autoconf/APKBUILD
+++ b/main/autoconf/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=autoconf
 pkgver=2.69
-pkgrel=1
+pkgrel=2
 pkgdesc="A GNU tool for automatically configuring source code"
 arch="noarch"
 license="GPL-2.0-or-later"
@@ -11,6 +11,7 @@ subpackages="$pkgname-doc"
 options="!check"
 source="ftp://ftp.gnu.org/pub/gnu/$pkgname/$pkgname-$pkgver.tar.gz
 	autoconf-2.69-fix-perl-regex.patch
+        autoconf-2.69-backport-runstatedir.patch
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver
@@ -42,4 +43,5 @@ package() {
 }
 
 sha512sums="e34c7818bcde14d2cb13cdd293ed17d70740d4d1fd7c67a07b415491ef85d42f450d4fe5f8f80cc330bf75c40a62774c51a4336e06e8da07a4cbc49922d975ee  autoconf-2.69.tar.gz
-8b779ecec178091c899b75df4471fb72334a062d6b413502d414e8827fe0c9e2f335a8bef6878ae261e1af1568e3fe71fe82d6b5e53cb54e6585ffd91f069d8d  autoconf-2.69-fix-perl-regex.patch"
+8b779ecec178091c899b75df4471fb72334a062d6b413502d414e8827fe0c9e2f335a8bef6878ae261e1af1568e3fe71fe82d6b5e53cb54e6585ffd91f069d8d  autoconf-2.69-fix-perl-regex.patch
+e040bf855011145d8edf3bc4886e7a11b6dad9c3c8698f07de2bfd6059a23eb90210cad8d9bc4fbcdd54cbd084e46bd6f9a48592948c8d02e7b99471fe9470a5  autoconf-2.69-backport-runstatedir.patch"

--- a/main/autoconf/autoconf-2.69-backport-runstatedir.patch
+++ b/main/autoconf/autoconf-2.69-backport-runstatedir.patch
@@ -1,0 +1,50 @@
+Source: http://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=patch;h=a197431414088a417b407b9b20583b2e8f7363bd
+
+diff --git a/lib/autoconf/general.m4 b/lib/autoconf/general.m4
+index 70b0168..1ce9922 100644
+--- a/lib/autoconf/general.m4
++++ b/lib/autoconf/general.m4
+@@ -586,6 +586,7 @@ AC_SUBST([datadir],        ['${datarootdir}'])dnl
+ AC_SUBST([sysconfdir],     ['${prefix}/etc'])dnl
+ AC_SUBST([sharedstatedir], ['${prefix}/com'])dnl
+ AC_SUBST([localstatedir],  ['${prefix}/var'])dnl
++AC_SUBST([runstatedir],    ['${localstatedir}/run'])dnl
+ AC_SUBST([includedir],     ['${prefix}/include'])dnl
+ AC_SUBST([oldincludedir],  ['/usr/include'])dnl
+ AC_SUBST([docdir],         [m4_ifset([AC_PACKAGE_TARNAME],
+@@ -812,6 +813,15 @@ do
+   | -silent | --silent | --silen | --sile | --sil)
+     silent=yes ;;
+ 
++  -runstatedir | --runstatedir | --runstatedi | --runstated \
++  | --runstate | --runstat | --runsta | --runst | --runs \
++  | --run | --ru | --r)
++    ac_prev=runstatedir ;;
++  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
++  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
++  | --run=* | --ru=* | --r=*)
++    runstatedir=$ac_optarg ;;
++
+   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
+     ac_prev=sbindir ;;
+   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
+@@ -921,7 +931,7 @@ fi
+ for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
+ 		datadir sysconfdir sharedstatedir localstatedir includedir \
+ 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
+-		libdir localedir mandir
++		libdir localedir mandir runstatedir
+ do
+   eval ac_val=\$$ac_var
+   # Remove trailing slashes.
+@@ -1058,6 +1068,7 @@ Fine tuning of the installation directories:
+   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
+   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
+   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
++  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
+   --libdir=DIR            object code libraries [EPREFIX/lib]
+   --includedir=DIR        C header files [PREFIX/include]
+   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
+-- 
+1.9.1
+


### PR DESCRIPTION
Autoconf release 2.70 appears to be stalled indefinitely, and with Alpine using `/run` instead of `/var/run`, having access to `--runstatedir=/run` for `configure` would be very nice indeed.

[Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=759647) has backported it, and given that it is small and unobtrusive in nature I was hoping we could do the same.

Thanks for considering!