### PR TITLE
community/drupal7: take maintainership

### DIFF
--- a/community/drupal7/APKBUILD
+++ b/community/drupal7/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
-# Maintainer:
+# Maintainer: Andy Postnikov <apostnikov@gmail.com>
 _php=php5
 pkgname=drupal7
 pkgver=7.57
-pkgrel=0
+pkgrel=1
 pkgdesc="An open source content management platform"
 url="https://www.drupal.org/"
 arch="noarch"


### PR DESCRIPTION
Package has no maintainer
I'm using Drupal in daily job so can update it

PS: on 28.03.18 highly critical release planned https://www.drupal.org/psa-2018-001 