### PR TITLE
Revert "testing/wireguard-tools: depends on bash"

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -3,12 +3,11 @@
 
 pkgname=wireguard-tools
 pkgver=0.0.20180304
-pkgrel=2
+pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
 url='https://www.wireguard.com'
 license="GPL-2.0"
-depends="bash"
 makedepends="libmnl-dev"
 subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch"
 options="!check"


### PR DESCRIPTION
This reverts commit 548c24ea1e19b3739a24556248ebbde4f300e14a, which was
snuck in while I was on vacation.

There are users of Alpine+WireGuard who don't need or use
wg-quick and thus don't need or use bash. This therefore should not be a
required dependency of the package. This also breaks the pkgrel
consistency with the kernel packages. So, we revert.

Signed-off-by: Jason A. Donenfeld <Jason@zx2c4.com>
Fixes: #3640