### PR TITLE
community/gsoap: upgrade to 2.8.65, clarify license

### DIFF
--- a/community/gsoap/APKBUILD
+++ b/community/gsoap/APKBUILD
@@ -1,11 +1,11 @@
 # Contributor: <xmingske@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gsoap
-pkgver=2.8.59
+pkgver=2.8.65
 pkgrel=0
 arch="all"
-pkgdesc='A cross-platform C and C++ SDK for SOAP/XML Web services'
-license="GPL-2.0 gSOAP"
+pkgdesc="Cross-platform C and C++ SDK for SOAP/XML Web services"
+license="GPL-2.0-or-later gSOAP-1.3b"
 url="http://gsoap2.sourceforge.net"
 makedepends="autoconf automake bison flex zlib-dev libressl-dev libtool"
 subpackages="$pkgname-dev"
@@ -13,7 +13,6 @@ source="http://downloads.sourceforge.net/project/gsoap2/gsoap-${pkgver%.*}/gsoap
 	musl-fixes.patch
 	libressl.patch
 	"
-
 builddir="$srcdir/$pkgname-${pkgver%.*}"
 
 build() {
@@ -23,7 +22,8 @@ build() {
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--exec-prefix=/usr \
-		--enable-ipv6
+		--enable-ipv6 \
+		--enable-c-locale
 	make -j1
 }
 
@@ -32,6 +32,6 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="d43320e6965c3f17d122ea7aeeecbc0b608dac52204e630c3254d32eadd3c93aaca446c92bb439b98207f8560b2ad6bff220c0502b75ebd18b99e37402570624  gsoap_2.8.59.zip
+sha512sums="2df8696971481e3728b4b8c2e5f038bb40f17e999eca2b8ca50b7f75b1e425d953eb930ad3094255e7e4d8fc7386a370e79920affb9fd293301b1b000c09be18  gsoap_2.8.65.zip
 ab917ece2b7fc507138c7920ddce99ef7a482bfef9e323366940987a75e7594ca91a081ed8d9b6a6b050346a6ebe7c9a9d2de9483beb54768384177e4bc15b9b  musl-fixes.patch
 a0892700b55562880a58cd8411fb3386a2ae1785c9212a59d0d1c8ccdfa86553bb8d6fb3dd6c923453a1a47c586edbc924c6e7bd4f2436948693e39bd3b1ec73  libressl.patch"


### PR DESCRIPTION
Building against `xlocale.h` fails.
Added configuration override`--enable-c-locale` to build against `locale.h`.