### PR TITLE
testing/qt5-webengine: new aport

### DIFF
--- a/testing/qt5-webengine/APKBUILD
+++ b/testing/qt5-webengine/APKBUILD
@@ -1,0 +1,115 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=qt5-webengine
+_pkgname=qtwebengine
+pkgver=5.9.3
+_pkgver=5.9
+pkgrel=0
+pkgdesc="Qt WebEngine integrates Chromium's fast moving web capabilities into Qt."
+url="http://wiki.qt.io/QtWebEngine"
+arch="x86_64 x86"
+license="GPL-2.0-or-later LGPL-3.0-only BSD-3-Clause MIT Apache-2.0 MPL-1.1 \
+	OFL-1.1 ISC GFDL-1.3 Libpng LGPL-2.1 NSCA SGI-B-2.0 NPL-1.1 ICU Ms-PL \
+	BSL-1.0 Zlib IJG custom"
+_license_build="$license BSD-2-Clause Artistic-1.0-cl8 LGPL-2.0-only MPL-2.0"
+makedepends="qt5-qtbase-dev
+	     paxmark
+	     gperf
+	     bison
+	     flex-dev
+	     libxcursor-dev
+	     qt5-qtdeclarative-dev
+	     qt5-qtwebchannel-dev
+	     libjpeg-turbo-dev
+	     ffmpeg-dev
+	     opus-dev
+	     libwebp-dev
+	     re2-dev
+	     alsa-lib-dev
+	     pulseaudio-dev
+	     gzip
+	     libintl
+	     icu-dev
+	     libxtst-dev
+	     libxrandr-dev
+	     libxcomposite-dev
+	     libxi-dev
+	     harfbuzz-dev
+	     jsoncpp-dev
+	     protobuf-dev
+	     snappy-dev
+	     minizip-dev
+	     nss-dev
+	     "
+_qtpkgname="qtwebengine-opensource-src"
+source="$pkgname-$pkgver.tar.xz::https://download.qt.io/official_releases/qt/$_pkgver/$pkgver/submodules/$_qtpkgname-$pkgver.tar.xz
+	allocator-shim-glibc.patch
+	chromium-widevine.patch
+	default-pthread-stacksize.patch
+	disable-allocator-shim-in-bootstrap.patch
+	disable-bootstrap-allocator-shim.patch
+	Dl_info.patch
+	glibc-logging.patch
+	intl.patch
+	libevent-compat-gn.patch
+	libevent-compat-py.patch
+	musl-fixes.patch
+	musl-hacks.patch
+	musl-sandbox.patch
+	paxmark-v8.patch
+	no-execinfo.patch
+	no-execinfo-2.patch
+	no-mallinfo.patch
+	no-pvalloc.patch
+	no-Wno-c++11-narrowing.patch
+	resolver.patch 
+	stackstart.patch
+	swiftshader.patch
+	"
+builddir="$srcdir/"$_qtpkgname-$pkgver
+subpackages="$pkgname-dev"
+
+build() {
+	cd "$builddir"
+	qmake-qt5 -- -ffmpeg -opus -webp -alsa -pulseaudio -webengine-icu
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	install -d "$pkgdir"/usr/share/licenses/$pkgname
+	make DESTDIR="${pkgdir}" INSTALL_ROOT="${pkgdir}" install
+	paxmark -m "$pkgdir"/usr/lib/qt5/libexec/QtWebEngineProcess
+	install -t "$pkgdir"/usr/share/licenses/$pkgname LICENSE.GPL3-EXCEPT \
+		src/3rdparty/chromium/v8/LICENSE.fdlibm
+}
+
+sha512sums="0db532b4d54540da1ca63de1cc4d561d72f052211535f75f60b99c1858ec0819ab0f831a3326d58da6350066748634000fe7ad0719ca545e12f3ed249a6eb90a  qt5-webengine-5.9.3.tar.xz
+9a6fc4edc99eeab9d163e14c88731fd1d83f8615d8c1b7a0fe842e5b6ac555113e78b54633aac5355e232c6c71240fbace9680fa32655832336e71c281b7f4c2  allocator-shim-glibc.patch
+24661f7d2c15be4499b9c5716075236fdda362a69256b6a4053c625717d0808bc8ddad55535b9d65d5540a9a5d6005e84ae0c8110e07821bd0f4871dea1413c5  chromium-widevine.patch
+254b088c10866dc9d970dee6b948a8ad31e30031bf868cb03f107bb03fb6aa32c839e000ce0262d47e88409b73e12bfcbb58efd9103480d98f94aaba44e3992e  default-pthread-stacksize.patch
+1dae173838064e49aebacb5ad3dcdd771b97b3bbcb88ab17cceed284df9f9897d35798b9c54dbd6fe8706ac9e482e9d846a12d4b9c1e90dcc230ff3b2fb44bec  disable-allocator-shim-in-bootstrap.patch
+24652e28124a74a6ddae642239ddc940ce644b837d1180ca411826ac442b65a6ec02e087993b409978a24605833d6ca71b4a68249ed53eb76a503a73d98d31b0  disable-bootstrap-allocator-shim.patch
+f04bfde79d8b1a011c12128e2286d191d33f5e450aae4adb89b2b066573c3b27ea8ed5712b718b9d82d86b7bbd96aa3455b817ccb1a361af1b763810cb588f94  Dl_info.patch
+01b74af17782cc5020d5e43cbaa7796021216e24537fe5f2a60bf9adc6c686a80fdf4c69eb5ddb967ae309eba3f0d939308250092f8d0f44176725bc4099d369  glibc-logging.patch
+9f1e97428c236ce6c59b2367f9e74d1df1fac8131fa6827422d54570a21a4914b32a44259bbc6b743e2b8c1cd2ec44cd9c1f14b745adb959b650cb620254ac01  intl.patch
+81f00395a51574e5a25824489e30e870065a6496aa32134c3aba556620355ae4eef884ffc6927970fd9f47e312df108b93e0e2fa32c0a456b4e7437f651ef180  libevent-compat-gn.patch
+4bd5e3b63856dc4c2049392ace2e05186e8d9895c98c609a59570b1a0426bc4deab378bba56cff8529eac7aa417d20476e1a6fae12c18dddf3e9657905cc1692  libevent-compat-py.patch
+bcc83a1900463c4450c661a52c07ace40536cd280e7df249bd2240d0a225746683af87af3120cc1a21bfd1a1303ca6d0bc50d5880d465ce6416206af29a897d1  musl-fixes.patch
+5b757436e690c5efcc40a570da55670fa445be73e98278ca872c98df4025c2b8394fe1c56b6b5226228a02bad4734e5e8db8fabc7db54da96d65529ae8279279  musl-hacks.patch
+687e1ce7a9e2ddc51fc02cda12219f853478ef01c9c482c3c23950d02c9ffef3ee0476e0340144f2d2492a73ff314f969c3856831e9dac66bdb5f5ef9c826775  musl-sandbox.patch
+e7b40b707f034122b76f48bacc0a34ff2f62cce2d9d0dfda056c07327cc4baec03fc25a69da703c83968440ec523c122c25c709501a5a836854b8915c838bb06  paxmark-v8.patch
+c0a53cf98eeddd7f2acf9dd011591e1cc4e3242bde5c5881c238bfd65dbecfb968f907ae7c9924638d028a0956ab200af9a3f3c0b8d3d73d90bfa348b2f54737  no-execinfo.patch
+49222f7f30dbd9f31eb527ac2f1afed888351df0bec42b8d1fa5494b25325b9c898eceba090af66f37a53f817f6ba982cc2409fb1b063b20196c6095fc2b4cf9  no-execinfo-2.patch
+5fc48df89c5cabe6a7642724840a22a95ac4c2f03cbd21b4a922398e4412a046bd86d996c9a0475795c4b82861a6ee337e99a64e50a5f780314ccd2941bba5f9  no-mallinfo.patch
+b932dae6dbfcd846b724fdd8d8364f94e7c7e02bbca90844d598606c1863f58c8bba674de5c0817414dff0308e64f3b5e8c772f5821c6b5812704a75b4a8eadf  no-pvalloc.patch
+04d5cd354d65814a8327351623667ca86643a2d07009483ee3136b0bcf926573737157242cb2c48ecb2ebdb0c4c5ee8cca1d55b439a1648916b1eefa47d3a599  no-Wno-c++11-narrowing.patch
+47cbfc15ba0dfa1f88d2364cd01e24d87579c78d9943925ffdf0400dd5d2ee3442fc6c2f8e35069d5bdb8550e3d0432299832e2fab867dd9343b3d909288e263  resolver.patch
+0fbfc37c31afe8b94cb98e9cb6d4eb0cbd260f859c80802aa1b71a31de973372e5dbabef104b3318414b92138c1b659442ea90391a7aadc8f287b043f861917e  stackstart.patch
+7149372ea5de74e0affbebff50e8059eb592ff78ac8f7225ce4e7f32bbe83878357450cbf0bf56c4424b300ed54a64fd80dc88f06a850d007b11e156ed900f92  swiftshader.patch"

