### PR TITLE
main/openvswitch: improve test coverage

### DIFF
--- a/main/openvswitch/APKBUILD
+++ b/main/openvswitch/APKBUILD
@@ -2,14 +2,16 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=openvswitch
 pkgver=2.9.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A production quality, multilayer virtual switch"
 url="http://openvswitch.org/"
 arch="all"
 license="Apache-2.0"
 depends=""
 depends_dev="libressl-dev"
-makedepends="$depends_dev perl python2 linux-headers bash py-six"
+checkdepends="diffutils"
+options="!check" # Travis on github is single threaded
+makedepends="$depends_dev perl python2 linux-headers bash py-six autoconf"
 subpackages="$pkgname-doc $pkgname-dbg $pkgname-dev
 	$pkgname-monitor::noarch $pkgname-bash-completion:bashcomp:noarch"
 source="http://openvswitch.org/releases/$pkgname-$pkgver.tar.gz
@@ -21,6 +23,7 @@ source="http://openvswitch.org/releases/$pkgname-$pkgver.tar.gz
 	musl-if_packet.patch
 	ifupdown-alpine.patch
 	readme.debian.patch
+	fix-sed-tests.patch
 	"
 
 builddir="$srcdir/$pkgname-$pkgver"
@@ -37,9 +40,17 @@ build() {
 }
 
 check() {
+	local start= end=
 	cd "$builddir"
 
-	make check || true
+	start=$(date +%M)
+
+	make check TESTSUITEFLAGS='-j4' || true
+
+	end=$(date +%M)
+	printf "\n===================================\n"
+	printf "## Tests completed in $(expr $end - $start) minutes ##\n"
+	printf "===================================\n\n"
 }
 
 monitor() {
@@ -96,4 +107,5 @@ b1588d076bbfc7ef2dd46fce8e46186f40cbbc4667697f7ac13ddc68e34568fdab315fde47838de7
 1e08aa5ac6ce55b97256478b9243c8a4c92a42a97fc70ea0439c832b12a775af28a127224ae6c4ce01642dde65f76c610a44105912338bf443d8ea390c2d9ccf  ovs-modules.initd
 c5f137bce28bf80c1e5a6ca18722dae9a5ecff03d20bf92642270951bbbb499e5fb05a08163442720e866d135fcd7426b88add0b42ed240d5f0c068aa9fcd9da  musl-if_packet.patch
 eca5b19954e6df7dc17c582e22e4b27533710d077039a54a2ba291ae7d3a2706872f5bcad8795ca58e06ca7e45a9b8c4c51e99aedbabd0e87623972ebcdca230  ifupdown-alpine.patch
-2874bc7b4552c21d21e06f73c63ac5cf72d7db5252b51a0ac17b58e8cd536453c15e494c59b432aacba03be5cc309a4074ccdac11420a1613c22aa3fe07def7f  readme.debian.patch"
+2874bc7b4552c21d21e06f73c63ac5cf72d7db5252b51a0ac17b58e8cd536453c15e494c59b432aacba03be5cc309a4074ccdac11420a1613c22aa3fe07def7f  readme.debian.patch
+5f21d97d028886ee26677352027ec1171a01cede385a4ead7ffbd2aafa179d9a6c819de6d37ddc396533b2ade869318c661a6012c852662b45b7f3607674a1ae  fix-sed-tests.patch"

--- a/main/openvswitch/fix-sed-tests.patch
+++ b/main/openvswitch/fix-sed-tests.patch
@@ -1,0 +1,20 @@
+Reported-by: Stuart Cardall
+Reported-at: https://mail.openvswitch.org/pipermail/ovs-discuss/2018-March/046460.html
+Signed-off-by: Ben Pfaff
+---
+ tests/pmd.at | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/pmd.at b/tests/pmd.at
+index 1568ab991e2f..532a182ba8c2 100644
+--- a/tests/pmd.at
++++ b/tests/pmd.at
+@@ -149,7 +149,7 @@ TMP=$(cat ovs-vswitchd.log | wc -l | tr -d [[:blank:]])
+ AT_CHECK([ovs-vsctl set Open_vSwitch . other_config:pmd-cpu-mask=0x3])
+ CHECK_PMD_THREADS_CREATED([2], [], [+$TMP])
+ 
+-AT_CHECK([ovs-appctl dpif-netdev/pmd-rxq-show | sed ':a;/AVAIL$/{N;s/\n//;ba}' | parse_pmd_rxq_show_group | sed SED_NUMA_CORE_QUEUE_PATTERN], [0], [dnl
++AT_CHECK([ovs-appctl dpif-netdev/pmd-rxq-show | sed ':a;/AVAIL$/{N;s/\n//;ba;}' | parse_pmd_rxq_show_group | sed SED_NUMA_CORE_QUEUE_PATTERN], [0], [dnl
+ port: p0 queue-id: <group>
+ port: p0 queue-id: <group>
+ ])


### PR DESCRIPTION
* adds `diffutils` as a `$checkdepends`

  without this tests incompatible with Busybox `diff` would be skipped