### PR TITLE
main/xz: Add explicit LD_LIBRARY_PATH for "make check"

### DIFF
--- a/main/xz/APKBUILD
+++ b/main/xz/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xz
 pkgver=5.2.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Library and command line tools for XZ and LZMA compressed files"
 url="https://tukaani.org/xz/"
 arch="all"
@@ -35,7 +35,7 @@ build() {
 
 check() {
 	cd "$builddir"
-	make check
+	LD_LIBRARY_PATH="$(pwd)/src/liblzma/.libs" make check
 }
 
 package() {


### PR DESCRIPTION
Without this, the tests in "make check" can't find libzma.so, if it isn't
installed, such as when running "abuild rootbld" or bootstrapping a system
where xz hasn't been built/installed yet.