### PR TITLE
community/zziplib: upgrade to 0.13.69, drop xmlto from makedeps

### DIFF
--- a/community/zziplib/APKBUILD
+++ b/community/zziplib/APKBUILD
@@ -1,22 +1,17 @@
 # Contributor: Mika Havela <mika.havela@gmail.com>
 # Maintainer: Mika Havela <mika.havela@gmail.com>
 pkgname=zziplib
-pkgver=0.13.67
-pkgrel=1
+pkgver=0.13.69
+pkgrel=0
 pkgdesc="Lightweight library to easily extract data from zip files"
 url="http://zziplib.sourceforge.net"
 arch="all"
 license="LGPL-2.0-or-later MPL-1.1"
-makedepends="zlib-dev python2 xmlto"
+makedepends="zlib-dev python2"
 checkdepends="zip"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-utils"
 source="$pkgname-$pkgver.tar.gz::https://github.com/gdraheim/$pkgname/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
-
-prepare() {
-	default_prepare
-	update_config_guess
-}
 
 build() {
 	cd "$builddir"
@@ -42,4 +37,4 @@ utils() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="a34b801a18a2051aa3898a572508ffd327521b69878413af679b10f6a68b37e770651884ae611bf9c01ce14013c6a1e06adeadd3ef6219d4b9278f1b9e7a6459  zziplib-0.13.67.tar.gz"
+sha512sums="ade026289737f43ca92a8746818d87dd7618d473dbce159546ce9071c9e4cbe164a6b1c9efff16efb7aa0327b2ec6b34f3256c6bda19cd6e325703fffc810ef0  zziplib-0.13.69.tar.gz"


### PR DESCRIPTION
man-pages are generated with new dbk2man.py - docbook xmlto is optional now