### PR TITLE
testing/dnsdist: new aport

### DIFF
--- a/testing/dnsdist/APKBUILD
+++ b/testing/dnsdist/APKBUILD
@@ -1,0 +1,116 @@
+# Contributor: Vince Mele <vmele@inoc.com>
+# Maintainer: Vince Mele <vmele@inoc.com>
+pkgname="dnsdist"
+pkgver="1.3.2"
+pkgrel=0
+pkgdesc="dnsdist is a highly DNS-, DoS-, and abuse-aware loadbalancer."
+url="https://dnsdist.org"
+arch="all"
+license="GPL2"
+_lua_version="5.1"
+depends="$pkgname-common !$pkgname-luajit"
+makedepends="boost-dev fstrm-dev libedit-dev libsodium-dev lua${_lua_version}-dev net-snmp-dev protobuf-dev re2-dev"
+pkgusers="dnsdist"
+pkggroups="dnsdist"
+install="$pkgname-common.pre-install"
+subpackages="$pkgname-common::noarch $pkgname-doc"
+source="https://downloads.powerdns.com/releases/$pkgname-$pkgver.tar.bz2"
+builddir="$srcdir/$pkgname-$pkgver"
+
+# luajit is not available for s390x
+case "$CARCH" in
+	s390x) ;;
+	*)
+		makedepends="$makedepends luajit-dev"
+		subpackages="$subpackages $pkgname-luajit"
+		;;
+esac
+
+prepare() {
+	default_prepare
+
+	case "$subpackages" in
+		*-luajit*) cp -a "$builddir" "$builddir-jit";;
+	esac
+}
+
+_configure() {
+	local _arg="$1"
+	local _luajit
+
+	[ "$_arg" = '-jit' ] || _arg='' _luajit="lua${_lua_version}"
+
+	cd "$builddir$_arg"
+
+	./configure \
+		--build="$CBUILD" \
+		--host="$CHOST" \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--enable-unit-tests \
+		--enable-dnscrypt \
+		--enable-dns-over-tls \
+		--enable-fstrm \
+		--enable-libsodium \
+		--enable-re2 \
+		--with-protobuf \
+		--with-boost=/usr/include \
+		--with-net-snmp \
+		--with-lua${_luajit:+=$_luajit}
+}
+
+build() {
+	cd "$builddir"
+
+	_configure
+	make
+
+	[ -d "$builddir-jit" ] || return 0
+
+	_configure -jit
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+	./dnsdist --version
+
+	[ -d "$builddir-jit" ] || return 0
+
+	cd "$builddir-jit"
+	make check
+	./dnsdist --version
+}
+
+package() {
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
+
+	mv "$pkgdir/usr/bin/$pkgname" "$pkgdir/usr/bin/$pkgname-lua"
+
+	if cd "$builddir-jit"; then
+		make -j1 DESTDIR="$pkgdir" install-exec
+		mv "$pkgdir/usr/bin/$pkgname" "$pkgdir/usr/bin/$pkgname-luajit"
+	fi
+
+	mv "$pkgdir/usr/bin/$pkgname-lua" "$pkgdir/usr/bin/$pkgname"
+}
+
+common() {
+	pkgdesc="$pkgname common files"
+	depends=""
+
+	mkdir -p "$subpkgdir"
+}
+
+luajit() {
+	pkgdesc="$pkgname with luajit bindings"
+	depends="$pkgname-common !$pkgname"
+
+	mkdir -p "$subpkgdir/usr/bin"
+	mv "$pkgdir/usr/bin/$pkgname-luajit" "$subpkgdir/usr/bin/$pkgname"
+}
+
+sha512sums="af7c360d6a5255bc9588622747b8939d30669e2d7d749275b30a9be8cf306a92768327057a93bfa901c44ac8a7572c9bb801a7f6ceca6d736f3e9c71f80f5726  dnsdist-1.3.2.tar.bz2"

--- a/testing/dnsdist/dnsdist-common.pre-install
+++ b/testing/dnsdist/dnsdist-common.pre-install
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+addgroup -S dnsdist 2>/dev/null
+adduser -S -D -s /sbin/nologin -G dnsdist -g dnsdist dnsdist 2>/dev/null
+
+exit 0


### PR DESCRIPTION
https://dnsdist.org
dnsdist is a highly DNS-, DoS-, and abuse-aware loadbalancer.

This is a reworked version of #2755

Depends on #3965