### PR TITLE
testing/rakudo: upgrade to 2018.03

### DIFF
--- a/testing/moarvm/APKBUILD
+++ b/testing/moarvm/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=moarvm
-pkgver=2018.02
+pkgver=2018.03
 pkgrel=0
 pkgdesc="A VM for NQP And Rakudo Perl 6"
 url="http://moarvm.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="3364a1af68b828de30affa4c21fe691d10353175cc18e815f962f8dcafb63947ce3fd3ae5c10c656b90f4cb02f3fd008a9a99f832d76098c12525b36e46924d0  MoarVM-2018.02.tar.gz"
+sha512sums="be613e038747d771de03129e52d6e65712ddf6f73ed87eb008ae78968f2d516b4fded792a67e1ce031378c223408101ceaf25f90abf9ba35ee20c6e8401b46f1  MoarVM-2018.03.tar.gz"

--- a/testing/nqp/APKBUILD
+++ b/testing/nqp/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=nqp
-pkgver=2018.02
+pkgver=2018.03
 pkgrel=0
 pkgdesc="Not Quite Perl"
 url="https://github.com/perl6/nqp"
@@ -42,4 +42,4 @@ doc() {
 	done
 }
 
-sha512sums="6e12bd191522c1acc4195dfb98982b6ddc54decb5a40b9995ffc16fb0988bb96fb27057e77dedcbf2dfbc1b222a4fe92df19cb585ed53bb021b9d07b20275efc  nqp-2018.02.tar.gz"
+sha512sums="2f6ac6a3be173ef92d80b80b5557aa49028c04b89fda5465a0c69e6a6253bce9d39662919f60867e7ededa499b81e4d2cd8f5fb0d7edfd022833c1f64f492440  nqp-2018.03.tar.gz"

--- a/testing/rakudo/APKBUILD
+++ b/testing/rakudo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=rakudo
-pkgver=2018.02.1
+pkgver=2018.03
 pkgrel=0
 pkgdesc="A compiler for the Perl 6 programming language"
 url="http://rakudo.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="8c7bdd69ff7765d15ec4a522448039ac7c08f8e24a22bf5e24dc3a4897f18011ae2a87f5524f167e8dcc1a8d55792e18b67cb20b0cdb40782edd844620050901  rakudo-2018.02.1.tar.gz"
+sha512sums="7e0162ccd818e6a9e64c3d2787bab2e1772471d066d050fa4dcb913d3663a66e23ebe11d42f061c782b113c99fd99437d9b048d4dd55b5c9effc1a6a69fda50d  rakudo-2018.03.tar.gz"


### PR DESCRIPTION
Upgrade moarvm, nqp, and rakudo to version 2018.03, must upgrade all three together.
