### PR TITLE
main/libseccomp: Upgrade to 2.3.3

### DIFF
--- a/main/libseccomp/APKBUILD
+++ b/main/libseccomp/APKBUILD
@@ -1,7 +1,8 @@
-# Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
+# Contributor: Carlo Landmeter <clandmeter@gmail.com>
+# Contributor: Dan Williams <dan@ma.ssive.co>
 pkgname=libseccomp
-pkgver=2.3.2
+pkgver=2.3.3
 pkgrel=1
 pkgdesc="An interface to the Linux Kernel's syscall filtering mechanism"
 url="https://github.com/seccomp/libseccomp"
@@ -39,5 +40,5 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-sha512sums="0864a53ba2be61d0207f7361af94bcda4acff84a1814f915e6ccb19ab24f6ccc978da0eedc5cee047fa655dc1a583e2eeb7ab985ebfc77491c6a2606727b79ec  libseccomp-2.3.2.tar.gz
+sha512sums="845c7e0e916b5f5ad74da446ceff3250148b745c909185f6d5059e807d1b42fa6b74f356cce2a396bff0d4c7a3120e7cdad98d490a97d549327c7693fe1918be  libseccomp-2.3.3.tar.gz
 f2c31dcafdc9a1ad78e32e76b75e1c1603071eaa3f979e1f2483b879a34ad07e0a4ef3642196a695415cdf81e1ed2bf325175872fb4e203ef9d0e668c287493f  remove-redefinition-prctl.patch"


### PR DESCRIPTION
Upgrades libseccomp to the latest version.