### PR TITLE
testing/grpc: new aport

### DIFF
--- a/testing/grpc/01-chttp2-maybe-uninitialized.patch
+++ b/testing/grpc/01-chttp2-maybe-uninitialized.patch
@@ -1,0 +1,10 @@
+--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
++++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+@@ -978,6 +978,7 @@
+   } else {
+     r = grpc_chttp2_begin_write(t);
+   }
++  #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+   if (r.writing) {
+     if (r.partial) {
+       GRPC_STATS_INC_HTTP2_PARTIAL_WRITES();

--- a/testing/grpc/APKBUILD
+++ b/testing/grpc/APKBUILD
@@ -1,0 +1,47 @@
+# Contributor: wener <wenermail@gmail.com>
+# Maintainer: wener <wenermail@gmail.com>
+pkgname=grpc
+pkgver=1.10.0
+pkgrel=0
+pkgdesc="The C based gRPC (C++, Python, Ruby, Objective-C, PHP, C#) "
+url="https://grpc.io/"
+giturl="https://github.com/grpc/grpc"
+arch="all"
+license="Apache2"
+depends="protobuf"
+depends_dev="protobuf-dev"
+makedepends="autoconf automake libtool libstdc++ protobuf-dev c-ares-dev openssl-dev gflags-dev gtest-dev zlib-dev yaml-dev"
+subpackages="$pkgname-dev $pkgname-cli"
+_googletest_rev=ec44c6c1675c25b9827aacd08c02433cccde7780
+source="$pkgname-$pkgver.tar.gz::https://github.com/grpc/grpc/archive/v$pkgver.tar.gz
+		googletest-$_googletest_rev.tar.gz::https://github.com/google/googletest/archive/$_googletest_rev.tar.gz
+		01-chttp2-maybe-uninitialized.patch"
+builddir="$srcdir/$pkgname-$pkgver"
+options="!check"
+
+unpack() {
+	default_unpack
+	cd "$srcdir"
+	rm -rf $pkgname-$pkgver/third_party/googletest
+	ln -sfn $PWD/googletest-$_googletest_rev/ $pkgname-$pkgver/third_party/googletest
+}
+
+build() {
+	cd "$builddir"
+	make -j$(nproc)
+}
+
+package() {
+	cd "$builddir"
+	make install prefix="$pkgdir/usr" -j$(nproc)
+	rm -f "$pkgdir/usr/share/grpc/roots.pem"
+}
+
+cli() {
+	cd "$builddir"
+	make install-grpc-cli prefix="$subpkgdir/usr" -j$(nproc)
+}
+
+sha512sums="52a3e2710fd51b92fb6345cddb9fd64a9b826bcb85dba86075b5e8465abf6dbc26a9245c9f79dd68b0c11a4fa3b983513091000991b61d77761b7debcdac3703  grpc-1.10.0.tar.gz
+dd55ab745c43c5c953d8cebd2fb44b4bb2cb87c95194965bffd0bd8219332d5f073c22947c8a8b1e2652805dff1cff4b93fe69645d4c0d635f98ae2cf54af14a  googletest-ec44c6c1675c25b9827aacd08c02433cccde7780.tar.gz
+7fa146ce86ddd4f160bb1ca9ff01cb7aca6b2b8c9aa50e4fa6b84504b9117b104be0d1e31ccb452d846549dfe1e9012ceccfcdc1f2357ed567621d71fb8b08c5  01-chttp2-maybe-uninitialized.patch"


### PR DESCRIPTION
options="!check" because test is way too complex to run, required a lot different languages, tools.

this package depends on gflags https://github.com/alpinelinux/aports/pull/3687

grpc-cli: most time, grpc-cli is not needed, grpc-cli is a util for debug grpc service.