### PR TITLE
testing/cask: new aport

### DIFF
--- a/testing/cask/APKBUILD
+++ b/testing/cask/APKBUILD
@@ -1,0 +1,71 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=cask
+pkgver=0.8.3
+pkgrel=0
+pkgdesc="Project management tool for Emacs"
+url="http://cask.readthedocs.io/en/latest/"
+arch="noarch"
+license="GPL-3.0-or-later GFDL-1.3-or-later"
+depends="emacs"
+makedepends="python-dev"
+source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/cask/archive/v$pkgver.tar.gz
+	$pkgname
+	test-increase-timeout.patch"
+builddir="$srcdir"/$pkgname-$pkgver
+subpackages="$pkgname-doc"
+options="!check" # disabled because can't start fake package manager 
+		# server on Travis CI that is required to pass 51 tests
+
+build() {
+	export PATH="$builddir/bin:$PATH"
+	cd "$builddir"
+	local c
+	for c in $(find $builddir -name "Cask") ; do
+		cd $(dirname $c)
+		cask --dev install
+	done
+	cask build
+}
+
+check() {
+	cd "$builddir"
+	local dirs=""
+	local elpa
+	for elpa in $(find . -name "elpa" -type d) ; do
+		for d in $(find $builddir/$elpa -maxdepth 1 -type d | sort) ; do
+			dirs="$dirs:$d"
+		done
+	done
+	local bindirs=""
+	local b=
+	for b in $(find . -name "bin" -type d) ; do
+		bindirs="$bindirs:$b"
+	done
+	export EMACSLOADPATH="$dirs:$builddir:$EMACSLOADPATH"
+	export PATH="$bindirs:$PATH"
+	make start-server
+	make test
+	if [[ -f "$builddir/servant/tmp/servant.pid" ]] ; then
+		make stop-server
+	fi
+}
+
+package() {
+	msg "running package"
+        cd "$builddir"
+	install -d "$pkgdir"/usr/share/emacs/site-lisp/$pkgname \
+		"$pkgdir"/usr/share/doc/$pkgname/ "$pkgdir"/usr/bin
+	cp -a *.el bin templates features fixtures \
+		"$pkgdir"/usr/share/emacs/site-lisp/$pkgname/
+	rm doc/conf.py
+	cp -a doc "$pkgdir"/usr/share/doc/$pkgname/
+	install -t "$pkgdir"/usr/share/doc/$pkgname/ README.md $pkgname.png
+	install -t "$pkgdir"/usr/bin "$srcdir"/$pkgname
+	chmod +x "$pkgdir"/usr/bin/$pkgname
+}
+
+sha512sums="338c59f4ddf9c825764f0d03be5a6e7dd12cfd85a54eb8641b09e1c4d72cd36158100a03f92ac7c463fc739d4650222e0efda91a927aff2bbc310acf143a92ac  cask-0.8.3.tar.gz
+0b27cf39a10f5fd96fb5a8ad0014ae0c3cb397d735ddeb24943554bb391c0da5c05cffe705f1eb58ef640035c044bf7d610a16c11d999352fa284d9eb8ff4ca0  cask
+a336e0d4cb4084a86f9c8796b7df1b13aea8ea90bfe1f2318d2caa9f8c28721d23869993fd179c499d2cefc06914f2d5f5b7e26375f911f6453bb9da8c1c0a3a  test-increase-timeout.patch"

--- a/testing/cask/cask
+++ b/testing/cask/cask
@@ -1,0 +1,13 @@
+#!/bin/sh
+CASKPATH="/usr/share/emacs/site-lisp/cask/"
+for elpa in $(find $CASKPATH -name "elpa" -type d) ; do
+	for d in $(ls -d $CASKPATH/* | sort) ; do
+		dirs="$dirs:$d"
+	done
+done
+for b in $(find $CASKPATH -name "bin" -type d) ; do
+	bindirs="$bindirs:$b"
+done
+export EMACSLOADPATH="$dirs:$CASKPATH:$EMACSLOADPATH"
+export PATH="$bindirs:$PATH"
+cask $@

--- a/testing/cask/test-increase-timeout.patch
+++ b/testing/cask/test-increase-timeout.patch
@@ -1,0 +1,11 @@
+--- a/test/test-helper.el.orig
++++ b/test/test-helper.el
+@@ -58,7 +58,7 @@
+ 
+ ;; The ert-async package is only used to make sure we reach a certain
+ ;; branch, so a long timeout is not needed.
+-(setq ert-async-timeout 2)
++(setq ert-async-timeout 15)
+ 
+ (defun cask-test/package-path (bundle package)
+   "Return path in BUNDLE to PACKAGE."


### PR DESCRIPTION
This is a dependency for emacs-ycmd.

check() was disabled because Travis CI won't allow it to run the fake package server (servant) for some reason.