### PR TITLE
main/haproxy: upgrade to 1.8.12

### DIFF
--- a/main/haproxy/APKBUILD
+++ b/main/haproxy/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jeff Bilyk <jbilyk@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=haproxy
-pkgver=1.8.5
+pkgver=1.8.12
 _pkgmajorver=${pkgver%.*}
 pkgrel=0
 pkgdesc="A TCP/HTTP reverse proxy for high availability environments"
@@ -49,7 +49,7 @@ package() {
 	        "$pkgdir"/etc/haproxy/haproxy.cfg
 }
 
-sha512sums="5fd8796e4e1964ba8f010dc775de7a0953c4a7137c817bd81c5b4b6a063f3f9694f122f48bebf014c5cc8b49cf8f0a57b6bed282af12c560bd6dcc6770792cf2  haproxy-1.8.5.tar.gz
+sha512sums="2b782a54988cc88d1af0e5f011af062910e8fac28eab13db7e05a58d0d23961f827da47e3871e8d081f5a2d222588480d81dec2e9f14ec9f54a1c3cb5bf3d56a  haproxy-1.8.12.tar.gz
 636bb2b18ad1de7f9cf97f69c8a911aae6575787eac999d1c419bf22989a3a36a7de14d21620a9919ae717be807518c9db0e20c46ca5788a3f9a5857ceb0bfee  libressl-2.7.patch
 3ab277bf77fe864ec6c927118dcd70bdec0eb3c54535812d1c3c0995fa66a3ea91a73c342edeb8944caeb097d2dd1a7761099182df44af5e3ef42de6e2176d26  haproxy.initd
 26bc8f8ac504fcbaec113ecbb9bb59b9da47dc8834779ebbb2870a8cadf2ee7561b3a811f01e619358a98c6c7768e8fdd90ab447098c05b82e788c8212c4c41f  haproxy.cfg"


### PR DESCRIPTION
Ref
- 1.8.6 https://www.mail-archive.com/haproxy@formilux.org/msg29496.html
- 1.8.7 https://www.mail-archive.com/haproxy@formilux.org/msg29522.html
- 1.8.8 https://www.mail-archive.com/haproxy@formilux.org/msg29683.html
- 1.8.9 https://www.mail-archive.com/haproxy@formilux.org/msg30047.html
- 1.8.10 https://www.mail-archive.com/haproxy@formilux.org/msg30464.html
- 1.8.11 https://www.mail-archive.com/haproxy@formilux.org/msg30537.html
- 1.8.12 https://www.mail-archive.com/haproxy@formilux.org/msg30554.html