### PR TITLE
 testing/php7-gmagick: upgrade to 2.0.5_rc1, add check, modernize

### DIFF
--- a/testing/php7-gmagick/APKBUILD
+++ b/testing/php7-gmagick/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=php7-gmagick
 _pkgreal=gmagick
-pkgver=2.0.4_rc1
+pkgver=2.0.5_rc1
 _pkgver=${pkgver/_rc/RC}
 pkgrel=4
 pkgdesc="PHP7 bindings to the GraphicsMagick library"
@@ -40,6 +40,4 @@ package() {
 		"$pkgdir"/etc/php7/conf.d/$_pkgreal.ini
 }
 
-md5sums="75bd382e666033dbb7a8fab9088dc827  gmagick-2.0.4RC1.tgz"
-sha256sums="4ead19640bebebfa68be41dc0097a93a7bf9beb56ea82b27343dba8ea4c5ecfa  gmagick-2.0.4RC1.tgz"
-sha512sums="c8d877ab371fe57e07134bbe09bb24dcf20cd3d6310a212c395c89e27e783cb939c05ff80efdd6c47580ef54e315d75793e5c85c90b11c79796e60315e063916  gmagick-2.0.4RC1.tgz"
+sha512sums="217ad5ba2df7f6092fbb2dc13918f85658793033ba03550657be1ff44dc51ae0533a7ae86c0b14c60e8a0dc8fe9af16daffa01cc50a4096d269ad55d60a3dfb8  gmagick-2.0.5RC1.tgz"

--- a/testing/php7-gmagick/APKBUILD
+++ b/testing/php7-gmagick/APKBUILD
@@ -4,40 +4,38 @@ pkgname=php7-gmagick
 _pkgreal=gmagick
 pkgver=2.0.5_rc1
 _pkgver=${pkgver/_rc/RC}
-pkgrel=4
+pkgrel=0
 pkgdesc="PHP7 bindings to the GraphicsMagick library"
 url="http://pecl.php.net/package/gmagick"
 arch="all"
 license="PHP"
-depends=
+depends=""
 makedepends="graphicsmagick-dev autoconf libtool php7-dev"
-install=
-subpackages=
 source="http://pecl.php.net/get/$_pkgreal-$_pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$_pkgver"
 
-prepare() {
-	default_prepare || return 1
-
-	cd "$builddir"
-	phpize7 || return 1
-}
-
 build() {
 	cd "$builddir"
+	phpize7
 	./configure \
 		--prefix=/usr \
-		--with-php-config=/usr/bin/php-config7 \
-	|| return 1
-	make || return 1
+		--with-php-config=/usr/bin/php-config7
+	make
+}
+
+check() {
+	cd "$builddir"
+	# Test broken because of fonts collisions ghostscript-fonts and libwmf
+	# https://bugs.alpinelinux.org/issues/8619
+	rm tests/gmagick-006-annotateimage.phpt
+	make NO_INTERACTION=1 REPORT_EXIT_STATUS=1 test
 }
 
 package() {
 	cd "$builddir"
-	make INSTALL_ROOT="$pkgdir" install || return 1
-	install -d "$pkgdir"/etc/php7/conf.d || return 1
-	echo "extension=$_pkgreal.so" > \
-		"$pkgdir"/etc/php7/conf.d/$_pkgreal.ini
+	make INSTALL_ROOT="$pkgdir" install
+	install -d "$pkgdir"/etc/php7/conf.d
+	echo "extension=$_pkgreal.so" "$pkgdir"/etc/php7/conf.d/$_pkgreal.ini
 }
 
 sha512sums="217ad5ba2df7f6092fbb2dc13918f85658793033ba03550657be1ff44dc51ae0533a7ae86c0b14c60e8a0dc8fe9af16daffa01cc50a4096d269ad55d60a3dfb8  gmagick-2.0.5RC1.tgz"


### PR DESCRIPTION
Very useful would be great to promote to contrib

@vakartel please check, this extension works better then `php7-imagick` and has less dependencies

