### PR TITLE
community/drupal7: security upgrade to 7.58

### DIFF
--- a/community/drupal7/APKBUILD
+++ b/community/drupal7/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 _php=php5
 pkgname=drupal7
-pkgver=7.57
+pkgver=7.58
 pkgrel=0
 pkgdesc="An open source content management platform"
 url="https://www.drupal.org/"
@@ -16,6 +16,10 @@ pkggroups="www-data"
 source="http://ftp.drupal.org/files/projects/drupal-$pkgver.tar.gz"
 
 builddir="$srcdir/drupal-$pkgver"
+
+# secfixes:
+#   7.58-r0:
+#     - CVE-2018-7600
 
 package() {
 	cd "$builddir"
@@ -52,4 +56,4 @@ package() {
 		"$pkgdir"/var/lib/$pkgname/sites/default/files
 }
 
-sha512sums="79e7e38c605cf60e458b2846ef4ce95f82368954f86fac6e79c19357e7a4ff714367c5580836ae2e45b22029d9ba2f2566901887d37bfa1ec2ed94a5a370fa0e  drupal-7.57.tar.gz"
+sha512sums="13e437e0458d6b45723ceeca28ec9f82a67497b3dafff0152512e3ad07e1a9b53cdc39404565089ea1531495a047f803e3a1006ca218cbe3dcbbb7a6119e154e  drupal-7.58.tar.gz"


### PR DESCRIPTION
CVE-2018-7600

backport of https://github.com/alpinelinux/aports/pull/3810