### PR TITLE
community/rpm: upgrade to 4.13.1, clarify license

### DIFF
--- a/community/rpm/APKBUILD
+++ b/community/rpm/APKBUILD
@@ -1,18 +1,17 @@
 # Contributor: William Pitcock <nenolod@dereferenced.org>
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=rpm
-pkgver=4.13.0.2
+pkgver=4.13.1
 pkgrel=0
-pkgdesc="The RPM package manager"
-url="http://www.rpm.org/"
+pkgdesc="Redhat Package Management utilities (RPM)"
+url="http://www.rpm.org"
 arch="all"
-license="GPL-2.0 LGPL-2.0-or-later"
-depends_dev="nspr-dev nss-dev db-dev lua-dev zlib-dev bzip2-dev xz-dev
-		libelf-dev file-dev popt-dev libcap-dev acl-dev libarchive-dev
-		binutils-dev"
-makedepends="$depends_dev graphviz gettext-dev python2-dev"
+license="GPL-2.0-or-later LGPL-2.0-or-later"
+depends_dev="acl-dev binutils-dev bzip2-dev db-dev file-dev libarchive-dev
+	libcap-dev libelf-dev lua-dev nspr-dev nss-dev popt-dev xz-dev zlib-dev"
+makedepends="$depends_dev gettext-dev graphviz python2-dev"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang py-rpm:py_rpm"
-source="http://ftp.rpm.org/releases/rpm-4.13.x/$pkgname-$pkgver.tar.bz2"
+source="http://ftp.rpm.org/releases/$pkgname-${pkgver%.*}.x/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -42,4 +41,4 @@ py_rpm() {
 	mv "$pkgdir"/usr/lib/python* "$subpkgdir"/usr/lib
 }
 
-sha512sums="9b15acb2684bc963f7164763568615b2484478eaec0cea8b3bd4ddb94b862a70b2f4b4ab432d896e5885c9a191c4d7d2ede573a5feabc8ec290108956a8a4917  rpm-4.13.0.2.tar.bz2"
+sha512sums="3aa3fc6ec0c2199058708f24b42672db831a96c89981bca1669b2e39c2427f0afb7ec36075e47aebecf4ff3627434f4ca47ba617b6f552c85e7bfde5c6f5c647  rpm-4.13.1.tar.bz2"


### PR DESCRIPTION
Changes in dependencies are only alphabetical sorting.