### PR TITLE
testing/hylafaxplus: fix ppc64le build break by controlling make parallelism

### DIFF
--- a/testing/hylafaxplus/APKBUILD
+++ b/testing/hylafaxplus/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=hylafaxplus
 _pkgname=hylafax
 pkgver=5.5.9
-pkgrel=1
+pkgrel=2
 pkgdesc="Making the Premier Open-Source Fax Management System Even Better"
 url="http://hylafax.sourceforge.net"
 arch="all"
@@ -26,6 +26,11 @@ build() {
 	# the configure script does not handle ccache or distcc
 	export CC=gcc
 	export CXX=g++
+	case "$CARCH" in
+		ppc64le)
+			par_options="-j1" 
+		;;
+	esac	
 	./configure \
 		--nointeractive \
 		--disable-pam \
@@ -47,7 +52,7 @@ build() {
 		--with-DSO=auto \
 		--with-PATH_EGETTY=/bin/false \
 		--with-PATH_VGETTY=/bin/false
-	make
+	make $par_options
 }
 
 package(){


### PR DESCRIPTION
ppc64le needs to make -j1 to avoid race conditions that cause errors when trying to create files in directories before they are fully created. Current build error:
/bin/bash: sman.apps/cqtest.1m: No such file or directory

Note: make parallelism was removed in https://github.com/alpinelinux/aports/commit/234bc57e60982d09a11caf752e31bb1c57522ca9#diff-10964c35ee611a48b0cf7ba679362ecc so I have added it back in just for the ppc64le case.