### PR TITLE
testing/php7-stats: exclude broken test for aarch64 and ppc64le

### DIFF
--- a/testing/php7-stats/APKBUILD
+++ b/testing/php7-stats/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=php7-stats
 _pkgreal=stats
 pkgver=2.0.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Extension that provides few dozens routines for statistical computation."
 url="http://pecl.php.net/package/$_pkgreal"
 arch="all"
@@ -22,6 +22,10 @@ build() {
 
 check() {
 	cd "$builddir"
+	case "$CARCH" in
+		# Remove test fail https://bugs.php.net/bug.php?id=76163
+		aarch64 | ppc64le) rm tests/stats_stat_correlation.phpt
+	esac
 	make NO_INTERACTION=1 REPORT_EXIT_STATUS=1 test
 }
 


### PR DESCRIPTION
https://bugs.php.net/bug.php?id=76163