### PR TITLE
main/rrdtool: upgrade to 1.7.0

### DIFF
--- a/main/rrdtool/APKBUILD
+++ b/main/rrdtool/APKBUILD
@@ -1,18 +1,18 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=rrdtool
-pkgver=1.5.6
-pkgrel=3
+pkgver=1.7.0
+pkgrel=0
 pkgdesc="Data logging and graphing application"
 url="http://www.rrdtool.org"
 arch="all"
 license="GPL"
 depends="font-sony-misc"
 makedepends="libart-lgpl-dev libpng-dev freetype-dev perl-dev cairo-dev libxml2-dev
-	pango-dev lua lua-dev python2-dev groff
+	pango-dev lua lua-dev python2-dev py-setuptools groff
 	autoconf automake libtool"
 subpackages="$pkgname-dev $pkgname-doc perl-rrd:perl_rrd lua-rrd:lua_rrd py-rrd:py_rrd
-	$pkgname-cached $pkgname-cgi $pkgname-utils librrd-th:libth librrd:libs"
+	$pkgname-cached $pkgname-cgi $pkgname-utils librrd:libs"
 source="http://oss.oetiker.ch/$pkgname/pub/$pkgname-$pkgver.tar.gz
 	lua-install-cmod.patch
 	libm-underlinking.patch
@@ -20,7 +20,7 @@ source="http://oss.oetiker.ch/$pkgname/pub/$pkgname-$pkgver.tar.gz
 	dont-install-in-usr-local.patch
 	rrdcached.initd
 	"
