### PR TITLE
testing/py-jedi: update to 0.11.1, fixes

### DIFF
--- a/testing/py-jedi/APKBUILD
+++ b/testing/py-jedi/APKBUILD
@@ -1,44 +1,67 @@
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
+
 pkgname=py-jedi
-pkgver=0.10.0
+_pkgname=jedi
+pkgver=0.11.1
 pkgrel=0
 pkgdesc="Awesome autocompletion and static analysis library for python."
 url="https://github.com/davidhalter/jedi"
 arch="noarch"
 license="MIT"
-makedepends="python2-dev python3-dev py-setuptools"
-subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
-source="$pkgname-$pkgver.tar.gz::https://github.com/davidhalter/${pkgname/py-/}/archive/v$pkgver.tar.gz"
-builddir="$srcdir/${pkgname/py-/}-$pkgver"
-
-
-build() {
-	cd "$builddir"
-	python2 setup.py build || return 1
-	python3 setup.py build || return 1
-}
+depends="py-parso"
+checkdepends="pytest py-pytest-cache py-pluggy py-tox py-docopt py2-typing \
+		py-coverage py-numpydoc py-colorama"
+makedepends="python2-dev python3-dev py-setuptools py3-setuptools py-attrs \
+		py-sphinx"
+subpackages="py2-$_pkgname:_py2 py3-$_pkgname:_py3 $pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/davidhalter/$_pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
 
 package() {
-	mkdir -p "$pkgdir"
+	install -d "$pkgdir"/usr/share/doc/$pkgname \
+		"$pkgdir"/usr/share/man/man1 "$pkgdir"/usr/share/html/$pkgname
+	cd "$builddir"
+	install -t "$pkgdir"/usr/share/doc/$pkgname CHANGELOG.rst AUTHORS.txt \
+		README.rst
+	cd "docs"
+	PYTHONPATH="$builddir/src:$PYTHONPATH" make html man
+	install -t "$pkgdir"/usr/share/man/man1 _build/man/*
+	mv _build/html/* "$pkgdir"/usr/share/html/$pkgname
 }
 
 _py2() {
+	depends="${depends//py-/py2-}"
 	replaces="$pkgname"
 	_py python2
 }
 
 _py3() {
+	depends="${depends//py-/py3-}"
 	_py python3
 }
 
 _py() {
 	local python="$1"
 	pkgdesc="$pkgdesc (for $python)"
-	depends="$depends $python"  ## remove if arch isn't noarch
+	depends="$depends $python"
 	install_if="$pkgname=$pkgver-r$pkgrel $python"
-
 	cd "$builddir"
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
+	rm -rf "$subpkgdir"/usr/lib/python*/site-packages/test/
 }
-sha512sums="64ff10cf041a107ca709802b41d9ae27b31fc7fa6cff0efdde4c78d01351efdc1333f1a02e2b8004453574199a4651043e7c3fea7149bfe5e3f0e93c23c38320  py-jedi-0.10.0.tar.gz"
+
+_getpythonver(){
+	echo $($1 -c 'import sys; print("%i%i" '\
+		'% (sys.version_info.major, sys.version_info.minor))')
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+	tox -e py$(_getpythonver python2),py$(_getpythonver python3)
+}
+
+sha512sums="61389704a318f89d12b053b786bfb6bda21d2696830c001d6d6e66191fc060d731bc05ea71f2e70725532dcbe109c5c7346a36d227e6f8ab0eb2512f4c1a8945  py-jedi-0.11.1.tar.gz"


### PR DESCRIPTION
Update to 0.11.1
Add check() and run test suite
Generate documentation
Add depends=, checkdepends=

It requires py-pytest-cache, py2-typing, py-numpydoc for checkdepends= I haven't uploaded yet.