### PR TITLE
main/fsarchiver: upgrade to 0.8.4, fix license

### DIFF
--- a/main/fsarchiver/APKBUILD
+++ b/main/fsarchiver/APKBUILD
@@ -1,14 +1,16 @@
 # Contributor: Bartłomiej Piotrowski <bpiotrowski@alpinelinux.org>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=fsarchiver
-pkgver=0.8.3
-pkgrel=1
+pkgver=0.8.4
+pkgrel=0
 pkgdesc="Safe and flexible file-system backup and deployment tool"
 arch="all"
 url="http://www.fsarchiver.org/"
-license="GPL-2.0"
+license="GPL-2.0-only"
 subpackages="$pkgname-doc"
-makedepends="linux-headers attr-dev bzip2-dev e2fsprogs-dev lz4-dev lzo-dev xz-dev libgcrypt-dev zlib-dev"
+makedepends="linux-headers attr-dev bzip2-dev e2fsprogs-dev lz4-dev
+	lzo-dev xz-dev libgcrypt-dev zlib-dev
+	"
 source="https://github.com/fdupoux/fsarchiver/releases/download/$pkgver/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -17,7 +19,8 @@ build() {
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr
+		--prefix=/usr \
+		--disable-zstd
 	make
 }
 
@@ -31,4 +34,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="a57e64b655e8f44feb9809a4a62207c7d9b63b4c6803d11807cb445f516823d8a97d49963f0eb0c8299a8c5c4538ecd6eb90a7ac0befe1b96f50012ae740b84a  fsarchiver-0.8.3.tar.gz"
+sha512sums="15712e5fdb9695148e8fe42791952acf0c7d34611c3467a0cb2e2631c9c5f1c55a4e839098085e6a72c2d8988b05e6f515ef772bcc5766b57a07da65a5209efd  fsarchiver-0.8.4.tar.gz"


### PR DESCRIPTION
~~added support for zstd compression~~
package built without zstd support, until further notice.