### PR TITLE
community/php7: update to 7.1.15

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -25,8 +25,8 @@
 
 pkgname=php7
 _pkgreal=php
-pkgver=7.1.14
-pkgrel=1
+pkgver=7.1.15
+pkgrel=0
 _apiver=20160303
 _suffix=${pkgname#php}
 # Is this package the default (latest) PHP version?
@@ -83,7 +83,7 @@ makedepends="
 	unixodbc-dev
 	zlib-dev
 	"
-provides="$pkgname-cli $pkgname-zlib"  # for backward compatibility
+provides="$pkgname-cli"  # for backward compatibility
 subpackages="$pkgname-dev $pkgname-doc $pkgname-apache2 $pkgname-phpdbg
 	$pkgname-embed $pkgname-litespeed $pkgname-cgi $pkgname-fpm
 	$pkgname-pear::noarch
@@ -536,6 +536,7 @@ pear() {
 
 common() {
 	pkgdesc="$pkgdesc (common config)"
+	provides="$pkgname-zlib" # for backward compatibility
 	depends=""
 
 	cd "$pkgdir"
@@ -637,7 +638,7 @@ _mv() {
 	mv $@
 }
 
-sha512sums="e676f066a3ad5fcf93a10c39305fe20a0f539a0df0bffc7add6186d6c2e119b7e5826a1119523880dc03b7e42fb950a67ed0e616671c31cccc9ce875826645a9  php-7.1.14.tar.bz2
+sha512sums="db10c0138a74165c6373f0d6cc7f5ca1f6b1ae26359cc2e2a9dec8895a491b8adccee59601cb9325e54768e9cca643e9f73858fef5cbe6502c683131f9cc8ccf  php-7.1.15.tar.bz2
 1c708de82d1086f272f484faf6cf6d087af7c31750cc2550b0b94ed723961b363f28a947b015b2dfc0765caea185a75f5d2c2f2b099c948b65c290924f606e4f  php7-fpm.initd
 cacce7bf789467ff40647b7319e3760c6c587218720538516e8d400baa75651f72165c4e28056cd0c1dc89efecb4d00d0d7823bed80b29136262c825ce816691  php7-fpm.logrotate
 274bd7b0b2b7002fa84c779640af37b59258bb37b05cb7dd5c89452977d71807f628d91b523b5039608376d1f760f3425d165242ca75ee5129b2730e71c4e198  php7-module.conf


### PR DESCRIPTION
now php7-zlib is provided by php7-common for backward compatibility