### PR TITLE
testing/ocaml-camomile: workaround ppc64le segfault while building

### DIFF
--- a/testing/ocaml-camomile/APKBUILD
+++ b/testing/ocaml-camomile/APKBUILD
@@ -3,12 +3,12 @@
 pkgname=ocaml-camomile
 _pkgname=camomile
 pkgver=0.8.7
-pkgrel=1
+pkgrel=2
 pkgdesc="A Unicode library for OCaml"
 url="https://github.com/yoriyuki/Camomile"
 # x86, armhf, s390x: limited by ocaml aport
-# ppc64le: https://github.com/yoriyuki/Camomile/issues/39
-arch="all !x86 !armhf !s390x !ppc64le"
+# ppc64le: https://github.com/yoriyuki/Camomile/issues/39. Workaround by setting hard and soft stack limits
+arch="all !x86 !armhf !s390x"
 license="LGPL-2.0-or-later"
 depends="$pkgname-data=$pkgver-r$pkgrel ocaml-runtime"
 makedepends="dune ocaml ocaml-compiler-libs ocaml-cppo ocaml-findlib opam"
@@ -17,6 +17,10 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/yoriyuki/$_pkgname/archive/r
 builddir="$srcdir/Camomile-rel-$pkgver"
 
 build() {
+        if [ "$CARCH" == "ppc64le" ]; then
+                ulimit -Hs unlimited
+                ulimit -Ss 65536
+        fi
 	cd "$builddir"
 	jbuilder build @install
 }


### PR DESCRIPTION
build on ppc64le segvs when (cd _build/default/Camomile && ./tools/camomilelocaledef.exe --file locales/zh__PINYIN.txt locales) per https://github.com/yoriyuki/Camomile/issues/39

This patch works around the issue by increasing the hard stack limit to unlimited and soft stack limit to 65536 prior to kicking off the build on ppc64le. 