### PR TITLE
testing/typescript: new aport

### DIFF
--- a/testing/typescript/APKBUILD
+++ b/testing/typescript/APKBUILD
@@ -1,0 +1,50 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=typescript
+_pkgname=TypeScript
+pkgver=2.7.2
+pkgrel=0
+pkgdesc="TypeScript is a superset of JavaScript that compiles to clean \
+JavaScript output."
+url="http://www.typescriptlang.org/"
+arch="noarch"
+license="Apache-2.0 MIT ISC BSD-2-Clause BSD-3-Clause CC0-1.0 WTFPL"
+depends="nodejs-npm"
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/Microsoft/$_pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	npm install
+}
+
+package() {
+	cd "$builddir"
+	install -d "$pkgdir"/usr/share/doc/$pkgname \
+		"$pkgdir"/usr/lib/node_modules/$pkgname "$pkgdir"/usr/bin \
+	"$pkgdir"/usr/share/licenses/$pkgname/third_party/lodash.isarguments \
+		"$pkgdir"/usr/share/licenses/$pkgname/third_party/path-is-inside
+	install -t "$pkgdir"/usr/share/doc/$pkgname AUTHORS.md README.md
+	cp -a doc/* "$pkgdir"/usr/share/doc/$pkgname
+	cp -a bin lib node_modules scripts package*.json \
+		"$pkgdir"/usr/lib/node_modules/$pkgname
+	cd "$pkgdir"/usr/lib/node_modules/$pkgname
+	ln -s /usr/lib/node_modules/$pkgname/bin/tsc "$pkgdir"/usr/bin
+	ln -s /usr/lib/node_modules/$pkgname/bin/tsserver "$pkgdir"/usr/bin
+	# CC0 is not OSI approved... silly huh
+	install -t \
+	"$pkgdir"/usr/share/licenses/$pkgname/third_party/lodash.isarguments \
+		node_modules/lodash.isarguments/LICENSE
+	install -t \
+	"$pkgdir"/usr/share/licenses/$pkgname/third_party/path-is-inside \
+		node_modules/path-is-inside/LICENSE.txt
+}
+
+check() {
+	cd "$builddir"
+	npm test
+}
+
+sha512sums="504cb927f95ad20a1d62768fc5fc76d5d2b0362edd5b8d26c258aae158d47f3aff3335f9fda29191841fd8a50850764bbf52afa28eccc2d807b08e94b4914fc5  typescript-2.7.2.tar.gz"


### PR DESCRIPTION
Add optional dependency for testing/py-ycmd.

TypeScript is a superset of JavaScript for large scale JavaScript applications.