### PR TITLE
main/glib: upgrade to 2.5.6.0

### DIFF
--- a/main/glib/APKBUILD
+++ b/main/glib/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=glib
-pkgver=2.54.2
+pkgver=2.56.0
 pkgrel=0
 pkgdesc="Common C routines used by Gtk+ and other libs"
 url="https://developer.gnome.org/glib/"
@@ -79,5 +79,5 @@ bashcomp() {
 	[ "$(ls -A "$pkgdir"/usr/share)" ] || rmdir "$pkgdir"/usr/share
 }
 
-sha512sums="09ee6fa3a6f3f15af229bd789bef536e3570f36d1e4ce624a57e97c4040577f6baccd6ab5746257863ccf7173b558cfa753951d562a278f854e52604104ba7ee  glib-2.54.2.tar.xz
+sha512sums="c7d7531c55dc81dbf60607e19550a3a841575f6b881dbadad1c251535b34b4444c47c4e3ccabdf468b12a8a6f41cd3fd2d4d827e764f41e7c0e1e73276740d48  glib-2.56.0.tar.xz
 32e5aca9a315fb985fafa0b4355e4498c1f877fc1f0b58ad4ac261fb9fbced9f026c7756a5f2af7d61ce756b55c8cd02811bb08df397040e93510056f073756b  0001-gquark-fix-initialization-with-c-constructors.patch"


### PR DESCRIPTION
99.95% backwards compatible - https://abi-laboratory.pro/tracker/timeline/glib/