### PR TITLE
testing/perl-sys-syscall: fix epoll tests on ppc64

### DIFF
--- a/testing/perl-sys-syscall/APKBUILD
+++ b/testing/perl-sys-syscall/APKBUILD
@@ -4,10 +4,10 @@
 pkgname=perl-sys-syscall
 _pkgreal=Sys-Syscall
 pkgver=0.25
-pkgrel=1
+pkgrel=2
 pkgdesc="Invoke system calls that are otherwise difficult to do from Perl"
 url="http://search.cpan.org/dist/Sys-Syscall/"
-arch="all !aarch64 !ppc64le !s390x"
+arch="all !aarch64 !s390x"
 license="GPL PerlArtistic"
 cpandepends=""
 cpanmakedepends=""
@@ -16,7 +16,9 @@ depends="$cpandepends"
 makedepends="perl-dev $cpanmakedepends"
 checkdepends="$cpancheckdepends"
 subpackages="$pkgname-doc"
-source="http://search.cpan.org/CPAN/authors/id/B/BR/BRADFITZ/$_pkgreal-$pkgver.tar.gz"
+source="http://search.cpan.org/CPAN/authors/id/B/BR/BRADFITZ/$_pkgreal-$pkgver.tar.gz
+	ppc64le_epoll.patch
+	"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 prepare() {
@@ -45,4 +47,5 @@ check() {
 	make test
 }
 
-sha512sums="8b0641c992865cc7a29874a2166a4f0542039958839c6305cd4c33d17cfbdecd4f4ee74dc8110bfb000e42cabd803a84c6ba39037765d61ccb2bdf60522be87f  Sys-Syscall-0.25.tar.gz"
+sha512sums="8b0641c992865cc7a29874a2166a4f0542039958839c6305cd4c33d17cfbdecd4f4ee74dc8110bfb000e42cabd803a84c6ba39037765d61ccb2bdf60522be87f  Sys-Syscall-0.25.tar.gz
+b8d9912ae7dba60dab3bbe742ab069b86ea3846454e97d3101e975cb5568a6ca161bd928f5d4b8bd305d99830da2668de496904851fa8569ca946235f54b891f  ppc64le_epoll.patch"

--- a/testing/perl-sys-syscall/ppc64le_epoll.patch
+++ b/testing/perl-sys-syscall/ppc64le_epoll.patch
@@ -1,0 +1,11 @@
+--- a/lib/Sys/Syscall.pm
++++ b/lib/Sys/Syscall.pm
+@@ -65,7 +65,7 @@
+         $SYS_epoll_wait   = 232;
+         $SYS_sendfile     =  40;
+         $SYS_readahead    = 187;
+-    } elsif ($machine eq "ppc64") {
++    } elsif ($machine =~ m/^ppc64/) {
+         $SYS_epoll_create = 236;
+         $SYS_epoll_ctl    = 237;
+         $SYS_epoll_wait   = 238;


### PR DESCRIPTION
Fix lib/Sys/Syscall.pm to make sure ppc64 machine type is discovered correctly so epoll constants can be assigned properly. Fixes failing epoll tests.