-options="!check"
+options="!check" # As of 1.7.0 9/21 tests fails.
 builddir="$srcdir"/$pkgname-$pkgver
 
 prepare() {
@@ -43,6 +43,11 @@ build() {
 		--enable-lua-site-install \
 		--with-perl-options="INSTALLDIRS=vendor"
 	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
@@ -109,21 +114,14 @@ utils() {
 		"$subpkgdir"/usr/bin
 }
 
-libth() {
-	depends=
-	pkgdesc="$pkgdesc (multi-threaded libraries)"
-	mkdir -p "$subpkgdir"/usr/lib
-	mv "$pkgdir"/usr/lib/librrd_th.so* "$subpkgdir"/usr/lib
-}
-
 libs() {
 	depends=
 	default_libs
 }
 
-sha512sums="b980e36932683dbe2c2793c291c34e1c3a7fba208bda35b4b2d4fc994a9539c3c19f568e184d4fc13f9647b2715151147deeaf975d978f820e449129f3cfb7fd  rrdtool-1.5.6.tar.gz
-0be4ebb864233cf32fa70c872f5421b2da50ad39d6a265c2f5869337b40647c0b88011ccf41fe17a8d35de915ca1c38d04d67696118e1e32ff774221b1816ab6  lua-install-cmod.patch
-94449972ccc7d1a057c2b827c041a16de1667c280a47ef30c1323ec9168812a96374704cc42dd832a30b8cc08d7fad94da44ff3695c66f3a0d324a87158fc23c  libm-underlinking.patch
-00d079161551a75f8d4fe5085741d45d9c6b06be0a5163090143c6ab47710e29633414bee4dd68bbf950bf0ba1796bf4623b4f307477265a48f49514c8b790ab  no-posix-fallocate.patch
-839d9a2fbb74332cc9d0de18828f1496103b0cca6f05b3f88437dff6289954952f51350dcf01543d234ded19798115d400d9d61722e7193cd7f2bce47c14f6be  dont-install-in-usr-local.patch
+sha512sums="36d979561601135d74622eaf183701de15cba5e25118f7a308926a695ba84ecb33c3d16511bf4bc80cff055853e2eb85065bc4ed8aef19fc0277c6430ecd319f  rrdtool-1.7.0.tar.gz
+904fb16b065d879d8cec95e1f4bf67f5a3ff29afc023e8ba2b5636ba1cf5213f24279f2e9179e8a1acb889eee68b0b6527803aad14fcae9c3b98afdbf9e1f89f  lua-install-cmod.patch
+49c1d9a8523d9b5a3e4df8e9cc8da58490d4329e88ec12021d50db0b45c780ed465a30521f3a397c0d28bab5d5c1a3839bbe1ae062d8bc645420d16690b9797c  libm-underlinking.patch
+853f21b1d4935fd25184e8ac1be683a95952237705e6f7b9072a8247d1307e38c4b31117bcdc12ce1a812d7a6ac711cebfba833ef640b01e4fff1f2b7d0018ef  no-posix-fallocate.patch
+7b01d5b7c83270e0e45f3186cd0882c206173d2801678c98f1a427be1927898e602535a4cd9c808e2ab8fd393a1fb5267efae53c889c368a502a06d18cfae9aa  dont-install-in-usr-local.patch
 c0c27b2c2dfa8e7ec1cb1160d2bda8d7996bbea67f4ce7779da029f583c35e5e415cf46e2a1e5cb8ed2e63d2c58a68fd7471ee6bd820db4c0f4eeeb5c252f8a3  rrdcached.initd"

--- a/main/rrdtool/dont-install-in-usr-local.patch
+++ b/main/rrdtool/dont-install-in-usr-local.patch
@@ -21,11 +21,9 @@ index b662270..0179122 100644
  
  --
  -- make sure require works with standard libraries
-diff --git a/configure.ac b/configure.ac
-index 5270b22..8d87da9 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -864,7 +864,7 @@ LUA_EOF
+@@ -843,7 +843,7 @@
            AC_MSG_WARN(Setting Lua include and lib flags to defaults in compat-5.1 and lua 5.1 sources)
            LUA_CFLAGS="-I/usr/local/include -I/usr/local/include/lua -I/usr/local/include/lua/$lua_vdot"
            LUA_LFLAGS="-L/usr/local/lib -L/usr/local/lib/lua -L/usr/local/lib/lua/$lua_vdot $lua_libs"
@@ -34,6 +32,3 @@ index 5270b22..8d87da9 100644
          fi
  
          dnl pass additional lua options
--- 
-2.11.1
-

--- a/main/rrdtool/libm-underlinking.patch
+++ b/main/rrdtool/libm-underlinking.patch
@@ -1,6 +1,6 @@
---- ./src/Makefile.am.orig	2013-07-24 09:38:33.088184877 +0000
-+++ ./src/Makefile.am	2013-07-24 09:38:48.788333567 +0000
-@@ -111,7 +111,7 @@
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -128,7 +128,7 @@
  
  rrdtool_SOURCES = rrd_tool.c
  rrdtool_DEPENDENCIES = librrd.la
@@ -8,4 +8,4 @@
 +rrdtool_LDADD	= librrd.la -lm
  
  rrdcached_SOURCES = rrd_daemon.c
- rrdcached_DEPENDENCIES = librrd_th.la
+ rrdcached_DEPENDENCIES = librrd.la librrdupd.la

--- a/main/rrdtool/lua-install-cmod.patch
+++ b/main/rrdtool/lua-install-cmod.patch
@@ -1,6 +1,6 @@
---- ./configure.orig
-+++ ./configure
-@@ -29330,7 +29330,9 @@
+--- a/configure
++++ b/configure
+@@ -21996,7 +21996,9 @@
  $as_echo "$as_me: WARNING: Setting Lua include and lib flags to defaults in compat-5.1 and lua 5.1 sources" >&2;}
            LUA_CFLAGS="-I/usr/local/include -I/usr/local/include/lua -I/usr/local/include/lua/$lua_vdot"
            LUA_LFLAGS="-L/usr/local/lib -L/usr/local/lib/lua -L/usr/local/lib/lua/$lua_vdot $lua_libs"

--- a/main/rrdtool/no-posix-fallocate.patch
+++ b/main/rrdtool/no-posix-fallocate.patch
@@ -1,6 +1,6 @@
---- rrdtool-1.4.8.orig/configure.ac
-+++ rrdtool-1.4.8/configure.ac
-@@ -280,9 +280,6 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -316,9 +316,6 @@
  #include <fcntl.h>])
  AC_CHECK_FUNCS(posix_fadvise)
  


### PR DESCRIPTION
As of 1.6.0 librrd is fully thread-safe and librrd_th was removed.

https://oss.oetiker.ch/rrdtool/pub/CHANGES


I was wondering if a py3 subpackage would be appropiate since:
`* all new and much more complete python bindings working on both python 2.6+ and 3.3+`

