### PR TITLE
main/tiff: fix CVE-2018-5784

### DIFF
--- a/main/tiff/APKBUILD
+++ b/main/tiff/APKBUILD
@@ -5,9 +5,9 @@ pkgname=tiff
 pkgver=4.0.9
 pkgrel=2
 pkgdesc="Provides support for the Tag Image File Format or TIFF"
-url="http://www.libtiff.org/"
+url="http://www.libtiff.org"
 arch="all"
-license="GPL"
+license="libtiff"
 depends=
 depends_dev="zlib-dev libjpeg-turbo-dev"
 makedepends="libtool autoconf automake $depends_dev"
@@ -41,9 +41,8 @@ source="http://download.osgeo.org/libtiff/$pkgname-$pkgver.tar.gz
 #     - CVE-2017-5225
 
 prepare() {
-	cd "$builddir"
-	update_config_sub
 	default_prepare
+	update_config_sub
 }
 
 build() {

--- a/main/tiff/APKBUILD
+++ b/main/tiff/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Michael Mason <ms13sp@gmail.com>
 pkgname=tiff
 pkgver=4.0.9
-pkgrel=1
+pkgrel=2
 pkgdesc="Provides support for the Tag Image File Format or TIFF"
 url="http://www.libtiff.org/"
 arch="all"
@@ -15,8 +15,11 @@ subpackages="$pkgname-doc $pkgname-dev $pkgname-tools"
 builddir="$srcdir/$pkgname-$pkgver"
 source="http://download.osgeo.org/libtiff/$pkgname-$pkgver.tar.gz
 	CVE-2017-18013.patch
+	CVE-2018-5784.patch
 	"
 # secfixes:
+#   4.0.9-r2:
+#     - CVE-2018-5784
 #   4.0.9-r1:
 #     - CVE-2017-18013
 #   4.0.9-r0:
@@ -73,4 +76,5 @@ tools() {
 }
 
 sha512sums="04f3d5eefccf9c1a0393659fe27f3dddd31108c401ba0dc587bca152a1c1f6bc844ba41622ff5572da8cc278593eff8c402b44e7af0a0090e91d326c2d79f6cd  tiff-4.0.9.tar.gz
-2baa66963302ff51e34774d6e0703f769ba1ca7f527456ae13ea230af69280e024440390df9b5a51776fc29cb6d2d40713431a2c2d98f29e50e3f8f5a7f4d73b  CVE-2017-18013.patch"
+3a31e4315ecc5c5bf709e2ca0fefb5bc7ff50c79f911b8b8366be38d007d3f79e89982700a620b2d82739313fbd79041428dbf3ecf0a790c9ec3bc2e211d6fce  CVE-2017-18013.patch
+c9cb1f712241c5bbd01910d4f4becf50ba8498bb04393f45451af4ace948b6a41b3d887adc9fbce1a53edeb0aeba03868f4d31428f3c5813ed14bb4b6f4c0f96  CVE-2018-5784.patch"

--- a/main/tiff/CVE-2017-18013.patch
+++ b/main/tiff/CVE-2017-18013.patch
@@ -11,7 +11,7 @@ diff --git a/libtiff/tif_print.c b/libtiff/tif_print.c
 index 9959d35..8deceb2 100644
 --- a/libtiff/tif_print.c
 +++ b/libtiff/tif_print.c
-@@ -665,13 +665,13 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd, long flags)
+@@ -667,13 +665,13 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd, long flags)
  #if defined(__WIN32__) && (defined(_MSC_VER) || defined(__MINGW32__))
  			fprintf(fd, "    %3lu: [%8I64u, %8I64u]\n",
  			    (unsigned long) s,

--- a/main/tiff/CVE-2018-5784.patch
+++ b/main/tiff/CVE-2018-5784.patch
@@ -1,0 +1,128 @@
+From 473851d211cf8805a161820337ca74cc9615d6ef Mon Sep 17 00:00:00 2001
+From: Nathan Baker <nathanb@lenovo-chrome.com>
+Date: Tue, 6 Feb 2018 10:13:57 -0500
+Subject: [PATCH] Fix for bug 2772
+
+It is possible to craft a TIFF document where the IFD list is circular,
+leading to an infinite loop while traversing the chain. The libtiff
+directory reader has a failsafe that will break out of this loop after
+reading 65535 directory entries, but it will continue processing,
+consuming time and resources to process what is essentially a bogus TIFF
+document.
+
+This change fixes the above behavior by breaking out of processing when
+a TIFF document has >= 65535 directories and terminating with an error.
+---
+ contrib/addtiffo/tif_overview.c | 14 +++++++++++++-
+ tools/tiff2pdf.c                | 10 ++++++++++
+ tools/tiffcrop.c                | 13 +++++++++++--
+ 3 files changed, 34 insertions(+), 3 deletions(-)
+
+diff --git a/contrib/addtiffo/tif_overview.c b/contrib/addtiffo/tif_overview.c
+index c61ffbb..03b3573 100644
+--- a/contrib/addtiffo/tif_overview.c
++++ b/contrib/addtiffo/tif_overview.c
+@@ -65,6 +65,8 @@
+ #  define MAX(a,b)      ((a>b) ? a : b)
+ #endif
+ 
++#define TIFF_DIR_MAX  65534
++
+ void TIFFBuildOverviews( TIFF *, int, int *, int, const char *,
+                          int (*)(double,void*), void * );
+ 
+@@ -91,6 +93,7 @@ uint32 TIFF_WriteOverview( TIFF *hTIFF, uint32 nXSize, uint32 nYSize,
+ {
+     toff_t	nBaseDirOffset;
+     toff_t	nOffset;
++    tdir_t	iNumDir;
+ 
+     (void) bUseSubIFDs;
+ 
+@@ -147,7 +150,16 @@ uint32 TIFF_WriteOverview( TIFF *hTIFF, uint32 nXSize, uint32 nYSize,
+         return 0;
+ 
+     TIFFWriteDirectory( hTIFF );
+-    TIFFSetDirectory( hTIFF, (tdir_t) (TIFFNumberOfDirectories(hTIFF)-1) );
++    iNumDir = TIFFNumberOfDirectories(hTIFF);
++    if( iNumDir > TIFF_DIR_MAX )
++    {
++        TIFFErrorExt( TIFFClientdata(hTIFF),
++                      "TIFF_WriteOverview",
++                      "File `%s' has too many directories.\n",
++                      TIFFFileName(hTIFF) );
++        exit(-1);
++    }
++    TIFFSetDirectory( hTIFF, (tdir_t) (iNumDir - 1) );
+ 
+     nOffset = TIFFCurrentDirOffset( hTIFF );
+ 
+diff --git a/tools/tiff2pdf.c b/tools/tiff2pdf.c
+index 984ef65..832a247 100644
+--- a/tools/tiff2pdf.c
++++ b/tools/tiff2pdf.c
+@@ -68,6 +68,8 @@ extern int getopt(int, char**, char*);
+ 
+ #define PS_UNIT_SIZE	72.0F
+ 
++#define TIFF_DIR_MAX    65534
++
+ /* This type is of PDF color spaces. */
+ typedef enum {
+ 	T2P_CS_BILEVEL = 0x01,	/* Bilevel, black and white */
+@@ -1049,6 +1053,14 @@ void t2p_read_tiff_init(T2P* t2p, TIFF* input){
+ 	uint16* tiff_transferfunction[3];
+ 
+ 	directorycount=TIFFNumberOfDirectories(input);
++	if(directorycount > TIFF_DIR_MAX) {
++		TIFFError(
++			TIFF2PDF_MODULE,
++			"TIFF contains too many directories, %s",
++			TIFFFileName(input));
++		t2p->t2p_error = T2P_ERR_ERROR;
++		return;
++	}
+ 	t2p->tiff_pages = (T2P_PAGE*) _TIFFmalloc(TIFFSafeMultiply(tmsize_t,directorycount,sizeof(T2P_PAGE)));
+ 	if(t2p->tiff_pages==NULL){
+ 		TIFFError(
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 91a38f6..e466dae 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -217,6 +215,8 @@ extern int getopt(int argc, char * const argv[], const char *optstring);
+ #define DUMP_TEXT   1
+ #define DUMP_RAW    2
+ 
++#define TIFF_DIR_MAX  65534
++
+ /* Offsets into buffer for margins and fixed width and length segments */
+ struct offset {
+   uint32  tmargin;
+@@ -2233,7 +2234,7 @@ main(int argc, char* argv[])
+     pageNum = -1;
+   else
+     total_images = 0;
+-  /* read multiple input files and write to output file(s) */
++  /* Read multiple input files and write to output file(s) */
+   while (optind < argc - 1)
+     {
+     in = TIFFOpen (argv[optind], "r");
+@@ -2241,7 +2242,14 @@ main(int argc, char* argv[])
+       return (-3);
+ 
+     /* If only one input file is specified, we can use directory count */
+-    total_images = TIFFNumberOfDirectories(in); 
++    total_images = TIFFNumberOfDirectories(in);
++    if (total_images > TIFF_DIR_MAX)
++      {
++      TIFFError (TIFFFileName(in), "File contains too many directories");
++      if (out != NULL)
++        (void) TIFFClose(out);
++      return (1);
++      }
+     if (image_count == 0)
+       {
+       dirnum = 0;
+--
+libgit2 0.26.0
+


### PR DESCRIPTION
CVE-2018-5784: [upstream](https://gitlab.com/libtiff/libtiff/commit/473851d211cf8805a161820337ca74cc9615d6ef)
[Description](https://www.cvedetails.com/cve/CVE-2018-5784/)