### PR TITLE
main/samba: security upgrade to 4.7.6

### DIFF
--- a/main/samba/APKBUILD
+++ b/main/samba/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=samba
-pkgver=4.7.4
+pkgver=4.7.6
 pkgrel=0
 pkgdesc="Tools to access a server's filespace and printers via SMB"
 url="http://www.samba.org"
@@ -42,7 +42,7 @@ depends="$pkgname-server=$pkgver-r$pkgrel
 makedepends="popt-dev ncurses-dev openldap-dev e2fsprogs-dev
 	talloc-dev tdb-dev py-tdb ldb-dev>=1.2.2 cups-dev python2-dev libcap-dev
 	tevent-dev py-tevent iniparser-dev perl subunit-dev docbook-xsl
-	libarchive-dev acl-dev fuse-dev"
+	libarchive-dev acl-dev fuse-dev libtirpc-dev"
 source="https://us1.samba.org/samba/ftp/stable/$pkgname-$pkgver.tar.gz
 	uclibc-xattr-create.patch
 	domain.patch
@@ -59,6 +59,8 @@ pkggroups="winbind"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   4.7.6-r0:
+#     - CVE-2018-1057
 #   4.7.3-r0:
 #     - CVE-2017-14746
 #     - CVE-2017-15275
@@ -508,7 +510,7 @@ libs() {
 		"$pkgdir"/usr
 }
 
-sha512sums="50af2ed0586116171b2fabb96a05118c447cd5a165a5328b02be832fda9eb1465052a6670415831484639921164ddbf03b6ec47857244cc164ea5a9e4e39cf65  samba-4.7.4.tar.gz
+sha512sums="8190b06f543cc3d4a9a98f93ad5e4e16e4e87ea462435723044a780942cea7efc77c66cd3e61941bf449a2ac0f4346ced378f032d5fb1776280a3c4bcb951b46  samba-4.7.6.tar.gz
 b43809d7ecbf3968f5154c2ded6ed47dae36921f1895ea98bcce50557eb2ad39b736345ffb4214655ed3154c143c20431d248cde828285380bafbf4d2627df9b  uclibc-xattr-create.patch
 62d373dbaee75121a1d73f2c09cdca7239705808ff807b171d1d5a28fd4ffc66bdb52494b62786d7aaba8aeece5c08433b532ca96a28d712452fe9daac8d8d2e  domain.patch
 0d4fd9862191554dc9c724cec0b94fd19afbfd0c4ed619e4c620c075e849cb3f3d44db1e5f119d890da23a3dd0068d9873703f3d86c47b91310521f37356208b  getpwent_r.patch


### PR DESCRIPTION
CVE-2018-1057

Should be backported to early releases

Library added as dependency because otherwise build failed
```
Checking for libtirpc headers                                : not found 
Checking for libntirpc headers                               : not found 
ERROR: No rpc/rpc.h header found, tirpc or libntirpc missing?
>>> ERROR: samba: all failed
```