### PR TITLE
main/imagemagick: upgrade to 7.0.7.27

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
-pkgver=7.0.7.26
+pkgver=7.0.7.27
 _abiver=7
 _pkgver=${pkgver%.*}-${pkgver##*.}
 pkgrel=0
@@ -80,4 +80,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="eaa0ab4e8bcca0ad2df9f7165401242bbfb8717b1f345b16db2ecab61df0791617ec62bb60f209728e3ebb4eff1f25bc9981a117df5042e5c48ce2e715146ae7  ImageMagick-7.0.7-26.tar.xz"
+sha512sums="fc5056c3015c98930c45435fc8667e1d28230eb1585b6fa0f908d37c696c88ce3f2c2c9aaa3c9e343edc51ca80c523c5338cf96bcf2425773c20993ba81f5b3b  ImageMagick-7.0.7-27.tar.xz"


### PR DESCRIPTION
100% backwards compatible - https://abi-laboratory.pro/tracker/timeline/imagemagick/