### PR TITLE
testing/py-boto3: depend on s3transfer

### DIFF
--- a/testing/py-boto3/APKBUILD
+++ b/testing/py-boto3/APKBUILD
@@ -3,12 +3,12 @@
 pkgname=py-boto3
 _pkgname=boto3
 pkgver=1.4.7
-pkgrel=0
+pkgrel=1
 pkgdesc="AWS SDK for Python (Boto3)"
 url="http://aws.amazon.com/sdk-for-python/"
 arch="noarch"
 license="Apache-2.0"
-depends="py-botocore"
+depends="py-botocore py-s3transfer"
 makedepends="python2-dev py-setuptools python3-dev"
 subpackages="py3-$_pkgname:_py3 py2-$_pkgname:_py2"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"


### PR DESCRIPTION
boto3 uses a separate library for managing Amazon S3 transfers.

Exception:
```text
Traceback (most recent call last):
  File "/app/app.py", line 52, in <module>
    main()
  File "/app/app.py", line 36, in main
    bucket = boto3.resource('s3').Bucket(bucket_name)
  File "/usr/lib/python3.6/site-packages/boto3/__init__.py", line 92, in resource
    return _get_default_session().resource(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/boto3/session.py", line 389, in resource
    aws_session_token=aws_session_token, config=config)
  File "/usr/lib/python3.6/site-packages/boto3/session.py", line 263, in client
    aws_session_token=aws_session_token, config=config)
  File "/usr/lib/python3.6/site-packages/botocore/session.py", line 861, in create_client
    client_config=config, api_version=api_version)
  File "/usr/lib/python3.6/site-packages/botocore/client.py", line 70, in create_client
    cls = self._create_client_class(service_name, service_model)
  File "/usr/lib/python3.6/site-packages/botocore/client.py", line 95, in _create_client_class
    base_classes=bases)
  File "/usr/lib/python3.6/site-packages/botocore/hooks.py", line 227, in emit
    return self._emit(event_name, kwargs)
  File "/usr/lib/python3.6/site-packages/botocore/hooks.py", line 210, in _emit
    response = handler(**kwargs)
  File "/usr/lib/python3.6/site-packages/boto3/utils.py", line 61, in _handler
    module = import_module(module)
  File "/usr/lib/python3.6/site-packages/boto3/utils.py", line 52, in import_module
    __import__(name)
  File "/usr/lib/python3.6/site-packages/boto3/s3/inject.py", line 15, in <module>
    from boto3.s3.transfer import create_transfer_manager
  File "/usr/lib/python3.6/site-packages/boto3/s3/transfer.py", line 127, in <module>
    from s3transfer.exceptions import RetriesExceededError as \
ModuleNotFoundError: No module named 's3transfer'
```