### PR TITLE
main/vim: upgrade to 8.0.1521, fix license

### DIFF
--- a/main/vim/APKBUILD
+++ b/main/vim/APKBUILD
@@ -3,13 +3,12 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=vim
-pkgver=8.0.1424
-pkgrel=1
-pkgdesc="advanced text editor"
+pkgver=8.0.1521
+pkgrel=0
+pkgdesc="Improved vi-style text editor"
 url="http://www.vim.org"
 arch="all"
-license="custom"
-depends=""
+license="VIM"
 options="!check"  # no tests available
 makedepends="ncurses-dev lua5.3-dev python3-dev"
 subpackages="$pkgname-doc ${pkgname}diff::noarch"
@@ -19,6 +18,9 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   8.0.1521-r0:
+#     - CVE-2017-6350
+#     - CVE-2017-6349
 #   8.0.0329-r0:
 #     - CVE-2017-5953
 #   8.0.0056-r0:
@@ -64,5 +66,5 @@ vimdiff() {
 	mv "$pkgdir"/usr/bin/vimdiff "$subpkgdir"/usr/bin
 }
 
-sha512sums="774d380edf87ed0c807508a37ad68168cb9c468a37a3e8df96a503a3b257f55905e299c23d2d0bcd52b78a516e2374304ac96997602c11facf86a3f697099872  vim-8.0.1424.tar.gz
+sha512sums="a22a069453117dfa571f7e67692fd56c9c871170fd3791a7719cebc1ac7b77a24f1114d5ebdddd30f6a4c10943b3ae8abac82f94c2fed203e1d5b4b483e9701d  vim-8.0.1521.tar.gz
 d9586b777881973cb5e48e18750336a522ed72c3127b2d6b6991e2b943468ca5b694476e7fa39ab469178c1375fc8f52627484e0fe377aea5811a513e35a7b02  vimrc"


### PR DESCRIPTION
fixes for:
- [CVE-2017-6349](https://security-tracker.debian.org/tracker/CVE-2017-6349)
- [CVE-2017-6350](https://security-tracker.debian.org/tracker/CVE-2017-6350)