### PR TITLE
main/clamav: security upgrade to 0.99.4

### DIFF
--- a/main/clamav/APKBUILD
+++ b/main/clamav/APKBUILD
@@ -3,8 +3,8 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=clamav
-pkgver=0.99.3
-pkgrel=3
+pkgver=0.99.4
+pkgrel=0
 pkgusers="clamav"
 pkggroups="clamav"
 pkgdesc="An anti-virus toolkit for UNIX eis-ng backport"
@@ -35,6 +35,12 @@ source="http://www.clamav.net/downloads/production/$pkgname-$pkgver.tar.gz
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   0.99.4-r0:
+#     - CVE-2012-6706
+#     - CVE-2017-6419
+#     - CVE-2017-11423
+#     - CVE-2018-0202
+#     - CVE-2018-1000085
 #   0.99.3-r0:
 #     - CVE-2017-12374
 #     - CVE-2017-12375
@@ -224,7 +230,7 @@ milter() {
 		"$subpkgdir"/etc/clamav/clamav-milter.conf
 }
 
-sha512sums="0d3c75d571ed4aa4937ef2b743a39a9a144f5adfd6f56f71046e5a8387b8ed7c3c4d9a4196aa85750f9ec4dc545720fdd659289d0cce086ab13a7cc505a0ab3e  clamav-0.99.3.tar.gz
+sha512sums="778d5ef510d8d4bdfac5dc33d92469ed4283c414b3d42da6e1a0b13ed70e37755d5c837622dc336bc728ba1f8bf5485fc8a8d3a67a90e9aaa9e4dc71ece0691d  clamav-0.99.4.tar.gz
 ed81be79bf9a25eec071312252121cc76c96838407377b75077bf94922055f1de99f327982ac4dccd5be85003baa95385e5d002fabab32bb851bb30178475edd  clamd.initd
 59c561b3dcb0b616b647cd8e4ebc46a2cc5e7144c8c7ea0054cc1c3021d1da8f67e4dad5c083c3fe712ed887aaabfca91b538f4759537e7c4c9ab71ba4fd5794  clamd.confd
 00daed8afb67a6e4a29893340246c8840cce970dd9103d26557ecdd26ef60b12551d2291c214fc657faaaa339484052079347411b0cad65e3a33ece56d57cf16  freshclam.initd


### PR DESCRIPTION
http://blog.clamav.net/2018/03/clamav-0994-has-been-released.html