### PR TITLE
testing/wireguard: upgrade to 0.0.20180304

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20180218
-_mypkgrel=1
+_ver=0.0.20180304
+_mypkgrel=2
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="975556e447934a5492ddf6f4faef14887794fe2fece3b811bad17b93aa5fe34f55653d2b87ceb6d06f0292406247a3b45b67f1a61387cf724995c0a67fcd42d2  WireGuard-0.0.20180218.tar.xz"
+sha512sums="dc7ad4c366625bc614f95abe163459804fa3b6a4dd9e1c7eee1571d3dab5a5bc88dbdc6cc79b9ec48f471ba71da54050f1bce8874ed130f15234a8353d276e50  WireGuard-0.0.20180304.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180218
+pkgver=0.0.20180304
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="975556e447934a5492ddf6f4faef14887794fe2fece3b811bad17b93aa5fe34f55653d2b87ceb6d06f0292406247a3b45b67f1a61387cf724995c0a67fcd42d2  WireGuard-0.0.20180218.tar.xz"
+sha512sums="dc7ad4c366625bc614f95abe163459804fa3b6a4dd9e1c7eee1571d3dab5a5bc88dbdc6cc79b9ec48f471ba71da54050f1bce8874ed130f15234a8353d276e50  WireGuard-0.0.20180304.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,7 +4,7 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180218
+_ver=0.0.20180304
 _rel=0
 _toolsrel=0
 
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="975556e447934a5492ddf6f4faef14887794fe2fece3b811bad17b93aa5fe34f55653d2b87ceb6d06f0292406247a3b45b67f1a61387cf724995c0a67fcd42d2  WireGuard-0.0.20180218.tar.xz"
+sha512sums="dc7ad4c366625bc614f95abe163459804fa3b6a4dd9e1c7eee1571d3dab5a5bc88dbdc6cc79b9ec48f471ba71da54050f1bce8874ed130f15234a8353d276e50  WireGuard-0.0.20180304.tar.xz"


### PR DESCRIPTION
```
  * queueing: skb_reset: mark as xnet
  
  This allows cgroups to classify packets.
  
  * contrib: embedded-wg-library: add ability to add and del interfaces
  * contrib: embedded-wg-library: add key generation functions
  
  The embeddable library gains a few extra tricks, for people implementing
  plugins for various network managers.
  
  * crypto: read only after init
  * allowedips: fix comment style
  * messages: MESSAGE_TOTAL is unused
  * global: in gnu code, use un-underscored asm
  * noise: fix function prototype
  
  Small cleanups.
  
  * compat: workaround netlink refcount bug
  
  An upstream refcounting bug meant that in certain situations it became
  impossible to unload the module. So, we work around it in the compat code. The
  problem has been fixed in 4.16.
  
  * contrib: keygen-html: rewrite in pure javascript
  * Revert "contrib: keygen-html: rewrite in pure javascript"
  
  We nearly moved away from emscripten'ing the fiat32 code, but the resultant
  floating point javascript was just too terrifying.
  
  * Kconfig: require DST_CACHE explicitly
  
  Required for certain frankenkernels.
  
  * compat: use correct -include path
  
  Fixes certain out-of-tree build systems.
  
  * noise: align static_identity keys
  
  Gives us better alignment of private keys.
  
  * wg-quick: if resolvconf/interface-order exists, use it
  * wg-quick: if resolvconf/run/iface exists, use it
  
  Better compatibility with Debian's resolvconf.
  
  * contrib: add extract-handshakes kprobe example
  
  Small utility for extracting ephemeral key data from the kernel's memory. More
  information can be found here:
  https://lists.zx2c4.com/pipermail/wireguard/2018-February/002439.html
```