### PR TITLE
testing/cloudi: upgrade to 1.7.3

### DIFF
--- a/testing/cloudi/APKBUILD
+++ b/testing/cloudi/APKBUILD
@@ -28,12 +28,12 @@
 #   (shown below with the assignment of CLOUDI_PID_FILE).
 
 pkgname=cloudi
-pkgver=1.7.2
-pkgrel=1
+pkgver=1.7.3
+pkgrel=0
 pkgdesc="Cloud computing framework for efficient, scalable, and stable soft-realtime event processing."
 url="http://cloudi.org/"
 license="MIT"
-arch="all !armhf"  # armhf: build error
+arch="all"
 depends="erlang
          g++"
 makedepends="autoconf
@@ -72,7 +72,7 @@ makedepends="autoconf
              "
 install=""
 subpackages=""
-source="https://downloads.sourceforge.net/project/$pkgname/$pkgver/$pkgname-$pkgver.tar.gz
+source="https://osdn.net/dl/$pkgname/$pkgname-$pkgver.tar.gz
         0005-Disable-tests-for-aports-buildservers.patch
         $pkgname.initd"
 builddir="$srcdir/cloudi-$pkgver/src"
@@ -81,7 +81,10 @@ builddir="$srcdir/cloudi-$pkgver/src"
 CONFIGURE_ARGS=""
 # Enable Haskell on the appropriate architectures
 case "$CTARGET_ARCH" in
-x86_64 | armhf)
+x86_64)
+	# Haskell is available on armhf though the compilation of the
+	# external Haskell dependencies fails with a gcc linker error
+	# (commit a55ed2043ebe1432fe30400d2aee3b080da32062)
 	makedepends="$makedepends ghc cabal zlib-dev"
 	CONFIGURE_ARGS="$CONFIGURE_ARGS --enable-haskell-support"
 	;;
@@ -132,6 +135,6 @@ package() {
 		"$pkgdir"/etc/init.d/$pkgname
 }
 
-sha512sums="8ba14f3436e354fbfc91135d05ea47a4af73f8150ffa2e687111e6aa9ee6b1db009cf9ef19a93cff36982b414cbefe0ad388c2d7725bea605b3f2e5c9b36a666  cloudi-1.7.2.tar.gz
+sha512sums="4a254983c45f12c0eb8cde6f9b4953219ce1e52abc3262d1703d28f2b1a2d1cc8eb9a2beae5e9e52b14d17704ab239948f895681bd4ac38e677a8bb025afc053  cloudi-1.7.3.tar.gz
 b2ef0cf07e207cbe62a34edb69ac4700bd5a75d9924e6597595e69f0988772d833d6af882cfa40278c9efe4b042da2952f9b7276b3c80c4b015b0c1490782b59  0005-Disable-tests-for-aports-buildservers.patch
 053f860f656617012208a0e1909e43b2f8979d381a90d3fa5a745a9cf5021fe54556a641fef2badaa9955f2394d00e32183389cb9b501169dcbf8cbe4fbb0329  cloudi.initd"


### PR DESCRIPTION
* Enable armhf after disabling Haskell support on armhf
  (enabling Haskell support for armhf requires other testing based on
   https://github.com/alpinelinux/aports/commit/a55ed2043ebe1432fe30400d2aee3b080da32062#diff-b024f920925e868b70a04b5359308a8e )
* Changed the download URL to point to osdn.net instead of sourceforge.net
  because SourceForge has had an outage for more than 78 hours