### PR TITLE
testing/freeimage: make sure fPIC CFLAGs picked up in Makefile.gnu

### DIFF
--- a/testing/freeimage/0005-makefile-gnu.patch
+++ b/testing/freeimage/0005-makefile-gnu.patch
@@ -1,0 +1,24 @@
+diff --git a/Makefile.gnu b/Makefile.gnu
+index 92f6358..293ee97 100644
+--- a/Makefile.gnu
++++ b/Makefile.gnu
+@@ -15,7 +15,8 @@ LIBRARIES = -lstdc++
+ 
+ MODULES = $(SRCS:.c=.o)
+ MODULES := $(MODULES:.cpp=.o)
+-CFLAGS ?= -O3 -fPIC -fexceptions -fvisibility=hidden
++CFLAGS ?= -O3
++CFLAGS += -fPIC -fexceptions -fvisibility=hidden
+ # OpenJPEG
+ CFLAGS += -DOPJ_STATIC
+ # LibRaw
+@@ -23,7 +24,8 @@ CFLAGS += -DNO_LCMS
+ # LibJXR
+ CFLAGS += -DDISABLE_PERF_MEASUREMENT -D__ANSI__
+ CFLAGS += $(INCLUDE)
+-CXXFLAGS ?= -O3 -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy
++CXXFLAGS ?= -O3
++CXXFLAGS += -fPIC -fexceptions -fvisibility=hidden -Wno-ctor-dtor-privacy
+ # LibJXR
+ CXXFLAGS += -D__ANSI__
+ CXXFLAGS += $(INCLUDE)

--- a/testing/freeimage/APKBUILD
+++ b/testing/freeimage/APKBUILD
@@ -2,10 +2,10 @@
 # Maintainer: Taner Tas <taner76@gmail.com>
 pkgname=freeimage
 pkgver=3.17.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Open Source library project for developers who would like to support popular graphics image formats."
 url="http://freeimage.sourceforge.net/"
-arch="!ppc64le"
+arch="all"
 license="GPL-2.0-only FreeImage"
 _distname="FreeImage"
 makedepends="dos2unix"
@@ -14,7 +14,8 @@ source="http://downloads.sourceforge.net/${pkgname}/${_distname}${pkgver//.}.zip
 	0001-no-root-install.patch
 	0002-fix-cpuid-x86.patch
 	0003-LibWebP-fix-compilation-issue-with-GCC-5.x-C-11.patch
-	0004-fix-gcc-6.patch"
+	0004-fix-gcc-6.patch
+	0005-makefile-gnu.patch"
 
 options="!check"
 
@@ -38,4 +39,5 @@ sha512sums="703c2626c0bcfe73eb40d720f45745208ca9650a7730759680a2b38ad3f6c719a430
 2dc51d700671962339cc1f27c0ad7e679e7ed6233d1534b81d68fcffb6e86960fa182b6916d19da7451bf34b69efe4a1b62b7f335b9802d7799706b766257d59  0001-no-root-install.patch
 ef88862593bd8d271d11f86ec389c8a92c131ffb03fb7028e87dfddc7ae74e22bef50327175a7dcee9c414df80e84579c59f3b8e1f825d54f0fdc76a0530c06f  0002-fix-cpuid-x86.patch
 4208d4f3ee49424d65c5e78c18c424543208a554855a6ea1cafd32e57b7354aa36131ea62a95a6856e19c5c0ef47e7d63616e690246c1b19716dca323c3476cc  0003-LibWebP-fix-compilation-issue-with-GCC-5.x-C-11.patch
-75050c6a6b2f30c42e9b5d1326499f4d088e3c79b23c92bea72b60fe6759d1e529b136f599d7de059c433cfc661b189d8dd6e32e9fcb0244fb27153c792d3c0e  0004-fix-gcc-6.patch"
+75050c6a6b2f30c42e9b5d1326499f4d088e3c79b23c92bea72b60fe6759d1e529b136f599d7de059c433cfc661b189d8dd6e32e9fcb0244fb27153c792d3c0e  0004-fix-gcc-6.patch
+18fba0dc68f94365ffbe7070594825b7e8f77f462ece31d96971de18f085b5110f3c3bdff780a02aa162ee9a64dd20c5fda7871d8759c8eeaa20d7bf3dddd72e  0005-makefile-gnu.patch"


### PR DESCRIPTION
Per the comments in https://github.com/alpinelinux/aports/pull/3590 making modifications in Makefile.gnu to ensure CFLAGS options are picked up correctly. Re-enable APKBUILD to support all archs