### PR TITLE
main/sdl2: fix DirectFB renderer regression

### DIFF
--- a/main/sdl2/APKBUILD
+++ b/main/sdl2/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=sdl2
 pkgver=2.0.8
-pkgrel=0
+pkgrel=1
 pkgdesc="A development library designed to provide low level access to audio, keyboard, mouse, joystick and graphics"
 url="http://www.libsdl.org"
 arch="all"
@@ -13,7 +13,8 @@ makedepends="alsa-lib-dev directfb-dev libxcursor-dev libxrandr-dev libxrender-d
 	libxscrnsaver-dev libxi-dev libx11-dev libxext-dev libusb-dev libxkbcommon-dev"
 subpackages="$pkgname-dev"
 source="https://www.libsdl.org/release/SDL2-$pkgver.tar.gz
-	fix-directfb-include.patch"
+	fix-directfb-include.patch
+	fix-directfb-renderer.patch"
 builddir="$srcdir/SDL2-$pkgver"
 
 build() {
@@ -45,4 +46,5 @@ package() {
 }
 
 sha512sums="673c6058b8692a36b4a3594456b10ef6051efe79e4fb644421fc5c76b11fd68b895840a2c8b72413418c378733e2993d33f19767d0d7ed101eda6310bd70c869  SDL2-2.0.8.tar.gz
-f57a7a7b89f11934835b5693d104354be1107ddd31d34f6cfc07cf480b0811d775c95685f6b6b20c6154f03744ed976c8092973ddb6e87773969b8394e852c24  fix-directfb-include.patch"
+f57a7a7b89f11934835b5693d104354be1107ddd31d34f6cfc07cf480b0811d775c95685f6b6b20c6154f03744ed976c8092973ddb6e87773969b8394e852c24  fix-directfb-include.patch
+bf4a8fa4392429252da0b2beed60cc6a0f74288987df6691413b1a2369f14ba07dd7c42d9c9255fe1204ffb96b5b6c28e92c220898ca595bc86d45fa33374c7c  fix-directfb-renderer.patch"

--- a/main/sdl2/fix-directfb-renderer.patch
+++ b/main/sdl2/fix-directfb-renderer.patch
@@ -1,0 +1,26 @@
+diff --git a/configure b/configure
+index 1c7f87e..c5ce9c3 100755
+--- a/configure
++++ b/configure
+@@ -21475,6 +21487,9 @@ fi
+ 
+ $as_echo "#define SDL_VIDEO_DRIVER_DIRECTFB 1" >>confdefs.h
+ 
++
++$as_echo "#define SDL_VIDEO_RENDER_DIRECTFB 1" >>confdefs.h
++
+             SOURCES="$SOURCES $srcdir/src/video/directfb/*.c"
+             EXTRA_CFLAGS="$EXTRA_CFLAGS $DIRECTFB_CFLAGS"
+ 
+diff --git a/configure.in b/configure.in
+index 1c7e793..262885b 100644
+--- a/configure.in
++++ b/configure.in
+@@ -2150,6 +2150,7 @@ AC_HELP_STRING([--enable-directfb-shared], [dynamically load directfb support [[
+                               , enable_directfb_shared=yes)
+ 
+             AC_DEFINE(SDL_VIDEO_DRIVER_DIRECTFB, 1, [ ])
++            AC_DEFINE(SDL_VIDEO_RENDER_DIRECTFB, 1, [ ])
+             SOURCES="$SOURCES $srcdir/src/video/directfb/*.c"
+             EXTRA_CFLAGS="$EXTRA_CFLAGS $DIRECTFB_CFLAGS"
+ 


### PR DESCRIPTION
The update to 2.0.8 broke the build of the DirectFB renderer such that
it cannot be used anymore, see
https://bugzilla.libsdl.org/show_bug.cgi?id=4123. This fixes the
regression by re-inserting the affected line in the configure script.

Having a working DirectFB renderer in SDL2 is crucial for postmarketOS
as it is used for unlocking full disk encryption and displaying the
charging animation on almost all devices, see also postmarketOS/osk-sdl#80.