### PR TITLE
community/tinc-pre: fix race in basic test that is failing on ppc64le

### DIFF
--- a/community/tinc-pre/APKBUILD
+++ b/community/tinc-pre/APKBUILD
@@ -3,11 +3,11 @@
 pkgname=tinc-pre
 _realver="1.1pre15"
 pkgver=${_realver/pre/.}
-pkgrel=1
+pkgrel=2
 pkgdesc="Virtual Private Network (VPN) daemon (pre-release)"
 url="http://tinc-vpn.org/"
-# tests hangs on s390x and fails in lxc on ppc64le
-arch="all !s390x !ppc64le"
+# tests hangs on s390x
+arch="all !s390x"
 license="GPL-2.0"
 depends=""
 makedepends="linux-headers ncurses-dev readline-dev
@@ -18,6 +18,7 @@ subpackages="$pkgname-doc $pkgname-gui::noarch"
 source="http://tinc-vpn.org/packages/tinc-$_realver.tar.gz
 	tinc-1.1-fix-paths.patch
 	disable-ping-tests.patch
+	fix_basic_test.patch
 	$pkgname.initd
 	$pkgname.confd
 	$pkgname.networks
@@ -70,6 +71,7 @@ gui() {
 sha512sums="29b109c84a89204a9fe298e3cfb092169a7c3cbb62e0cabdb7fe8eaa01b03343b7d48bf028525754af1a340781de209e0b9412669c256a30e7226a8a21412c17  tinc-1.1pre15.tar.gz
 55bd0e61a1d10a89d879d5113082f0cdb5ff6bf1d1fb3f618c459eb2658836bf602f72fe27ac03ec78746e300a3a5178db053eef6f08d3cb34b11410dbeb05de  tinc-1.1-fix-paths.patch
 8a140f53c1913334ef6b37438c29a53932369b1b82f8196635379041d2c8f0152207cbf5deb5cde9f2052e4fd47c14b3c62bce17de898965dd05af4b9105d99b  disable-ping-tests.patch
+4b7043f9a364ef0787329173ae93c1e2438efd29f7b610259739c45317ac00deb19845467424cac4b59e577489daf29ee81551dfad593b7017d0a94d5f6a2e1b  fix_basic_test.patch
 59811c3e5241d08ebdfbd539556b7cee0dfaab89727ad503512c98f1a696fae143ecdf2682a652c5d71d077ed254ffe2e1c442b1c305c7e7ea94d9af9a1d385e  tinc-pre.initd
 f8d9354af5ebc07420ced98059262751bffef434b61c6333964338f327e2ac01ae676e375954efa794a1bccf8b939c78387b9fb7261f675f1237b0d946b529c9  tinc-pre.confd
 f7cb459c170898e51176bd92c642335386db90b7bca2abb3f6eb2514546efbd74e5fd2c8845060111dd48a0dd2cc1890717a03315c9b86185047c259cdc27135  tinc-pre.networks"

--- a/community/tinc-pre/fix_basic_test.patch
+++ b/community/tinc-pre/fix_basic_test.patch
@@ -1,0 +1,12 @@
+--- a/src/sptps_test.c
++++ b/src/sptps_test.c
+@@ -382,7 +382,8 @@
+ 					if(!datagram)
+ 						return 1;
+ 				} else {
+-					break;
++					if(datagram)
++						break;
+ 				}
+ 
+ 				bufp += done;


### PR DESCRIPTION
if multiple rx packets are received in by sptps_receive_data(&s, bufp, len) invoked in sptps_test.c,  the loop only processes the first one and breaks leaving the second unprocessed. This creates a potential race condition that could result in failures/hangs in sptps-basic.test