### PR TITLE
main/py-oauth2client: fix bug #8686

### DIFF
--- a/main/py-oauth2client/APKBUILD
+++ b/main/py-oauth2client/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=py-oauth2client
 _pkgname=oauth2client
 pkgver=4.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A client library for OAuth 2.0"
 url="https://github.com/google/oauth2client"
 arch="noarch"
@@ -25,12 +25,12 @@ package() {
 
 _py2() {
 	replaces="$pkgname"
-	depends="${depends//py-/py2}"
+	depends="${depends//py-/py2-}"
 	_py python2
 }
 
 _py3() {
-	depends="${depends//py-/py3}"
+	depends="${depends//py-/py3-}"
 	_py python3
 }
 


### PR DESCRIPTION
Corrects the dependencies of py-oauth2client. For example for the Python
3 sub-package before this change there was a dependency upon `py3six`,
which is not an Alpine Linux package. After this change the dependency
is upon `py3-six`.

Required for an up to date version of py-google-api-python-client

Fixes #8686