### PR TITLE
main/nano: upgrade to 2.9.4

### DIFF
--- a/main/nano/APKBUILD
+++ b/main/nano/APKBUILD
@@ -1,15 +1,15 @@
 # Contributor: Michael Mason <ms13sp@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nano
-pkgver=2.9.3
+pkgver=2.9.4
 pkgrel=0
 pkgdesc="Enhanced clone of the Pico text editor"
 url="https://www.nano-editor.org"
 arch="all"
 license="GPL-3.0-or-later"
-makedepends="ncurses-dev file-dev"
+makedepends="file-dev linux-headers ncurses-dev"
 subpackages="$pkgname-doc $pkgname-syntax::noarch"
-source="https://www.nano-editor.org/dist/v${pkgver%.*}/$pkgname-$pkgver.tar.gz"
+source="https://www.nano-editor.org/dist/v${pkgver%.*}/$pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -53,4 +53,4 @@ syntax() {
 		"$subpkgdir"/usr/share/$pkgname/
 }
 
-sha512sums="cce389a00dc4db899d7f73522e991bee5fa1fd0538a1af08aa75563e29e6cfba38b53acbba1d95e7876f3cac6298b5cada102d700334446419aadfe61ac18d2a  nano-2.9.3.tar.gz"
+sha512sums="d8ef564ab9db2cd5f230061e5bb55f6bc36b6450c7585562ee32a27702a44276d94febd3c988b70eaf5b2e1a453426042c079a9eb40a4e71744da1ddde269863  nano-2.9.4.tar.xz"


### PR DESCRIPTION
Build fails (requiring linux/vt.h) without linux-headers.