### PR TITLE
community/xcb-util-xrm: upgrade to 1.3

### DIFF
--- a/community/xcb-util-xrm/APKBUILD
+++ b/community/xcb-util-xrm/APKBUILD
@@ -1,14 +1,14 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 # Author: Jakub Skrzypnik <j.skrzypnik@openmailbox.org>
 pkgname=xcb-util-xrm
-pkgver=1.2
-pkgrel=1
+pkgver=1.3
+pkgrel=0
 pkgdesc="Utility functions for the X resource manager"
-url="https://github.com/Airblader/xcb-util-xrm/"
+url="https://github.com/Airblader/xcb-util-xrm"
 arch="all"
 license="MIT"
-makedepends="libx11-dev libxcb-dev xcb-util-dev util-macros bsd-compat-headers m4"
-source="https://github.com/Airblader/$pkgname/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz"
+makedepends="autoconf automake bsd-compat-headers libtool libx11-dev libxcb-dev util-macros xcb-util-dev"
+source="https://github.com/Airblader/xcb-util-xrm/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz"
 subpackages="$pkgname-dev"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -23,4 +23,4 @@ package() {
 	make DESTDIR="$pkgdir/" install
 }
 
-sha512sums="7f992eaca739b9518ffe8f39b921617e092f4a8534cab95f072071ea952e86269971bfc422945ae5f63eda661f61424c1315ece862e2689d1048e5c2b49ff673  xcb-util-xrm-1.2.tar.gz"
+sha512sums="d8a427ed6d1f1568ce58db9b89284e4fafcc7b7929c31bccf70e5ccd91f3f6cb9c87ff25c4e64d95b0c6215cfecde6c0ee2b3a18759817aea3169ba87602c5de  xcb-util-xrm-1.3.tar.gz"


### PR DESCRIPTION
Since the versioned source tarballs do not include m4 macro generation functions, `autogen.sh` fails. The included *.m4s were manually generated by:

1. `git clone https://github.com/Airblader/xcb-util-xrm.git`
2. `git submodule update --init `

This initializes the git submodule and fetches the missing *.m4s.