### PR TITLE
main/cmake: upgrade to 3.11.0

### DIFF
--- a/main/cmake/APKBUILD
+++ b/main/cmake/APKBUILD
@@ -1,16 +1,16 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cmake
-pkgver=3.10.3
+pkgver=3.11.0
 pkgrel=0
 pkgdesc="Cross-platform, open-source make system"
 url="http://www.cmake.org"
 arch="all"
 license="BSD-3-Clause"
-makedepends="ncurses-dev curl-dev expat-dev zlib-dev bzip2-dev libarchive-dev
-	libuv-dev xz-dev rhash-dev jsoncpp-dev"
+makedepends="bzip2-dev curl-dev expat-dev jsoncpp-dev libarchive-dev
+	libuv-dev ncurses-dev rhash-dev xz-dev zlib-dev"
 options="!checkroot !check"
-checkdepends="musl-utils file"
+checkdepends="filel musl-utils"
 subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch
 	"
 case $pkgver in
@@ -63,4 +63,4 @@ bashcomp() {
                 "$subpkgdir"/usr/share/bash-completion/
 }
 
-sha512sums="1ba6381321cb34c3c050548a1346d3b92d590a196d8aff7435c079cd485d01f7a6cd650ad97d00931aff424fcdc195bbaa6d9d7db679bf02f72f586c7b528ae4  cmake-3.10.3.tar.gz"
+sha512sums="03b058483d236d4f4427c93cc41af77068c243fc4b6f24aeaf2daf97af215bc664bc1b733195463af4cfc94ec70076710f425661859d752ddf3b9610adca9834  cmake-3.11.0.tar.gz"


### PR DESCRIPTION
Changes in dependencies are only alphabetical sorting.