### PR TITLE
testing/haxe: update to 3.4.7

### DIFF
--- a/testing/haxe/APKBUILD
+++ b/testing/haxe/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Jon Ong <jonongjs@rottenmage.com>
 # Maintainer: Andy Li <andy@onthewings.net>
 pkgname=haxe
-pkgver=3.4.5
+pkgver=3.4.7
 _versuffix=
-pkgrel=1
+pkgrel=0
 pkgdesc="Cross-platform toolkit and programming language"
 url="https://haxe.org"
 arch="x86_64 aarch64 ppc64le"
@@ -13,9 +13,11 @@ makedepends="camlp4 ocaml neko-dev zlib-dev pcre-dev"
 options="!strip !makeflags"
 install=""
 subpackages="$pkgname-doc"
+_commit_haxelib="a494d8be523e26fcf875e2c33915808dc221e17a"
+_commit_ocamllibs="ab5be31c6dd1fcd761c2ba16c5d767bcf6792490"
 source="${pkgname}-${pkgver}.tar.gz::https://github.com/HaxeFoundation/haxe/archive/${pkgver}${_versuffix}.tar.gz
-	haxelib.tar.gz::https://github.com/HaxeFoundation/haxelib/archive/eeac8f4e77b23b120f27d27502f43589db26d143.tar.gz
-	ocamllibs.tar.gz::https://github.com/HaxeFoundation/ocamllibs/archive/0e6ea857c0f7df5e69628f949d0d33a3ce5552a8.tar.gz
+	haxelib-${_commit_haxelib}.tar.gz::https://github.com/HaxeFoundation/haxelib/archive/${_commit_haxelib}.tar.gz
+	ocamllibs-${_commit_ocamllibs}.tar.gz::https://github.com/HaxeFoundation/ocamllibs/archive/${_commit_ocamllibs}.tar.gz
 	haxe.sh
 	"
 
