### PR TITLE
community/py-distutils-extra: add Python 3 version

### DIFF
--- a/community/py-distutils-extra/APKBUILD
+++ b/community/py-distutils-extra/APKBUILD
@@ -3,24 +3,53 @@
 pkgname=py-distutils-extra
 _pkgname=python-distutils-extra
 pkgver=2.39
-pkgrel=1
+pkgrel=2
 pkgdesc="Enhanced distutils package for python"
 url="https://launchpad.net/python-distutils-extra"
 arch="noarch"
 license="GPL"
 depends="py-setuptools"
-makedepends="python2-dev"
+makedepends="python2-dev python3-dev"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="https://launchpad.net/python-distutils-extra/trunk/$pkgver/+download/$_pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
 	python2 setup.py build
+	python3 setup.py build
 }
 
-package() {
+check() {
 	cd "$builddir"
-	python2 setup.py install --root="$pkgdir"
+	python2 setup.py check
+	python3 setup.py check
+}
+
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --root="$subpkgdir"
 }
 
 sha512sums="e3b4d1ed22767fb4c6dbbdccef960865b6fda01d18dc38cb8f9357c09c7eabb78466fce053e407a196eca257d07d57c5c1ef47f358a5979c7f22e4b11775124e  python-distutils-extra-2.39.tar.gz"


### PR DESCRIPTION
This adds Python 3 support to py-distutils-extra (which has been missing previously).