### PR TITLE
main/linux-firmware: Fix name of subfolder packages

### DIFF
--- a/main/linux-firmware/APKBUILD
+++ b/main/linux-firmware/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=linux-firmware
 pkgver=20180110
-pkgrel=0
+pkgrel=1
 pkgdesc="firmware files for linux"
 #url="http://git.kernel.org/?p=linux/kernel/git/dwmw2/linux-firmware.git;a=summary"
 url="http://git.kernel.org/?p=linux/kernel/git/firmware/linux-firmware.git;a=summary"
@@ -67,7 +67,7 @@ package() {
 
 folder() {
 	local folder=${subpkgname##linux-firmware-}
-	pkgdesc="firmware files for linux ($_folder folder)"
+	pkgdesc="firmware files for linux ($folder folder)"
 	depends=""
 
 	# Move /lib/firmware/$folder (case insensitive)


### PR DESCRIPTION
Currently, the packages are named, for example:

	linux-firmware-3com-20180110-r0 - firmware files for linux ( folder)

This patch fixes the code in folder() that generates the names. Now, it's:

	linux-firmware-3com-20180110-r1 - firmware files for linux (3com folder)


Fixes: 0f1c436cdb ("main/linux-firmware: lowercase subpackages / use local")