### PR TITLE
main/hdparm: upgrade to 9.55, clarify license

### DIFF
--- a/main/hdparm/APKBUILD
+++ b/main/hdparm/APKBUILD
@@ -1,16 +1,21 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=hdparm
-pkgver=9.52
+pkgver=9.55
 pkgrel=0
-pkgdesc="A shell utility for manipulating Linux IDE drive/driver parameters"
-url="https://sourceforge.net/projects/hdparm/"
+pkgdesc="Utility for manipulating IDE device parameters"
+url="https://sourceforge.net/projects/hdparm"
 arch="all"
-license="BSD"
+license="BSD GPL-2.0"
 makedepends="linux-headers"
 options="!check"
 subpackages="$pkgname-doc"
 source="http://downloads.sourceforge.net/sourceforge/$pkgname/$pkgname-$pkgver.tar.gz"
-builddir="$srcdir"/$pkgname-$pkgver
+builddir="$srcdir/$pkgname-$pkgver"
+
+prepare() {
+	default_prepare
+	sed -i '/^LDFLAGS/d' "$builddir"/Makefile 
+}
 
 build() {
 	cd "$builddir"
@@ -20,11 +25,10 @@ build() {
 
 package() {
 	cd "$builddir"
-	mkdir -p "$pkgdir"/usr "$pkgdir"/sbin
 	make DESTDIR="$pkgdir" install
-	install -m755 contrib/idectl "$pkgdir"/sbin
-	install -m755 contrib/ultrabayd "$pkgdir"/sbin
-	install -D -m 644 LICENSE.TXT $pkgdir/usr/share/licenses/hdparm/LICENSE.TXT
+	install -D -m755 contrib/idectl "$pkgdir"/sbin
+	install -D -m755 contrib/ultrabayd "$pkgdir"/sbin
+	install -D -m644 LICENSE.TXT "$pkgdir"/usr/share/licenses/hdparm/LICENSE.TXT
 }
 
-sha512sums="7c37d1381c1dd2d46762a8cdcaba2015b0b051ee7bd135dbcf6346def51b085cc2f9ecd7e1ebdc67e12ab4b765df548d4757b3700ed6e7514c2b13ed40661c59  hdparm-9.52.tar.gz"
+sha512sums="a9b5be38fda9db7f125ecc5a174668e81464266493672184d214ea9b50437e089482799fb5c817c433f897eac8741fe3dc052658969bb1ebac158606dee51196  hdparm-9.55.tar.gz"


### PR DESCRIPTION
Changed installation directory from `/sbin` to `/usr/bin`