### PR TITLE
testing/ocaml-cppo allow textrels and fix asr

### DIFF
--- a/testing/ocaml-cppo/APKBUILD
+++ b/testing/ocaml-cppo/APKBUILD
@@ -3,16 +3,19 @@
 pkgname=ocaml-cppo
 _pkgname=cppo
 pkgver=1.6.4
-pkgrel=0
+pkgrel=1
 pkgdesc="C-style preprocessor for OCaml"
 url="https://github.com/mjambon/cppo"
 # ocaml is not avail for x86, armhf, s390x
 # test fails on ppc64le
-arch="all !x86 !armhf !s390x !ppc64le"
+arch="all !x86 !armhf !s390x"
 license="BSD-3-Clause"
 makedepends="dune ocaml ocamlbuild ocaml-findlib opam"
+options="textrels"
 subpackages="$pkgname-dev"
-source="$pkgname-$pkgver.tar.gz::https://github.com/mjambon/$_pkgname/archive/v$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/mjambon/$_pkgname/archive/v$pkgver.tar.gz
+	ppc64le-asr.patch
+	"
 builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
@@ -51,4 +54,5 @@ dev() {
 	mv *.cmx *.cmxa *.ml *.mli "$subpkgdir"/$sitelib/
 }
 
-sha512sums="89c6df66d597d929be7532ad82f0206b028bdbd79a0b4b39451bce3fa5bd63a80dce931d575f69bd7066de829347498c736657dfe9610b20700a652b9b542a4d  ocaml-cppo-1.6.4.tar.gz"
+sha512sums="89c6df66d597d929be7532ad82f0206b028bdbd79a0b4b39451bce3fa5bd63a80dce931d575f69bd7066de829347498c736657dfe9610b20700a652b9b542a4d  ocaml-cppo-1.6.4.tar.gz
+718b0bfb4c0106e153bde9cf9a52f79858f113b3a8ffd6c9f887c2b2fec16dd330e952786e322a3532200e34ae533828d9d98c3fa784910cd3f92fec56250533  ppc64le-asr.patch"

--- a/testing/ocaml-cppo/ppc64le-asr.patch
+++ b/testing/ocaml-cppo/ppc64le-asr.patch
@@ -1,0 +1,11 @@
+--- a/src/cppo_parser.mly
++++ b/src/cppo_parser.mly
+@@ -252,7 +252,7 @@
+   | aexpr MOD aexpr          { `Mod ($2, $1, $3) }
+   | aexpr LSL aexpr          { `Lsl ($1, $3) }
+   | aexpr LSR aexpr          { `Lsr ($1, $3) }
+-  | aexpr ASR aexpr          { `Lsr ($1, $3) }
++  | aexpr ASR aexpr          { `Asr ($1, $3) }
+   | aexpr LAND aexpr         { `Land ($1, $3) }
+   | aexpr LOR aexpr          { `Lor ($1, $3) }
+   | aexpr LXOR aexpr         { `Lxor ($1, $3) }


### PR DESCRIPTION
Fix textrels and correct asr expression definition that was causing test.cppo failure.