### PR TITLE
main/py-pynacl: depend on py-cffi and py-six

### DIFF
--- a/main/py-pynacl/APKBUILD
+++ b/main/py-pynacl/APKBUILD
@@ -3,11 +3,12 @@
 pkgname=py-pynacl
 _pkgname=${pkgname/py-/}
 pkgver=1.2.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Python binding to the Networking and Cryptography (NaCl) library"
 url="https://github.com/pyca/pynacl"
 arch="all"
 license="Apache-2.0"
+depends="py-cffi py-six"
 makedepends="py-setuptools python2-dev python3-dev libffi-dev"
 subpackages="py3-${pkgname/py-/}:_py3 py2-${pkgname/py-/}:_py2"
 source="$pkgname-$pkgver.tar.gz::https://github.com/pyca/$_pkgname/archive/$pkgver.tar.gz"
@@ -32,17 +33,20 @@ package() {
 _py() {
 	local python=$1
 	pkgdesc="$pkgdesc - $python"
+	depends="$depends $python"
 	install_if="$pkgname=$pkgver-r$pkgrel $python"
 	cd "$builddir"
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
 _py2() {
-	_py python2
 	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
 }
 
 _py3() {
+	depends="${depends//py-/py3-}"
 	_py python3
 }
 


### PR DESCRIPTION
PyNaCl depends on CFFI (for the bindings to libsodium) and six.

At the moment an exception gets thrown:
```
Traceback (most recent call last):
  File "/app/app.py", line 5, in <module>
    import nacl.public
  File "/usr/lib/python3.6/site-packages/nacl/public.py", line 17, in <module>
    import nacl.bindings
  File "/usr/lib/python3.6/site-packages/nacl/bindings/__init__.py", line 17, in <module>
    from nacl.bindings.crypto_box import (
  File "/usr/lib/python3.6/site-packages/nacl/bindings/crypto_box.py", line 18, in <module>
    from nacl._sodium import ffi, lib
ModuleNotFoundError: No module named '_cffi_backend'
```