### PR TITLE
main/protobuf: upgrade to 3.5.2 + testing/py-protobuf

### DIFF
--- a/main/protobuf/APKBUILD
+++ b/main/protobuf/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=protobuf
 _gemname=google-protobuf
-pkgver=3.5.1
-pkgrel=1
+pkgver=3.5.2
+pkgrel=0
 pkgdesc="Library for extensible, efficient structure packing"
 url="https://github.com/google/protobuf"
 arch="all"
@@ -87,7 +87,7 @@ vim() {
 		"$subpkgdir"/usr/share/vim/vimfiles/syntax/proto.vim
 }
 
-sha512sums="51fcab8ccb77c34bc0e5fc75c9a86325c379339b8ea43c13ca66b40d14491943f98426675acdd4c9cccf624263edfc9b2907dc1b495f5b7fc2f99f29bd2d09b9  protobuf-3.5.1.tar.gz
+sha512sums="09d10cf0c07a0ba249428bbf20f5dbed840965fa06b3c09682f286a4dee9d84bb96f3b5b50e993d48ef1f20440531255ce7d0e60a648bf3fe536a5f2b0b74181  protobuf-3.5.2.tar.gz
 b321cf82a959263d3173cc1c5cce4c77d4720f5dd824f20c98abb94f11eccf2907afce8b8a86340b4fc1bd1c7d5df1afca4672c17a97feb089521e167b20c70f  musl-fix.patch
-e1f6483b7e8d38b07cd01883bda439b2017fa0a87626fa49628f1d2042b5097ba8a68bdf1a03cd385e3e9a7c0bd2af6fbccec25e1c061617c3cceccabd17dce4  trim-rakefile.patch
+e09f83b6cd1c4d046390704333f72825166b841474f37ac5181ae7a67c9acc6fe6098660064890517c41380544e4cac7cb73acc2815b7a2decd16ea8fd3fb92b  trim-rakefile.patch
 269184e48fc0b645134a08a0e1e2709970109f283a75cef5e8de9b8b61344d6ca9dea2e7ff15aee26dd8049c5b424fd94262729e7fcc1e688a1d7fc486d9d2e4  adding_release_compareandswap_64-bit_variant.patch"

--- a/main/protobuf/trim-rakefile.patch
+++ b/main/protobuf/trim-rakefile.patch
@@ -37,13 +37,13 @@ Remove code that we don't use to avoid installing additional dependencies.
 -
 -  task 'gem:windows' do
 -    require 'rake_compiler_dock'
--    RakeCompilerDock.sh "bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION=2.4.0:2.3.0:2.2.2:2.1.5:2.0.0"
+-    RakeCompilerDock.sh "bundle && IN_DOCKER=true rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0"
 -  end
 -
 -  if RUBY_PLATFORM =~ /darwin/
 -    task 'gem:native' do
 -      system "rake genproto"
--      system "rake cross native gem RUBY_CC_VERSION=2.4.0:2.3.0:2.2.2:2.1.5:2.0.0"
+-      system "rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0"
 -    end
 -  else
 -    task 'gem:native' => [:genproto, 'gem:windows']
@@ -54,13 +54,13 @@ Remove code that we don't use to avoid installing additional dependencies.
  # Proto for tests.
  genproto_output << "tests/generated_code.rb"
  genproto_output << "tests/test_import.rb"
-@@ -93,9 +52,6 @@
- 
- task :clean do
+@@ -95,9 +54,6 @@
    sh "rm -f #{genproto_output.join(' ')}"
--end
--
--Gem::PackageTask.new(spec) do |pkg|
  end
  
+-Gem::PackageTask.new(spec) do |pkg|
+-end
+-
  Rake::TestTask.new(:test => :build) do |t|
+   t.test_files = FileList["tests/*.rb"].exclude("tests/gc_test.rb")
+ end

--- a/testing/py-protobuf/APKBUILD
+++ b/testing/py-protobuf/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Corentin Henry <corentinhenry@gmail.com>
 pkgname=py-protobuf
 _pkgname=${pkgname#py-}
-pkgver=3.5.1
+pkgver=3.5.2
 pkgrel=0
 pkgdesc="Google's data interchange format."
 url="https://github.com/google/protobuf"
@@ -53,4 +53,4 @@ _py() {
 	chmod +r "$subpkgdir"/usr/lib/*/site-packages/*/*
 }
 
-sha512sums="4406bb9687a949a92cad27a7c9cdf63dca9c73041e796da6731c0d5076ea8e46299be17e77df453bf94340fe5d96b2b6f2436962a126c3157cf21606b42a60ae  py-protobuf-3.5.1.tar.gz"
+sha512sums="b9ad019476f12506c3176f41ed8935a16b6f2dacc167414075bc0a775c382b02e57b3fcf00df6e7dba28fafd631adad982128ff88efc84caf4f718a12b8d2ae6  py-protobuf-3.5.2.tar.gz"


### PR DESCRIPTION
There's some dependent packages but looks they does not need bump