### PR TITLE
community/qt5-qtbase: Allow more ssl API use (libressl compat patch)

### DIFF
--- a/community/qt5-qtbase/libressl-compat.patch
+++ b/community/qt5-qtbase/libressl-compat.patch
@@ -98,15 +98,6 @@
  int q_PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert, STACK_OF(X509) **ca);
 --- qtbase/src/network/ssl/qsslcontext_openssl.cpp	2017-01-18 15:20:58.000000000 +0100
 +++ qtbase/src/network/ssl/qsslcontext_openssl.cpp	2017-02-21 19:23:04.291975945 +0100
-@@ -344,7 +344,7 @@
- 
-     const QVector<QSslEllipticCurve> qcurves = sslContext->sslConfiguration.ellipticCurves();
-     if (!qcurves.isEmpty()) {
--#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(OPENSSL_NO_EC)
-+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L) && !defined(OPENSSL_NO_EC) && !defined(LIBRESSL_VERSION_NUMBER)
-         // Set the curves to be used
-         if (q_SSLeay() >= 0x10002000L) {
-             // SSL_CTX_ctrl wants a non-const pointer as last argument,
 @@ -462,7 +462,7 @@
          m_npnContext.data = reinterpret_cast<unsigned char *>(m_supportedNPNVersions.data());
          m_npnContext.len = m_supportedNPNVersions.count();


### PR DESCRIPTION
Current libressl actually supports SSL_CTRL_SET_CURVES: don't prevent
using it with libressl.