### PR TITLE
community/fzf: shell subpackages

### DIFF
--- a/community/fzf/APKBUILD
+++ b/community/fzf/APKBUILD
@@ -48,11 +48,11 @@ tmux() {
 }
 
 extras() {
-        description="additional scripts like shell completion and keybindings"
+	description="additional scripts like shell completion and keybindings"
 
-        cd "$builddir"
-        install -dm0755 "$subpkgdir"/usr/share/fzf
-        install -m0644 shell/* "$subpkgdir"/usr/share/fzf
+	cd "$builddir"
+	install -dm0755 "$subpkgdir"/usr/share/fzf
+	install -m0644 shell/*.$1 "$subpkgdir"/usr/share/fzf
 }
 
 sha512sums="2713ef7adb0dd278ac0a0c362c5cd23e7b0f1867efdfa964ad1f63f48c7f518e0cf96cc0b2571487585a0271fb0d2398edfebdbe603ec2bb42d3bd87febd2156  fzf-0.17.3.tar.gz

--- a/community/fzf/APKBUILD
+++ b/community/fzf/APKBUILD
@@ -8,7 +8,12 @@ url="https://github.com/junegunn/fzf"
 arch="x86 x86_64"
 license="MIT"
 makedepends="go glide bash tmux"
-subpackages="$pkgname-tmux::noarch $pkgname-extras::noarch"
+subpackages="
+	$pkgname-tmux::noarch
+	$pkgname-bash-completion:bashcomp:noarch
+	$pkgname-zsh-completion:zshcomp:noarch
+	$pkgname-fish-completion:fishcomp:noarch
+	"
 source="$pkgname-$pkgver.tar.gz::https://github.com/junegunn/fzf/archive/$pkgver.tar.gz
 	no-glide-install.patch
 	disable-vet-for-tests.patch"
@@ -42,18 +47,36 @@ package() {
 
 tmux() {
 	depends="tmux bash"
-	description="Helper script to start fzf in a tmux pane"
+	pkgdesc="Helper script to start fzf in a tmux pane"
 
 	cd "$builddir"
 	install -Dm0755 bin/fzf-tmux "$subpkgdir"/usr/bin/fzf-tmux
 }
 
-extras() {
-	description="additional scripts like shell completion and keybindings"
+bashcomp() {
+	pkgdesc="additional scripts for bash like shell completion and keybindings"
+	install_if="$pkgname=$pkgver-r$pkgrel bash-completion"
 
 	cd "$builddir"
-	install -dm0755 "$subpkgdir"/usr/share/fzf
-	install -m0644 shell/*.$1 "$subpkgdir"/usr/share/fzf
+	install -Dm0644 shell/completion.bash "$subpkgdir"/usr/share/bash-completion/completions/$pkgname
+	install -Dm0644 shell/key-bindings.bash "$subpkgdir"/usr/share/$pkgname/key-bindings.bash
+}
+
+zshcomp() {
+	pkgdesc="additional scripts for zsf like shell completion and keybindings"
+	install_if="$pkgname=$pkgver-r$pkgrel zsh"
+
+	cd "$builddir"
+	install -Dm0644 shell/completion.zsh "$subpkgdir"/usr/share/zsh/site-functions/_$pkgname
+	install -Dm0644 shell/key-bindings.zsh "$subpkgdir"/usr/share/$pkgname/key-bindings.zsh
+}
+
+fishcomp() {
+	pkgdesc="keybindings for fish"
+	install_if="$pkgname=$pkgver-r$pkgrel fish"
+
+	cd "$builddir"
+	install -Dm0644 shell/key-bindings.zsh "$subpkgdir"/usr/share/fzf/keybindings.fish
 }
 
 sha512sums="2713ef7adb0dd278ac0a0c362c5cd23e7b0f1867efdfa964ad1f63f48c7f518e0cf96cc0b2571487585a0271fb0d2398edfebdbe603ec2bb42d3bd87febd2156  fzf-0.17.3.tar.gz

--- a/community/fzf/APKBUILD
+++ b/community/fzf/APKBUILD
@@ -9,10 +9,10 @@ arch="x86 x86_64"
 license="MIT"
 makedepends="go glide bash tmux"
 subpackages="
+	$pkgname-doc
 	$pkgname-tmux::noarch
 	$pkgname-bash-completion:bashcomp:noarch
 	$pkgname-zsh-completion:zshcomp:noarch
-	$pkgname-fish-completion:fishcomp:noarch
 	"
 source="$pkgname-$pkgver.tar.gz::https://github.com/junegunn/fzf/archive/$pkgver.tar.gz
 	no-glide-install.patch
@@ -43,6 +43,9 @@ package() {
 	make install
 
 	install -Dm0755 bin/fzf "$pkgdir"/usr/bin/fzf
+	install -Dm0644 shell/key-bindings.bash "$pkgdir"/usr/share/doc/$pkgname/examples/key-bindings.bash
+	install -Dm0644 shell/key-bindings.zsh "$pkgdir"/usr/share/doc/$pkgname/examples/key-bindings.zsh
+	install -Dm0644 shell/key-bindings.fish "$pkgdir"/usr/share/doc/$pkgname/examples/keybindings.fish
 }
 
 tmux() {
@@ -59,7 +62,6 @@ bashcomp() {
 
 	cd "$builddir"
 	install -Dm0644 shell/completion.bash "$subpkgdir"/usr/share/bash-completion/completions/$pkgname
-	install -Dm0644 shell/key-bindings.bash "$subpkgdir"/usr/share/$pkgname/key-bindings.bash
 }
 
 zshcomp() {
@@ -68,15 +70,6 @@ zshcomp() {
 
 	cd "$builddir"
 	install -Dm0644 shell/completion.zsh "$subpkgdir"/usr/share/zsh/site-functions/_$pkgname
-	install -Dm0644 shell/key-bindings.zsh "$subpkgdir"/usr/share/$pkgname/key-bindings.zsh
-}
-
-fishcomp() {
-	pkgdesc="keybindings for fish"
-	install_if="$pkgname=$pkgver-r$pkgrel fish"
-
-	cd "$builddir"
-	install -Dm0644 shell/key-bindings.zsh "$subpkgdir"/usr/share/fzf/keybindings.fish
 }
 
 sha512sums="2713ef7adb0dd278ac0a0c362c5cd23e7b0f1867efdfa964ad1f63f48c7f518e0cf96cc0b2571487585a0271fb0d2398edfebdbe603ec2bb42d3bd87febd2156  fzf-0.17.3.tar.gz

--- a/community/fzf/APKBUILD
+++ b/community/fzf/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Kevin Daudt <ops@ikke.info>
 pkgname=fzf
 pkgver="0.17.3"
-pkgrel=0
+pkgrel=1
 pkgdesc="A command-line fuzzy finder"
 url="https://github.com/junegunn/fzf"
 arch="x86 x86_64"
@@ -10,7 +10,8 @@ license="MIT"
 makedepends="go glide bash tmux"
 subpackages="$pkgname-tmux::noarch $pkgname-extras::noarch"
 source="$pkgname-$pkgver.tar.gz::https://github.com/junegunn/fzf/archive/$pkgver.tar.gz
-	no-glide-install.patch"
+	no-glide-install.patch
+	disable-vet-for-tests.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
@@ -56,4 +57,5 @@ extras() {
 }
 
 sha512sums="2713ef7adb0dd278ac0a0c362c5cd23e7b0f1867efdfa964ad1f63f48c7f518e0cf96cc0b2571487585a0271fb0d2398edfebdbe603ec2bb42d3bd87febd2156  fzf-0.17.3.tar.gz
-daa16985079e3b55ccf5e74dde356e1e13e43865c9809e432b5d272b053f541f1eacd402f3b04957ee855fb8c0ca1820b507d08e408f55dc80004990a949874c  no-glide-install.patch"
+daa16985079e3b55ccf5e74dde356e1e13e43865c9809e432b5d272b053f541f1eacd402f3b04957ee855fb8c0ca1820b507d08e408f55dc80004990a949874c  no-glide-install.patch
+f48323c71e9a4c23d1617f1e1ee498634c25ad517e3a2e2c059cc1a96265e2b36e6c887a9fd143f0ae59b2b6f79f306c74305ab31882f2c03caeaedb5c1909db  disable-vet-for-tests.patch"

--- a/community/fzf/disable-vet-for-tests.patch
+++ b/community/fzf/disable-vet-for-tests.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 5f68100828..123bfe9974 100644
+--- a/Makefile
++++ b/Makefile
+@@ -102,7 +102,7 @@ vendor: $(GLIDE_YAML)
+ 	touch $@
+ 
+ test: $(SOURCES) vendor
+-	SHELL=/bin/sh GOOS= go test -v -tags "$(TAGS)" \
++	SHELL=/bin/sh GOOS= go test -v -tags "$(TAGS)" -vet=off\
+ 				github.com/junegunn/fzf/src \
+ 				github.com/junegunn/fzf/src/algo \
+ 				github.com/junegunn/fzf/src/tui \


### PR DESCRIPTION
Split shell scripts in separate subpackages

The first commit makes everything consistently use tabs. The second commit fixes a build issue where the tests failed due to new checks added in Go 1.10