### PR TITLE
community/namecoin: patched to build with boost 1.66.0

### DIFF
--- a/community/namecoin/APKBUILD
+++ b/community/namecoin/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=namecoin
 pkgver=0.13.0_rc1
 _ver=${pkgver/_/}
-pkgrel=9
+pkgrel=10
 pkgdesc="Namecoin is a peer to peer DNS based on bitcoin"
 url="https://www.namecoin.org/"
 arch="all"
@@ -15,6 +15,7 @@ install="$pkgname.post-install $pkgname.pre-install"
 subpackages="$pkgname-dev $pkgname-qt $pkgname-cli $pkgname-tx $pkgname-tests $pkgname-bench"
 source="$pkgname-$_ver.tar.gz::https://github.com/$pkgname/$pkgname-core/archive/nc${_ver}.tar.gz
 	ssize_t.patch
+	boost_1.66.0-compat.patch
 	$pkgname.initd
 	$pkgname.conf
 	"
@@ -90,5 +91,6 @@ dev() {
 
 sha512sums="48f07e68872de69c522eaa76a5f519ba0a161bdaf3ce9979bd5af2a42dd67cd3bad7d6b695f55322c0cfdbad482ee5d279331f4e7c062fef8f09dc9001c1d368  namecoin-0.13.0rc1.tar.gz
 98aa5ad81bdb4ae961b791bc978c39117cdf2d83c2181f92bebbb0db107d9b6e86eda265fb3f93ff8a5ca8a7754d7148818b98095d57201dff9363d60b97e7dd  ssize_t.patch
+09b83eecf5f00c87ca9140bda47cb38b4e4e48abba9caa2438a5f433d05f84038b81c8233448806121359fbdb7890e7f64dc19ec436733aeaa8bc12d3e1b5611  boost_1.66.0-compat.patch
 1753132f349e02cc248a622eb17f2f98a180d561d46f2e8916b84cc26c98d546214ca305bb1ea378ae14090c0abf8d6ac257c98c6776bbe4dabd68c108f595a3  namecoin.initd
 3f92cb9a5f66d0e9e3792691b2e62b929c092030273bb87ebd9564e0c02196a5a9f69c458162f1b35099ac28e9b79b1c4035144b9d2dae4ad3e87d05a40d7ed4  namecoin.conf"

--- a/community/namecoin/boost_1.66.0-compat.patch
+++ b/community/namecoin/boost_1.66.0-compat.patch
@@ -1,0 +1,72 @@
+diff --git a/src/miner.h b/src/miner.h
+index 36276dc36..d81ec6421 100644
+--- a/src/miner.h
++++ b/src/miner.h
+@@ -71,7 +71,7 @@ struct modifiedentry_iter {
+ // except operating on CTxMemPoolModifiedEntry.
+ // TODO: refactor to avoid duplication of this logic.
+ struct CompareModifiedEntry {
+-    bool operator()(const CTxMemPoolModifiedEntry &a, const CTxMemPoolModifiedEntry &b)
++    bool operator()(const CTxMemPoolModifiedEntry &a, const CTxMemPoolModifiedEntry &b) const
+     {
+         double f1 = (double)a.nModFeesWithAncestors * b.nSizeWithAncestors;
+         double f2 = (double)b.nModFeesWithAncestors * a.nSizeWithAncestors;
+@@ -86,7 +86,7 @@ struct CompareModifiedEntry {
+ // This is sufficient to sort an ancestor package in an order that is valid
+ // to appear in a block.
+ struct CompareTxIterByAncestorCount {
+-    bool operator()(const CTxMemPool::txiter &a, const CTxMemPool::txiter &b)
++    bool operator()(const CTxMemPool::txiter &a, const CTxMemPool::txiter &b) const
+     {
+         if (a->GetCountWithAncestors() != b->GetCountWithAncestors())
+             return a->GetCountWithAncestors() < b->GetCountWithAncestors();
+diff --git a/src/txmempool.h b/src/txmempool.h
+index 346585ab1..86a008d7b 100644
+--- a/src/txmempool.h
++++ b/src/txmempool.h
+@@ -204,7 +204,7 @@ struct mempoolentry_txid
+ class CompareTxMemPoolEntryByDescendantScore
+ {
+ public:
+-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
++    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
+     {
+         bool fUseADescendants = UseDescendantScore(a);
+         bool fUseBDescendants = UseDescendantScore(b);
+@@ -226,7 +226,7 @@ public:
+     }
+ 
+     // Calculate which score to use for an entry (avoiding division).
+-    bool UseDescendantScore(const CTxMemPoolEntry &a)
++    bool UseDescendantScore(const CTxMemPoolEntry &a) const
+     {
+         double f1 = (double)a.GetModifiedFee() * a.GetSizeWithDescendants();
+         double f2 = (double)a.GetModFeesWithDescendants() * a.GetTxSize();
+@@ -241,7 +241,7 @@ public:
+ class CompareTxMemPoolEntryByScore
+ {
+ public:
+-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
++    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
+     {
+         double f1 = (double)a.GetModifiedFee() * b.GetTxSize();
+         double f2 = (double)b.GetModifiedFee() * a.GetTxSize();
+@@ -255,7 +255,7 @@ public:
+ class CompareTxMemPoolEntryByEntryTime
+ {
+ public:
+-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
++    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
+     {
+         return a.GetTime() < b.GetTime();
+     }
+@@ -264,7 +264,7 @@ public:
+ class CompareTxMemPoolEntryByAncestorFee
+ {
+ public:
+-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
++    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
+     {
+         double aFees = a.GetModFeesWithAncestors();
+         double aSize = a.GetSizeWithAncestors();
+-- 


### PR DESCRIPTION
@itoffshore 
After upgrading boost from 1.62.0 to 1.66.0 the build of namecoin will fail. This patch will solve it.
The patch does not change the behavior if still using boost 1.62.0