### PR TITLE
testing/py3-lit: new package

### DIFF
--- a/testing/py3-lit/APKBUILD
+++ b/testing/py3-lit/APKBUILD
@@ -1,0 +1,41 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+pkgname=py3-lit
+pkgver=0.6.0_rc1
+_pkgver=0.6.0rc1
+pkgrel=0
+pkgdesc="lit is a tool for executing LLVM and Clang style test suites, summarizing their results, and providing indication of failures."
+url="https://pypi.python.org/pypi/lit"
+arch="noarch"
+license="BSD-3-Clause NSCA"
+makedepends="py3-setuptools"
+options="check !archcheck"
+source="$pkgname-$pkgver.tar.gz::https://pypi.python.org/packages/b7/38/8bbbaca02c8f98e797db9b265bab6e9fc9c3402ffdebd825c6fcf05a49fb/lit-0.6.0rc1.tar.gz#md5=52535811efe285dcf58a97fe16d1c845"
+builddir="$srcdir/"${pkgname#py3-}-$_pkgver
+subpackages="$pkgname:_py3 $pkgname-doc"
+
+build() {
+        cd "$builddir"
+	python3 setup.py build
+}
+
+check() {
+        cd "$builddir"
+	python3 setup.py check
+}
+
+package() {
+	install -d "$pkgdir"/usr/share/doc/$pkgname/
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ "$builddir"/README.txt
+}
+
+_py3() {
+	local python="python3"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"  ## remove if arch isn't noarch
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="c6572ed06bfb99796be49d305e31c4da87dd964cf7125aa7b37cf61ffce7bf68b0835771bafbfa9a98b067c3edfa1294e36bac6f4d96cb36aaa1aece04f8e069  py3-lit-0.6.0_rc1.tar.gz"


### PR DESCRIPTION
Add unit testing tool using LLVM and Clang style test suite.  This is used for Bear (#3172) check().

More info: https://pypi.python.org/pypi/lit
License: BSD-3-Clause