### PR TITLE
testing/tlp: bump to 1.1

### DIFF
--- a/testing/tlp/APKBUILD
+++ b/testing/tlp/APKBUILD
@@ -2,14 +2,15 @@
 # Maintainer: Ivan Tham <pickfire@riseup.net>
 pkgname=tlp
 _pkgname=TLP
-pkgver=0.9
-pkgrel=1
+pkgver=1.1
+pkgrel=0
 pkgdesc="Linux Advanced Power Management"
 url="http://linrunner.de/en/tlp/tlp.html"
 arch="noarch"
-license="GPL-2.0"
+license="GPL-2.0+"
+options="!check"  # No test suite.
 subpackages="$pkgname-doc $pkgname-rdw:rdw $pkgname-bash-completion:bashcomp"
-source="$_pkgname-$pkgver.tar.gz::https://github.com/linrunner/${_pkgname}/archive/${pkgver}.tar.gz
+source="$pkgname-$pkgver.tar.gz::https://github.com/linrunner/${_pkgname}/archive/${pkgver}.tar.gz
 	$pkgname.initd"
 builddir="$srcdir/"$_pkgname-$pkgver
 
@@ -37,13 +38,13 @@ rdw() {
 }
 
 bashcomp() {
-        depends=""
-        pkgdesc="Bash completions for $pkgname"
-        install_if="$pkgname=$pkgver-r$pkgrel bash-completion"
+	depends=""
+	pkgdesc="Bash completions for $pkgname"
+	install_if="$pkgname=$pkgver-r$pkgrel bash-completion"
 
-        mkdir -p "$subpkgdir"/usr/share
-        mv "$pkgdir"/usr/share/bash-completion "$subpkgdir"/usr/share
+	mkdir -p "$subpkgdir"/usr/share
+	mv "$pkgdir"/usr/share/bash-completion "$subpkgdir"/usr/share
 }
 
-sha512sums="126d11739f2438eb9cf8c496fc7d8cecfb05b578c2ae99264ee53d9fb85dfeab59456483867f21c621d0db6793468f7b0bd77868e999801115e157e1ba383610  TLP-0.9.tar.gz
+sha512sums="3400f2b6c249fd2e1bbbc61f23e3450ff90fabb8dd74f2903ce1f0d07e7ce3d1e61b07295736138d4697235dbee9157d3f32a8d296a649c93f73e03e3555af1e  tlp-1.1.tar.gz
 e6de216b2540413812711b3304cdc29c8729d527080cfd747ba382db50166dd21c6c27ff467f9f2a967e92007c7a311b00e88262952c34a22f417578c66cf4e7  tlp.initd"


### PR DESCRIPTION
* Bump from 0.9 (released 18 Aug 2016) to 1.1 (released 24 Jan 2018)
* Add `!check`: no test suite
* Correct license
* Retab bashcomp