### PR TITLE
testing/py-beautifulsoup4: fix doc

### DIFF
--- a/testing/py-beautifulsoup4/APKBUILD
+++ b/testing/py-beautifulsoup4/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=py-beautifulsoup4
 _pkgname=beautifulsoup4
 pkgver=4.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A Python HTML/XML parser"
 url="http://www.crummy.com/software/BeautifulSoup/index.html"
 arch="noarch"
@@ -41,8 +41,9 @@ package() {
 	install -d "$pkgdir"/usr/share/doc/$pkgname "$pkgdir"/usr/share/man/man1 "$pkgdir"/usr/share/html/$pkgname
 	install -t "$pkgdir"/usr/share/doc/$pkgname AUTHORS.txt README.txt TODO.txt
 	cd doc
-	PYTHONPATH="$builddir/src" make html man
+	PYTHONPATH="$builddir/src" make man
 	install -t "$pkgdir"/usr/share/man/man1 build/man/*
+	PYTHONPATH="$builddir/src" make html
 	mv build/html/* "$pkgdir"/usr/share/html/$pkgname
 }
 


### PR DESCRIPTION
Split command into two.

It could be a x86 problem.  I am on x86_64.

Addresses: http://build.alpinelinux.org/buildlogs/build-edge-x86/testing/py-beautifulsoup4/py-beautifulsoup4-4.6.0-r1.log