### PR TITLE
testing/gdal: upgrade to 2.2.4

### DIFF
--- a/testing/gdal/APKBUILD
+++ b/testing/gdal/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Trevor R.H. Clarke <trevor@notcows.com>
 # Maintainer: Trevor R.H. Clarke <trevor@notcows.com>
 pkgname=gdal
-pkgver=2.2.3
-pkgrel=1
+pkgver=2.2.4
+pkgrel=0
 pkgdesc="A translator library for raster and vector geospatial data formats"
 url="http://gdal.org"
 arch="all"
@@ -73,4 +73,4 @@ check() {
 	apps/ogr2ogr --formats | grep "PostgreSQL -vector- (rw+): PostgreSQL/PostGIS"
 }
 
-sha512sums="205c1723e2c5d7c1c5b6bb0a92e880db80eae5944da8f00705e7acc58a664474f7d3eb6e2783a1cd6eef7c6b43c76f94c75d109f43805438e8f0560b2f4843cf  gdal-2.2.3.tar.xz"
+sha512sums="3a857d47e66f879146981f36ae658a27eac771accb60fb8eaf243d7c06a053f484f6a0992e47b206a757faab4df4edba222e24604168299189b80a23a46b32b6  gdal-2.2.4.tar.xz"


### PR DESCRIPTION
upgrade GDAL to the latest version 2.2.4.