### PR TITLE
main/zsh: fix CVE-2018-1071, CVE-2018-1083

### DIFF
--- a/main/zsh/APKBUILD
+++ b/main/zsh/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=zsh
 pkgver=5.4.2
-pkgrel=0
+pkgrel=1
 pkgdesc="A very advanced and programmable command interpreter (shell)"
 url="http://www.zsh.org/"
 arch="all"
@@ -13,6 +13,8 @@ makedepends="ncurses-dev"
 install="zsh.post-install zsh.post-upgrade zsh.pre-deinstall"
 source="https://www.zsh.org/pub/$pkgname-$pkgver.tar.gz
 	zprofile
+	CVE-2018-1071.patch
+	CVE-2018-1083.patch
 	"
 subpackages="$pkgname-doc $pkgname-calendar::noarch $pkgname-vcs::noarch $pkgname-zftp"
 builddir="$srcdir/$pkgname-$pkgver"
@@ -147,4 +149,6 @@ _submv() {
 	mv "$pkgdir"/$path "$subpkgdir"/${path%/*}/
 }
 sha512sums="5eaa2ff3dc8052dfb50d2be19bfeed1856b00f7c2dc698129c95c2373a516ee61dba5b42ded390ac20b171abe352b1875f177a4dda8fdc15a4f2a05bb7a024e2  zsh-5.4.2.tar.gz
-59182b99447872ded8adf0d890e9359ee47fce0b7acb2808f4308f945885fbf6d977a0917bbb5c0f21454caf3ba06ab092127732da4f84292d6ab0989a0110fe  zprofile"
+59182b99447872ded8adf0d890e9359ee47fce0b7acb2808f4308f945885fbf6d977a0917bbb5c0f21454caf3ba06ab092127732da4f84292d6ab0989a0110fe  zprofile
+9e645c31ace8e255a3859fe732572be7e4f7bde025c17f0cc4cdfedfc5ffb30b42e5051162efcb2f58bb89e92701dab0528fa3157faf2445aca3cec3d85e1da8  CVE-2018-1071.patch
+4e4c3c67c4ce73607d735e99884ca2ef833f4f8859f30882b69bf6e785f99a4637c0650f6a8d474e0f3d86f7400499557a04c327990ef999c1aedca598e13848  CVE-2018-1083.patch"

--- a/main/zsh/APKBUILD
+++ b/main/zsh/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=zsh
 pkgver=5.4.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A very advanced and programmable command interpreter (shell)"
 url="http://www.zsh.org/"
 arch="all"
@@ -65,7 +65,7 @@ prepare() {
 		_pack _pax _perforce _pine _pkgadd _pkginfo _pkgrm _prcs \
 		_quilt _raggle _rcs _rlogin _rubber _sablotron _sisu _socket \
 		_stgit _surfraw _tardy _telnet _tin _tla _topgit _totd _twidge \
-		_unace _unison _units _uzbl _vcsh _vux _wiggle _xmms2 _yodl
+		_unace _unison _units _uzbl _vcsh _vux _wiggle _xmms2
 	cd ../../Linux/Command
 	rm -f _acpitool _mondo _tpb _tpconfig _uml _vserver
 	cd ../../X/Command

--- a/main/zsh/APKBUILD
+++ b/main/zsh/APKBUILD
@@ -22,6 +22,11 @@ builddir="$srcdir/$pkgname-$pkgver"
 _libdir="usr/lib/zsh/$pkgver"
 _sharedir="usr/share/zsh/$pkgver"
 
+# secfixes:
+#   5.4.2-r1:
+#     - CVE-2018-1083
+#     - CVE-2018-1071
+
 # Move some bigger completion files to subpackages.
 _comps="android-tools:Unix/_adb
 	bzr:Unix/_bzr

--- a/main/zsh/CVE-2018-1071.patch
+++ b/main/zsh/CVE-2018-1071.patch
@@ -1,0 +1,37 @@
+From 679b71ec4d852037fe5f73d35bf557b0f406c8d4 Mon Sep 17 00:00:00 2001
+From: Oliver Kiddle <okiddle@yahoo.co.uk>
+Date: Sat, 24 Mar 2018 15:02:41 +0100
+Subject: [PATCH] 42518, CVE-2018-1071: check bounds when copying path in
+ hashcmd()
+
+diff --git a/Src/exec.c b/Src/exec.c
+index 35b0bb191..e154d1249 100644
+--- a/Src/exec.c
++++ b/Src/exec.c
+@@ -920,7 +920,7 @@ hashcmd(char *arg0, char **pp)
+     for (; *pp; pp++)
+ 	if (**pp == '/') {
+ 	    s = buf;
+-	    strucpy(&s, *pp);
++	    struncpy(&s, *pp, PATH_MAX);
+ 	    *s++ = '/';
+ 	    if ((s - buf) + strlen(arg0) >= PATH_MAX)
+ 		continue;
+diff --git a/Src/utils.c b/Src/utils.c
+index 3b589aa35..998b16220 100644
+--- a/Src/utils.c
++++ b/Src/utils.c
+@@ -2283,10 +2283,10 @@ struncpy(char **s, char *t, int n)
+ {
+     char *u = *s;
+ 
+-    while (n--)
+-	*u++ = *t++;
++    while (n-- && (*u++ = *t++));
+     *s = u;
+-    *u = '\0';
++    if (n > 0) /* just one null-byte will do, unlike strncpy(3) */
++	*u = '\0';
+ }
+ 
+ /* Return the number of elements in an array of pointers. *

--- a/main/zsh/CVE-2018-1083.patch
+++ b/main/zsh/CVE-2018-1083.patch
@@ -1,0 +1,36 @@
+From 259ac472eac291c8c103c7a0d8a4eaf3c2942ed7 Mon Sep 17 00:00:00 2001
+From: Oliver Kiddle <okiddle@yahoo.co.uk>
+Date: Sat, 24 Mar 2018 15:04:39 +0100
+Subject: [PATCH] 42519, CVE-2018-1083: check bounds on PATH_MAX-sized buffer
+ used for file completion candidates
+
+diff --git a/Src/Zle/compctl.c b/Src/Zle/compctl.c
+index e9d165780..87d13afc1 100644
+--- a/Src/Zle/compctl.c
++++ b/Src/Zle/compctl.c
+@@ -2176,6 +2176,8 @@ gen_matches_files(int dirs, int execs, int all)
+     if (prpre && *prpre) {
+ 	pathpref = dupstring(prpre);
+ 	unmetafy(pathpref, &pathpreflen);
++	if (pathpreflen > PATH_MAX)
++	    return;
+ 	/* system needs NULL termination, not provided by unmetafy */
+ 	pathpref[pathpreflen] = '\0';
+     } else {
+@@ -2218,6 +2220,8 @@ gen_matches_files(int dirs, int execs, int all)
+ 		     * the path buffer by appending the filename.       */
+ 		    ums = dupstring(n);
+ 		    unmetafy(ums, &umlen);
++		    if (umlen + pathpreflen + 1 > PATH_MAX)
++			continue;
+ 		    memcpy(q, ums, umlen);
+ 		    q[umlen] = '\0';
+ 		    /* And do the stat. */
+@@ -2232,6 +2236,8 @@ gen_matches_files(int dirs, int execs, int all)
+ 			/* We have to test for a path suffix. */
+ 			int o = strlen(p), tt;
+ 
++			if (o + strlen(psuf) > PATH_MAX)
++			    continue;
+ 			/* Append it to the path buffer. */
+ 			strcpy(p + o, psuf);


### PR DESCRIPTION
[CVE-2018-1071](https://sourceforge.net/p/zsh/code/ci/679b71ec4d852037fe5f73d35bf557b0f406c8d4): check bounds when copying path in hashcmd()
[CVE-2018-1083](https://sourceforge.net/p/zsh/code/ci/259ac472eac291c8c103c7a0d8a4eaf3c2942ed7): check bounds on PATH_MAX-sized buffer used for file completion candidates