### PR TITLE
testing/php7-tideways_xhprof: update timer function for ppc64le

### DIFF
--- a/testing/php7-tideways_xhprof/APKBUILD
+++ b/testing/php7-tideways_xhprof/APKBUILD
@@ -5,15 +5,17 @@ _pkgext=tideways_xhprof
 _pkgreal=php-xhprof-extension
 pkgver=5.0_beta2
 _pkgver=${pkgver/_/-}
-pkgrel=0
+pkgrel=1
 pkgdesc="Modern XHProf compatible Profiler for PHP 7"
 url="http://tideways.io"
 # ppc64le: fails to build
-arch="all !ppc64le"
+arch="all"
 license="Apache-2.0"
 depends="php7"
 makedepends="php7-dev autoconf"
-source="$pkgname-$pkgver.tar.gz::https://github.com/tideways/$_pkgreal/archive/v$_pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/tideways/$_pkgreal/archive/v$_pkgver.tar.gz
+	timer_ppc64le.patch	
+	"
 builddir="$srcdir/$_pkgreal-$_pkgver"
 
 build() {
@@ -38,4 +40,5 @@ package() {
 	echo "extension=$_pkgext.so" > "$pkgdir"/etc/php7/conf.d/$_pkgext.ini
 }
 
-sha512sums="1e42589b81f39272cf62a058e1ecd82532b076bebe583d13b797d448891ff615aedf1e990785fbba7302daa34a977bf748cf2deaaf4fd334af800a556849334c  php7-tideways_xhprof-5.0_beta2.tar.gz"
+sha512sums="1e42589b81f39272cf62a058e1ecd82532b076bebe583d13b797d448891ff615aedf1e990785fbba7302daa34a977bf748cf2deaaf4fd334af800a556849334c  php7-tideways_xhprof-5.0_beta2.tar.gz
+62f09c950a5b85efd87159e9e747298fd7c9b2bbec060745adf120c5cf5748e4cdfa4625c8b49e15f9905bf3833dab91f81a297e5a68fbb9e3778025846c12b6  timer_ppc64le.patch"

--- a/testing/php7-tideways_xhprof/timer_ppc64le.patch
+++ b/testing/php7-tideways_xhprof/timer_ppc64le.patch
@@ -1,0 +1,15 @@
+--- a/timer.h
++++ b/timer.h
+@@ -75,8 +75,12 @@
+             return 0;
+ #endif
+         case TIDEWAYS_XHPROF_CLOCK_TSC:
++#if !defined (__powerpc64__)
+             asm volatile("rdtsc" : "=a" (a), "=d" (d));
+             (val) = ((uint64)a) | (((uint64)d)<<32);
++#else
++	     asm volatile ("mftb %0" : "=r" (val));
++#endif
+             return val / timebase_factor;
+ 
+         default:


### PR DESCRIPTION
powerpc64 fails build with invalid opcode for rdtsc. Adding conditional check for powerpc64 and use equivalent timebase instruction. 