### PR TITLE
Added missing dependencies to ghi

### DIFF
--- a/main/ghi/APKBUILD
+++ b/main/ghi/APKBUILD
@@ -6,7 +6,7 @@ pkgdesc="GitHub Issues on the command line"
 url="https://github.com/stephencelis/ghi"
 arch="noarch"
 license="MIT"
-depends="ruby ncurses"
+depends="ruby ncurses ruby-json less"
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/stephencelis/ghi/archive/$pkgver.tar.gz"
 


### PR DESCRIPTION
This adds ruby-json so ghi doesn't crash and less because it isn't compatible with the less applet from busybox