### PR TITLE
testing/qutebrowser: new aport

### DIFF
--- a/testing/qutebrowser/APKBUILD
+++ b/testing/qutebrowser/APKBUILD
@@ -1,0 +1,42 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=qutebrowser
+pkgver=1.1.1
+pkgrel=0
+pkgdesc="A keyboard-driven, vim-like browser based on PyQt5."
+url="https://www.qutebrowser.org/"
+arch="noarch"
+license="GPL-3.0-or-later Apache-2.0"
+depends="py3-qt5 qt5-qtdeclarative qt5-webengine py3-jinja2 py3-qt5-qtwebengine"
+depends+="py3-qt5-qtwebchannel>=5.9.3-r1 py3-attrs py3-yaml py3-pygments"
+depends+="py3-jinja2 py3-pypeg2 py3-markupsafe"
+makedepends="py3-setuptools"
+subpackages="$pkgname:_py3 $pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/qutebrowser/qutebrowser/archive/v$pkgver.tar.gz"
+builddir="$srcdir/"$pkgname-$pkgver
+
+check() {
+	cd "$builddir"
+	python3 setup.py check
+}
+
+build() {
+	cd "$builddir"
+	python3 setup.py build
+}
+
+package() {
+	install -d "$pkgdir"/usr/share/doc/$pkgname
+	install -t "$pkgdir"/usr/share/doc/$pkgname "$builddir"/README.asciidoc
+}
+
+_py3() {
+	local python="python3"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"  ## remove if arch isn't noarch
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="a836e91d54240b31edede3ad691b02112fbf48608131ed8c84dffbc20b33bea6e32f47e03bafcd4108dda561c04ed50667d97b4539e4f9fb211a9f0151c3d39f  qutebrowser-1.1.1.tar.gz"


### PR DESCRIPTION
This is a lightweight web browser based on Qt's WebEngine (which is based on Chromium’s Blink).  It supports link hints, and vim navigation. It depends on #3338 , #3339 , #3337 , #3424 .

More info:  https://www.qutebrowser.org/
Source code: https://github.com/qutebrowser/qutebrowser
Primary license: GPL-3.0-or-later