### PR TITLE
main/cryptsetup: add bash to checkdepend to avoid test not found errors

### DIFF
--- a/main/cryptsetup/APKBUILD
+++ b/main/cryptsetup/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cryptsetup
 pkgver=2.0.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Userspace setup tool for transparent encryption of block devices using the Linux 2.6 cryptoapi"
 url="https://gitlab.com/cryptsetup/cryptsetup"
 arch="all"
@@ -13,7 +13,7 @@ makedepends_build=""
 makedepends_host="lvm2-dev libressl-dev popt-dev util-linux-dev
 	json-c-dev argon2-dev"
 makedepends="$makedepends_build $makedepends_host"
-checkdepends="device-mapper sharutils which"
+checkdepends="device-mapper sharutils which bash"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
 source="https://www.kernel.org/pub/linux/utils/$pkgname/v${pkgver%.*}/$pkgname-$pkgver.tar.gz
 	flush-stdout.patch


### PR DESCRIPTION
check() failed on ppc64le in fresh alpine build container without adding bash as a check depenency.