### PR TITLE
main/dovecot: security upgrade to 2.2.34

### DIFF
--- a/main/dovecot/APKBUILD
+++ b/main/dovecot/APKBUILD
@@ -3,9 +3,9 @@
 # Contributor: Michael Mason <ms13sp@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dovecot
-pkgver=2.2.33.2
+pkgver=2.2.34
 _pkgvermajor=2.2
-pkgrel=4
+pkgrel=0
 _pigeonholever=0.4.21
 _pluginextdataver=39
 _pigeonholevermajor=${_pigeonholever%.*}
@@ -39,6 +39,11 @@ builddir="$srcdir/$pkgname-$pkgver"
 _builddirpigeonhole="$srcdir/$pkgname-${_pkgvermajor}-pigeonhole-$_pigeonholever"
 _builddirpluginextdata="$srcdir/pigeonhole-${_pigeonholevermajor/./-}-sieve-extdata-$_pluginextdataver"
 
+# secfixes:
+#   2.2.34-r0:
+#     - CVE-2017-15130
+#     - CVE-2017-14461
+#     - CVE-2017-15132
 
 _configure() {
 	./configure \
@@ -225,7 +230,7 @@ _fts_lucene() {
 	depends="$pkgname"
 	_mv $(cd "$pkgdir" && find usr -name '*fts*lucene*')
 }
-sha512sums="028910a4d02b1630f1ada4d1c45fcc3ea2057969db7078a78d46e2a578b4dceaf8be0ac8de4a613b4890019e721871f2d366ec651db658da4cc72977d3e09931  dovecot-2.2.33.2.tar.gz
+sha512sums="9f08a7116a08a08495aa0e7b4cb6b11a924ea61006970487946e338bc79bba7fd7619c345cbf278a74de285d548af04fc66eaaee508185b8b9d7335cf5612055  dovecot-2.2.34.tar.gz
 4751f449ede1b05173c706b414ebf9f7f670ff78589ce6f0b687c32c9abe6dae8b3064ed1b20e893d9ec0147b0139ce479e1d74ebe94747c33f2d8ca177912de  dovecot-2.2-pigeonhole-0.4.21.tar.gz
 832a80264fb9bd3021c4e192eb7594c203100783df547aff35acf4dc4d8de5eddfd676fcc5a07a0691d9bb6eb884c9497a692b72a2af5bf9e9bb7a2d3f38923e  39.tar.gz
 09bae967d35b9e5d7d91c81337e1bf5e5aba3abb7b0ab06427f1a0d6f9bb5b2f2e39306cfe45d80488110fc0414e3e2515c0265286c1584d80f8af366d1568a9  skip-iconv-check.patch


### PR DESCRIPTION
https://www.dovecot.org/list/dovecot-news/2018-February/000370.html