### PR TITLE
community/py3-qt5: subpackage qtwebkit, qtwebkitengine, qtwebchannel

### DIFF
--- a/community/py3-qt5/APKBUILD
+++ b/community/py3-qt5/APKBUILD
@@ -1,18 +1,20 @@
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=py3-qt5
 _pkgname=PyQt5
 pkgver=5.10
-pkgrel=0
+pkgrel=1
 pkgdesc="A set of Python 3 bindings for the Qt toolkit"
 url="http://riverbankcomputing.co.uk/software/pyqt/intro"
 arch="all"
 license="GPL-2.0-or-later"
 depends="py-sip"
 makedepends="python3-dev py-dbus-dev py-sip-dev
-	qt5-qtbase-dev libx11-dev qt5-qtsvg-dev qt5-websockets-dev"
+	qt5-qtbase-dev libx11-dev qt5-qtsvg-dev qt5-websockets-dev qt5-qtwebchannel-dev qt5-webengine-dev qt5-qtwebkit-dev"
 source="https://sourceforge.net/projects/pyqt/files/$_pkgname/PyQt-$pkgver/${_pkgname}_gpl-$pkgver.zip"
 builddir="${srcdir}/${_pkgname}_gpl-${pkgver}"
+subpackages="${pkgname#py-}-qtwebkit ${pkgname#py-}-qtwebengine ${pkgname#py-}-qtwebchannel"
 
 prepare() {
 	default_prepare
@@ -32,13 +34,55 @@ build() {
 }
 
 check() {
-    cd "$builddir"
-    make check
+	cd "$builddir"
+	make check
 }
 
-package(){
+package() {
 	cd "$builddir"
 	make DESTDIR="${pkgdir}" INSTALL_ROOT="${pkgdir}" install
+}
+
+_getpythonver() {
+	local python="python3"
+	local _PY_VERSION=$($python -c 'import sys; print("%i.%i" % (sys.version_info.major, sys.version_info.minor))')
+	echo "$_PY_VERSION"
+}
+
+_PY_VERSION=$(_getpythonver)
+
+qtwebkit() {
+	pkgdesc="$pkgname (qtwebkit)"
+	depends="$pkgname qt5-qtwebkit"
+	install -d "$subpkgdir"/usr/share/sip/PyQt5 "$subpkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/uic/widget-plugins/
+	mv "$pkgdir"/usr/share/sip/PyQt5/QtWebKit* \
+		"$subpkgdir"/usr/share/sip/PyQt5
+	mv "$pkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/uic/widget-plugins/qtwebkit.py \
+		"$subpkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/uic/widget-plugins/
+	mv "$pkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/QtWebKit* \
+		"$subpkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/
+}
+
+qtwebengine() {
+	pkgdesc="$pkgname (qtwebengine)"
+	depends="$pkgname qt5-webengine"
+	install -d "$subpkgdir"/usr/share/sip/PyQt5/ "$subpkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/ "$subpkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/uic/widget-plugins/
+	mv "$pkgdir"/usr/share/sip/PyQt5/QtWebEngine* \
+		"$subpkgdir"/usr/share/sip/PyQt5/
+	mv "$pkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/QtWebEngine* \
+		"$subpkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/
+	mv "$pkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/uic/widget-plugins/qtwebenginewidgets.py \
+		"$subpkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/uic/widget-plugins/
+}
+
+qtwebchannel() {
+	pkgdesc="$pkgname (qtwebchannel)"
+	depends="$pkgname qt5-qtwebchannel"
+	install -d "$subpkgdir"/usr/share/sip/PyQt5/ "$subpkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/
+	mv "$pkgdir"/usr/share/sip/PyQt5/QtWebChannel \
+		"$subpkgdir"/usr/share/sip/PyQt5/
+	mv "$pkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/QtWebChannel* \
+		"$subpkgdir"/usr/lib/python${_PY_VERSION}/site-packages/PyQt5/
 }
 
 sha512sums="32897291717df734ac6e0992f23e3ab2104708c10240cc824586f9622c1d0bdc0fb240569826ffa38ed2f3357dec216e6a0b9d6241b64e97cc3226807378ac91  PyQt5_gpl-5.10.zip"


### PR DESCRIPTION
This will generate Python bindings for qtwebchannel, qtwebengine, qt5webkit.  py3-qt5-qtwebengine requires qt5-webengine-dev (#3338 ) which is not in aports yet.  The py3-qt5-qtwebengine subpackage is used by qutebrowser (not in aports yet).