### PR TITLE
testing/qt5-qtwebchannel: expose qml for qtwebchannel

### DIFF
--- a/testing/qt5-qtwebchannel/APKBUILD
+++ b/testing/qt5-qtwebchannel/APKBUILD
@@ -7,13 +7,13 @@ _ver=${pkgver/_/-}
 _ver=${_ver/beta0/beta}
 _ver=${_ver/rc0/rc}
 _V=${_ver/rc/RC}
-pkgrel=0
+pkgrel=1
 pkgdesc="library for seamless integration of C++ +and QML applications with HTML/JavaScript clients."
 url="http://qt-project.org/"
 arch="all"
 license="LGPL-2.0 with exceptions or GPL-3.0 with exceptions"
 options="!check" #upstream does not provide check
-makedepends="qt5-qtbase-dev qt5-websockets-dev"
+makedepends="qt5-qtbase-dev qt5-websockets-dev qt5-qtdeclarative-dev"
 subpackages="$pkgname-dev"
 
 case $pkgver in


### PR DESCRIPTION
This is required for PyQt (py3-qt5).  When you add the old package, it doesn't contain the extra files that are required.  It only provided .so files.