### PR TITLE
main/libvorbis: fix for CVE-2017-14632 & CVE-2017-14633, fix license

### DIFF
--- a/main/libvorbis/APKBUILD
+++ b/main/libvorbis/APKBUILD
@@ -1,21 +1,26 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libvorbis
 pkgver=1.3.5
-pkgrel=3
+pkgrel=4
 pkgdesc="Vorbis codec library"
 url="https://xiph.org/vorbis/"
 arch="all"
-license="custom"
+license="BSD-3-Clause"
 subpackages="$pkgname-dev $pkgname-doc"
 makedepends="libogg-dev"
 source="http://downloads.xiph.org/releases/vorbis/$pkgname-$pkgver.tar.gz
 	CVE-2017-14160.patch
+	CVE-2017-14632.patch
+	CVE-2017-14633.patch
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
 #   1.3.5-r3:
 #   - CVE-2017-14160
+#   1.3.5-r4:
+#   - CVE-2017-14632
+#   - CVE-2017-14633
 
 build() {
 	cd "$builddir"
@@ -35,4 +40,6 @@ package() {
 }
 
 sha512sums="6c729a227143abc744a779ec4d4ce9932cd1234e301b766cb5111c3894b7cd866f0267590c7864afd3841ac0d4ae2eb2386e8d14345b7c41c8ce35e996e3656c  libvorbis-1.3.5.tar.gz
-4c2f7be947f2159ae47175cba89950c7b7d357b37a20d54382e4fbecd8c268b148e6cb86cb148945c7b68bbe8b14f466e910b35b80903ab51f1b02cfccf5806e  CVE-2017-14160.patch"
+4c2f7be947f2159ae47175cba89950c7b7d357b37a20d54382e4fbecd8c268b148e6cb86cb148945c7b68bbe8b14f466e910b35b80903ab51f1b02cfccf5806e  CVE-2017-14160.patch
+656db69d915fb30e26b6370a9b6f7c2c1f1caaec7051eb13602983935d716ae78a1a3ceaa901d63e2a2169cf00c50d90a86530d461fd53191d545e8d82dbae92  CVE-2017-14632.patch
+1b4b1a6a31feca7e9cabc9274149788f0134a3be7575d530092e42864ff6f6d129f923282da7378d29d953e6be4519b3aa7f782e2cca70a623024c7c050614f1  CVE-2017-14633.patch"

--- a/main/libvorbis/CVE-2017-14632.patch
+++ b/main/libvorbis/CVE-2017-14632.patch
@@ -1,0 +1,10 @@
+--- a/lib/info.c
++++ b/lib/info.c
+@@ -584,6 +584,7 @@ int vorbis_analysis_headerout(vorbis_dsp
+   private_state *b=v->backend_state;
+ 
+   if(!b||vi->channels<=0){
++    b = NULL;
+     ret=OV_EFAULT;
+     goto err_out;
+   }

--- a/main/libvorbis/CVE-2017-14633.patch
+++ b/main/libvorbis/CVE-2017-14633.patch
@@ -1,0 +1,11 @@
+--- a/lib/info.c
++++ b/lib/info.c
+@@ -583,7 +583,7 @@ int vorbis_analysis_headerout(vorbis_dsp
+   oggpack_buffer opb;
+   private_state *b=v->backend_state;
+ 
+-  if(!b||vi->channels<=0){
++  if(!b||vi->channels<=0||vi->channels>256){
+     b = NULL;
+     ret=OV_EFAULT;
+     goto err_out;


### PR DESCRIPTION
upstream issue: [issues/2328](https://gitlab.xiph.org/xiph/vorbis/issues/2328)
upstream issue: [issues/2329](https://gitlab.xiph.org/xiph/vorbis/issues/2329)