### PR TITLE
community/vis: upgrade to 0.5

### DIFF
--- a/community/vis/APKBUILD
+++ b/community/vis/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Sören Tempel <soeren+alpine@soeren-tempel.net>
 pkgname=vis
-pkgver=0.4
-_testver=0.2
-pkgrel=1
-pkgdesc="A vim like text editor"
+pkgver=0.5
+_testver=0.3
+pkgrel=0
+pkgdesc="Modern, legacy free, simple yet efficient vim-like editor"
 url="https://github.com/martanne/vis"
 arch="all"
 license="ISC"
@@ -16,8 +16,8 @@ install=""
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/martanne/$pkgname/archive/v$pkgver.tar.gz
 	$pkgname-test-$pkgver.tar.gz::https://github.com/martanne/$pkgname-test/archive/v$_testver.tar.gz
-	fortify-source.patch"
-
+	fortify-source.patch
+	"
 _testdir="$srcdir"/$pkgname-test-$_testver
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -39,6 +39,6 @@ package() {
 	make -C "$builddir" DESTDIR="$pkgdir" install
 }
 
-sha512sums="d8fcf667ecad7b32752d6c5dbd004544e1a9283775d54d93c24ce8f314b98154aed5c6014cc03223d8427c2b1e3fd0d4b348dfa12ce30236fddd93b34521ee5f  vis-0.4.tar.gz
-892effa08c80c75e78eeb993ba8a0ddc110cc6f654fa1bf970454c35c839e9467b0ab41578f49af1fba0514c61f887fa044b9d01ab58f4dd749582a9550a2c29  vis-test-0.4.tar.gz
-53a2f70a67e4fdb7462904428bbd556f5452989ada746ec8d67b7a90aabbf806377ef7d66d760d0d74ab3101d4af2154b1a59403fce60b20ef11476242cba713  fortify-source.patch"
+sha512sums="e6ee7228c13d26342a4fb7884412c018118199a809cf18985eaa48232081fad0d7110364e55937e71e139bbe2cd24c2964d801e64f078d7ba7f2a999eeef72cc  vis-0.5.tar.gz
+5f68a70cf6f1fb64f9b50c1a56940c966f205e51240c7dd1175bc15f3e42b475fb6842a53e36547113955c2efa359de0cc71e0800305b0e45881c319a14564e5  vis-test-0.5.tar.gz
+fbcb897cb7d8cdfdc1f647691bbe23b383901a3dc9af97e2218cac18da72535ec4d138998d6016d5424e5882e15236fe13909509ca50c387227aecd2071acb9d  fortify-source.patch"

--- a/community/vis/fortify-source.patch
+++ b/community/vis/fortify-source.patch
@@ -5,7 +5,7 @@ it here silences a bunch of compiler warnings.
 diff -upr vis-0.2.orig/configure vis-0.2/configure
 --- vis-0.2.orig/configure	2016-04-06 23:36:44.232477390 +0200
 +++ vis-0.2/configure	2016-04-06 23:36:59.705671155 +0200
-@@ -199,7 +199,7 @@ tryflag   CFLAGS_TRY  -Werror=unused-com
+@@ -220,7 +220,7 @@ tryflag   CFLAGS_TRY  -Werror=unused-com
  tryldflag LDFLAGS_TRY -Werror=unknown-warning-option
  tryldflag LDFLAGS_TRY -Werror=unused-command-line-argument
  


### PR DESCRIPTION
Testing succeeds locally, but fails consistently for both vis 0.5 and vis 0.4.