### PR TITLE
testing/xf86-input-wacom: upgrade to 0.36.1, clarify license

### DIFF
--- a/testing/xf86-input-wacom/APKBUILD
+++ b/testing/xf86-input-wacom/APKBUILD
@@ -1,18 +1,18 @@
 # Contributor: Ivan Tham <pickfire@riseup.net>
 # Maintainer: Ivan Tham <pickfire@riseup.net>
 pkgname=xf86-input-wacom
-pkgver=0.35.0
-pkgrel=1
+pkgver=0.36.1
+pkgrel=0
 pkgdesc="X.org Wacom tablet input driver"
-url="http://linuxwacom.sourceforge.net/"
+url="https://github.com/linuxwacom/xf86-input-wacom"
 arch="all"
-license="GPL-2.0"
+license="GPL-2.0-or-later"
 makedepends="xorg-server-dev libxext-dev libxi-dev libxrandr-dev
 	libxinerama-dev eudev-dev"
 checkdepends="bash findutils"
 subpackages="$pkgname-dev $pkgname-doc"
-source="https://downloads.sourceforge.net/project/linuxwacom/$pkgname/$pkgname-$pkgver.tar.bz2"
-builddir="$srcdir/"$pkgname-$pkgver
+source="$url/releases/download/$pkgname-$pkgver/$pkgname-$pkgver.tar.bz2"
+builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
@@ -21,8 +21,7 @@ build() {
 }
 
 check() {
-	cd "$builddir"
-	make check
+	make -C "$builddir" check
 }
 
 package() {
@@ -30,4 +29,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="9586348e8da91651bc9a9ee9e74dd77f4311060538dcb228681b98300f7624401878190322dcbc4e798bd1eeeb7d2900abc3f5e949a583b6cda44821b8821058  xf86-input-wacom-0.35.0.tar.bz2"
+sha512sums="2618bb53f4d6ed4166cd738022efcd3f35b31e27b04b8293834a1650131f2cbe9e1f11594bbcfb309861360311ae68dfb179d86d27fcb57033847a7b26d6e832  xf86-input-wacom-0.36.1.tar.bz2"


### PR DESCRIPTION
Project moved from sourceforge to github.