### PR TITLE
testing/wireguard-tools: depends on bash

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -3,11 +3,12 @@
 
 pkgname=wireguard-tools
 pkgver=0.0.20180304
-pkgrel=0
+pkgrel=1
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
 url='https://www.wireguard.com'
 license="GPL-2.0"
+depends="bash"
 makedepends="libmnl-dev"
 subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch"
 options="!check"


### PR DESCRIPTION
wg-quick is explicitly a bash script, so it requires bash to be installed.