### PR TITLE
Cleanup and streamline kernel module packages

### DIFF
--- a/community/virtualbox-guest-modules-vanilla/APKBUILD
+++ b/community/virtualbox-guest-modules-vanilla/APKBUILD
@@ -1,27 +1,39 @@
 # Maintainer: Ben Allen <bensallen@me.com>
 # Contributor: Ben Allen <bensallen@me.com>
 
+# when chaning _ver we *must* bump _rel
+_name=virtualbox-guest-modules
+_ver=5.2.2
+_rel=0
+
 _flavor=${FLAVOR:-vanilla}
 _kpkg=linux-$_flavor
 _kver=4.14.20
-_kpkgrel=0
+_krel=0
 
-# when chaning _ver we *must* bump _mypkgrel
-_ver=5.2.2
-_mypkgrel=0
-_name=virtualbox-guest-modules
+_kpkgver="$_kver-r$_krel"
+_kabi=$_kver-$_krel-$_flavor
+_kabi_virt=$_kver-$_krel-virt
 
-_kpkgver="$_kver-r$_kpkgrel"
-_abi_release=${_kver}-${_kpkgrel}-${_flavor}
-_abi_release_virt=${_kver}-${_kpkgrel}-virt
+# verify the kernel version before entering chroot
+_kapkbuild=../../main/linux-vanilla/APKBUILD
+if [ -f $_kapkbuild ]; then
+	(	. $_kapkbuild
+		pkgname=$_name-$_flavor
+		[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
+		[ "$_krel" != "$pkgrel" ] && die "please update _krel to $pkgrel"
+		return 0
+	)
+fi
 
-pkgname=${_name}-${_flavor}
+pkgname=$_name-$_flavor
 pkgver=$_kver
-pkgrel=$(($_kpkgrel + $_mypkgrel))
+pkgrel=$(($_krel + $_rel))
+
 pkgdesc="VirtualBox Additions guest kernel modules for $_flavor"
 arch='x86 x86_64'
 url='http://virtualbox.org'
-license="GPL custom"
+license="GPL-2.0 custom"
 makedepends="linux-vanilla-dev=$_kpkgver linux-virt-dev=$_kpkgver sed coreutils"
 subpackages="$_name-virt:virt"
 source="http://download.virtualbox.org/virtualbox/$_ver/VirtualBox-$_ver.tar.bz2
@@ -33,27 +45,12 @@ builddir="$srcdir"/VirtualBox-$_ver
 prepare() {
 	local i
 
-	(
-	# verify the kernel version before entering chroot
-	_kapkbuild="$startdir"/../../main/linux-${_flavor}/APKBUILD
-	if [ -f $_kapkbuild ]; then
-		. $_kapkbuild
-		pkgname=$_name-$_flavor
-		if [ "$_kver" != "$pkgver" ]; then
-			die "please update _kver to $pkgver"
-		fi
-		if [ "$_kpkgrel" != "$pkgrel" ]; then
-			die "please update _kpkgrel to $pkgrel"
-		fi
-	fi
-	)
-
 	cd "$builddir"
 	default_prepare
 	"$builddir"/src/VBox/Additions/linux/export_modules.sh \
 		"$srcdir/vbox-kmod-$_ver.tar.gz"
 
-	for i in $_abi_release $_abi_release_virt; do
+	for i in $_kabi $_kabi_virt; do
 		mkdir -p "$srcdir/$i"
 		tar -C "$srcdir/$i" -zxf "$srcdir"/vbox-kmod-$_ver.tar.gz
 	done
@@ -61,7 +58,7 @@ prepare() {
 
 build() {
 	local i
-	for i in $_abi_release $_abi_release_virt; do
+	for i in $_kabi $_kabi_virt; do
 		cd "$srcdir/$i"
 		# Build Kernel Modules
 		make KERN_DIR=/lib/modules/${i}/build
@@ -70,7 +67,7 @@ build() {
 
 package() {
 	local i module=
-	for i in $_abi_release $_abi_release_virt; do
+	for i in $_kabi $_kabi_virt; do
 		cd "$srcdir/$i"
 		for module in *.ko; do
 			install -v -D -m644 ${module} \
@@ -83,8 +80,8 @@ virt() {
 	pkgdesc="VirtualBox Additions kernel modules for virt"
 	mkdir -p "$subpkgdir"/lib/modules/
 	# vboxvideo.ko won't load with virt kernel as it doesn't have DRM
-	rm "$pkgdir"/lib/modules/$_abi_release_virt/misc/vboxvideo.ko
-	mv "$pkgdir"/lib/modules/$_abi_release_virt \
+	rm "$pkgdir"/lib/modules/$_kabi_virt/misc/vboxvideo.ko
+	mv "$pkgdir"/lib/modules/$_kabi_virt \
 		"$subpkgdir"/lib/modules/
 }
 

--- a/main/dahdi-linux-vanilla/APKBUILD
+++ b/main/dahdi-linux-vanilla/APKBUILD
@@ -1,33 +1,45 @@
 # Contributor: Timo Teras <timo.teras@iki.fi>
 # Maintainer: Timo Teras <timo.teras@iki.fi>
 
-_flavor=vanilla
+# when changing _ver we *must* bump _rel
+_name=dahdi-linux
+_ver=2.11.1
+_rel=0
+
+_flavor=${FLAVOR:-vanilla}
 _kpkg=linux-$_flavor
 _kver=4.14.20
-_kpkgrel=0
-_mypkgrel=0
+_krel=0
 
-_kpkgver="$_kver-r$_kpkgrel"
-_abi_release=${_kver}-${_kpkgrel}-${_flavor}
-_realname=dahdi-linux
+_kpkgver="$_kver-r$_krel"
+_kabi="$_kver-$_krel-$_flavor"
 
-pkgname=${_realname}-${_flavor}
+# verify the kernel version before entering chroot
+_kapkbuild=../../main/linux-vanilla/APKBUILD
+if [ -f $_kapkbuild ]; then
+	(	. $_kapkbuild
+		pkgname=$_name-$_flavor
+		[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
+		[ "$_krel" != "$pkgrel" ] && die "please update _krel to $pkgrel"
+		return 0
+	)
+fi
+
+pkgname=$_name-$_flavor
 pkgver=$_kver
-# when chaning _dahdiver we *must* bump _mypkgrel
-_dahdiver=2.11.1
-pkgrel=$(( $_kpkgrel + $_mypkgrel ))
-pkgdesc="Digium Asterisk Hardware Device Interface drivers $_dahdiver"
+pkgrel=$(( $_krel + $_rel ))
+
+pkgdesc="Digium Asterisk Hardware Device Interface drivers $_ver"
 url="http://www.asterisk.org"
 arch="x86 x86_64"
-license="GPL"
-depends="dahdi-linux linux-${_flavor}=${_kpkgver}"
+license="GPL-2.0"
+depends="dahdi-linux $_kpkg=$_kpkgver"
 # we need wget and tar because make install downloads firmware and uses fancy
 # options for tar and wget.
-makedepends="linux-${_flavor}-dev=${_kpkgver} wget tar perl"
-install=
+makedepends="$_kpkg-dev=$_kpkgver wget tar perl"
 subpackages="$pkgname-dev"
-provides="${_realname}-grsec=${pkgver}-r${pkgrel}"
-source="http://downloads.digium.com/pub/telephony/dahdi-linux/releases/${_realname}-$_dahdiver.tar.gz
+#provides="${_name}-grsec=${pkgver}-r${pkgrel}"
+source="http://downloads.digium.com/pub/telephony/dahdi-linux/releases/${_name}-$_ver.tar.gz
 	dahdi-depmod.patch
 	dahdi-bri_dchan.patch
 	dahdi-zaphfc.patch
@@ -42,44 +54,22 @@ source="http://downloads.digium.com/pub/telephony/dahdi-linux/releases/${_realna
 	linux-4.13.patch
 	"
 
-prepare() {
-	cd "$srcdir/$_realname-$_dahdiver"
-	# verify the kernel version
-	(
+builddir="$srcdir/$_name-$_ver"
 
-	if [ -f "$startdir"/../linux-${_flavor}/APKBUILD ]; then
-		. "$startdir"/../linux-${_flavor}/APKBUILD
-		if [ "$_kver" != "$pkgver" ]; then
-			die "dahdi-linux-grsec: please update _kver to $pkgver"
-		fi
-		if [ "$_kpkgrel" != "$pkgrel" ]; then
-			die "dahdi-linux-grsec: please update _kpkgrel to $pkgrel"
-		fi
-	fi
-	) || return 1
-
-	for i in $source; do
-		case $i in
-		*.patch|*.diff)
-			msg "Applying $i"
-			patch -p1 -i "$srcdir"/$i || return 1
-			;;
-		esac
-	done
-}
+# grsec legacy
+[ "$_flavor" = "hardened" ] && provides="$_name-grsec=$pkgver-r$pkgrel"
 
 build() {
-	cd "$srcdir/$_realname-$_dahdiver"
-	make KVERS="${_abi_release}" DYNFS="yes" MODULES_EXTRA="zaphfc" \
-		|| return 1
+	cd "$srcdir/$_name-$_ver"
+	make KVERS="${_kabi}" DYNFS="yes" MODULES_EXTRA="zaphfc"
 }
 
 package() {
-	cd "$srcdir/$_realname-$_dahdiver"
-	make KVERS="${_abi_release}" DYNFS="yes" MODULES_EXTRA="zaphfc" \
-		DESTDIR="$pkgdir" install-modules || return 1
+	cd "$srcdir/$_name-$_ver"
+	make KVERS="${_kabi}" DYNFS="yes" MODULES_EXTRA="zaphfc" \
+		DESTDIR="$pkgdir" install-modules
 	rm -rf "$pkgdir"/lib/firmware "$pkgdir"/usr/lib/hotplug/firmware \
-		"$pkgdir"/usr/include
+		"$pkgdir"/usr/include || true
 }
 
 # since we sourced the APKBUILD above we got the dev() function there to
@@ -87,8 +77,8 @@ package() {
 depends_dev="dahdi-linux-dev"
 dev() {
 	default_dev
-	local dir="$subpkgdir"/usr/src/dahdi-headers-${_abi_release}
-	install -D "$srcdir"/$_realname-$_dahdiver/drivers/dahdi/Module.symvers \
+	local dir="$subpkgdir"/usr/src/dahdi-headers-${_kabi}
+	install -D "$srcdir"/$_name-$_ver/drivers/dahdi/Module.symvers \
 		"$dir"/drivers/dahdi/Module.symvers
 	ln -s /usr/include "$dir"/include
 }

--- a/main/devicemaster-linux-vanilla/APKBUILD
+++ b/main/devicemaster-linux-vanilla/APKBUILD
@@ -1,58 +1,56 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 
-_flavor=vanilla
+# when changing _ver we *must* bump _rel
+_name=devicemaster-linux
+_ver=7.26
+_rel=0
+
+_flavor=${FLAVOR:-vanilla}
 _kpkg=linux-$_flavor
 _kver=4.14.20
-_kpkgrel=0
-_mypkgrel=0
+_krel=0
 
-_kpkgver="$_kver-r$_kpkgrel"
-_abi_release=${_kver}-${_kpkgrel}-${_flavor}
-_realname=devicemaster-linux
+_kpkgver="$_kver-r$_krel"
+_kabi="$_kver-$_krel-$_flavor"
 
-pkgname=${_realname}-${_flavor}
+# verify the kernel version before entering chroot
+_kapkbuild=../../main/linux-vanilla/APKBUILD
+if [ -f $_kapkbuild ]; then
+	(	. $_kapkbuild
+		pkgname=$_name-$_flavor
+		[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
+		[ "$_krel" != "$pkgrel" ] && die "please update _krel to $pkgrel"
+		return 0
+	)
+fi
+
+pkgname=$_name-$_flavor
 pkgver=$_kver
-# when changing _realver we *must* bump _mypkgrel
-_realver=7.26
-pkgrel=$(( $_kpkgrel + $_mypkgrel ))
-pkgdesc="NS-Link Device Drivers $_realver for linux-$_flavor"
+pkgrel=$(( $_krel + $_rel ))
+
+pkgdesc="NS-Link Device Drivers $_ver for $_kpkg"
 url="http://www.comtrol.com/resources/product-resources-white-papers/ns-link-device-drivers"
 arch="x86 x86_64 armhf"
-license="GPL"
-depends="linux-${_flavor}=${_kpkgver}"
-makedepends="linux-${_flavor}-dev=${_kpkgver} linux-headers"
-install=
-install_if="$_kpkg=$_kpkgver $_realname"
-subpackages=""
-provides="${_realname}-grsec=${pkgver}-r${pkgrel}"
-source="http://dev.alpinelinux.org/archive/devicemaster-linux/devicemaster-linux-$_realver.tar.gz
-	"
+license="GPL-2.0"
+depends="$_kpkg=$_kpkgver"
+makedepends="$_kpkg-dev=$_kpkgver linux-headers"
+install_if="$_kpkg=$_kpkgver $_name"
+#provides="${_name}-grsec=${pkgver}-r${pkgrel}"
+source="http://dev.alpinelinux.org/archive/devicemaster-linux/devicemaster-linux-$_ver.tar.gz"
+builddir="$srcdir"/$_name-$_ver
 
-builddir="$srcdir"/devicemaster-linux-$_realver
-prepare() {
-	# verify the kernel version
-	(if [ -f ../../main/linux-${_flavor}/APKBUILD ]; then
-		_name=$pkgname
-		. ../../main/linux-${_flavor}/APKBUILD
-		pkgname=$_name
-		[ "$_kver" != "$pkgver" ] \
-			&& die "please update _kver to $pkgver"
-		[ "$_kpkgrel" != "$pkgrel" ] \
-			&& die "please update _kpkgrel to $pkgrel"
-	fi)
-	default_prepare
-}
+# grsec legacy
+[ "$_flavor" = "hardened" ] && provides="$_name-grsec=$pkgver-r$pkgrel"
 
 build() {
-	cd "$srcdir/$_realname-$_realver"
-	make -C /lib/modules/$_abi_release/build SUBDIRS="$PWD" modules \
-		V=1
+	cd "$srcdir/$_name-$_ver"
+	make -C /lib/modules/$_kabi/build SUBDIRS="$PWD" modules V=1
 }
 
 package() {
-	cd "$srcdir/$_realname-$_realver"
-	mkdir -p "$pkgdir/lib/modules/${_abi_release}/misc/"
-	cp *.ko "$pkgdir/lib/modules/${_abi_release}/misc/"
+	cd "$srcdir/$_name-$_ver"
+	mkdir -p "$pkgdir/lib/modules/$_kabi/misc/"
+	cp *.ko "$pkgdir/lib/modules/$_kabi/misc/"
 }
 
 sha512sums="5ae164645824018b99e8e8917d81f336fdef5745cb43fb93582c4e61f58a5c005202c19fcc8b13a4a24f4fc94287bf11f496b447db62bbf67b07da5793a9d8f7  devicemaster-linux-7.26.tar.gz"

--- a/main/drbd9-vanilla/APKBUILD
+++ b/main/drbd9-vanilla/APKBUILD
@@ -1,64 +1,51 @@
 # Contributor: Roland Kammerer <roland.kammerer@linbit.com>
 # Maintainer: Roland Kammerer <roland.kammerer@linbit.com>
-_usname=drbd
-_flavor=${FLAVOR:-vanilla}
-_name=$_usname-$_flavor
 
+# when changing _ver we *must* bump _rel
+_name=drbd
+_ver=9.0.9
+_rel=1
+
+_flavor=${FLAVOR:-vanilla}
 _kpkg=linux-$_flavor
 _kver=4.14.20
-_kpkgrel=0
+_krel=0
+_kabi="$_kver-$_krel-$_flavor"
+_kpkgver="$_kver-r$_krel"
 
-_usver=9.0.9
-# upstream now also has a -rel in the tar-balls
-# set it here for "source", but don't mangle it into pkgrel/_mypkgrel
-# if there is a new upstream rel (eg. 9.0.1-2), we just increase _mypkgrel
-_usrel=1
+# verify the kernel version before entering chroot
+_kapkbuild=../../main/linux-vanilla/APKBUILD
+if [ -f $_kapkbuild ]; then
+	(	. $_kapkbuild
+		pkgname=$_name-$_flavor
+		[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
+		[ "$_krel" != "$pkgrel" ] && die "please update _krel to $pkgrel"
+		return 0
+	)
+fi
 
-_mypkgrel=0
-
-_kernelver=$_kver-r$_kpkgrel
-_abi_release=${_kver}-${_kpkgrel}-${_flavor}
-
-pkgname=${_usname}9-$_flavor
+pkgname=$_name-$_flavor
 pkgver=$_kver
-pkgrel=$(($_kpkgrel + $_mypkgrel))
+pkgrel=$(( $_krel + $_rel ))
+
 pkgdesc="Network-based RAID 1 version 9"
 url="http://www.drbd.org"
 arch="all"
-license="GPL"
-depends="linux-${_flavor}=${_kernelver}"
-depends_dev=""
-makedepends="linux-${_flavor}-dev bash"
-install=""
-subpackages=""
-source="https://links.linbit.com/sources/$_usname/${_usver%.*}/$_usname-$_usver-$_usrel.tar.gz"
+license="GPL-2.0"
+depends="$_kpkg=$_kpkgver"
+makedepends="$_kpkg-dev=$_kpkgver bash"
+source="https://links.linbit.com/sources/$_name/${_ver%.*}/$_name-$_ver-$_rel.tar.gz"
 
-_builddir=$srcdir/$_usname-$_usver-$_usrel
-prepare() {
-	local i
-	# verify the kernel version
-	(cd $startdir
-	if [ -f ../../main/linux-${_flavor}/APKBUILD ]; then
-		. ../../main/linux-${_flavor}/APKBUILD
-		[ "$_kver" != "$pkgver" ] \
-			&& die "please update _kver to $pkgver"
-		[ "$_kpkgrel" != "$pkgrel" ] \
-			&& die "please update _kpkgrel to $pkgrel"
-	else
-		die "could not determine kernel flavor: linux-${_flavor}"
-	fi
-	return 0)
-	default_prepare
-}
+builddir=$srcdir/$_name-$_ver-$_rel
 
 build() {
-	cd "$_builddir"
+	cd "$builddir"
 	unset LDFLAGS
-	make KVER=$_abi_release
+	make KVER=$_kabi
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
 

--- a/main/linux-vanilla/APKBUILD
+++ b/main/linux-vanilla/APKBUILD
@@ -53,7 +53,6 @@ fi
 arch="all"
 license="GPL-2.0"
 
-_abi_release=${pkgver}
 _carch=${CARCH}
 case "$_carch" in
 aarch64*) _carch="arm64" ;;

--- a/main/spl-vanilla/APKBUILD
+++ b/main/spl-vanilla/APKBUILD
@@ -1,53 +1,55 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
-_flavor=${FLAVOR:-vanilla}
-_realname=spl
-_name=$_realname-$_flavor
+
+# when changing _ver we *must* bump _rel
+_name=spl
+_ver=0.7.5
+_rel=0
 
 _kpkg=linux-$_flavor
 _kver=4.14.20
-_kpkgrel=0
+_krel=0
 
-_realver=0.7.5
-_mypkgrel=0
+_flavor=${FLAVOR:-vanilla}
+_kpkg=linux-$_flavor
+_kver=4.14.20
+_krel=0
 
+_kpkgver="$_kver-r$_krel"
+_kabi="$_kver-$_krel-$_flavor"
 
-_kernelver=$_kver-r$_kpkgrel
-_abi_release=${_kver}-${_kpkgrel}-${_flavor}
+# verify the kernel version before entering chroot
+_kapkbuild=../../main/linux-vanilla/APKBUILD
+if [ -f $_kapkbuild ]; then
+	(	. $_kapkbuild
+		pkgname=$_name-$_flavor
+		[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
+		[ "$_krel" != "$pkgrel" ] && die "please update _krel to $pkgrel"
+		return 0
+	)
+fi
 
-pkgname=$_name
+pkgname=$_name-$_flavor
 pkgver=$_kver
-pkgrel=$(($_kpkgrel + $_mypkgrel))
+pkgrel=$(( $_krel + $_rel ))
+
 pkgdesc="Solaris Porting Layer"
 url="http://zfsonlinux.org"
 arch="x86 x86_64 aarch64"
-license="GPL"
-depends="linux-${_flavor}=${_kernelver}"
-depends_dev="linux-vanilla-dev=$_kernelver"
+license="GPL-2.0"
+depends="$_kpkg=$_kpkgver"
+depends_dev="$_kpkg-dev=$_kpkgver"
 makedepends="$depends_dev linux-headers file"
-install=""
 subpackages="$pkgname-dev"
-source="https://github.com/zfsonlinux/zfs/releases/download/zfs-$_realver/spl-$_realver.tar.gz"
+source="https://github.com/zfsonlinux/zfs/releases/download/zfs-$_ver/spl-$_ver.tar.gz"
 
-builddir="$srcdir"/spl-$_realver
+builddir="$srcdir/$_name-$_ver"
 
 prepare() {
 	# do not remove as it sources other prepare
 	default_prepare
 	update_config_sub
 	update_config_guess
-	# source the kernel version
-	(
-	if [ -f "$startdir"/../../main/linux-$_flavor/APKBUILD ]; then
-	        . "$startdir"/../../main/linux-$_flavor/APKBUILD
-	        if [ "$_kver" != "$pkgver" ]; then
-			die "$_name: Please update _kver to $pkgver"
-		fi
-		if [ "$_kpkgrel" != "$pkgrel" ]; then
-			die "$_name: Please update _kpkgrel to $pkgrel"
-		fi
-	fi
-	)
 }
 
 build() {
@@ -58,13 +60,13 @@ build() {
 		--infodir=/usr/share/info \
 		--localstatedir=/var \
 		--with-config=kernel \
-		--with-linux=/usr/src/linux-headers-${_abi_release}
+		--with-linux=/usr/src/linux-headers-$_kabi
 	make
 }
 
 package() {
-        cd "$builddir"
-        make DESTDIR="$pkgdir" install
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 }
 
 dev() {

--- a/main/xtables-addons-vanilla/APKBUILD
+++ b/main/xtables-addons-vanilla/APKBUILD
@@ -1,53 +1,46 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
+
+# when changing _ver we *must* bump _rel
+_name=xtables-addons
+_ver=2.14
+_rel=0
+
 _flavor=${FLAVOR:-vanilla}
 _kpkg=linux-$_flavor
-_realname=xtables-addons
-_name=$_realname-$_flavor
-
 _kver=4.14.20
-_kpkgrel=0
+_krel=0
 
-_realver=2.14
-_mypkgrel=0
+_kpkgver="$_kver-r$_krel"
+_kabi="$_kver-$_krel-$_flavor"
 
-_kernelver=$_kver-r$_kpkgrel
-_abi_release=${_kver}-${_kpkgrel}-${_flavor}
+# verify the kernel version before entering chroot
+_kapkbuild=../../main/linux-vanilla/APKBUILD
+if [ -f $_kapkbuild ]; then
+	(	. $_kapkbuild
+		pkgname=$_name-$_flavor
+		[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
+		[ "$_krel" != "$pkgrel" ] && die "please update _krel to $pkgrel"
+		return 0
+	)
+fi
 
-pkgname=$_name
+pkgname=$_name-$_flavor
 pkgver=$_kver
-pkgrel=$(($_kpkgrel + $_mypkgrel))
+pkgrel=$(( $_krel + $_rel ))
+
 pkgdesc="Iptables extensions kernel modules"
 url="http://xtables-addons.sourceforge.net/"
 arch="all"
-license="GPL"
-depends="linux-${_flavor}=${_kernelver}"
-makedepends="linux-${_flavor}-dev=${_kernelver} iptables-dev linux-headers"
-install=
-install_if="linux-$_flavor=$_kernelver $_realname"
-subpackages=
-source="http://downloads.sourceforge.net/$_realname/$_realname-$_realver.tar.xz"
+license="GPL-2.0"
+depends="$_kpkg=$_kpkgver"
+makedepends="$_kpkg-dev=$_kpkgver iptables-dev linux-headers"
+install_if="$_kpkg=$_kpkgver $_name"
+source="http://downloads.sourceforge.net/$_name/$_name-$_ver.tar.xz"
 # temporary disable the provides til hardened is fully removed
-#provides="$_realname-grsec=${pkgver}-r${pkgrel}"
-#replaces="$_realname-hardened"
-builddir="$srcdir/$_realname-$_realver"
+#provides="${_name}-grsec=${pkgver}-r${pkgrel}"
+#replaces="$_name-hardened"
+builddir="$srcdir/$_name-$_ver"
 options="!check"
-
-prepare() {
-	cd "$builddir"
-	# source the kernel version
-	(
-	if [ -f "$startdir"/../linux-$_flavor/APKBUILD ]; then
-		. "$startdir"/../linux-$_flavor/APKBUILD
-		if [ "$_kver" != "$pkgver" ]; then
-			die "$_name: Please update _kver to $pkgver"
-		fi
-		if [ "$_kpkgrel" != "$pkgrel" ]; then
-			die "$_name: Please update _kpkgrel to $pkgrel"
-		fi
-	fi
-	) || return 1
-
-}
 
 build() {
 	cd "$builddir"
@@ -56,11 +49,10 @@ build() {
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--with-kbuild=/usr/src/linux-headers-${_abi_release} \
-		|| return 1
+		--with-kbuild=/usr/src/linux-headers-$_kabi
 
 	cd extensions
-	make modules || return 1
+	make modules
 }
 
 package() {

--- a/main/zfs-vanilla/APKBUILD
+++ b/main/zfs-vanilla/APKBUILD
@@ -1,56 +1,51 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 
-_flavor=${FLAVOR:-vanilla}
-_realname=zfs
-_name=$_realname-$_flavor
+# when changing _ver we *must* bump _rel
+_name=zfs
+_ver=0.7.5
+_rel=0
 
+_flavor=${FLAVOR:-vanilla}
 _kpkg=linux-$_flavor
 _kver=4.14.20
-_kpkgrel=0
+_krel=0
 
-_realver=0.7.5
-_mypkgrel=0
+_kpkgver="$_kver-r$_krel"
+_kabi="$_kver-$_krel-$_flavor"
 
-_kernelver=$_kver-r$_kpkgrel
-_abi_release=${_kver}-${_kpkgrel}-${_flavor}
+# verify the kernel version before entering chroot
+_kapkbuild=../../main/linux-vanilla/APKBUILD
+if [ -f $_kapkbuild ]; then
+	(	. $_kapkbuild
+		pkgname=$_name-$_flavor
+		[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
+		[ "$_krel" != "$pkgrel" ] && die "please update _krel to $pkgrel"
+		return 0
+	)
+fi
 
-pkgname=$_name
+pkgname=$_name-$_flavor
 pkgver=$_kver
-pkgrel=$(($_kpkgrel + $_mypkgrel))
+pkgrel=$(( $_krel + $_rel ))
+
 pkgdesc="ZFS for Linux"
 url="http://zfsonlinux.org"
 arch="x86 x86_64 aarch64"
-license="CDDL"
-depends="spl-$_flavor linux-${_flavor}=${_kernelver}"
+license="CDDL-1.0"
+depends="spl-$_flavor $_kpkg=$_kpkgver"
 depends_dev="glib-dev e2fsprogs-dev util-linux-dev libtirpc-dev
-	linux-$_flavor-dev=$_kernelver spl-$_flavor-dev"
+	$_kpkg-dev=$_kpkgver spl-$_flavor-dev"
 makedepends="$depends_dev automake autoconf libtool linux-headers"
-install_if="zfs linux-vanilla-$_kver"
-install=""
+install_if="zfs $_kpkg=$_kpkgver"
 subpackages="$pkgname-dev"
-source="https://github.com/zfsonlinux/zfs/releases/download/zfs-$_realver/zfs-$_realver.tar.gz
-	"
+source="https://github.com/zfsonlinux/zfs/releases/download/zfs-$_ver/zfs-$_ver.tar.gz"
 
-
-builddir="$srcdir/$_realname-$_realver"
+builddir="$srcdir/$_name-$_ver"
 
 prepare() {
-	# source the kernel version
-	(
-	if [ -f "$startdir"/../../main/linux-$_flavor/APKBUILD ]; then
-	        . "$startdir"/../../main/linux-$_flavor/APKBUILD
-	        if [ "$_kver" != "$pkgver" ]; then
-			die "$_name: Please update _kver to $pkgver"
-		fi
-	        if [ "$_kpkgrel" != "$pkgrel" ]; then
-			die "$_name: Please update _kpkgrel to $pkgrel"
-		fi
-	fi
-	) || return 1
-
 	default_prepare
-	autoreconf -vif || return 1
+	autoreconf -vif
 }
 
 build() {
@@ -62,22 +57,21 @@ build() {
 		--infodir=/usr/share/info \
 		--localstatedir=/var \
 		--with-config=kernel \
-		--with-linux=/usr/src/linux-headers-${_abi_release} \
-		--with-spl=/usr/src/spl-${_realver} \
-		|| return 1
-	make || return 1
+		--with-linux=/usr/src/linux-headers-${_kabi} \
+		--with-spl=/usr/src/spl-${_ver}
+
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" \
-		install || return 1
+	make DESTDIR="$pkgdir" install 
 }
 
 dev() {
 	mkdir -p "$subpkgdir"/usr
-	mv "$pkgdir"/usr/src "$subpkgdir"/usr || return 1
-        default_dev
+	mv "$pkgdir"/usr/src "$subpkgdir"/usr
+	default_dev
 }
 
 sha512sums="3512aaa6225f74323f2d14e029a113593e0cf44be2ab18cc42dcb82d237b88843ccd7e48ed73a4c6f6da574151c1af461e0528725e11bcb42280467e37f63df2  zfs-0.7.5.tar.gz"

--- a/testing/ipt-netflow-vanilla/APKBUILD
+++ b/testing/ipt-netflow-vanilla/APKBUILD
@@ -1,69 +1,53 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 
-_flavor=vanilla
+# when chaning _ver we *must* bump _rel
+_name=ipt-netflow
+_ver=2.3_pre20180201
+_rel=0
+
+_flavor=${FLAVOR:-vanilla}
 _kpkg=linux-$_flavor
 _kver=4.14.20
-_kpkgrel=0
+_krel=0
 
-# when chaning _ver we *must* bump _mypkgrel
-_ver=2.3_pre20180201
-
-_mypkgrel=0
+_kpkgver="$_kver-r$_krel"
+_kabi="$_kver-$_krel-$_flavor"
 
 # verify the kernel version before entering chroot
-if [ -f ../linux-${_flavor}/APKBUILD ]; then
-	. ../linux-${_flavor}/APKBUILD
-	pkgname=ipt-netflow-${_flavor}
-	[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
-	[ "$_kpkgrel" != "$pkgrel" ] && die "please update _kpkgrel to $pkgrel"
+_kapkbuild=../../main/linux-vanilla/APKBUILD
+if [ -f $_kapkbuild ]; then
+	(	. $_kapkbuild
+		pkgname=$_name-$_flavor
+		[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
+		[ "$_krel" != "$pkgrel" ] && die "please update _krel to $pkgrel"
+		return 0
+	)
 fi
 
-_kpkgver="$_kver-r$_kpkgrel"
-_abi_release=${_kver}-${_kpkgrel}-${_flavor}
-
-pkgname=ipt-netflow-${_flavor}
+pkgname=$_name-$_flavor
 pkgver=$_kver
+pkgrel=$(( $_krel + $_rel ))
 
-pkgrel=$(( $_kpkgrel + $_mypkgrel ))
 pkgdesc="Linux kernel netflow sensor module"
 url="http://ipt-netflow.sourceforge.net/"
 arch="x86 x86_64 armhf"
-license=GPL3+
-source="ipt-netflow-$_ver.tar.xz::http://turtle.dereferenced.org/~kaniini/ipt-netflow-$_ver.tar.xz
-	"
-#provides="ipt-netflow-grsec=${pkgver}-r${pkgrel}"
-depends="${_kpkg}=${_kpkgver}"
-depends_dev="$_kpkg-dev=$_kpkgver"
-makedepends="linux-${_flavor}-dev=$_kpkgver iptables-dev bash"
+license="GPL-3.0-or-later"
+depends="$_kpkg=$_kpkgver"
+makedepends="$_kpkg-dev=$_kpkgver iptables-dev bash"
 install_if="$_kpkg=$_kpkgver ipt-netflow"
-
-_builddir="$srcdir"/ipt-netflow-$_ver
-prepare() {
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+#provides="${_name}-grsec=${pkgver}-r${pkgrel}"
+source="ipt-netflow-$_ver.tar.xz::http://turtle.dereferenced.org/~kaniini/ipt-netflow-$_ver.tar.xz"
+builddir="$srcdir/$_name-$_ver"
 
 build() {
-        cd "$_builddir"
-        ./configure --kver=$_abi_release \
-		--ipt-inc=/usr/include/libiptc \
-		|| return 1
-	make ipt_NETFLOW.ko || return 1
+	cd "$builddir"
+	./configure --kver=$_kabi --ipt-inc=/usr/include/libiptc
+	make ipt_NETFLOW.ko
 }
 
 package() {
-        cd "$_builddir"
-        make -j1 minstall DEPMOD=: DESTDIR="$pkgdir" \
-		|| return 1
-}
-
-# override dev() from kernel's APKBUILD
-dev() {
-	default_dev
+	cd "$builddir"
+	make -j1 minstall DEPMOD=: DESTDIR="$pkgdir"
 }
 
 sha512sums="8216baf824380bceb9279c07a5314f7a3c21a140b82d83fdf31e123c11d7f8afdfc1942f7ac8a5d1af7fe980dc404c932a052b26839a01d99cc79334870c12b4  ipt-netflow-2.3_pre20180201.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -1,41 +1,43 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
+# when changing _ver we *must* bump _rel
+# we must also match up _toolsrel with wireguard-tools
+_name=wireguard
+_ver=0.0.20180218
+_rel=0
+_toolsrel=0
+
 _flavor=${FLAVOR:-vanilla}
 _kpkg=linux-$_flavor
 _kver=4.14.20
-_kpkgrel=0
+_krel=0
 
-# when changing _ver we *must* bump _mypkgrel
-# we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20180218
-_mypkgrel=0
-_toolsrel=0
-_name=wireguard
+_kpkgver="$_kver-r$_krel"
+_kabi="$_kver-$_krel-$_flavor"
 
 # verify the kernel version before entering chroot
-_kapkbuild=../../linux-${_flavor}/APKBUILD
+_kapkbuild=../../main/linux-vanilla/APKBUILD
 if [ -f $_kapkbuild ]; then
-	. $_kapkbuild
-	pkgname=$_name-$_flavor
-	[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
-	[ "$_kpkgrel" != "$pkgrel" ] && die "please update _kpkgrel to $pkgrel"
+	(	. $_kapkbuild
+		pkgname=$_name-$_flavor
+		[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
+		[ "$_krel" != "$pkgrel" ] && die "please update _krel to $pkgrel"
+		return 0
+	)
 fi
 
-_kpkgver="$_kver-r$_kpkgrel"
-_toolsver="$_ver-r$toolsrel"
-_abi_release=${_kver}-${_kpkgrel}-${_flavor}
-
-pkgname=${_name}-${_flavor}
+pkgname=$_name-$_flavor
 pkgver=$_kver
-pkgrel=$(($_kpkgrel + $_mypkgrel))
+pkgrel=$(( $_krel + $_rel ))
+
 pkgdesc="Next generation secure network tunnel: kernel modules for $_flavor"
 arch='all'
 url='https://www.wireguard.com'
 license="GPL-2.0"
-depends="${_kpkg}=${_kpkgver}"
-makedepends="linux-vanilla-dev=$_kpkgver libmnl-dev"
-install_if="wireguard-tools=$_toolsver linux-vanilla=$_kpkgver"
+depends="$_kpkg=$_kpkgver"
+makedepends="$_kpkg-dev=$_kpkgver libmnl-dev"
+install_if="wireguard-tools=$_ver-r$toolsrel $_kpkg=$_kpkgver"
 options="!check"
 source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$_ver.tar.xz"
 builddir="$srcdir"/WireGuard-$_ver
@@ -45,7 +47,7 @@ build() {
 	# only building module: see wireguard-tools for userspace
 	unset LDFLAGS
 	make -C src/ \
-		KERNELDIR=/lib/modules/${_abi_release}/build \
+		KERNELDIR=/lib/modules/$_kabi/build \
 		module
 }
 
@@ -55,7 +57,7 @@ package() {
 	local module=
 	for module in *.ko; do
 		install -v -D -m644 ${module} \
-			"$pkgdir/lib/modules/$_abi_release/extra/${module}"
+			"$pkgdir/lib/modules/$_kabi/extra/${module}"
 	done
 }
 


### PR DESCRIPTION
After encountering many bugs caused by typos (like `install_if="zfs linux-vanilla-$_kver"`) in those packages, I decided to refactor them. The new format is based on wireguard-vanilla/APKBUILD. 
Since "-hardened is dead" only `-vanilla` packages were patched. Each compiled successfully.