### PR TITLE
community/emacs enabled emacs also for aarch64

### DIFF
--- a/community/emacs/APKBUILD
+++ b/community/emacs/APKBUILD
@@ -3,9 +3,9 @@
 
 pkgname=emacs
 pkgver=25.3
-pkgrel=0
+pkgrel=1
 pkgdesc="The extensible, customizable, self-documenting real-time display editor"
-arch="all !aarch64"
+arch="all"
 depends="emacs-nox"
 url="https://www.gnu.org/software/emacs/emacs.html"
 license="GPL-3.0"


### PR DESCRIPTION
ellingtonsantos@gmail.com reports: I already compiled emacs in aarch64 with success.