### PR TITLE
main/openssl: security upgrade to 1.0.2o

### DIFF
--- a/community/nodejs-current/APKBUILD
+++ b/community/nodejs-current/APKBUILD
@@ -13,7 +13,7 @@
 pkgname=nodejs-current
 # The current stable version, i.e. non-LTS.
 pkgver=9.10.1
-pkgrel=0
+pkgrel=1
 pkgdesc="JavaScript runtime built on V8 engine - current stable version"
 url="https://nodejs.org/"
 arch="all"

--- a/community/tomcat-native/APKBUILD
+++ b/community/tomcat-native/APKBUILD
@@ -3,7 +3,7 @@
 # TODO: Patch for LibreSSL.
 pkgname=tomcat-native
 pkgver=1.2.16
-pkgrel=0
+pkgrel=1
 pkgdesc="Native resources optional component for Apache Tomcat"
 url="http://tomcat.apache.org/native-doc/"
 arch="all"

--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -22,7 +22,7 @@ pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
 pkgver=8.11.1
-pkgrel=0
+pkgrel=1
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="https://nodejs.org/"
 arch="all"

--- a/main/openssl/APKBUILD
+++ b/main/openssl/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Timo Teras <timo.teras@iki.fi>
 pkgname=openssl
-pkgver=1.0.2n
+pkgver=1.0.2o
 pkgrel=0
 pkgdesc="Toolkit for SSL v2/v3 and TLS v1"
 url="http://openssl.org"
@@ -57,6 +57,10 @@ source="http://www.openssl.org/source/${pkgname}-${pkgver}.tar.gz
 #   1.0.2n-r0:
 #     - CVE-2017-3737
 #     - CVE-2017-3738
+#   1.0.2o-r0:
+#     - CVE-2017-3738
+#     - CVE-2018-0733
+#     - CVE-2018-0739
 
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -128,7 +132,7 @@ libssl() {
 	done
 }
 
-sha512sums="144bf0d6aa27b4af01df0b7b734c39962649e1711554247d42e05e14d8945742b18745aefdba162e2dfc762b941fd7d3b2d5dc6a781ae4ba10a6f5a3cadb0687  openssl-1.0.2n.tar.gz
+sha512sums="8a2c93657c85143e76785bb32ee836908c31a6f5f8db993fa9777acba6079e630cdddd03edbad65d1587199fc13a1507789eacf038b56eb99139c2091d9df7fd  openssl-1.0.2o.tar.gz
 2244f46cb18e6b98f075051dd2446c47f7590abccd108fbab707f168a20cad8d32220d704635973f09e3b2879f523be5160f1ffbc12ab3900f8a8891dc855c5c  0002-busybox-basename.patch
 58e42058a0c8086c49d681b1e226da39a8cf8cb88c51cf739dec2ff12e1bb5d7208ac5033264b186d58e9bdfe992fe9ddb95701d01caf1824396b2cefe30c0a4  0003-use-termios.patch
 c67472879a31b5dbdd313892df6d37e7c93e8c0237d406c30d50b1016c2618ead3c13277f5dc723ef1ceed092d36e3c15a9777daa844f59b9fa2b0a4f04fd9ae  0004-fix-default-ca-path-for-apps.patch


### PR DESCRIPTION
CVE-2017-3738, CVE-2018-0739, CVE-2018-0733