### PR TITLE
testing/py-logbook: upgrade to 1.3.0, add python3, modernize

### DIFF
--- a/testing/py-logbook/APKBUILD
+++ b/testing/py-logbook/APKBUILD
@@ -1,39 +1,46 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=py-logbook
-pkgver=0.12.5
+pkgver=1.3.0
 pkgrel=0
-pkgdesc="A logging replacement for Python"
+pkgdesc="Logging replacement for Python"
 url="https://pypi.python.org/pypi/Logbook"
-arch="all"
-license="BSD"
+arch="noarch"
+license="BSD-3-Clause"
 depends=""
 depends_dev=""
-makedepends="$depends_dev python2 py-setuptools"
+makedepends="python3 py-setuptools"
 install=""
-subpackages=""
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="https://files.pythonhosted.org/packages/source/L/Logbook/Logbook-$pkgver.tar.gz"
 
-_builddir="$srcdir"/Logbook-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/Logbook-$pkgver
 
 build() {
-	cd "$_builddir"
-	python2 setup.py build || return 1
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
 }
 
 package() {
-	cd "$_builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	mkdir -p "$pkgdir"
 }
 
-md5sums="1bf64289b9b4cada5a61817c63dd9e82  Logbook-0.12.5.tar.gz"
-sha256sums="3567eca498179609433f9dba0dea3d07a74d79822c1e086340dfcd33eb8a8d7e  Logbook-0.12.5.tar.gz"
-sha512sums="79139e09e1ee6534236af53f59fb09e45acdf777070076d51e23490f6832422295b6ee1106d467a26a22c0c470921cca9f1830b69b345ff3e0cea95564ddf6f5  Logbook-0.12.5.tar.gz"
+_py2() {
+	replaces="$pkgname"
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="a542430ee55906867f4149e925280d4ec296808d4f38cf00ea0e64f04a903a70de8caa0f2c682bd0441ce534e8a3d93222ff536c86d0e32e4d979303515263ea  Logbook-1.3.0.tar.gz"


### PR DESCRIPTION
switch to `noarch` since we don't compile the native extensions (speedups)