--- a/testing/qt5-webengine/Dl_info.patch
+++ b/testing/qt5-webengine/Dl_info.patch
@@ -1,0 +1,11 @@
+--- a/src/3rdparty/chromium/third_party/WebKit/Source/wtf/Assertions.cpp.orig
++++ b/src/3rdparty/chromium/third_party/WebKit/Source/wtf/Assertions.cpp
+@@ -142,7 +142,7 @@
+ };
+ 
+ FrameToNameScope::FrameToNameScope(void* addr) : m_name(0), m_cxaDemangled(0) {
+-#if OS(MACOSX) || (OS(LINUX) && !defined(__UCLIBC__))
++#if OS(MACOSX) || (OS(LINUX) && defined(__GLIBC__))
+   Dl_info info;
+   if (!dladdr(addr, &info) || !info.dli_sname)
+     return;

--- a/testing/qt5-webengine/allocator-shim-glibc.patch
+++ b/testing/qt5-webengine/allocator-shim-glibc.patch
@@ -1,0 +1,11 @@
+--- a/src/3rdparty/chromium/base/allocator/allocator_shim_internals.h.orig
++++ b/src/3rdparty/chromium/base/allocator/allocator_shim_internals.h
+@@ -5,7 +5,7 @@
+ #ifndef BASE_ALLOCATOR_ALLOCATOR_SHIM_INTERNALS_H_
+ #define BASE_ALLOCATOR_ALLOCATOR_SHIM_INTERNALS_H_
+ 
+-#if defined(__GNUC__)
++#if defined(__GNUC__) && defined(__GLIBC__)
+ 
+ #include <sys/cdefs.h>  // for __THROW
+ 

--- a/testing/qt5-webengine/chromium-widevine.patch
+++ b/testing/qt5-webengine/chromium-widevine.patch
@@ -1,0 +1,9 @@
+--- a/src/3rdparty/chromium/third_party/widevine/cdm/stub/widevine_cdm_version.h	2016-01-14 01:05:17.000000000 +0200
++++ b/src/3rdparty/chromium/third_party/widevine/cdm/stub/widevine_cdm_version.h	2016-01-21 19:18:51.287978456 +0200
+@@ -12,4 +12,6 @@
+ 
+ #define WIDEVINE_CDM_AVAILABLE
+ 
++#define WIDEVINE_CDM_VERSION_STRING "@WIDEVINE_VERSION@"
++
+ #endif  // WIDEVINE_CDM_VERSION_H_

--- a/testing/qt5-webengine/default-pthread-stacksize.patch
+++ b/testing/qt5-webengine/default-pthread-stacksize.patch
@@ -1,0 +1,6 @@
+--- a/src/3rdparty/chromium/base/threading/platform_thread_linux.cc.orig
++++ b/src/3rdparty/chromium/base/threading/platform_thread_linux.cc
+@@ -99 +99,2 @@ size_t GetDefaultThreadStackSize(const p
+-  return 0;
++  // use 8mb like glibc to avoid running out of space
++  return (1 << 23);

--- a/testing/qt5-webengine/disable-allocator-shim-in-bootstrap.patch
+++ b/testing/qt5-webengine/disable-allocator-shim-in-bootstrap.patch
@@ -1,0 +1,11 @@
+--- a/src/3rdparty/chromium/tools/gn/bootstrap/bootstrap.py.orig
++++ b/src/3rdparty/chromium/tools/gn/bootstrap/bootstrap.py
+@@ -168,7 +168,7 @@
+   mkdir_p(root_gen_dir)
+ 
+   write_buildflag_header_manually(root_gen_dir, 'base/allocator/features.h',
+-      {'USE_EXPERIMENTAL_ALLOCATOR_SHIM': 'true' if is_linux else 'false'})
++      {'USE_EXPERIMENTAL_ALLOCATOR_SHIM': 'false' if is_linux else 'false'})
+ 
+   write_buildflag_header_manually(root_gen_dir, 'base/debug/debugging_flags.h',
+       {'ENABLE_PROFILING': 'false'})

--- a/testing/qt5-webengine/disable-bootstrap-allocator-shim.patch
+++ b/testing/qt5-webengine/disable-bootstrap-allocator-shim.patch
@@ -1,0 +1,13 @@
+--- a/src/3rdparty/chromium/tools/gn/bootstrap/bootstrap.py.orig
++++ b/src/3rdparty/chromium/tools/gn/bootstrap/bootstrap.py
+@@ -585,8 +585,8 @@
+         'tool': 'cxx',
+     }
+     static_libraries['base']['sources'].extend([
+-        'base/allocator/allocator_shim.cc',
+-        'base/allocator/allocator_shim_default_dispatch_to_glibc.cc',
++#        'base/allocator/allocator_shim.cc',
++#        'base/allocator/allocator_shim_default_dispatch_to_glibc.cc',
+         'base/memory/shared_memory_posix.cc',
+         'base/nix/xdg_util.cc',
+         'base/process/internal_linux.cc',

--- a/testing/qt5-webengine/glibc-logging.patch
+++ b/testing/qt5-webengine/glibc-logging.patch
@@ -1,0 +1,11 @@
+--- a/src/3rdparty/chromium/base/logging.cc.orig
++++ b/src/3rdparty/chromium/base/logging.cc
+@@ -526,7 +526,7 @@
+ }
+ 
+ LogMessage::~LogMessage() {
+-#if !defined(OFFICIAL_BUILD) && !defined(OS_NACL) && !defined(__UCLIBC__)
++#if !defined(OFFICIAL_BUILD) && !defined(OS_NACL) && defined(__GLIBC__)
+   if (severity_ == LOG_FATAL && !base::debug::BeingDebugged()) {
+     // Include a stack trace on a fatal, unless a debugger is attached.
+     base::debug::StackTrace trace;

--- a/testing/qt5-webengine/intl.patch
+++ b/testing/qt5-webengine/intl.patch
@@ -1,0 +1,22 @@
+--- a/src/3rdparty/chromium/third_party/yasm/BUILD.gn.orig
++++ b/src/3rdparty/chromium/third_party/yasm/BUILD.gn
+@@ -46,6 +46,7 @@
+     if (is_posix) {
+       cflags = [ "-std=gnu99" ]
+     }
++    libs = [ "intl" ]
+   }
+ 
+   executable("genmacro") {
+--- a/src/3rdparty/chromium/third_party/skia/gyp/yasm.gyp.orig
++++ b/src/3rdparty/chromium/third_party/skia/gyp/yasm.gyp
+@@ -199,6 +199,9 @@
+         '-mthumb',
+         '-march=armv7-a',
+       ],
++      'link_settings': {
++        'libraries': [ '-lintl' ],
++      }
+       'xcode_settings': {
+         'WARNING_CFLAGS': [
+           '-w',

--- a/testing/qt5-webengine/libevent-compat-gn.patch
+++ b/testing/qt5-webengine/libevent-compat-gn.patch
@@ -1,0 +1,11 @@
+--- a/src/3rdparty/chromium/base/third_party/libevent/BUILD.gn.orig
++++ b/src/3rdparty/chromium/base/third_party/libevent/BUILD.gn
+@@ -33,7 +33,7 @@
+     include_dirs = [ "mac" ]
+   } else if (is_linux) {
+     sources += [ "epoll.c" ]
+-    include_dirs = [ "linux" ]
++    include_dirs = [ "linux", "compat" ]
+   } else if (is_android) {
+     sources += [ "epoll.c" ]
+     include_dirs = [ "android" ]

--- a/testing/qt5-webengine/libevent-compat-py.patch
+++ b/testing/qt5-webengine/libevent-compat-py.patch
@@ -1,0 +1,12 @@
+--- a/src/3rdparty/chromium/tools/gn/bootstrap/bootstrap.py.orig
++++ b/src/3rdparty/chromium/tools/gn/bootstrap/bootstrap.py
+@@ -599,7 +599,8 @@
+         'base/threading/platform_thread_linux.cc',
+     ])
+     static_libraries['libevent']['include_dirs'].extend([
+-        os.path.join(SRC_ROOT, 'base', 'third_party', 'libevent', 'linux')
++        os.path.join(SRC_ROOT, 'base', 'third_party', 'libevent', 'linux'),
++        os.path.join(SRC_ROOT, 'base', 'third_party', 'libevent', 'compat')
+     ])
+     static_libraries['libevent']['sources'].extend([
+         'base/third_party/libevent/epoll.c',

--- a/testing/qt5-webengine/musl-fixes.patch
+++ b/testing/qt5-webengine/musl-fixes.patch
@@ -1,0 +1,97 @@
+--- a/src/3rdparty/chromium/base/native_library_posix.cc
++++ b/src/3rdparty/chromium/base/native_library_posix.cc
+@@ -12,6 +12,10 @@
+ #include "base/strings/utf_string_conversions.h"
+ #include "base/threading/thread_restrictions.h"
+ 
++#ifndef RTLD_DEEPBIND
++#define RTLD_DEEPBIND 0
++#endif
++
+ namespace base {
+ 
+ std::string NativeLibraryLoadError::ToString() const {
+--- a/src/3rdparty/chromium/device/serial/serial_io_handler_posix.cc
++++ b/src/3rdparty/chromium/device/serial/serial_io_handler_posix.cc
+@@ -6,6 +6,7 @@
+ 
+ #include <sys/ioctl.h>
+ #include <termios.h>
++#include <asm-generic/ioctls.h>
+ 
+ #include "base/files/file_util.h"
+ #include "base/posix/eintr_wrapper.h"
+--- a/src/3rdparty/chromium/net/dns/dns_config_service_posix.cc
++++ b/src/3rdparty/chromium/net/dns/dns_config_service_posix.cc
+@@ -120,7 +120,7 @@
+ ConfigParsePosixResult ReadDnsConfig(DnsConfig* config) {
+   ConfigParsePosixResult result;
+   config->unhandled_options = false;
+-#if defined(OS_OPENBSD)
++#if defined(OS_OPENBSD) || defined(_GNU_SOURCE)
+   // Note: res_ninit in glibc always returns 0 and sets RES_INIT.
+   // res_init behaves the same way.
+   memset(&_res, 0, sizeof(_res));
+--- a/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/trap.cc
++++ b/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/trap.cc
+@@ -168,7 +168,7 @@
+   // most versions of glibc don't include this information in siginfo_t. So,
+   // we need to explicitly copy it into a arch_sigsys structure.
+   struct arch_sigsys sigsys;
+-  memcpy(&sigsys, &info->_sifields, sizeof(sigsys));
++  memcpy(&sigsys, &info->__si_fields, sizeof(sigsys));
+ 
+ #if defined(__mips__)
+   // When indirect syscall (syscall(__NR_foo, ...)) is made on Mips, the
+--- a/src/3rdparty/chromium/sandbox/linux/suid/process_util.h
++++ b/src/3rdparty/chromium/sandbox/linux/suid/process_util.h
+@@ -12,6 +12,14 @@
+ #include <stdint.h>
+ #include <sys/types.h>
+ 
++// Some additional functions
++# define TEMP_FAILURE_RETRY(expression) \
++	(__extension__			\
++	 ({ long int __result;		\
++	  do __result = (long int) (expression); \
++	  while (__result == -1L && errno == EINTR); \
++	  __result; }))
++
+ // This adjusts /proc/process/oom_score_adj so the Linux OOM killer
+ // will prefer certain process types over others. The range for the
+ // adjustment is [-1000, 1000], with [0, 1000] being user accessible.
+--- a/src/3rdparty/chromium/third_party/ffmpeg/libavutil/cpu.c
++++ b/src/3rdparty/chromium/third_party/ffmpeg/libavutil/cpu.c
+@@ -39,7 +39,6 @@
+ #include <sys/param.h>
+ #endif
+ #include <sys/types.h>
+-#include <sys/sysctl.h>
+ #endif
+ #if HAVE_UNISTD_H
+ #include <unistd.h>
+--- a/src/3rdparty/chromium/third_party/lss/linux_syscall_support.h
++++ b/src/3rdparty/chromium/third_party/lss/linux_syscall_support.h
+@@ -1211,6 +1211,12 @@
+ #ifndef __NR_fallocate
+ #define __NR_fallocate          285
+ #endif
++
++#undef __NR_pread
++#define __NR_pread __NR_pread64
++#undef __NR_pwrite
++#define __NR_pwrite __NR_pwrite64
++
+ /* End of x86-64 definitions                                                 */
+ #elif defined(__mips__)
+ #if _MIPS_SIM == _MIPS_SIM_ABI32
+--- a/src/3rdparty/chromium/third_party/ots/include/opentype-sanitiser.h
++++ b/src/3rdparty/chromium/third_party/ots/include/opentype-sanitiser.h
+@@ -20,6 +20,7 @@
+ #define htonl(x) _byteswap_ulong (x)
+ #define htons(x) _byteswap_ushort (x)
+ #else
++#include <sys/types.h>
+ #include <arpa/inet.h>
+ #include <stdint.h>
+ #endif

--- a/testing/qt5-webengine/musl-hacks.patch
+++ b/testing/qt5-webengine/musl-hacks.patch
@@ -1,0 +1,23 @@
+--- a/src/3rdparty/chromium/base/debug/stack_trace.cc.orig
++++ b/src/3rdparty/chromium/base/debug/stack_trace.cc
+@@ -211,7 +211,7 @@
+ 
+ std::string StackTrace::ToString() const {
+   std::stringstream stream;
+-#if !defined(__UCLIBC__)
++#if defined(__GLIBC__)
+   OutputToStream(&stream);
+ #endif
+   return stream.str();
+--- a/src/3rdparty/chromium/v8/src/base/debug/stack_trace.cc.orig
++++ b/src/3rdparty/chromium/v8/src/base/debug/stack_trace.cc
+@@ -31,7 +31,9 @@
+ 
+ std::string StackTrace::ToString() const {
+   std::stringstream stream;
++#if defined(__GLIBC__)
+   OutputToStream(&stream);
++#endif
+   return stream.str();
+ }
+ 

--- a/testing/qt5-webengine/musl-sandbox.patch
+++ b/testing/qt5-webengine/musl-sandbox.patch
@@ -1,0 +1,70 @@
+--- a/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
++++ b/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
+@@ -114,23 +114,13 @@
+ // CLONE_VM, nor CLONE_THREAD, which includes all fork() implementations.
+ ResultExpr RestrictCloneToThreadsAndEPERMFork() {
+   const Arg<unsigned long> flags(0);
++  const int required = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND |
++                       CLONE_THREAD | CLONE_SYSVSEM;
++  const int safe = CLONE_SETTLS | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID |
++                   CLONE_DETACHED;
++  const BoolExpr thread_clone_ok = (flags&~safe)==required;
+ 
+-  // TODO(mdempsky): Extend DSL to support (flags & ~mask1) == mask2.
+-  const uint64_t kAndroidCloneMask = CLONE_VM | CLONE_FS | CLONE_FILES |
+-                                     CLONE_SIGHAND | CLONE_THREAD |
+-                                     CLONE_SYSVSEM;
+-  const uint64_t kObsoleteAndroidCloneMask = kAndroidCloneMask | CLONE_DETACHED;
+-
+-  const uint64_t kGlibcPthreadFlags =
+-      CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD |
+-      CLONE_SYSVSEM | CLONE_SETTLS | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID;
+-  const BoolExpr glibc_test = flags == kGlibcPthreadFlags;
+-
+-  const BoolExpr android_test =
+-      AnyOf(flags == kAndroidCloneMask, flags == kObsoleteAndroidCloneMask,
+-            flags == kGlibcPthreadFlags);
+-
+-  return If(IsAndroid() ? android_test : glibc_test, Allow())
++  return If(thread_clone_ok, Allow())
+       .ElseIf((flags & (CLONE_VM | CLONE_THREAD)) == 0, Error(EPERM))
+       .Else(CrashSIGSYSClone());
+ }
+--- a/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc.orig
++++ b/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+@@ -494,6 +494,7 @@
+     case __NR_mlock:
+     case __NR_munlock:
+     case __NR_munmap:
++    case __NR_mremap:
+       return true;
+     case __NR_madvise:
+     case __NR_mincore:
+@@ -509,7 +510,6 @@
+     case __NR_modify_ldt:
+ #endif
+     case __NR_mprotect:
+-    case __NR_mremap:
+     case __NR_msync:
+     case __NR_munlockall:
+     case __NR_readahead:
+diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+index 80f02c0..21fbe21 100644
+--- a/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
++++ b/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+@@ -373,6 +373,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
+ #if defined(__i386__)
+     case __NR_waitpid:
+ #endif
++    case __NR_set_tid_address:
+       return true;
+     case __NR_clone:  // Should be parameter-restricted.
+     case __NR_setns:  // Privileged.
+@@ -385,7 +386,6 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
+     case __NR_set_thread_area:
+ #endif
+-    case __NR_set_tid_address:
+     case __NR_unshare:
+ #if !defined(__mips__) && !defined(__aarch64__)
+     case __NR_vfork:

--- a/testing/qt5-webengine/no-Wno-c++11-narrowing.patch
+++ b/testing/qt5-webengine/no-Wno-c++11-narrowing.patch
@@ -1,0 +1,11 @@
+--- a/src/3rdparty/chromium/tools/gn/bootstrap/bootstrap.py.orig
++++ b/src/3rdparty/chromium/tools/gn/bootstrap/bootstrap.py
+@@ -327,7 +327,7 @@
+         '-fno-exceptions',
+         '-D__STDC_FORMAT_MACROS'
+     ])
+-    cflags_cc.extend(['-std=c++11', '-Wno-c++11-narrowing'])
++    cflags_cc.extend(['-std=c++11', ''])
+   elif is_win:
+     if not options.debug:
+       cflags.extend(['/Ox', '/DNDEBUG', '/GL'])

--- a/testing/qt5-webengine/no-execinfo-2.patch
+++ b/testing/qt5-webengine/no-execinfo-2.patch
@@ -1,0 +1,11 @@
+--- a/src/3rdparty/chromium/third_party/WebKit/Source/wtf/Assertions.cpp.orig
++++ b/src/3rdparty/chromium/third_party/WebKit/Source/wtf/Assertions.cpp
+@@ -164,7 +164,7 @@
+ }
+ 
+ void WTFGetBacktrace(void** stack, int* size) {
+-#if OS(MACOSX) || (OS(LINUX) && !defined(__UCLIBC__))
++#if OS(MACOSX) || (OS(LINUX) && defined(__GLIBC__))
+   *size = backtrace(stack, *size);
+ #elif OS(WIN)
+   // The CaptureStackBackTrace function is available in XP, but it is not

--- a/testing/qt5-webengine/no-execinfo.patch
+++ b/testing/qt5-webengine/no-execinfo.patch
@@ -1,0 +1,103 @@
+--- a/src/3rdparty/chromium/base/debug/stack_trace_posix.cc.orig
++++ b/src/3rdparty/chromium/base/debug/stack_trace_posix.cc
+@@ -25,7 +25,7 @@
+ #if defined(__GLIBCXX__)
+ #include <cxxabi.h>
+ #endif
+-#if !defined(__UCLIBC__)
++#if defined(__GLIBC__)
+ #include <execinfo.h>
+ #endif
+ 
+@@ -76,7 +76,7 @@
+   // Note: code in this function is NOT async-signal safe (std::string uses
+   // malloc internally).
+ 
+-#if defined(__GLIBCXX__) && !defined(__UCLIBC__)
++#if defined(__GLIBCXX__) && defined(__GLIBC__)
+ 
+   std::string::size_type search_from = 0;
+   while (search_from < text->size()) {
+@@ -125,7 +125,7 @@
+   virtual ~BacktraceOutputHandler() {}
+ };
+ 
+-#if !defined(__UCLIBC__)
++#if defined(__GLIBC__)
+ void OutputPointer(void* pointer, BacktraceOutputHandler* handler) {
+   // This should be more than enough to store a 64-bit number in hex:
+   // 16 hex digits + 1 for null-terminator.
+@@ -679,6 +679,10 @@
+ }  // namespace
+ 
+ bool EnableInProcessStackDumping() {
++#if defined(OS_LINUX) && !defined(__GLIBC__)
++// let system handler deal with the dumps
++  return true;
++#else
+ #if defined(USE_SYMBOLIZE)
+   SandboxSymbolizeHelper::GetInstance();
+ #endif  // USE_SYMBOLIZE
+@@ -712,13 +716,14 @@
+ #endif  // !defined(OS_LINUX)
+ 
+   return success;
++#endif
+ }
+ 
+ StackTrace::StackTrace() {
+   // NOTE: This code MUST be async-signal safe (it's used by in-process
+   // stack dumping signal handler). NO malloc or stdio is allowed here.
+ 
+-#if !defined(__UCLIBC__)
++#if defined(__GLIBC__)
+   // Though the backtrace API man page does not list any possible negative
+   // return values, we take no chance.
+   count_ = base::saturated_cast<size_t>(backtrace(trace_, arraysize(trace_)));
+@@ -731,13 +736,13 @@
+   // NOTE: This code MUST be async-signal safe (it's used by in-process
+   // stack dumping signal handler). NO malloc or stdio is allowed here.
+ 
+-#if !defined(__UCLIBC__)
++#if defined(__GLIBC__)
+   PrintBacktraceOutputHandler handler;
+   ProcessBacktrace(trace_, count_, &handler);
+ #endif
+ }
+ 
+-#if !defined(__UCLIBC__)
++#if defined(__GLIBC__)
+ void StackTrace::OutputToStream(std::ostream* os) const {
+   StreamBacktraceOutputHandler handler(os);
+   ProcessBacktrace(trace_, count_, &handler);
+--- a/src/3rdparty/chromium/third_party/WebKit/Source/wtf/Assertions.cpp.orig
++++ b/src/3rdparty/chromium/third_party/WebKit/Source/wtf/Assertions.cpp
+@@ -60,7 +60,7 @@
+ #include <windows.h>
+ #endif
+ 
+-#if OS(MACOSX) || (OS(LINUX) && !defined(__UCLIBC__))
++#if OS(MACOSX) || (OS(LINUX) && defined(__GLIBC__))
+ #include <cxxabi.h>
+ #include <dlfcn.h>
+ #include <execinfo.h>
+--- a/src/3rdparty/chromium/third_party/webrtc/base/checks.cc.orig
++++ b/src/3rdparty/chromium/third_party/webrtc/base/checks.cc
+@@ -16,7 +16,7 @@
+ #include <cstdio>
+ #include <cstdlib>
+ 
+-#if defined(__GLIBCXX__) && !defined(__UCLIBC__)
++#if defined(__GLIBCXX__) && defined(__GLIBC__)
+ #include <cxxabi.h>
+ #include <execinfo.h>
+ #endif
+@@ -60,7 +60,7 @@
+ // to get usable symbols on Linux. This is copied from V8. Chromium has a more
+ // advanced stace trace system; also more difficult to copy.
+ void DumpBacktrace() {
+-#if defined(__GLIBCXX__) && !defined(__UCLIBC__)
++#if defined(__GLIBCXX__) && defined(__GLIBC__)
+   void* trace[100];
+   int size = backtrace(trace, sizeof(trace) / sizeof(*trace));
+   char** symbols = backtrace_symbols(trace, size);

--- a/testing/qt5-webengine/no-mallinfo.patch
+++ b/testing/qt5-webengine/no-mallinfo.patch
@@ -1,0 +1,83 @@
+--- a/src/3rdparty/chromium/base/trace_event/malloc_dump_provider.cc.orig
++++ b/src/3rdparty/chromium/base/trace_event/malloc_dump_provider.cc
+@@ -248,7 +248,7 @@
+   resident_size = all_heap_info.committed_size;
+   allocated_objects_size = all_heap_info.allocated_size;
+   allocated_objects_count = all_heap_info.block_count;
+-#else
++#elif defined(OS_LINUX) && defined(__GLIBC__)
+   struct mallinfo info = mallinfo();
+   DCHECK_GE(info.arena + info.hblkhd, info.uordblks);
+ 
+--- a/src/3rdparty/chromium/content/child/content_child_helpers.cc.orig
++++ b/src/3rdparty/chromium/content/child/content_child_helpers.cc
+@@ -25,7 +25,7 @@
+ // though, this provides only a partial and misleading value.
+ // Unfortunately some telemetry benchmark rely on it and these need to
+ // be refactored before getting rid of this. See crbug.com/581365 .
+-#if defined(OS_LINUX) || defined(OS_ANDROID)
++#if defined(OS_LINUX) && defined(__GLIBC__) || defined(OS_ANDROID)
+ size_t GetMemoryUsageKB() {
+   struct mallinfo minfo = mallinfo();
+   uint64_t mem_usage =
+--- a/src/3rdparty/chromium/content/renderer/render_thread_impl.cc.orig
++++ b/src/3rdparty/chromium/content/renderer/render_thread_impl.cc
+@@ -1822,6 +1822,49 @@
+ }
+ 
+ }  // namespace
++#elif defined(OS_LINUX) && !defined(__GLIBC__)
++namespace {
++
++static size_t GetMallocUsage() {
++  char *line=NULL;
++  size_t n,usage=0;
++  FILE *f = fopen("/proc/self/maps", "r");
++  char *path, *perm;
++  if (f == NULL) {
++    perror("/proc/self/maps");
++    return 0;
++  }
++  path = (char *)malloc(PATH_MAX+16);
++  if (path == NULL)
++    goto out;
++  perm = path + PATH_MAX;
++
++  while (getline(&line, &n, f) >=0) {
++    size_t start,end,offset,inode;
++    int devmaj, devmin, items;
++
++    items = sscanf(line, "%zx-%zx %s %zx %x:%x %zu %s",
++                   &start, &end, perm, &offset,
++                   &devmaj, &devmin, &inode, path);
++
++    if (items < 7)
++      continue;
++
++    if (items < 8)
++      path[0] = '\0';
++
++    if ((strcmp(perm, "rw-p") == 0 && devmaj+devmin == 0)
++        && (path[0] == '\0' || strcmp(path, "[heap]") == 0))
++      usage += end-start;
++  }
++  free(line);
++  free(path);
++out:
++  fclose(f);
++  return usage;
++}
++
++}  // namespace
+ #endif
+ 
+ // TODO(tasak): Once it is possible to use memory-infra without tracing,
+@@ -1840,7 +1883,7 @@
+                           blink_stats.partitionAllocTotalAllocatedBytes / 1024);
+   UMA_HISTOGRAM_MEMORY_KB("PurgeAndSuspend.Memory.BlinkGCKB",
+                           blink_stats.blinkGCTotalAllocatedBytes / 1024);
+-#if defined(OS_LINUX) || defined(OS_ANDROID)
++#if (defined(__GLIBC__) && defined(__GLIBC__)) || defined(OS_ANDROID)
+   struct mallinfo minfo = mallinfo();
+ #if defined(USE_TCMALLOC)
+   size_t malloc_usage = minfo.uordblks;

--- a/testing/qt5-webengine/no-pvalloc.patch
+++ b/testing/qt5-webengine/no-pvalloc.patch
@@ -1,0 +1,24 @@
+--- a/src/core/api/qtbug-61521.cpp.orig
++++ b/src/core/api/qtbug-61521.cpp
+@@ -74,10 +74,6 @@
+ void* __valloc(size_t size)
+     SHIM_ALIAS_SYMBOL(ShimValloc);
+ 
+-SHIM_SYMBOL_VERSION(pvalloc);
+-void* __pvalloc(size_t size)
+-    SHIM_ALIAS_SYMBOL(ShimPvalloc);
+-
+ SHIM_SYMBOL_VERSION(posix_memalign);
+ int __posix_memalign(void** r, size_t a, size_t s)
+     SHIM_ALIAS_SYMBOL(ShimPosixMemalign);
+@@ -108,10 +104,6 @@
+ 
+ SHIM_HIDDEN void* ShimValloc(size_t size) {
+     return  valloc(size);
+-}
+-
+-SHIM_HIDDEN void* ShimPvalloc(size_t size) {
+-    return pvalloc(size);
+ }
+ 
+ SHIM_HIDDEN int ShimPosixMemalign(void** r, size_t a, size_t s) {

--- a/testing/qt5-webengine/paxmark-v8.patch
+++ b/testing/qt5-webengine/paxmark-v8.patch
@@ -1,0 +1,11 @@
+--- a/src/3rdparty/chromium/v8/tools/run.py.orig
++++ b/src/3rdparty/chromium/v8/tools/run.py
+@@ -9,4 +9,8 @@
+ import subprocess
+ import sys
+ 
++subprocess.call(["pwd"])
++subprocess.call(["paxmark", "-m", "obj/v8/mksnapshot"])
++subprocess.call(["paxmark", "-m", "mksnapshot"])
++
+ sys.exit(subprocess.call(sys.argv[1:]))

--- a/testing/qt5-webengine/resolver.patch
+++ b/testing/qt5-webengine/resolver.patch
@@ -1,0 +1,36 @@
+--- a/src/3rdparty/chromium/net/dns/host_resolver_impl.cc.orig
++++ b/src/3rdparty/chromium/net/dns/host_resolver_impl.cc
+@@ -2074,8 +2074,7 @@
+   NetworkChangeNotifier::AddIPAddressObserver(this);
+   NetworkChangeNotifier::AddConnectionTypeObserver(this);
+   NetworkChangeNotifier::AddDNSObserver(this);
+-#if defined(OS_POSIX) && !defined(OS_MACOSX) && !defined(OS_OPENBSD) && \
+-    !defined(OS_ANDROID)
++#if defined(__GLIBC__)
+   EnsureDnsReloaderInit();
+ #endif
+ 
+--- a/src/3rdparty/chromium/net/dns/dns_reloader.cc.orig
++++ b/src/3rdparty/chromium/net/dns/dns_reloader.cc
+@@ -4,8 +4,7 @@
+ 
+ #include "net/dns/dns_reloader.h"
+ 
+-#if defined(OS_POSIX) && !defined(OS_MACOSX) && !defined(OS_OPENBSD) && \
+-    !defined(OS_ANDROID)
++#if defined(__GLIBC__)
+ 
+ #include <resolv.h>
+ 
+--- a/src/3rdparty/chromium/net/dns/host_resolver_proc.cc.orig
++++ b/src/3rdparty/chromium/net/dns/host_resolver_proc.cc
+@@ -193,8 +193,7 @@
+   // Restrict result set to only this socket type to avoid duplicates.
+   hints.ai_socktype = SOCK_STREAM;
+ 
+-#if defined(OS_POSIX) && !defined(OS_MACOSX) && !defined(OS_OPENBSD) && \
+-    !defined(OS_ANDROID)
++#if defined(__GLIBC__)
+   DnsReloaderMaybeReload();
+ #endif
+   int err = getaddrinfo(host.c_str(), NULL, &hints, &ai);

--- a/testing/qt5-webengine/stackstart.patch
+++ b/testing/qt5-webengine/stackstart.patch
@@ -1,0 +1,20 @@
+--- a/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/StackFrameDepth.cpp.orig
++++ b/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/StackFrameDepth.cpp
+@@ -68,7 +68,7 @@
+ // FIXME: On Mac OSX and Linux, this method cannot estimate stack size
+ // correctly for the main thread.
+ 
+-#if defined(__GLIBC__) || OS(ANDROID) || OS(FREEBSD)
++#if defined(OS_LINUX) || OS(ANDROID) || OS(FREEBSD)
+   // pthread_getattr_np() can fail if the thread is not invoked by
+   // pthread_create() (e.g., the main thread of webkit_unit_tests).
+   // If so, a conservative size estimate is returned.
+@@ -135,7 +135,7 @@
+ }
+ 
+ void* StackFrameDepth::getStackStart() {
+-#if defined(__GLIBC__) || OS(ANDROID) || OS(FREEBSD)
++#if defined(OS_LINUX) || OS(ANDROID) || OS(FREEBSD)
+   pthread_attr_t attr;
+   int error;
+ #if OS(FREEBSD)

--- a/testing/qt5-webengine/swiftshader.patch
+++ b/testing/qt5-webengine/swiftshader.patch
@@ -1,0 +1,56 @@
+--- a/src/3rdparty/chromium/third_party/swiftshader/third_party/LLVM/include-linux/llvm/Config/config.h.orig
++++ b/src/3rdparty/chromium/third_party/swiftshader/third_party/LLVM/include-linux/llvm/Config/config.h
+@@ -125,7 +125,7 @@
+ #define HAVE_ERROR_T 1
+ 
+ /* Define to 1 if you have the <execinfo.h> header file. */
+-#define HAVE_EXECINFO_H 1
++/* #undef HAVE_EXECINFO_H */
+ 
+ /* Define to 1 if you have the <fcntl.h> header file. */
+ #define HAVE_FCNTL_H 1
+@@ -240,10 +240,10 @@
+ /* #undef HAVE_MACH_O_DYLD_H */
+ 
+ /* Define if mallinfo() is available on this platform. */
+-#define HAVE_MALLINFO 1
++/* #undef HAVE_MALLINFO */
+ 
+ /* Define to 1 if you have the <malloc.h> header file. */
+-#define HAVE_MALLOC_H 1
++/* #undef HAVE_MALLOC_H */
+ 
+ /* Define to 1 if you have the <malloc/malloc.h> header file. */
+ /* #undef HAVE_MALLOC_MALLOC_H */
+--- a/src/3rdparty/chromium/third_party/swiftshader/third_party/LLVM/lib/Support/DynamicLibrary.cpp.orig
++++ b/src/3rdparty/chromium/third_party/swiftshader/third_party/LLVM/lib/Support/DynamicLibrary.cpp
+@@ -160,7 +160,7 @@
+ // On linux we have a weird situation. The stderr/out/in symbols are both
+ // macros and global variables because of standards requirements. So, we
+ // boldly use the EXPLICIT_SYMBOL macro without checking for a #define first.
+-#if defined(__linux__) && !defined(__ANDROID__)
++#if defined(__GLIBC__)
+   {
+     EXPLICIT_SYMBOL(stderr);
+     EXPLICIT_SYMBOL(stdout);
+--- a/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-subzero/include/llvm/Config/config.h.orig
++++ b/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-subzero/include/llvm/Config/config.h
+@@ -172,7 +172,7 @@
+ /* #undef HAVE_MALLINFO */
+ 
+ /* Define to 1 if you have the <malloc.h> header file. */
+-#define HAVE_MALLOC_H 1
++/* #define HAVE_MALLOC_H 1 */
+ 
+ /* Define to 1 if you have the <malloc/malloc.h> header file. */
+ /* #undef HAVE_MALLOC_MALLOC_H */
+--- a/src/3rdparty/chromium/third_party/swiftshader/src/Common/Socket.cpp.orig
++++ b/src/3rdparty/chromium/third_party/swiftshader/src/Common/Socket.cpp
+@@ -17,6 +17,7 @@
+ #if defined(_WIN32)
+ 	#include <ws2tcpip.h>
+ #else
++	#include <sys/select.h>
+ 	#include <unistd.h>
+ 	#include <netdb.h>
+ 	#include <netinet/in.h>


### PR DESCRIPTION
This is required for qutebrowser.  I think qt5-webengine uses Blink.

PulseAudio was enabled for those wanting to play audio over TCP/IP or another computer/sound system from YouTube for example.

I put x86_64 and x86.  Other archs may need to be tested or added.

Some external dependencies couldn't be met like external libxml2, libvpx for example but rather uses internal library.  It may require additional patches to use the external library.

I recommend updating the qt5-webchannel first (#3339 ) so that it avoids mismatched dependencies for the newer qt5-qtwebchannel-5.9.3-r1 versus qt5-qtwebchannel-5.9.3-r0.