### PR TITLE
community/drupal7: security upgrade to 7.57

### DIFF
--- a/community/drupal7/APKBUILD
+++ b/community/drupal7/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 _php=php5
 pkgname=drupal7
-pkgver=7.56
+pkgver=7.57
 pkgrel=0
 pkgdesc="An open source content management platform"
 url="https://www.drupal.org/"
@@ -52,4 +52,4 @@ package() {
 		"$pkgdir"/var/lib/$pkgname/sites/default/files
 }
 
-sha512sums="ab7ad8d9cb26e89b9d81280b1677584072db627d508ccade9442c95a90f24c94d11561013c8a7297ddae6ae43696d0b711b8c37ab98f89539f6f0e0154db6344  drupal-7.56.tar.gz"
+sha512sums="79e7e38c605cf60e458b2846ef4ce95f82368954f86fac6e79c19357e7a4ff714367c5580836ae2e45b22029d9ba2f2566901887d37bfa1ec2ed94a5a370fa0e  drupal-7.57.tar.gz"


### PR DESCRIPTION
https://www.drupal.org/SA-CORE-2018-001