### PR TITLE
testing/py2-configparser: new package

### DIFF
--- a/testing/py2-configparser/APKBUILD
+++ b/testing/py2-configparser/APKBUILD
@@ -1,0 +1,27 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
+# Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
+
+pkgname=py2-configparser
+_pkgname=configparser
+pkgver=3.5.0
+pkgrel=0
+pkgdesc="This library brings the updated configparser from Python 3.5 to \
+Python 2.6-3.5."
+url="http://docs.python.org/3/library/configparser.html"
+arch="noarch"
+license="MIT"
+depends="python2"
+makedepends="py-setuptools"
+source="$pkgname-$pkgver.tar.gz::https://pypi.python.org/packages/7c/69/c2ce7e91c89dc073eb1aa74c0621c3eefbffe8216b3f9af9d3885265c01c/$_pkgname-$pkgver.tar.gz#md5=cfdd915a5b7a6c09917a64a573140538"
+builddir="$srcdir/$_pkgname-$pkgver"
+subpackages="$pkgname-doc"
+options="!check" # no test suite
+
+package() {
+	cd "$builddir"
+	install -d "$pkgdir"/usr/share/doc/$pkgname
+	python2 setup.py install --prefix=/usr --root="$pkgdir"
+	install -t "$pkgdir"/usr/share/doc/$pkgname README.rst configparser.rst
+}
+
+sha512sums="490b9f7807bce02667f41a48389b51f550818d2bd4296b528833d65d4b04bdbe5b906e7584e55eee4495405267a697ba26a056e6504fe6b3f8cf07ea8f55f7d3  py2-configparser-3.5.0.tar.gz"


### PR DESCRIPTION
It should fix the import error with testing/py-ycmd caused by py-flake8 not pulling the package.

Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/lib/python2.7/site-packages/flake8/__main__.py", line 2, in <module>
    from flake8.main import cli
  File "/usr/lib/python2.7/site-packages/flake8/main/cli.py", line 2, in <module>
    from flake8.main import application
  File "/usr/lib/python2.7/site-packages/flake8/main/application.py", line 14, in <module>
    from flake8.main import options
  File "/usr/lib/python2.7/site-packages/flake8/main/options.py", line 4, in <module>
    from flake8.main import vcs
  File "/usr/lib/python2.7/site-packages/flake8/main/vcs.py", line 4, in <module>
    from flake8.main import mercurial
  File "/usr/lib/python2.7/site-packages/flake8/main/mercurial.py", line 7, in <module>
    import configparser
