### PR TITLE
testing/bird: upgrade to 2.0.2

### DIFF
--- a/testing/bird/APKBUILD
+++ b/testing/bird/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Katie Holly <holly@fuslvz.ws>
 # Maintainer: Francesco Zanini <francesco@zanini.me>
 pkgname=bird
-pkgver=2.0.1
+pkgver=2.0.2
 pkgrel=0
 pkgdesc="BIRD Internet Routing Daemon"
 url="http://bird.network.cz/"
@@ -44,6 +44,6 @@ package() {
 	install -Dm755 "$srcdir"/bird.initd "$pkgdir"/etc/init.d/bird
 }
 
-sha512sums="4ca4d5aa57d1262b69511446cd1d70bd5f48d69a42b12aa617afdbf7ed69f73ace67b9606126c0799e1151ca5539ae891f58423568ec2dfb341d06311bee624c  bird-2.0.1.tar.gz
+sha512sums="aef96f246484a52269b44963df033ccc584e62d50d1ae31a97a97b9c7375e576d70d00f61a0f6da336e60cefc4c921945df0cc821d5fd1c737b19f508e65d30b  bird-2.0.2.tar.gz
 e0a9bab1bb84ab4efbf51c4c015bf35196d146560f737979d3a17c44dc2397d9578e61a3bba0c58f3cdbb108074f17288bf536db5d8d4dce87c91f1be3dc6282  bird-make-test-bsprintf.patch
 59245af3fd514421d0babcefed556597022a36d14615d596bb5c08c7dd0a6ed4519928e35a0b7ff14fe27ecfa50fa8011283c92bfc9b8355b15b3263df189d5d  bird.initd"


### PR DESCRIPTION
```
Version 2.0.2 (2018-03-22)
  o Source-specific routing support for Linux kernel and Babel
  o BGP: New option 'disable after cease'
  o Filter: Allow silent filter execution
  o Filter: Fixed stack overflow in BGP mask expressions.  <----
  o Several bugfixes

  Notes:

  Syntax prefix:netmask for IPv4 prefixes was dropped. Just use prefix/pxlen.
```