### PR TITLE
main/ttf-freefont: modernize; correct license

### DIFF
--- a/main/ttf-freefont/APKBUILD
+++ b/main/ttf-freefont/APKBUILD
@@ -5,21 +5,23 @@ pkgrel=0
 pkgdesc="A set of free high-quality TrueType fonts covering the UCS character set"
 url="http://www.nongnu.org/freefont/"
 arch="noarch"
-license="GPL"
+license="GPL-3.0+ with exception"
+options="!check"  # No test suite.
 depends="fontconfig encodings mkfontdir mkfontscale"
 makedepends="font-util-dev"
-install=
 source="http://ftp.gnu.org/gnu/freefont/freefont-ttf-$pkgver.zip"
+builddir="$srcdir/freefont-$pkgver"
 
-_builddir="$srcdir/freefont-$pkgver"
 build() {
 	return 0
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	install -d "$pkgdir/usr/share/fonts/TTF"
 	install -m644 *.ttf "$pkgdir/usr/share/fonts/TTF/"
+	# Licensing exception is discussed in README in pkgver==20120503
+	install -Dm644 README "$pkgdir/usr/share/licenses/$pkgname/README"
 }
 
 sha512sums="dcd6f525e8f97631c6f84ab4cc2a31af4614dcdb9a4d434bd890baf18e0c2934032f2915384fc27fbecf60d259d792e48f52d357b07e3ed2616d3c8c3544268e  freefont-ttf-20120503.zip"


### PR DESCRIPTION
Note that `COPYING` is not installed since it's just a boilerplate GPL-3.0 `COPYING` file; the `README` is what contains the licensing exception that allows embedding (also discussed [here](https://www.gnu.org/software/freefont/license.html)).