### PR TITLE
testing/wireguard: upgrade to 0.0.20180218

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20180202
-_mypkgrel=2
+_ver=0.0.20180218
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="81eb66b2abe3b3013fc7fbc7f6601808d1676f1fa5e7942d0af09e2ec56e91c396ded2b23eece7c63d1b76f6c3209d93b7cdf06c9d30a59e626d08a604a6780a  WireGuard-0.0.20180202.tar.xz"
+sha512sums="975556e447934a5492ddf6f4faef14887794fe2fece3b811bad17b93aa5fe34f55653d2b87ceb6d06f0292406247a3b45b67f1a61387cf724995c0a67fcd42d2  WireGuard-0.0.20180218.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180202
+pkgver=0.0.20180218
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="81eb66b2abe3b3013fc7fbc7f6601808d1676f1fa5e7942d0af09e2ec56e91c396ded2b23eece7c63d1b76f6c3209d93b7cdf06c9d30a59e626d08a604a6780a  WireGuard-0.0.20180202.tar.xz"
+sha512sums="975556e447934a5492ddf6f4faef14887794fe2fece3b811bad17b93aa5fe34f55653d2b87ceb6d06f0292406247a3b45b67f1a61387cf724995c0a67fcd42d2  WireGuard-0.0.20180218.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20180202
-_mypkgrel=0
+_ver=0.0.20180218
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="81eb66b2abe3b3013fc7fbc7f6601808d1676f1fa5e7942d0af09e2ec56e91c396ded2b23eece7c63d1b76f6c3209d93b7cdf06c9d30a59e626d08a604a6780a  WireGuard-0.0.20180202.tar.xz"
+sha512sums="975556e447934a5492ddf6f4faef14887794fe2fece3b811bad17b93aa5fe34f55653d2b87ceb6d06f0292406247a3b45b67f1a61387cf724995c0a67fcd42d2  WireGuard-0.0.20180218.tar.xz"


### PR DESCRIPTION
```

  * keygen-html: fix up copyright
  
  Copy and paste errors.
  
  * tools: do not collide types with libc clashes
  * tools: FreeBSD doesn't have EAI_NODATA
  * tools: fixup errno handling
  * tools: endian.h is not portable
  
  Fixes compilation and correctness several places.
  
  * tools: allow in-line comments
  
  You can now put a # comment anywhere in a line, in which case, it extends
  until the end of the line.
  
  * wg-quick: match from beginning rather than shift right
  
  This raises the proper error when providing interface names that are too long.
  
  * qemu: add support for powerpc
  
  Now that we have known PPC users, it's probably a good thing to ensure we
  don't introduce bugs, so PPC has been added to our CI on build.wireguard.com.
  
  * poly1305: fix up selftest counter
  
  Make sure we're using the right array length in the debug-mode-only
  self-tests.
  
  * netns: replace n0 ip with ip0, per custom
  
  Fixes up console output consistency.
  
  * qemu: more granular memleak detection
  
  This avoids us getting memory leak errors due to upstream's power management
  drivers leaking, or the like, when we're only interested in WireGuard memory
  leaks.
  
  * socket: free skb if there isn't an endpoint
  
  Fixes a memory leak.
  
  * allowedips: indicate to clang-analyzer that trie is non-null
  
  Hopefully future versions are slightly smarter...
  
  * blake2s: use union instead of casting
  
  Similarly fixes a clang-analyzer issue, as well as ensuring alignment.
  
  * tools: normalize strncpy/snprintf usage
  
  Correctness.
  
  * contrib: add embeddable wireguard library
  
  See: https://lists.zx2c4.com/pipermail/wireguard/2018-February/002387.html
  And: https://git.zx2c4.com/WireGuard/tree/contrib/examples/embeddable-wg-library/README
```