### PR TITLE
main/fribidi: upgrade to 1.0.2

### DIFF
--- a/main/fribidi/APKBUILD
+++ b/main/fribidi/APKBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=fribidi
-pkgver=1.0.1
+pkgver=1.0.2
 pkgrel=0
-pkgdesc="A Free Implementation of the Unicode Bidirectional Algorithm"
+pkgdesc="Free Implementation of the Unicode Bidirectional Algorithm"
 url="http://fribidi.org"
 arch="all"
 license="LGPL-2.0-or-later"
-subpackages="$pkgname-dev $pkgname-doc"
+subpackages="$pkgname-dev"
 depends=""
 makedepends=""
 source="https://github.com/fribidi/fribidi/releases/download/v$pkgver/fribidi-$pkgver.tar.bz2"
@@ -18,6 +18,7 @@ build() {
 		--host=$CHOST \
 		--prefix=/usr \
 		--disable-static \
+		--disable-docs \
 		--with-glib=no
 	make
 }
@@ -32,4 +33,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="333dddba3dc54f3bbf8d739f670455c3c930c4a207c2642053f7f6b4d782cd6199fef41a007630e3ed20b5040e686ee30e9e63f5c0722fff6f73493058e0e5ac  fribidi-1.0.1.tar.bz2"
+sha512sums="a474d01368b85c166e08a236425b6f13b88f2cf83308bf0df21c9fe034b1909edea30b778122719fcb8af72bdcf34f2f82f696031bcce077cf8ac764f019acaa  fribidi-1.0.2.tar.bz2"


### PR DESCRIPTION
Dropped `fribidi-doc` due to upstream requiring [c2man](http://www.ciselant.de/c2man/c2man.html)