### PR TITLE
testing/wireguard-tools: Fix examples installation path

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -3,7 +3,7 @@
 
 pkgname=wireguard-tools
 pkgver=0.0.20180304
-pkgrel=1
+pkgrel=2
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
 url='https://www.wireguard.com'
@@ -22,7 +22,7 @@ build() {
 
 package() {
 	cd "$builddir"
-	mkdir -p "$pkgdir"/usr/share/doc/$_name
+	mkdir -p "$pkgdir/usr/share/doc/$pkgname"
 
 	make -C src/tools \
 		DESTDIR="$pkgdir" \
@@ -32,7 +32,7 @@ package() {
 		install
 
 	find "$builddir"/contrib/examples -name '.gitignore' -delete
-	cp -rf "$builddir"/contrib/examples "$pkgdir"/usr/share/doc/$_name/
+	cp -rf "$builddir"/contrib/examples "$pkgdir/usr/share/doc/$pkgname/"
 }
 
 bashcomp() {


### PR DESCRIPTION
WireGuard's examples directory should be installed to
/usr/share/doc/wireguard-tools/examples, not /usr/share/doc/examples.
It seems that this was intended in the APKBUILD, but the code that copies the
examples directory relies on $_name, which is not set. Use $pkgname instead.