### PR TITLE
testing/tcc: updated source

### DIFF
--- a/testing/tcc/APKBUILD
+++ b/testing/tcc/APKBUILD
@@ -2,38 +2,37 @@
 # Contributor: Hinata Yanagi <hinasssan@gmail.com>
 # Maintainer: Hinata Yanagi <hinasssan@gmail.com>
 pkgname=tcc
-pkgver=2017.10.19
-_commit=fc0188ffbcf29f856caedee8cef07d88be01e439
+pkgver=0.9.27
 pkgrel=0
 pkgdesc="Tiny C Compiler"
-url="http://repo.or.cz/tinycc.git"
+url="htto://download.savannah.nongnu.org/releases/tinycc/"
 arch="all !ppc64le !s390x"
 license="LGPL-2.1"
 makedepends="texinfo"
 options="!check" # test suite currently fails on the server
-source="$pkgname-$pkgver.tar.gz::http://repo.or.cz/tinycc.git/snapshot/$_commit.tar.gz"
+source="$pkgname-$pkgver.tar.bz2::http://download.savannah.nongnu.org/releases/tinycc/${pkgname}-${pkgver}.tar.bz2"
 subpackages="$pkgname-doc"
-builddir="$srcdir/tinycc-fc0188f"
+builddir="$srcdir/tcc-${pkgver}"
 
 build() {
-	./configure \
-		--prefix=/usr \
-		--config-musl
-	make
+        ./configure \
+                --prefix=/usr \
+                --config-musl
+        make
 }
 
 check() {
-	cd "$builddir"
-	make test
+        cd "$builddir"
+        make test
 }
 
 package() {
-	cd "$builddir"
-	make DESTDIR="$pkgdir" install
+        cd "$builddir"
+        make DESTDIR="$pkgdir" install
 
-	mkdir -p "$pkgdir"/usr/share/doc/$pkgname/
-	install -m644 Changelog CodingStyle README TODO \
-		"$pkgdir"/usr/share/doc/$pkgname/
+        mkdir -p "$pkgdir"/usr/share/doc/$pkgname/
+        install -m644 Changelog CodingStyle README TODO \
+                "$pkgdir"/usr/share/doc/$pkgname/
 }
 
-sha512sums="2a32ec62fce539fb1168a21bd542aa370c7f6a9c7bc490bd9f86bb46b745a3db816c173f739e891631ec0b0ccbd89358226f7d5767ccbc3d7634890f83fbfa68  tcc-2017.10.19.tar.gz"
+sha512sums="835184292d97c07f0ff7b36ec550e855e649b04e23c7e2a1c706d223409eb60708dc1ae969f28eba45e56c8b96ae56936b93caf9d8a13ac5adf119014d5367a7  tcc-0.9.27.tar.bz2"


### PR DESCRIPTION
Surprisingly, tinycc has made a major release for the first time after the original developer Bellard declared giving up working on tinycc.
As tinycc has not progressed its version number for 5 years long, I adopted a date of the latest snapshot as its pkgver.
However, this update confirms that the version of tinycc is still in progress.
Forgive pkgver regression, or find some settlement.
Additionally, Arch has switched its tcc source to nongnu.org from repo.or.cz (see the [diff](https://git.archlinux.org/svntogit/community.git/commit/trunk?h=packages/tcc&id=1f223217ce2913cf471c6022151021b94b64efec)).
So we'd better follow it.