### PR TITLE
main/memcached: upgrade to 1.5.6, 

### DIFF
--- a/main/memcached/APKBUILD
+++ b/main/memcached/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Jeff Bilyk <jbilyk@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=memcached
-pkgver=1.5.5
-pkgrel=1
+pkgver=1.5.6
+pkgrel=0
 pkgdesc="Distributed memory object caching system"
 url="http://memcached.org/"
 arch="all"
@@ -22,8 +22,7 @@ build() {
 		--host=$CHOST \
 		--prefix=/usr \
 		--enable-sasl \
-		--enable-sasl-pwdb \
-		--enable-seccomp
+		--enable-sasl-pwdb
 	make
 }
 
@@ -44,6 +43,6 @@ package() {
 sha1sums="29cb75cc234dbaceed6e89db029af8363706f0fe  memcached-1.5.4.tar.gz
 a9c12a750a354c8d33849d106e285ddba150b6d2  memcached.confd
 4092666ae58207034e0de40d25b15c6b6cd31b5f  memcached.initd"
-sha512sums="38883600398b5d9378bb57508ed94b80ed2c4ef0e2610e328a60bcb79268f85c67c99159993040b36eac964138822862fa78f62c649560abc4818233b1b2f3d0  memcached-1.5.5.tar.gz
+sha512sums="b8bb3b69358a476c6f11f42e89565dd0261cba3f1eaa6b0999dba7c2cb2d7c5e9ca24dedc6b7fd46ec78e40e52d66fe4694ebafd6bbd4557d25d66757d9024a4  memcached-1.5.6.tar.gz
 31bd788433b8021ed332f86d291e7f03222ae234520e52ba673b581d5da2adf5656e8f73e8b985df73258dea9b2a1b8ef36195163fe47a92fda59825deedfed4  memcached.confd
 9615769b14175a25b50c9871b48c0635b5397ebe45231b43ee29a603eceb7b16bfc5ac744017b89b19082209c09597b3038a03ed0d5d9b45c60454d5b2717a55  memcached.initd"


### PR DESCRIPTION
disabled seccomp as it does not work when enabled
No connection with `telnet localhost 11211` is possible if compiled with seccomp

This was reported in https://bugs.alpinelinux.org/issues/8608