### PR TITLE
community/py-sensehat: upgrade to 2.2.0 and enable py3

### DIFF
--- a/community/py-sensehat/APKBUILD
+++ b/community/py-sensehat/APKBUILD
@@ -2,31 +2,53 @@
 # Maintainer: ScrumpyJack <scrumpyjack@st.ilet.to>
 pkgname=py-sensehat
 _pkgname=python-sense-hat
-pkgver=2.1.0
+pkgver=2.2.0
 pkgrel=0
 pkgdesc="Python module to control the Raspberry Pi Sense HAT"
 url="https://www.raspberrypi.org/products/sense-hat/"
 arch="armhf"
 license="BSD-3-Clause"
-depends="python2"
-depends_dev=""
-makedepends="python2-dev py-setuptools"
-install=""
-subpackages=""
+depends=""
+# Package doesn't provide tests
+options="!check"
+makedepends="python2-dev python3-dev py-setuptools"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="$_pkgname-$pkgver.tar.gz::https://github.com/RPi-Distro/${_pkgname}/archive/v${pkgver}.tar.gz"
-
-_builddir=${srcdir}/${_pkgname}-${pkgver}
+builddir=${srcdir}/${_pkgname}-${pkgver}
 
 build() {
-	cd "$_builddir"
-	python2 setup.py build || return 1
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
 }
+
+#check() {
+#	cd "$builddir"
+#	python2 setup.py test
+#	python3 setup.py test
+#}
 
 package() {
-	cd "$_builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	mkdir -p "$pkgdir"
 }
 
-md5sums="eec4a6d9d718232f69475f17cd3864c2  python-sense-hat-2.1.0.tar.gz"
-sha256sums="fdc26c296955b7b7cca9279e4cbe309b835afbd4912e0b46cbeac20051ff84e5  python-sense-hat-2.1.0.tar.gz"
-sha512sums="f1d6e1d152ec226702f63cd2ce72e76994bb2106eda5a0d22ea04bdc3021640a45f82c2f927fc24bda6de572bd328f72d3632dd73e05ddd1ccfbc1ee39d3f61b  python-sense-hat-2.1.0.tar.gz"
+_py2() {
+	replaces="$pkgname"
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="71914f6f22206cff23992a6908698978741a46bf9b98648388bac4550f39e8de73db6bd389b79585eba6e82160649a8c8da4217d515bbdbcb50d47218415f3ac  python-sense-hat-2.2.0.tar.gz"


### PR DESCRIPTION
No armhf hardware available. I have to rely on Travis.