### PR TITLE
Remove --enable-seccomp from APKBUILD to fix broken memcache.

### DIFF
--- a/main/memcached/APKBUILD
+++ b/main/memcached/APKBUILD
@@ -22,8 +22,7 @@ build() {
 		--host=$CHOST \
 		--prefix=/usr \
 		--enable-sasl \
-		--enable-sasl-pwdb \
-		--enable-seccomp
+		--enable-sasl-pwdb
 	make
 }
 


### PR DESCRIPTION
Relevant github thread: https://github.com/memcached/memcached/issues/347#issuecomment-368677213