### PR TITLE
testing/freeimage: Allow ppc64le to pickup Makefile defined CFLAGS

### DIFF
--- a/testing/freeimage/APKBUILD
+++ b/testing/freeimage/APKBUILD
@@ -2,10 +2,10 @@
 # Maintainer: Taner Tas <taner76@gmail.com>
 pkgname=freeimage
 pkgver=3.17.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Open Source library project for developers who would like to support popular graphics image formats."
 url="http://freeimage.sourceforge.net/"
-arch="!ppc64le"
+arch="all"
 license="GPL-2.0-only FreeImage"
 _distname="FreeImage"
 makedepends="dos2unix"
@@ -25,6 +25,9 @@ prepare() {
 }
 
 build() {
+	if [ "$CARCH" == "ppc64le" ]; then
+                unset CFLAGS CPPFLAGS CXXFLAGS
+        fi
 	cd "$builddir"
 	make
 }


### PR DESCRIPTION
ppc64le needs -fPIC compiler option. Unsetting the compiler flags environment variables for ppc64le allows them to be setup by the freeimage makefile. 