### PR TITLE
community/unison: modernize, fix license, split -gui

### DIFF
--- a/community/unison/APKBUILD
+++ b/community/unison/APKBUILD
@@ -2,15 +2,15 @@
 # Maintainer: Jean-Louis Fuchs <ganwell@fangorn.ch>
 pkgname=unison
 pkgver=2.48.4
-pkgrel=3
+pkgrel=4
 pkgdesc="Unison - efficient file-synchronization tool"
 url="https://www.cis.upenn.edu/~bcpierce/unison/"
 # ocaml is not built for x86, armhf, s390x
 # lablgtk is not built for aarch64
 arch="all !x86 !armhf !aarch64 !s390x"
-license="GPL"
-makedepends="ocaml lablgtk-dev linux-headers emacs-nox"
-subpackages="$pkgname-doc"
+license="GPL-3.0+"
+makedepends="ocaml lablgtk-dev linux-headers emacs-nox bash"
+subpackages="$pkgname-doc $pkgname-gui"
 source="http://www.seas.upenn.edu/~bcpierce/unison/download/releases/stable/unison-$pkgver.tar.gz
 	http://www.seas.upenn.edu/~bcpierce/unison/download/releases/stable/unison-$pkgver-manual.html
 	fix_inotify_check.patch
@@ -31,36 +31,34 @@ build() {
 	for ui in text gtk2; do
 		make -j1 clean
 		make -j1 mkProjectInfo
-		make -j1 UISTYLE=$ui DEBUGGING=false THREADS=true
-		mv unison unison-$ui
+		make -j1 UISTYLE="$ui" DEBUGGING=false THREADS=true
+		mv unison unison-"$ui"
 	done
-}
-
-doc() {
-	pkgdesc="Unison - efficient file-synchronization tool (documentation)"
-	local _docdir="$subpkgdir"/usr/share/doc/$pkgname/
-	mkdir -p "$_docdir"
-	cd "$srcdir"
-	cp unison-$pkgver-manual.html "$_docdir"
 }
 
 package() {
 	cd "$builddir"
-	install -d "${pkgdir}"/usr/bin
-	install -m755 unison-* "${pkgdir}"/usr/bin
-	cd "${pkgdir}"/usr/bin
+	install -d "$pkgdir"/usr/bin
+	install -m755 unison-text unison-fsmonitor "$pkgdir"/usr/bin
+	cd "$pkgdir"/usr/bin
 	ln -s unison-text unison
-	ln -s unison unison-${pkgver%.*}
+	ln -s unison "unison-${pkgver%.*}"
+
+	cd "$srcdir"
+	install -d "$pkgdir"/usr/share/doc/"$pkgname"
+	install -m644 unison-"$pkgver"-manual.html "$pkgdir"/usr/share/doc/"$pkgname"
 }
 
-md5sums="5334b78c7e68169df7de95f4c6c4b60f  unison-2.48.4.tar.gz
-3dc5de6c0609ae2e3019d22f76345b91  unison-2.48.4-manual.html
-c40a53099c98f7a82eaad52b7e5d0df2  fix_inotify_check.patch
-e4da5777b26376de728f22b2c296950d  marshalling.patch"
-sha256sums="30aa53cd671d673580104f04be3cf81ac1e20a2e8baaf7274498739d59e99de8  unison-2.48.4.tar.gz
-2b5674e2fd7751148784a716ce5a03f8cd0a321c8a3bd4343832ed9b83d2d404  unison-2.48.4-manual.html
-ef0371e70c94250ca04e80a5fddf61f3edab1c6ec0854e9bf5b2edd6dd18e986  fix_inotify_check.patch
-6e652b120f1b526557ab0a88c162aec3957444bfdeaf7f9c52ca0f3c48c58d9a  marshalling.patch"
+gui() {
+	description="Unison - efficient file-synchronization tool (GTK+2 GUI)"
+	depends="$pkgname"
+	install_if="$pkgname=$pkgver-r$pkgrel gtk+2.0"
+
+	cd "$builddir"
+	install -d "$subpkgdir"/usr/bin
+	install -m755 unison-gtk2 "$subpkgdir"/usr/bin
+}
+
 sha512sums="c8e7bd2b14edae31e7d08154cdc2dce8173546b6163b9e5f4f2b1c8255792a7645d8449da88d7acfcbf498746481d24d0a3936978969920530a15a16bcbc6024  unison-2.48.4.tar.gz
 b995712cda51d612bd81c89589d872099b3b9c90f7413268b24ab399a1eff7690200980514a834ee3d12bd3c89ef61bb8a29b3970c01433e0c4671d363a96b68  unison-2.48.4-manual.html
 27eaf4f347dc827dc14b338ef2be40d25507c6c9d65ecdc8f811ebe994f6e23577ad85fcc86b63d148b57844b24e6034061c869b641fbd3173532a26e0828803  fix_inotify_check.patch


### PR DESCRIPTION
It's sometimes useful to use unison with the text-only interface without having to pull in all of the GUI dependencies, so I think splitting it into a separate package is a good idea.