### PR TITLE
testing/lmms: new aport

### DIFF
--- a/testing/lmms/APKBUILD
+++ b/testing/lmms/APKBUILD
@@ -1,0 +1,613 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=lmms
+pkgver=1.2.0_rc5
+_pkgver=${pkgver//_/-}
+pkgrel=0
+pkgdesc="Cross-platform music production software"
+url="https://lmms.io/"
+arch="x86_64 x86"
+license="GPL-2.0-or-later GPL-2.0-only LGPL-2.1-or-later LGPL-2.1-only MIT \
+	CC-BY-3.0"
+_license_build="$license BSD-3-Clause"
+_guitoolkit="qt5"
+if [[ -n "$_guitoolkit" && "$_guitoolkit" == "qt5" ]]; then
+	msg "qt5 selected"
+	_guitoolkitdeps="qt5-qtbase-dev qt5-qttools-dev qt5-x11extras-dev"
+	_cmaketookit="-DWANT_QT5=ON"
+elif [[ -n "$_guitoolkit" && "$_guitoolkit" == "qt4" ]]; then
+	msg "qt4 selected"
+	_guitoolkitdeps="qt-dev"
+	_cmaketookit="-DWANT_QT5=OFF"
+else
+	msg "need to specify gui toolkit as either qt4 or qt5"
+	return 1
+fi
+# no multilib so we can't use vst wine plugins on x86_64
+case "$CARCH" in
+	x86) _vstnowine="OFF" ; _vstwinedeps="wine-dev" ;;
+	*)   _vstnowine="ON"  ;	_vstwinedeps= ;;
+esac
+checkdepends=""
+makedepends="cmake
+	     $_guitoolkitdeps
+	     libsndfile-dev
+	     fftw-dev
+	     libsamplerate-dev
+	     alsa-lib-dev
+	     pulseaudio-dev
+	     lame-dev
+	     libvorbis-dev
+	     $_vstwinedeps
+	     doxygen
+	     libxcb-dev
+	     xcb-util-keysyms-dev
+	     paxmark
+	     ladspa-dev
+	     fltk-fluid
+	     fltk-dev
+	     zlib-dev
+	     mxml-dev
+	     libx11-dev
+	     libxinerama-dev
+	     jack-dev"
+subpackages="$pkgname-samples
+	     $pkgname-shorties
+	     $pkgname-tutorials
+	     $pkgname-templates
+	     $pkgname-dev
+	     $pkgname-doc
+	     $pkgname-themeclassic
+	     $pkgname-plugincmt
+	     $pkgname-plugincalf
+	     $pkgname-plugincaps
+	     $pkgname-plugintap
+	     $pkgname-pluginswh
+	     $pkgname-pluginvestige
+	     $pkgname-pluginnescaline
+	     $pkgname-pluginamplifier
+	     $pkgname-pluginbassbooster
+	     $pkgname-pluginbitcrush
+	     $pkgname-pluginbitinvader
+	     $pkgname-plugincrossoverequalizer
+	     $pkgname-plugindelay
+	     $pkgname-plugindualfilter
+	     $pkgname-pluginequalizer
+	     $pkgname-pluginflanger
+	     $pkgname-pluginpeakcontroller
+	     $pkgname-pluginhydrogenimport
+	     $pkgname-pluginmidiexport
+	     $pkgname-pluginmidiimport
+	     $pkgname-pluginmultitapecho
+	     $pkgname-pluginreverbsc
+	     $pkgname-pluginspectrumanalyzer
+	     $pkgname-pluginvst
+	     $pkgname-pluginaudiofileprocessor
+	     $pkgname-plugindynamicsprocessor
+	     $pkgname-pluginkicker
+	     $pkgname-pluginladspa
+	     $pkgname-pluginlb302
+	     $pkgname-pluginmonstro
+	     $pkgname-pluginopulenz
+	     $pkgname-pluginorganic
+	     $pkgname-pluginfreeboy
+	     $pkgname-pluginpatman
+	     $pkgname-pluginsfxr
+	     $pkgname-pluginsid
+	     $pkgname-pluginstereoenhancereffect
+	     $pkgname-pluginstereomatrix
+	     $pkgname-plugintripleoscillator
+	     $pkgname-pluginvibed
+	     $pkgname-pluginvstbase
+	     $pkgname-pluginwatsyn
+	     $pkgname-pluginwaveshapereffect
+	     $pkgname-pluginzynaddsubfx
+	     $pkgname-pluginladspabrowser"
+# disabled subpackages (due to missing packages)
+#	     $pkgname-plugingigplayer
+#            http://www.linuxsampler.org/libgig/
+#
+#	     $pkgname-plugincarlapatchbay
+#	     $pkgname-plugincarlabase
+#	     $pkgname-plugincarlarack
+#            https://github.com/falkTX/Carla/
+#
+#	     $pkgname-pluginsf2player
+#            needs fluidsynth http://www.fluidsynth.org/
+#
+#	     $pkgname-pluginmallets
+#            needs libstk https://ccrma.stanford.edu/software/stk/
+_qt5x11embedpkgname="qt5-x11embed"
+_qt5x11embed_gitrev="022b39a1d496d72eb3e5b5188e5559f66afca957"
+_ecmpkgname="extra-cmake-modules"
+_ecm_gitrev="6604694848d8f313fe96e3b1a8d0b4ddd07eb51d"
+_rpmallocpkgname="rpmalloc"
+_rpmalloc_gitrev="2e0479192b8dfb15e0084969fdf06208cffbfd09"
+source="$pkgname-$pkgver.tar.gz::https://github.com/LMMS/lmms/archive/v$_pkgver.tar.gz
+        $pkgname-$_qt5x11embedpkgname.zip::https://github.com/lukas-w/$_qt5x11embedpkgname/archive/$_qt5x11embed_gitrev.zip
+	$pkgname-$_ecmpkgname.zip::https://github.com/KDE/$_ecmpkgname/archive/$_ecm_gitrev.zip
+	$pkgname-$_rpmallocpkgname.zip::https://github.com/rampantpixels/$_rpmallocpkgname/archive/$_rpmalloc_gitrev.zip
+	rpmalloc-rel-path-fix.patch
+	musl-math.patch
+	rpmalloc-include-path.patch
+	"
+builddir="$srcdir/"$pkgname-$_pkgver
+
+unpack() {
+	default_unpack
+	mv "$srcdir"/$_qt5x11embedpkgname-$_qt5x11embed_gitrev/* \
+		"$builddir"/src/3rdparty/$_qt5x11embedpkgname
+	mv "$srcdir"/$_ecmpkgname-$_ecm_gitrev/* \
+		"$builddir"/src/3rdparty/$_qt5x11embedpkgname/3rdparty/ECM
+	mv "$srcdir"/$_rpmallocpkgname-$_rpmalloc_gitrev/* \
+		"$builddir"/src/3rdparty/$_rpmallocpkgname
+}
+
+build() {
+	cd "$builddir"
+	cmake -DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=/usr/lib \
+		-DCMAKE_BUILD_TYPE=Release \
+		$_cmaketookit \
+		-DWANT_SDL=OFF \
+		-DWANT_PORTAUDIO=OFF \
+		-DWANT_JACK=ON \
+		-DWANT_WEAKJACK=OFF \
+		-DWANT_CARLA=OFF \
+		-DWANT_SF2=OFF \
+		-DWANT_GIG=OFF \
+		-DWANT_STK=OFF \
+		-DWANT_CALF=ON \
+		-DWANT_CAPS=ON \
+		-DWANT_CMT=ON \
+		-DWANT_SWH=ON \
+		-DWANT_TAP=ON \
+		-DWANT_VST=ON \
+		-DWANT_VST_NOWINE=$_vstnowine \
+		-DWANT_WINMM=OFF \
+		.
+	make
+	cd doc
+	make doc
+}
+
+package() {
+	cd "$builddir"
+	make install DESTDIR="$pkgdir"
+	paxmark -cr "$pkgdir"/usr/bin/$pkgname
+	rm -rf "$pkgdir"/usr/share/lmms/projects/demos
+	install -d "$pkgdir"/usr/share/doc/$pkgname \
+		"$pkgdir"/usr/share/html/$pkgname
+	mv doc/doc/html/* "$pkgdir"/usr/share/doc/$pkgname
+}
+
+samples() {
+	pkgdesc="$pkgname (samples)"
+	mkdir -p "$subpkgdir"/usr/share/lmms/
+	mv "$pkgdir"/usr/share/lmms/samples "$subpkgdir"/usr/share/lmms/
+}
+
+shorties() {
+	pkgdesc="$pkgname (shorties)"
+	mkdir -p "$subpkgdir"/usr/share/lmms/projects/
+	mv "$pkgdir"/usr/share/lmms/projects/shorties \
+		"$subpkgdir"/usr/share/lmms/projects/
+}
+
+tutorials() {
+	pkgdesc="$pkgname (tutorials)"
+	mkdir -p "$subpkgdir"/usr/share/lmms/projects/
+	mv "$pkgdir"/usr/share/lmms/projects/tutorials \
+		"$subpkgdir"/usr/share/lmms/tutorials/
+}
+
+templates() {
+	pkgdesc="$pkgname (templates)"
+	mkdir -p "$subpkgdir"/usr/share/lmms/projects/
+	mv "$pkgdir"/usr/share/lmms/projects/templates \
+		"$subpkgdir"/usr/share/lmms/projects/
+}
+
+_plugingenerator() {
+	local propername="$1"
+	shift
+	local dest="$1"
+	shift
+	local src="$1"
+	shift
+	local files="$@"
+	pkgdesc="$pkgname ($propername plugin)"
+	depends="$pkgname"
+	install -d "$dest"
+	cd "$src"
+	install -t "$dest" $files
+}
+
+plugincalf() {
+	_plugingenerator "CALF" "$subpkgdir/usr/lib/lmms/ladspa/" \
+		"$pkgdir/usr/lib/lmms/ladspa/" calf.so
+}
+
+plugincmt() {
+	_plugingenerator "CMT" "$subpkgdir/usr/lib/lmms/ladspa/" \
+		"$pkgdir/usr/lib/lmms/ladspa/" cmt.so
+}
+
+plugincaps() {
+	_plugingenerator "C* Audio Plugin Suite / CAPS" \
+		"$subpkgdir/usr/lib/lmms/ladspa/" \
+		"$pkgdir/usr/lib/lmms/ladspa/" caps.so
+}
+
+plugintap() {
+	_plugingenerator "TAP" "$subpkgdir/usr/lib/lmms/ladspa/" \
+		"$pkgdir/usr/lib/lmms/ladspa/" tap_dynamics_st.so \
+		tap_limiter.so \
+		tap_pinknoise.so \
+		tap_sigmoid.so \
+		tap_tremolo.so \
+		tap_doubler.so \
+		tap_rotspeak.so \
+		tap_dynamics_m.so \
+		tap_reverb.so \
+		tap_deesser.so \
+		tap_autopan.so \
+		tap_tubewarmth.so \
+		tap_pitch.so \
+		tap_echo.so \
+		tap_chorusflanger.so \
+		tap_eqbw.so \
+		tap_vibrato.so \
+		tap_eq.so \
+		tap_reflector.so
+}
+
+pluginswh() {
+	_plugingenerator "SWH" "$subpkgdir/usr/lib/lmms/ladspa/" \
+		"$pkgdir/usr/lib/lmms/ladspa/" foverdrive_1196.so \
+		delayorama_1402.so \
+		gong_1424.so \
+		imp_1199.so \
+		fad_delay_1192.so \
+		wave_terrain_1412.so \
+		hilbert_1440.so \
+		dyson_compress_1403.so \
+		vocoder_1337.so \
+		vynil_1905.so \
+		ls_filter_1908.so \
+		pitch_scale_1193.so \
+		fast_lookahead_limiter_1913.so \
+		chebstortion_1430.so \
+		delay_1898.so \
+		zm1_1428.so \
+		multivoice_chorus_1201.so \
+		valve_1209.so \
+		dj_flanger_1438.so \
+		comb_splitter_1411.so \
+		pitch_scale_1194.so \
+		sc4m_1916.so \
+		mod_delay_1419.so \
+		latency_1914.so \
+		sc4_1882.so \
+		mbeq_1197.so \
+		flanger_1191.so \
+		const_1909.so \
+		comb_1190.so \
+		comb_1887.so \
+		matrix_st_ms_1420.so \
+		sc1_1425.so \
+		inv_1429.so \
+		notch_iir_1894.so \
+		bandpass_iir_1892.so \
+		crossover_dist_1404.so \
+		allpass_1895.so \
+		single_para_1203.so \
+		shaper_1187.so \
+		triple_para_1204.so \
+		svf_1214.so \
+		impulse_1885.so \
+		fm_osc_1415.so \
+		amp_1181.so \
+		matrix_spatialiser_1422.so \
+		split_1406.so \
+		revdelay_1605.so \
+		decimator_1202.so \
+		bode_shifter_1431.so \
+		foldover_1213.so \
+		plate_1423.so \
+		gsm_1215.so \
+		harmonic_gen_1220.so \
+		dj_eq_1901.so \
+		step_muxer_1212.so \
+		hermes_filter_1200.so \
+		lcr_delay_1436.so \
+		giant_flange_1437.so \
+		satan_maximiser_1408.so \
+		analogue_osc_1416.so \
+		sc3_1427.so \
+		xfade_1915.so \
+		transient_1206.so \
+		am_pitchshift_1433.so \
+		retro_flange_1208.so \
+		lowpass_iir_1891.so \
+		karaoke_1409.so \
+		decay_1886.so \
+		bode_shifter_cv_1432.so \
+		divider_1186.so \
+		declip_1195.so \
+		diode_1185.so \
+		matrix_ms_st_1421.so \
+		freq_tracker_1418.so \
+		highpass_iir_1890.so \
+		se4_1883.so \
+		surround_encoder_1401.so \
+		butterworth_1902.so \
+		sifter_1210.so \
+		gate_1410.so \
+		bandpass_a_iir_1893.so \
+		sinus_wavewrapper_1198.so \
+		gverb_1216.so \
+		gong_beater_1439.so \
+		dc_remove_1207.so \
+		sin_cos_1881.so \
+		sc2_1426.so \
+		hard_limiter_1413.so \
+		rate_shifter_1417.so \
+		ringmod_1188.so \
+		valve_rect_1405.so \
+		alias_1407.so \
+		phasers_1217.so \
+		ladspa-util.so \
+		pointer_cast_1910.so \
+		smooth_decimate_1414.so \
+		tape_delay_1211.so
+}
+
+pluginnescaline() {
+	_plugingenerator "Nescaline" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libnes.so"
+}
+
+pluginamplifier() {
+	_plugingenerator "Amplifier" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libamplifier.so"
+}
+
+pluginaudiofileprocessor() {
+	_plugingenerator "AudioFileProcessor" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libaudiofileprocessor.so"
+}
+
+pluginbassbooster() {
+	_plugingenerator "BassBooster" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libbassbooster.so"
+}
+
+pluginbitcrush() {
+	_plugingenerator "Bitcrush" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libbitcrush.so"
+}
+
+pluginbitinvader() {
+	_plugingenerator "BitInvader" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libbitinvader.so"
+}
+
+plugincrossoverequalizer() {
+	_plugingenerator "Crossover Equalizer" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libcrossovereq.so"
+}
+
+plugindelay() {
+	_plugingenerator "Delay" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libdelay.so"
+}
+
+plugindualfilter() {
+	_plugingenerator "Dual Filter" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libdualfilter.so"
+}
+
+plugindynamicsprocessor() {
+	_plugingenerator "Dynamics Processor" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libdynamicsprocessor.so"
+}
+
+pluginequalizer() {
+	_plugingenerator "Equalizer" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libeq.so"
+}
+
+pluginflanger() {
+	_plugingenerator "Flanger" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libflanger.so"
+}
+
+#plugingigplayer() {
+#	_plugingenerator "GIG Player" "$subpkgdir/usr/lib/lmms/" \
+#		"$pkgdir/usr/lib/lmms/" "libgigplayer.so"
+#}
+
+pluginhydrogenimport() {
+	_plugingenerator "Hydrogen Import" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libhydrogenimport.so"
+}
+
+pluginkicker() {
+	_plugingenerator "Kicker" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libkicker.so"
+}
+
+pluginladspabrowser() {
+	_plugingenerator "LADSPA Plugin Browser" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libladspabrowser.so"
+}
+
+pluginladspa() {
+	_plugingenerator "LADSPA" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libladspaeffect.so"
+}
+
+pluginlb302() {
+	_plugingenerator "LB302" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "liblb302.so"
+}
+
+pluginmidiexport() {
+	_plugingenerator "MIDI Export" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libmidiexport.so"
+}
+
+pluginmidiimport() {
+	_plugingenerator "MIDI Import" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libmidiimport.so"
+}
+
+pluginmonstro() {
+	_plugingenerator "Monstro" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libmonstro.so"
+}
+
+pluginopulenz() {
+	_plugingenerator "OpulenZ" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libOPL2.so"
+}
+
+pluginorganic() {
+	_plugingenerator "Organic" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "liborganic.so"
+}
+
+pluginfreeboy() {
+	_plugingenerator "FreeBoy" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libpapu.so"
+}
+
+pluginpatman() {
+	_plugingenerator "PatMan" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libpatman.so"
+}
+
+pluginpeakcontroller() {
+	_plugingenerator "Peak Controller" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libpeakcontrollereffect.so"
+}
+
+pluginreverbsc() {
+	_plugingenerator "ReverbSC" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libreverbsc.so"
+}
+
+pluginsfxr() {
+	_plugingenerator "sfxr" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libsfxr.so"
+}
+
+pluginsid() {
+	_plugingenerator "SID" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libsid.so"
+}
+
+pluginspectrumanalyzer() {
+	_plugingenerator "Spectrum Analyzer" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libspectrumanalyzer.so"
+}
+
+pluginstereoenhancereffect() {
+	_plugingenerator "StereoEnhancer Effect" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libstereoenhancer.so"
+}
+
+pluginstereomatrix() {
+	_plugingenerator "Stereo Matrix" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libstereomatrix.so"
+}
+
+#pluginmallets() {
+#	_plugingenerator "Mallets" "$subpkgdir/usr/lib/lmms/" \
+#		"$pkgdir/usr/lib/lmms/" "libmalletsstk.so"
+#}
+
+plugintripleoscillator() {
+	_plugingenerator "TripleOscillator" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libtripleoscillator.so"
+}
+
+pluginvestige() {
+	_plugingenerator "VeSTige" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libvestige.so"
+	depends="$depends $pkgname-pluginvstbase"
+}
+
+pluginvibed() {
+	_plugingenerator "Vibed" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libvibedstrings.so"
+}
+
+pluginvstbase() {
+	_plugingenerator "VST Base" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libvstbase.so"
+}
+
+pluginvst() {
+	_plugingenerator "VST" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libvsteffect.so"
+	depends="$depends $pkgname-pluginvstbase"
+}
+
+pluginwatsyn() {
+	_plugingenerator "Watsyn" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libwatsyn.so"
+}
+
+pluginwaveshapereffect() {
+	_plugingenerator "Waveshaper Effect" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libwaveshaper.so"
+}
+
+pluginmultitapecho() {
+	_plugingenerator "Multitap Echo" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libmultitapecho.so"
+}
+
+#plugincarlarack() {
+#	_plugingenerator "Carla Rack" "$subpkgdir/usr/lib/lmms/" \
+#		"$pkgdir/usr/lib/lmms/" "libcarlarack.so"
+#	depends="$depends $pkgname-plugincarlabase"
+#}
+
+#plugincarlapatchbay() {
+#	_plugingenerator "Carla Patchbay" "$subpkgdir/usr/lib/lmms/" \
+#		"$pkgdir/usr/lib/lmms/" "libcarlapatchbay.so"
+#	depends="$depends $pkgname-plugincarlabase"
+#}
+
+#plugincarlabase() {
+#	_plugingenerator "Carla Base" "$subpkgdir/usr/lib/lmms/" \
+#		"$pkgdir/usr/lib/lmms/" "libcarlabase.so"
+#}
+
+pluginzynaddsubfx() {
+	_plugingenerator "ZynAddSubFX" "$subpkgdir/usr/lib/lmms/" \
+		"$pkgdir/usr/lib/lmms/" "libzynaddsubfx.so"
+}
+
+themeclassic() {
+	pkgdesc="$pkgname (theme classic)"
+	install -d "$subpkgdir"/usr/share/lmms/themes
+	mv "$pkgdir"/usr/share/lmms/themes/classic \
+		"$subpkgdir"/usr/share/lmms/themes/
+}
+
+check() {
+	cd "$builddir"
+	ctest
+}
+
+sha512sums="a500178a6f94228e2a1660d64b13a9ba3609020d49a5ed9ac54a4fab5d034ed4ce8d0081cd1d80f58d150d57a9ac3a45bdc8d3480ca06593c1de41d74c8cc170  lmms-1.2.0_rc5.tar.gz
+e4595b3e70f484d2a08fd88f8589fa64bb31ebbbd1deec39e594588174d79798986b09f2c629922db191abc51641caf68a5125d7b49ea3e3fbc0ac1aba9caaf7  lmms-qt5-x11embed.zip
+3f66803051ffec27405e3d4f200d688b7ea4685eabe4bd658b0387a61e8f4eb430e77dce2d84bef953e657cf825dc67a6422a30beaf451d6a3b82af0a5ea6f68  lmms-extra-cmake-modules.zip
+bc9d2a0ec90ecaae5aea41297bce6cdac3f261c91783253184574b43d6b221b9db4cf92be611412541ea2e715b61c076cb4b070359792ce5b8ce837e56e63641  lmms-rpmalloc.zip
+365be1d917f429169a650250ae1efd1c9d689de387eabcfbb9e87a3ab0e08822daf6710f40edbccadf6c41046e976b367cd13ea7eb0d3e01ff44571a1b162e50  rpmalloc-rel-path-fix.patch
+28cbcadb08fb04efca8b37774be1d77e29817df29c2757903bf54366776aa3c6435bf0811b6d0fe67c53dbe3e0db78e798533e5b2eb4a989a073d65565497209  musl-math.patch
+32778301a4cd7ce89254fecca7ff03217169f857e7074e29b695d108ac2186ada96c6f75ff015880e794fda8755d12a97b2d0be96f5ccfbf3fb948b9d9f7469d  rpmalloc-include-path.patch"

--- a/testing/lmms/musl-math.patch
+++ b/testing/lmms/musl-math.patch
@@ -1,0 +1,14 @@
+--- a/include/lmms_math.h.orig
++++ b/include/lmms_math.h
+@@ -55,6 +55,11 @@
+ #endif
+ #endif
+ 
++#if ! defined (__GLIBC__)
++#define isnanf isnan
++#define isinff isinf
++#endif
++
+ #ifdef __INTEL_COMPILER
+ 
+ static inline float absFraction( const float _x )

--- a/testing/lmms/rpmalloc-include-path.patch
+++ b/testing/lmms/rpmalloc-include-path.patch
@@ -1,0 +1,13 @@
+--- a/CMakeLists.txt.orig
++++ b/CMakeLists.txt
+@@ -133,6 +133,10 @@
+ 
+ LIST(APPEND CMAKE_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}")
+ 
++INCLUDE_DIRECTORIES(
++	 ${CMAKE_SOURCE_DIR}/src/3rdparty/rpmalloc/rpmalloc
++)
++
+ IF(WANT_QT5)
+ 	SET(QT5 TRUE)
+ 

--- a/testing/lmms/rpmalloc-rel-path-fix.patch
+++ b/testing/lmms/rpmalloc-rel-path-fix.patch
@@ -1,0 +1,14 @@
+--- a/src/3rdparty/rpmalloc/CMakeLists.txt.orig
++++ b/src/3rdparty/rpmalloc/CMakeLists.txt
+@@ -1,8 +1,8 @@
+ set(CMAKE_C_FLAGS "-std=c11")
+ 
+ add_library(rpmalloc STATIC
+-	rpmalloc/rpmalloc/rpmalloc.c
+-	rpmalloc/rpmalloc/rpmalloc.h
++	rpmalloc/rpmalloc.c
++	rpmalloc/rpmalloc.h
+ )
+ 
+ target_include_directories(rpmalloc PUBLIC
+


### PR DESCRIPTION
LMMS is a free alternative to FruityLoops / FL Studio.  It can be used to produce music.

ALSA, PulseAudio [for casual users that want share audio across IP address, etc], Jack [for low latency for professional producers] were enabled.

The plugins (representing instruments, sound effects) were subpackaged, so there could be a warning about them when you start up the program.  If you don't like warnings just add them all.

Some subpackages were not enabled because there was missing packages like fluidsynth.  The APKBUILD can be modified if you need them.  A note was left in the APKBUILD for those interested in accessing those plugins.  Make a feature pull request to enable them after this pull request is merge.

QT5 is the default but QT4 might be considered for low resource builds.

More information:  https://lmms.io/
Source Code: https://github.com/LMMS/lmms
Main License: GPL-2.0-or-later
Other Licenses: GPL-2.0-only LGPL-2.1-or-later LGPL-2.1-only MIT CC-BY-3.0