### PR TITLE
testing/ledger: new aport (Bug #8363)

### DIFF
--- a/testing/ledger/APKBUILD
+++ b/testing/ledger/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Roberto Oliveira <robertoguimaraes8@gmail.com>
+# Maintainer: Roberto Oliveira <robertoguimaraes8@gmail.com>
+pkgname=ledger
+pkgver=3.1.1
+pkgrel=0
+pkgdesc="Double-entry accounting system with a command-line reporting interface"
+url="https://www.ledger-cli.org/"
+arch="all"
+license="BSD"
+makedepends="cmake boost-dev gmp-dev mpfr-dev texinfo graphviz doxygen gettext"
+subpackages="$pkgname-doc"
+options="!check" # FIXME: some tests are failing
+source="$pkgname-$pkgver.tar.gz::https://github.com/ledger/$pkgname/archive/v$pkgver.tar.gz
+	fix-build-with-new-boost.patch"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	cmake -DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="3f81b98a414cdfc0e272de4e958770149fb1acc8bda880d270e1459ce35294a220c52820bb9af49a751ac3a80b878f81fc7799ba41e0a1be43eba72081351bf5  ledger-3.1.1.tar.gz
+1a70bf192425b19abc34bb00ee84621e5a069fbe8fdcd56593d8c0dd3b8676f40c6a6c30c488320d22fd206eeb09db7ee7d1f8a2b3ffdb996c5978f98160cdbb  fix-build-with-new-boost.patch"

--- a/testing/ledger/fix-build-with-new-boost.patch
+++ b/testing/ledger/fix-build-with-new-boost.patch
@@ -1,0 +1,26 @@
+From a4436f782c4a6b7f919b74110939113af60fa5e7 Mon Sep 17 00:00:00 2001
+From: Alexis Hildebrandt <afh@surryhill.net>
+Date: Mon, 26 Sep 2016 18:19:52 +0200
+Subject: [PATCH] Merge pull request #465 from dkasak/patch-1
+
+Fix compilation error with boost 1.61
+---
+ src/item.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/item.h b/src/item.h
+index ca16d87b..4dc6df7e 100644
+--- a/src/item.h
++++ b/src/item.h
+@@ -92,7 +92,7 @@ public:
+ 
+   typedef std::pair<optional<value_t>, bool> tag_data_t;
+   typedef std::map<string, tag_data_t,
+-                   function<bool(string, string)> > string_map;
++                   std::function<bool(string, string)> > string_map;
+ 
+   state_t              _state;
+   optional<date_t>     _date;
+-- 
+2.16.2
+


### PR DESCRIPTION
Tests are disabled for now because some of them are failing.

Some of the failures in the archs that I tried to build:
* ppc64le:
99% tests passed, 2 tests failed out of 344
The following tests FAILED:
	142 - BaselineTest_opt-lots (Failed)
	227 - RegressTest_1057 (Failed)

* x86_64:
99% tests passed, 4 tests failed out of 344
The following tests FAILED:
	27 - BaselineTest_cmd-org (Failed)
	29 - BaselineTest_cmd-pricedb (Failed)
	31 - BaselineTest_cmd-prices (Failed)
	283 - RegressTest_786A3DD0 (Failed)