### PR TITLE
main/gconf: add orbit2 to runtime deps

### DIFF
--- a/main/gconf/APKBUILD
+++ b/main/gconf/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gconf
 pkgver=3.2.6
-pkgrel=2
+pkgrel=3
 pkgdesc="GNOME configuration system"
 url="http://projects.gnome.org/gconf"
 arch="all"
 license="GPL-2.0+"
-depends=
+depends="orbit2"
 depends_dev="libxml2-dev gtk+3.0-dev polkit-dev"
 makedepends="$depends_dev gobject-introspection-dev orbit2-dev glib-dev"
 install=""


### PR DESCRIPTION
If gconf is compiled with orbit2, it's required as a runtime dependency as well. When a package depends on the orbit2 part of gconf, and orbit2 itself isn't actually installed, you'll get errors like `gconf/gconf-value.h: file not found` (while the file is actually located on the system in the proper location). This PR fixes this.

Thanks @abucodonosor for finding the cause and this fix!