@@ -24,8 +26,8 @@ build() {
 	cd "$_builddir"
 
 	rmdir libs extra/haxelib_src || return 1
-	mv "$srcdir"/haxelib-* extra/haxelib_src || return 1
-	mv "$srcdir"/ocamllibs-* libs || return 1
+	mv "$srcdir"/haxelib-${_commit_haxelib} extra/haxelib_src || return 1
+	mv "$srcdir"/ocamllibs-${_commit_ocamllibs} libs || return 1
 
 	# Check to see if ocamlopt exists. If not, bytecompile everything.
 	command -v ocamlopt && make -j1 || make -j1 BYTECODE=1 || return 1
@@ -47,7 +49,7 @@ package() {
 	install -Dm 644 extra/LICENSE.txt "$pkgdir"/usr/share/licenses/$pkgname/LICENSE.txt
 	install -Dm 644 "$srcdir/haxe.sh" "$pkgdir/etc/profile.d/haxe.sh"
 }
-sha512sums="1df0a011752c93fd6bc659da0d03f328a011acdb27d6fd37512342f74a4836c52a60a72525caa86b79ac14b1dd1b93872955e3f640d1e175811a2ce2066be515  haxe-3.4.5.tar.gz
-711a58dae9311a2614467a04b294c6b0b3064849d4840f98d24c152a49abf856c79567aa810c59701e76d42db43359c04ae29a8b5d0404132b5cd107ae6b58e1  haxelib.tar.gz
-a09864fa5b00210695f9d1d5f6b4c4f0a5f37ec7c5020671e32185e0f205e46535103673eaa1a585627e7aebc4b64185414c6cd4dd59f12bfda2191d372be3b5  ocamllibs.tar.gz
+sha512sums="5b15018b714922aa362aeb9eab672ed76d32db73d06a0d976d14445bcd644661f2ff397016c41bdc2d092c513ad1458f3b377ca040c6c293f5d0711fdd6ba26d  haxe-3.4.7.tar.gz
+549d8eead2236a60747acc50a88129e587d52f7408342f657965d4f2faf638d62fd556f0d0d23a122ef03ee7164b966d6234f35dc81c1cebd703e254e2f57265  haxelib-a494d8be523e26fcf875e2c33915808dc221e17a.tar.gz
+4aa501389bde4a9bef8e2e571dc012ccab10b98c3c37903ab5a262c2a9bec57fa4bee936222397c484ecefe917f28e98f6513bf83007cf89434f93e80ccc9d23  ocamllibs-ab5be31c6dd1fcd761c2ba16c5d767bcf6792490.tar.gz
 c756571769bcdb0d7040b44b3d486e445c56a01a8d23d26f668be19b8d147e9f324166f004872d04e912f329e45ad821672a0a365df4ba27fb1dc22bb34130a3  haxe.sh"

--- a/testing/haxe/APKBUILD
+++ b/testing/haxe/APKBUILD
@@ -13,8 +13,12 @@ makedepends="camlp4 ocaml neko-dev zlib-dev pcre-dev"
 options="!strip !makeflags"
 install=""
 subpackages="$pkgname-doc"
+
+# haxelib and ocamllibs are git submodules in the haxe repo.
+# To get the commits, run `git sumodule status`.
 _commit_haxelib="a494d8be523e26fcf875e2c33915808dc221e17a"
 _commit_ocamllibs="ab5be31c6dd1fcd761c2ba16c5d767bcf6792490"
+
 source="${pkgname}-${pkgver}.tar.gz::https://github.com/HaxeFoundation/haxe/archive/${pkgver}${_versuffix}.tar.gz
 	haxelib-${_commit_haxelib}.tar.gz::https://github.com/HaxeFoundation/haxelib/archive/${_commit_haxelib}.tar.gz
 	ocamllibs-${_commit_ocamllibs}.tar.gz::https://github.com/HaxeFoundation/ocamllibs/archive/${_commit_ocamllibs}.tar.gz

--- a/testing/haxe/APKBUILD
+++ b/testing/haxe/APKBUILD
@@ -29,20 +29,20 @@ _builddir="$srcdir/$pkgname-$pkgver$_versuffix"
 build() {
 	cd "$_builddir"
 
-	rmdir libs extra/haxelib_src || return 1
-	mv "$srcdir"/haxelib-${_commit_haxelib} extra/haxelib_src || return 1
-	mv "$srcdir"/ocamllibs-${_commit_ocamllibs} libs || return 1
+	rmdir libs extra/haxelib_src
+	mv "$srcdir"/haxelib-${_commit_haxelib} extra/haxelib_src
+	mv "$srcdir"/ocamllibs-${_commit_ocamllibs} libs
 
 	# Check to see if ocamlopt exists. If not, bytecompile everything.
-	command -v ocamlopt && make -j1 || make -j1 BYTECODE=1 || return 1
-	make -j1 tools || return 1
+	command -v ocamlopt && make -j1 || make -j1 BYTECODE=1
+	make -j1 tools
 }
 
 check() {
 	cd "$_builddir"
 	
-	./haxe -version || return 1
-	./haxelib version || return 1
+	./haxe -version
+	./haxelib version
 }
 
 package() {

--- a/testing/haxe/APKBUILD
+++ b/testing/haxe/APKBUILD
@@ -15,7 +15,7 @@ install=""
 subpackages="$pkgname-doc"
 
 # haxelib and ocamllibs are git submodules in the haxe repo.
-# To get the commits, run `git sumodule status`.
+# To get the commits, run `git submodule status`.
 _commit_haxelib="a494d8be523e26fcf875e2c33915808dc221e17a"
 _commit_ocamllibs="ab5be31c6dd1fcd761c2ba16c5d767bcf6792490"
 


### PR DESCRIPTION
- Update from 3.4.5 to 3.4.7
  * Backward compatible to Haxe 3.4.5.
  * Fixed compiler cannot find std lib when executed by another program.
  * Fixed compiler failure for some output directories.
  * Bugfixes to php, as3 targets as well as code completion.
  * Detail available at https://github.com/HaxeFoundation/haxe/blob/3.4.7/extra/CHANGES.txt#L1-L18 