### PR TITLE
main/sic: apply two official patches

### DIFF
--- a/main/sic/APKBUILD
+++ b/main/sic/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=sic
 pkgver=1.2
-pkgrel=0
+pkgrel=1
 pkgdesc="an extremely simple IRC client"
 url="http://tools.suckless.org/sic"
 arch="all"
@@ -10,14 +10,16 @@ license="GPL"
 depends=""
 subpackages="$pkgname-doc"
 source="http://dl.suckless.org/tools/sic-$pkgver.tar.gz
-	musl-fix.patch"
+	musl-fix.patch
+	lineprint.patch
+	hidecommand.patch"
 
 _builddir="$srcdir"/$pkgname-$pkgver
 prepare() {
 	cd "$_builddir"
 	for i in $source; do
 		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
+		*.patch) msg $i; patch --ignore-whitespace -p1 -i "$srcdir"/$i || return 1;;
 		esac
 	done
 }
@@ -32,9 +34,7 @@ package() {
 	make DESTDIR="$pkgdir" PREFIX=/usr install
 }
 
-md5sums="eb099e790c3ce7866df50d3fe1a52c25  sic-1.2.tar.gz
-216be8b79c23f4a5fa59a64ec06188af  musl-fix.patch"
-sha256sums="ac07f905995e13ba2c43912d7a035fbbe78a628d7ba1c256f4ca1372fb565185  sic-1.2.tar.gz
-e6b089bf64a7ac8ce7c531698aaede0ba93064b8b7c052ab7f6a44b70673530c  musl-fix.patch"
 sha512sums="5659ed9d8a5986dda90dbe1155c27a5fd0ab4b1fcad2c1a20997c530bf03864e6c08bdeffc025c728629ab11872af6a1250761160b91f148dc37d77a49046dc9  sic-1.2.tar.gz
-94d9dc44a1a33c67141db312004a2c9d2113223c921ae210a6451b1c0f408d93fff4b16049f49d393ab4ca3ffca3fb5fc62265ec6195317abfbb70abdcd8ad5e  musl-fix.patch"
+94d9dc44a1a33c67141db312004a2c9d2113223c921ae210a6451b1c0f408d93fff4b16049f49d393ab4ca3ffca3fb5fc62265ec6195317abfbb70abdcd8ad5e  musl-fix.patch
+85128d8f230542e942e9b7300e09fb6896d2c2f689509cf643d98c1b200eb23fc53e4a6684a62a203ab0643604e146944246d674ed45c96c91d7105b6d44e4c4  lineprint.patch
+c49dac73f1ba21970670e1274a7839cd0a4e6230462014b5885befe500a58477c20208873a8b6d74998e1364f8026007c6888d4f44e0df72356938eee61be553  hidecommand.patch"

--- a/main/sic/hidecommand.patch
+++ b/main/sic/hidecommand.patch
@@ -1,0 +1,31 @@
+diff --git a/sic.c b/sic.c
+--- a/sic.c
++++ b/sic.c
+@@ -19,6 +19,7 @@
+ static char bufin[4096];
+ static char bufout[4096];
+ static char channel[256];
++static char hidecmd[128] = {0};
+ static time_t trespond;
+ static FILE *srv;
+ 
+@@ -99,6 +100,9 @@
+        case 's':
+            strlcpy(channel, p, sizeof channel);
+            return;
++       case 'h':
++           strlcpy(hidecmd, p, sizeof hidecmd);
++           return;
+        }
+    }
+    sout("%s", s);
+@@ -129,7 +133,8 @@
+    else if(!strcmp("PING", cmd))
+        sout("PONG %s", txt);
+    else {
+-       pout(usr, ">< %s (%s): %s", cmd, par, txt);
++       if (!strcasestr(hidecmd, cmd))
++           pout(usr, ">< %s (%s): %s", cmd, par, txt);
+        if(!strcmp("NICK", cmd) && !strcmp(usr, nick))
+            strlcpy(nick, txt, sizeof nick);
+    }

--- a/main/sic/lineprint.patch
+++ b/main/sic/lineprint.patch
@@ -1,0 +1,42 @@
+diff --git a/sic.c b/sic.c
+index 8a0301b..6401414 100644
+--- a/sic.c
++++ b/sic.c
+@@ -18,6 +18,7 @@ static char *password;
+ static char nick[32];
+ static char bufin[4096];
+ static char bufout[4096];
++static char bufln[4096];
+ static char channel[256];
+ static time_t trespond;
+ static FILE *srv;
+@@ -60,11 +61,29 @@ privmsg(char *channel, char *msg) {
+ 
+ static void
+ parsein(char *s) {
++	int i, off;
+ 	char c, *p;
+ 
+ 	if(s[0] == '\0')
+ 		return;
+ 	skip(s, '\n');
++
++	/* input reprint */
++	i = strlen(s) - 1;
++	off = (*bufln ? strlen(bufln) : 0);
++	if(s[i] == '\\') {
++		s[i] = '\0';
++		if(i)
++			snprintf(&bufln[off], (sizeof bufln - off), "%s", s);
++		printf("%s", bufln);
++		return;
++	}
++	else if(*bufln) {
++		snprintf(&bufln[off], sizeof bufln, "%s", s);
++		strlcpy(s, bufln, 4096);
++		*bufln = '\0';
++	}
++
+ 	if(s[0] != ':') {
+ 		privmsg(channel, s);
+ 		return;


### PR DESCRIPTION
The first patch is lineprint.patch (https://tools.suckless.org/sic/patches/lineprint).
This patch allow to store and reprint the current inserting line.
This is done by appending a suffix character ('\') to the input.
The line is (obviously) not sent.
This is useful, for example, when receiving data from the server in the middle of a sentence you’re writing.

The second patch is hidecommand.patch (https://tools.suckless.org/sic/patches/hidecommand).
This patch lets you hide IRC messages such as JOIN/QUIT.
You can use the sic command ‘h’ to specify what messages are hidden.
Example: :h JOIN,QUIT
Now all JOIN and QUIT messages will not be displayed.
The delimiter is unimportant (use what you like or nothing at all)
Use the command without arguments to stop hiding any messages.