### PR TITLE
main/freetds: upgrade to 1.00.83

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: trusty
 sudo: required
 install:
   - sudo .travis/install-alpine

--- a/main/freetds/APKBUILD
+++ b/main/freetds/APKBUILD
@@ -1,15 +1,15 @@
 # Contributor: Michael Mason <ms13sp@gmail.com>
 # Maintainer: Michael Mason <ms13sp@gmail.com>
 pkgname=freetds
-pkgver=1.00.82
-pkgrel=1
+pkgver=1.00.83
+pkgrel=0
 pkgdesc="Tabular Datastream Library"
 url="http://www.freetds.org/"
 arch="all"
 license="GPL-2.0+, LGPL-2.0+"
 makedepends="unixodbc-dev readline-dev linux-headers libressl-dev"
 subpackages="$pkgname-doc $pkgname-dev"
-source="ftp://ftp.freetds.org/pub/freetds/stable/$pkgname-$pkgver.tar.gz
+source="http://www.freetds.org/files/stable/$pkgname-$pkgver.tar.gz
 	fix-includes.patch
 	libressl.patch"
 builddir="$srcdir/$pkgname-$pkgver"
@@ -41,6 +41,6 @@ package() {
 	make -j1 DESTDIR="$pkgdir" install
 }
 
-sha512sums="a4703599620f028094677241fd8f571966902b88a5eb3cc49cadb0211f18dc255555ac2602948881861e159803d2aac251cd9a8ca59567fb5348998fd2c00692  freetds-1.00.82.tar.gz
+sha512sums="6957c5b81ad7863e2fc00f1ae38e28489e98dd487342bd1e4324cb0cc0014e63f24209fd9f5733e3e8128db5ecaec88bc626a195ce5cf0a1fb85da2e4a498b99  freetds-1.00.83.tar.gz
 d75d1aab6687586697f3e430db1e82f21208f10076b45996542eea682e36cbbbb344f479a9336fcfd294b5b87d7acb2ec5fb8ddd1914e990e23dd5e7ae93a0b6  fix-includes.patch
 0c1e8d7e2e64551a55fc879173f1f6319fc1c79c8a3225af93ec77e95fac36d05b6b6a8ac79feb11dc7a9b771f38f2dde332efb85f803f4d22aedfb0ced4ab46  libressl.patch"

--- a/main/libseccomp/APKBUILD
+++ b/main/libseccomp/APKBUILD
@@ -1,7 +1,8 @@
-# Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
+# Contributor: Carlo Landmeter <clandmeter@gmail.com>
+# Contributor: Dan Williams <dan@ma.ssive.co>
 pkgname=libseccomp
-pkgver=2.3.2
+pkgver=2.3.3
 pkgrel=1
 pkgdesc="An interface to the Linux Kernel's syscall filtering mechanism"
 url="https://github.com/seccomp/libseccomp"
@@ -39,5 +40,5 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-sha512sums="0864a53ba2be61d0207f7361af94bcda4acff84a1814f915e6ccb19ab24f6ccc978da0eedc5cee047fa655dc1a583e2eeb7ab985ebfc77491c6a2606727b79ec  libseccomp-2.3.2.tar.gz
+sha512sums="845c7e0e916b5f5ad74da446ceff3250148b745c909185f6d5059e807d1b42fa6b74f356cce2a396bff0d4c7a3120e7cdad98d490a97d549327c7693fe1918be  libseccomp-2.3.3.tar.gz
 f2c31dcafdc9a1ad78e32e76b75e1c1603071eaa3f979e1f2483b879a34ad07e0a4ef3642196a695415cdf81e1ed2bf325175872fb4e203ef9d0e668c287493f  remove-redefinition-prctl.patch"


### PR DESCRIPTION
Memory leak fixed https://github.com/FreeTDS/freetds/commit/ef99f677219198282d063b9c4e5ce575bb43a718