### PR TITLE
testing/ocaml-lwt: avoid ocaml-lambda-term ppc64 build failure by inl…

### DIFF
--- a/testing/ocaml-lwt/APKBUILD
+++ b/testing/ocaml-lwt/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=ocaml-lwt
 _pkgname=lwt
 pkgver=3.2.1
-pkgrel=3
+pkgrel=4
 pkgdesc="OCaml promises and concurrent I/O"
 url="https://github.com/ocsigen/lwt"
 arch="all !x86 !armhf !s390x"  # limited by ocaml aport
@@ -27,7 +27,8 @@ makedepends="$depends_dev
 	opam
 	"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-react"
-source="$pkgname-$pkgver.tar.gz::https://github.com/ocsigen/$_pkgname/archive/$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/ocsigen/$_pkgname/archive/$pkgver.tar.gz
+	result_lseek_noinline.patch"
 builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
@@ -86,4 +87,5 @@ dev() {
 	mv *.cmx *.cmxa *.mli "$subpkgdir"/$sitelib/
 }
 
-sha512sums="ddea7561c12b0c7f1ee557462766c2f04d08b9e452fac14a906c17aba643be90299a6aa0aee20dfc16031eca4f557bfc0e7f6779643eeaee2337129f77da836d  ocaml-lwt-3.2.1.tar.gz"
+sha512sums="ddea7561c12b0c7f1ee557462766c2f04d08b9e452fac14a906c17aba643be90299a6aa0aee20dfc16031eca4f557bfc0e7f6779643eeaee2337129f77da836d  ocaml-lwt-3.2.1.tar.gz
+dc3abce70b3ad022066e8023a9b37346df0ecbbc6351186cc24b569189142ad3e7e32f27c33a4378f11ec8c40df5c96f4c37190ca4797bc228ca8943f53cf5bf  result_lseek_noinline.patch"

--- a/testing/ocaml-lwt/result_lseek_noinline.patch
+++ b/testing/ocaml-lwt/result_lseek_noinline.patch
@@ -1,0 +1,20 @@
+--- a/src/unix/unix_c/unix_lseek_job.c
++++ b/src/unix/unix_c/unix_lseek_job.c
+@@ -92,7 +92,7 @@
+ }
+ 
+ /* The function building the caml result. */
+-static value result_lseek(struct job_lseek* job)
++__attribute__((noinline)) static value result_lseek(struct job_lseek* job)
+ {
+   value result;
+   /* Check for errors. */
+@@ -113,7 +113,7 @@
+ }
+ 
+ /* The function building the caml result. */
+-static value result_lseek_64(struct job_lseek* job)
++__attribute__((noinline))  static value result_lseek_64(struct job_lseek* job)
+ {
+   value result;
+   /* Check for errors. */


### PR DESCRIPTION
…ining result_lseek functions

testing/ocaml-lambda-term fails to build on ppc64le when linking with the ocaml lwt libraries with errors:

```
/usr/lib/gcc/powerpc64le-alpine-linux-musl/6.4.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: /usr/lib/ocaml/lwt/liblwt_unix_stubs.a(unix_lseek_job.o): In function `result_lseek':
    /home/buildozer/aports/testing/ocaml-lwt/src/lwt-3.2.1/_build/default/src/unix/unix_lseek_job.c:113:(.text+0xb8): call to `result_lseek.part.0' lacks nop, can't restore toc; (-mcmodel=small toc adjust stub)
    /usr/lib/gcc/powerpc64le-alpine-linux-musl/6.4.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: /usr/lib/ocaml/lwt/liblwt_unix_stubs.a(unix_lseek_job.o): In function `result_lseek_64':
    /home/buildozer/aports/testing/ocaml-lwt/src/lwt-3.2.1/_build/default/src/unix/unix_lseek_job.c:134:(.text+0x134): call to `result_lseek_64.part.1' lacks nop, can't restore toc; (-mcmodel=small toc adjust stub)
```

The ocaml-lwt result_lseek.part.0 and result_lseek.part.1 library objects are created by compiler optimizing the result_lseek() and result_lseek_64() functions. To prevent this add the __attribute__((noinline)) to these functions. Once the ocaml lwt library is built like this the error in testing/ocaml-limbda-term that occurs during link to the ocaml lwt library should be fixed.