### PR TITLE
main/gtk+3.0 Enable Wayland support

### DIFF
--- a/main/gtk+3.0/APKBUILD
+++ b/main/gtk+3.0/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gtk+3.0
 pkgver=3.22.26
-pkgrel=1
+pkgrel=2
 pkgdesc="The GTK+ Toolkit (v3)"
 url="https://www.gtk.org/"
 install="$pkgname.post-install $pkgname.post-upgrade $pkgname.post-deinstall"
@@ -33,6 +33,10 @@ depends_dev="
 	libxinerama-dev
 	libxrandr-dev
 	pango-dev
+	wayland-protocols
+	wayland-libs-client
+	wayland-libs-cursor
+	libxkbcommon-dev
 	"
 makedepends="
 	$depends_dev
@@ -64,6 +68,7 @@ build() {
 		--enable-xcomposite \
 		--enable-xdamage \
 		--enable-x11-backend \
+		--enable-wayland-backend \
 		|| return 1
 
 	# https://bugzilla.gnome.org/show_bug.cgi?id=655517


### PR DESCRIPTION
Allows GTK3.0 apps to be ran in a Wayland-only environment.