### PR TITLE
linux-virt kernel does no longer depend on linux-firmware

### DIFF
--- a/main/linux-vanilla/APKBUILD
+++ b/main/linux-vanilla/APKBUILD
@@ -7,10 +7,10 @@ case $pkgver in
 	*.*.*)	_kernver=${pkgver%.*};;
 	*.*) _kernver=$pkgver;;
 esac
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux vanilla kernel"
 url="http://kernel.org"
-depends="mkinitfs linux-firmware"
+depends="mkinitfs"
 _depends_dev="perl gmp-dev elfutils-dev bash"
 makedepends="$_depends_dev sed installkernel bc linux-headers"
 options="!strip"


### PR DESCRIPTION
As written in issue https://bugs.alpinelinux.org/issues/8481 the unnecessary dependency to linux-firmware for the linux-virt kernel increases a virtual installation a lot. Also, this dependency is not there for linux-virthardened.