### PR TITLE
testing/py-parso: new aport

### DIFF
--- a/testing/py-parso/APKBUILD
+++ b/testing/py-parso/APKBUILD
@@ -1,0 +1,58 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=py-parso
+_pkgname=parso
+pkgver=0.1.1
+pkgrel=0
+pkgdesc="A Python Parser"
+url="https://github.com/davidhalter/parso"
+arch="noarch"
+license="MIT"
+checkdepends="py-tox py-pytest-cache pytest py-coverage"
+makedepends="py-setuptools py3-setuptools py-future py-sphinx"
+source="$pkgname-$pkgver.tar.gz::https://github.com/davidhalter/$_pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir/"$_pkgname-$pkgver
+subpackages="py3-$_pkgname:_py3 py2-$_pkgname:_py2 $pkgname-doc"
+
+_getpythonver(){
+	echo $($1 -c 'import sys; print("%i%i" '\
+		'% (sys.version_info.major, sys.version_info.minor))')
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+	tox -e py$(_getpythonver python2),py$(_getpythonver python3)
+}
+
+package() {
+	cd "$builddir"
+	install -d "$pkgdir"/usr/share/doc/$pkgname/ \
+		"$pkgdir"/usr/share/html/$pkgname "$pkgdir"/usr/share/man/man1
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ AUTHORS.txt CHANGELOG.rst
+	cd docs
+	PYTHONPATH="$builddir/src:$PYTHONPATH" make html man
+	install -t "$pkgdir"/usr/share/man/man1 _build/man/*
+	mv _build/html/* "$pkgdir"/usr/share/html/$pkgname
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+_py2() {
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+sha512sums="1199651136af1c9f0801a031a197e367f7fa73b5878b863103a506481e8b325e6b305e4260510a567dccf91f298fd7e9e5674f4dc410765ae1f9112f742aa6a0  py-parso-0.1.1.tar.gz"


### PR DESCRIPTION
Add dependency for py-jedi ( #3425 )

It currently fails on Travis CI because of missing py-pytest-cache which I need to upload.