### PR TITLE
testing/libspotify: new aport

### DIFF
--- a/testing/libspotify/APKBUILD
+++ b/testing/libspotify/APKBUILD
@@ -1,0 +1,62 @@
+# Contributor: Guilhem Saurel <guilhem.saurel@gmail.com>
+# Maintainer: Guilhem Saurel <guilhem.saurel@gmail.com>
+pkgname=libspotify
+pkgver=12.1.51
+pkgrel=0
+pkgdesc="C API package allowing third-party developers to write applications that utilize the Spotify music streaming service"
+url="https://developer.spotify.com/technologies/libspotify/"
+arch="all"
+license="custom"
+subpackages="$pkgname-dev $pkgname-doc"
+builddir="$srcdir/"
+options="!check"  # there is no test suite/unit tests
+depends="libc6-compat"
+
+case $CARCH in
+	"armv6h")
+		pkgver=12.1.103
+		_SPOTIFY_ARCH="armv6-bcm2708hardfp"
+		sha512sums="057f3f4b06a9e85daf9028864a41ab940e2ca8613c56dd49c5ee8463d9cfe55b4224ba3425b2725163eeb4b45e10ed551e4ea44cf84b5aed4151f4166bae1a73  libspotify-${pkgver}-Linux-${_SPOTIFY_ARCH}-release.tar.gz"
+		;;
+	"armv7h")
+		_SPOTIFY_ARCH="armv7"
+		sha512sums="384255babf70778eaeb7f25c8a8c4831fce5f392ff8cf165ee0f589c321017bbbf8ac48e6ccf6bc474b21ec72c9473508507d8f4c2ab3fd988e404e9c172e762  libspotify-${pkgver}-Linux-${_SPOTIFY_ARCH}-release.tar.gz"
+		;;
+	"x86_64")
+		_SPOTIFY_ARCH="$CARCH"
+		sha512sums="3c636e1739a75910a0da9270c3d2203b52fe1c2d69615159a09bcc8b57c8909f1d005aa22dc5cef529489c6f3a9ee5bde4d6a922be536f8017185c25432c3666  libspotify-${pkgver}-Linux-${_SPOTIFY_ARCH}-release.tar.gz"
+		;;
+	"i686")
+		_SPOTIFY_ARCH="$CARCH"
+		sha512sums="c16d53d8ec57913eb5b47ad3c2d01a804bd494a681c23a770f436b712cdadf89baa0c4c7db13ef96bf7b1e14599afbcb1323556ec24669f9020fc824d9ecd59e  libspotify-${pkgver}-Linux-${_SPOTIFY_ARCH}-release.tar.gz"
+esac
+
+source="http://developer.spotify.com/download/libspotify/libspotify-${pkgver}-Linux-${_SPOTIFY_ARCH}-release.tar.gz"
+
+build() {
+	cd "$builddir/$pkgname-$pkgver-Linux-${_SPOTIFY_ARCH}-release"
+
+	# Don't do stupid things from a Makefile
+	msg2 "Patching Makefile..."
+	sed -i 's/ldconfig//' Makefile
+
+	# Busybox doesn't have "install -T"
+	sed -i 's/install -T/install/' Makefile
+}
+
+package() {
+	cd "$builddir/$pkgname-$pkgver-Linux-${_SPOTIFY_ARCH}-release"
+	install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/COPYING
+
+	make prefix="$pkgdir/usr" install
+
+	# Install documentation
+	cp -R share "$pkgdir"/usr/share
+	mkdir -p "$pkgdir"/usr/share/man
+	mv "$pkgdir"/usr/share/share/man3 "$pkgdir"/usr/share/man/man3
+
+	# Correct pkgconfig file
+	sed -e s:PKG_PREFIX:/usr:g \
+		< lib/pkgconfig/libspotify.pc \
+		> "$pkgdir"/usr/lib/pkgconfig/libspotify.pc
+}


### PR DESCRIPTION
https://developer.spotify.com/technologies/libspotify/
C API package allowing third-party developers to write applications that utilize the Spotify music streaming service

Adapdated from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=libspotify