### PR TITLE
main/linux-vanilla: add perf subpackage

### DIFF
--- a/main/linux-vanilla/APKBUILD
+++ b/main/linux-vanilla/APKBUILD
@@ -1,3 +1,4 @@
+# Contributor: Orson Teodoro <orsonteodoro@hotmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 
 _flavor=vanilla
@@ -7,18 +8,26 @@ case $pkgver in
 	*.*.*)	_kernver=${pkgver%.*};;
 	*.*) _kernver=$pkgver;;
 esac
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux vanilla kernel"
 url="http://kernel.org"
 depends="mkinitfs"
 _depends_dev="perl gmp-dev elfutils-dev bash"
-makedepends="$_depends_dev sed installkernel bc linux-headers"
+_perfver="0.1"
+_perfurl="http://perf.wiki.kernel.org"
+_perf_dev="libunwind-dev xz-dev perl-dev python2-dev zlib-dev libelf-dev \
+		audit-dev slang-dev numactl-dev libressl-dev flex-dev bison \
+		xmlto asciidoc diffutils gtk+2.0-dev elfutils-dev \
+		binutils-dev openjdk8"
+makedepends="$_depends_dev sed installkernel bc linux-headers $_perf_dev"
+_openjdkver=1.8
 options="!strip"
 _config=${config:-config-vanilla.${CARCH}}
 install=
 source="https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/linux-$_kernver.tar.xz
 
 	0001-HID-apple-fix-Fn-key-Magic-Keyboard-on-bluetooth.patch
+	flock.patch
 
 	config-vanilla.aarch64
 	config-vanilla.armhf
@@ -31,7 +40,7 @@ source="https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/linux-$_kernver
 	config-virt.x86
 	config-virt.x86_64
 	"
-subpackages="$pkgname-dev:_dev:$CBUILD_ARCH"
+subpackages="$pkgname-dev:_dev:$CBUILD_ARCH perf:_perf:$CBUILD_ARCH perf-doc:_perf_doc:$CBUILD_ARCH"
 _flavors=
 for _i in $source; do
 	case $_i in
@@ -110,6 +119,18 @@ prepare() {
 	done
 }
 
+_build_perf() {
+	local _builddir="$1"
+	local _builddir2="$srcdir/linux-${pkgver%.*}"
+	cp -a "$_builddir2"/arch/x86/include/asm/disabled-features.h "$_builddir2"/tools/arch/x86/include/asm/disabled-features.h
+	cp -a "$_builddir2"/arch/x86/include/asm/required-features.h "$_builddir2"/tools/arch/x86/include/asm/required-features.h
+	cp -a "$_builddir2"/arch/x86/include/asm/cpufeatures.h "$_builddir2"/tools/arch/x86/include/asm/cpufeatures.h
+	export JDIR="/usr/lib/jvm/java-${_openjdkver}-openjdk/"
+	make -C "$srcdir"/linux-$_kernver/tools \
+		ARCH="$_carch" HOSTCC="$HOSTCC" \
+		perf
+}
+
 build() {
 	unset LDFLAGS
 	for i in $_flavors; do
@@ -118,6 +139,7 @@ build() {
 			KBUILD_BUILD_VERSION="$((pkgrel + 1 ))-Alpine" \
 			|| return 1
 	done
+	_build_perf "$srcdir"/build-${_flavor}
 }
 
 _package() {
@@ -168,6 +190,25 @@ package() {
 # subflavors install in $subpkgdir
 virt() {
 	_package virt "$subpkgdir"
+}
+
+# this package needs the .config
+_perf() {
+	depends="$depends $pkgname"
+	pkgdesc="Interface with the Linux profiling infrastructure"
+	url="$_perfurl"
+	pkgver="$_perfver" # from setup.py
+	local _builddir="$srcdir"/build-${_flavor}
+	make -C "$srcdir"/linux-$_kernver/tools \
+		DESTDIR="$subpkgdir" perf_install
+}
+
+_perf_doc() {
+	pkgdesc="Documentation for perf"
+	url="$_perfurl"
+	pkgver="$_perfver" # from setup.py
+	make -C "$srcdir"/linux-$_kernver/tools/perf/Documentation \
+		DESTDIR="$subpkgdir" install
 }
 
 _dev() {
@@ -222,6 +263,7 @@ _dev() {
 
 sha512sums="77e43a02d766c3d73b7e25c4aafb2e931d6b16e870510c22cef0cdb05c3acb7952b8908ebad12b10ef982c6efbe286364b1544586e715cf38390e483927904d8  linux-4.14.tar.xz
 5373728be2b507c3db5e042e1d768740df7965078868afdc46418b1adc4cae3d8f9f1aedb59975a0f2acf8754340499354fcf97c503397a5d9886ccc9689b782  0001-HID-apple-fix-Fn-key-Magic-Keyboard-on-bluetooth.patch
+be511e628028f934c6f4ce608b059d09ba08d4ade9531266f8b0c4720c970ad4422c934b50f681d9e81d721106c2912839a1f8a5e456159789414ad8d4c71b19  flock.patch
 19f9ba6dea142b531e21b79389c498e8c07e8bf617c3fff09830a37e7a16c01baa050c8740400eb00539a8f17f9b210e8bc8e4c43051fd8e19dca16d9b82152e  config-vanilla.aarch64
 a401a5c5c5e2785f373707620c18fdd74dbfe10e4e934803451a3208e99c72970f35527875e31dd78d4b82b6f77de21361cd432ffc296251737508eb545f451a  config-vanilla.armhf
 34198a6830d64b5ec685452a5880e3c7090da18857b1ce600c8c07932b5ee43b3ca68d0bdfeb6b080fef865a6eaa08bb48bfa8c6430a84b975d3e1282269fbd3  config-vanilla.x86

--- a/main/linux-vanilla/flock.patch
+++ b/main/linux-vanilla/flock.patch
@@ -1,0 +1,9 @@
+--- a/tools/perf/trace/beauty/flock.c.orig	2017-11-12 10:46:13.000000000 -0800
++++ b/tools/perf/trace/beauty/flock.c	2018-03-16 21:53:47.165279679 -0700
+@@ -1,5 +1,6 @@
+ // SPDX-License-Identifier: GPL-2.0
+ #include <fcntl.h>
++#include <sys/file.h>
+ 
+ #ifndef LOCK_MAND
+ #define LOCK_MAND	 32


### PR DESCRIPTION
Homepage: https://perf.wiki.kernel.org/index.php/Main_Page

Perf is a performance analysis tool.  I tried to create a separate package but requires parts of the kernel sources and the config files.

openjdk8 is in community branch.
numactl-dev is in testing branch.

