### PR TITLE
testing/libtickit: new aport

### DIFF
--- a/testing/libtickit/APKBUILD
+++ b/testing/libtickit/APKBUILD
@@ -1,0 +1,39 @@
+# Contributor: Roberto Oliveira <robertoguimaraes8@gmail.com>
+# Maintainer: Roberto Oliveira <robertoguimaraes8@gmail.com>
+pkgname=libtickit
+pkgver=0.2
+pkgrel=0
+pkgdesc="A library that provides an abstracted mechanism for building interactive full-screen terminal programs"
+url="http://www.leonerd.org.uk/code/libtickit/"
+arch="all"
+license="MIT"
+depends=""
+makedepends="libtermkey-dev"
+checkdepends="perl-test-harness-utils"
+# See https://bugs.launchpad.net/libtickit/+bug/1756523
+options="!check" #FIXME: some tests are failing
+subpackages="$pkgname-dev $pkgname-doc"
+source="http://www.leonerd.org.uk/code/$pkgname/$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+prepare() {
+	default_prepare
+	cd "$builddir"
+	sed -i -e "s/PREFIX=\/usr\/local/PREFIX=\/usr/g" Makefile
+}
+build() {
+	cd "$builddir"
+	make PREFIX=/usr
+}
+
+check() {
+	cd "$builddir"
+	make test
+}
+
+package() {
+	cd "$builddir"
+	make install DESTDIR="$pkgdir"
+}
+
+sha512sums="5ba8581dfc17d0f56fc9e543aa452980ce864a5079a34d60db3a15b49c82c894ce082598865aeaa28c32c32549c40582fb40d1209ea893c8c6993604cae9437b  libtickit-0.2.tar.gz"


### PR DESCRIPTION
Disabled tests for now, seems they are passing
but in the end they failed with error:

t/15term-input.t        (Wstat: 9 Tests: 29 Failed: 0)
  Non-zero wait status: 9
  Parse errors: No plan found in TAP output

See bug: https://bugs.launchpad.net/libtickit/+bug/1756523