### PR TITLE
community/iotop: upgrade to python3

### DIFF
--- a/community/iotop/0001-Fix-build-error-with-Python-3-caused-by-itervalues-i.patch
+++ b/community/iotop/0001-Fix-build-error-with-Python-3-caused-by-itervalues-i.patch
@@ -1,0 +1,32 @@
+From 99c8d7cedce81f17b851954d94bfa73787300599 Mon Sep 17 00:00:00 2001
+From: Christophe Vu-Brugier <cvubrugier@fastmail.fm>
+Date: Fri, 17 Oct 2014 13:49:31 +0200
+Subject: [PATCH] Fix build error with Python 3 caused by itervalues() in
+ setup.py
+
+The itervalues() method is not available in Python 3. As a
+consequence, this patch replaces the call to itervalues() in setup.py
+with a call to values() which works on both Python 2 and Python 3.
+
+Signed-off-by: Christophe Vu-Brugier <cvubrugier@fastmail.fm>
+Signed-off-by: Paul Wise <pabs3@bonedaddy.net>
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 7150102..9de6068 100755
+--- a/setup.py
++++ b/setup.py
+@@ -7,7 +7,7 @@ from iotop.version import VERSION
+ # Dirty hack to make setup.py install the iotop script to sbin/ instead of bin/
+ # while still honoring the choice of installing into local/ or not.
+ if hasattr(distutils_install, 'INSTALL_SCHEMES'):
+-    for d in distutils_install.INSTALL_SCHEMES.itervalues():
++    for d in distutils_install.INSTALL_SCHEMES.values():
+         if d.get('scripts', '').endswith('/bin'):
+             d['scripts'] = d['scripts'][:-len('/bin')] + '/sbin'
+ 
+-- 
+2.17.0
+

--- a/community/iotop/APKBUILD
+++ b/community/iotop/APKBUILD
@@ -2,30 +2,32 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=iotop
 pkgver=0.6
-pkgrel=1
+pkgrel=2
 pkgdesc="I/O monitoring tool"
 url="http://guichaz.free.fr/iotop/"
 arch="noarch"
 license="GPL-2.0"
-depends="python2"
+depends="python3"
 depends_dev=""
-makedepends="python2-dev py-setuptools"
+makedepends="python3-dev py3-setuptools"
 install=""
 subpackages="$pkgname-doc"
-source="http://guichaz.free.fr/iotop/files/iotop-$pkgver.tar.bz2"
+source="http://guichaz.free.fr/iotop/files/iotop-$pkgver.tar.bz2
+	0001-Fix-build-error-with-Python-3-caused-by-itervalues-i.patch
+	fix-python-path.patch"
 
 builddir="$srcdir"/iotop-$pkgver
 
 build() {
 	cd "$builddir"
-	python2 setup.py build || return 1
+	python3 setup.py build || return 1
 }
 
 package() {
 	cd "$builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	python3 setup.py install --prefix=/usr --root="$pkgdir" || return 1
 }
 
-md5sums="5ef9456b26d7694abf3101a72e1e0d1d  iotop-0.6.tar.bz2"
-sha256sums="3adea2a24eda49bbbaeb4e6ed2042355b441dbd7161e883067a02bfc8dcef75b  iotop-0.6.tar.bz2"
-sha512sums="b1047da3bc46604447cc8ab22442a3a5381e1a79a6b176fe9ee8402ee5cebb959205407a6aeaffccccde9d2f67624ff8ee6717b051838f13ab88bf3a16db3ab9  iotop-0.6.tar.bz2"
+sha512sums="b1047da3bc46604447cc8ab22442a3a5381e1a79a6b176fe9ee8402ee5cebb959205407a6aeaffccccde9d2f67624ff8ee6717b051838f13ab88bf3a16db3ab9  iotop-0.6.tar.bz2
+80e32c6ef37315c27ef93bab5295ace1e1626b8935361b43243a9302796174d3eef2012840e6be10ee4931d652a309e4bfeaba65c54f8f4ce88b93515b1640d2  0001-Fix-build-error-with-Python-3-caused-by-itervalues-i.patch
+704f2bed6863f9e2c9bf5a6a58b6ff95b8172bdcdf33d15c7eddf7ecccbb7689f51eca2424343128247fa45521c68c0a68772d2fbbce044b7f1da228e29e3a15  fix-python-path.patch"

--- a/community/iotop/APKBUILD
+++ b/community/iotop/APKBUILD
@@ -4,9 +4,9 @@ pkgname=iotop
 pkgver=0.6
 pkgrel=2
 pkgdesc="I/O monitoring tool"
-url="http://guichaz.free.fr/iotop/"
+url="http://guichaz.free.fr/iotop"
 arch="noarch"
-license="GPL-2.0"
+license="GPL-2.0-or-later"
 depends="python3"
 depends_dev=""
 makedepends="python3-dev py3-setuptools"
@@ -14,18 +14,18 @@ install=""
 subpackages="$pkgname-doc"
 source="http://guichaz.free.fr/iotop/files/iotop-$pkgver.tar.bz2
 	0001-Fix-build-error-with-Python-3-caused-by-itervalues-i.patch
-	fix-python-path.patch"
-
+	fix-python-path.patch
+	"
 builddir="$srcdir"/iotop-$pkgver
 
 build() {
 	cd "$builddir"
-	python3 setup.py build || return 1
+	python3 setup.py build
 }
 
 package() {
 	cd "$builddir"
-	python3 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
 }
 
 sha512sums="b1047da3bc46604447cc8ab22442a3a5381e1a79a6b176fe9ee8402ee5cebb959205407a6aeaffccccde9d2f67624ff8ee6717b051838f13ab88bf3a16db3ab9  iotop-0.6.tar.bz2

--- a/community/iotop/fix-python-path.patch
+++ b/community/iotop/fix-python-path.patch
@@ -1,0 +1,8 @@
+--- a/setup.py
++++ b/setup.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/python3
+ 
+ from distutils.core import setup
+ from distutils.command import install as distutils_install


### PR DESCRIPTION
`0001-Fix-build-error-with-Python-3-caused-by-itervalues-i.patch` is sourced from [upstream](http://repo.or.cz/w/iotop.git/commit/99c8d7cedce81f17b851954d94bfa73787300599) and enables building with python3.