### PR TITLE
community/nodejs-current: upgrade to 9.10.1

### DIFF
--- a/community/nodejs-current/APKBUILD
+++ b/community/nodejs-current/APKBUILD
@@ -2,14 +2,18 @@
 # Maintainer: Jose-Luis Rivas <ghostbar@riseup.net>
 #
 # secfixes:
+#   9.10.0-r0:
+#     - CVE-2018-7158
+#     - CVE-2018-7159
+#     - CVE-2018-7160
 #   9.2.1-r0:
 #     - CVE-2017-15896
 #     - CVE-2017-15897
 #
 pkgname=nodejs-current
 # The current stable version, i.e. non-LTS.
-pkgver=9.10.0
-pkgrel=1
+pkgver=9.10.1
+pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - current stable version"
 url="https://nodejs.org/"
 arch="all"
@@ -74,5 +78,5 @@ package() {
 	rm "$pkgdir"/usr/bin/npm "$pkgdir"/usr/bin/npx
 }
 
-sha512sums="779843eae41089686b09039e4b3bc961e2f14bab9019897105d524fbd4b66070f3abdf79b664587bf230d7be1a565f905d91336fc030cdec2c9776f121b305b8  node-v9.10.0.tar.gz
+sha512sums="cf2f6afc0e7b597bea426522dec79a53aa7668ca3e594a95ec33bc3dd042e410fde6dc1980cb1626497f64bdcaebaeac1a08ee66f19cb70694200b469e83de8e  node-v9.10.1.tar.gz
 ba95f21b1e80717ef63941854e7ed412f64a91da068c0dbf0d6d9697333ee266c9f4cd7bf1a01111eeb28aa66adefd8a58cfb3e82debb84b43e35e9dc914dd36  dont-run-gyp-files-for-bundled-deps.patch"


### PR DESCRIPTION
Add lost secfixes