### PR TITLE
main/alpine-mirrors: add tuna and aliyun mirror

### DIFF
--- a/main/alpine-mirrors/mirrors.yaml
+++ b/main/alpine-mirrors/mirrors.yaml
@@ -141,3 +141,15 @@
   - https://mirror.neostrada.nl/alpine/
   - ftp://mirror.neostrada.nl/alpine/
   - rsync://mirror.neostrada.nl/alpine/
+- name: Tsinghua Open Source Mirror
+  location: China, Beijing
+  bandwidth: 1Gbit/s
+  urls:
+  - https://mirrors.tuna.tsinghua.edu.cn/alpine/
+  - rsync://mirrors.tuna.tsinghua.edu.cn/alpine/
+- name: Aliyun Open Source Mirror
+  location: China, Hangzhou
+  bandwidth: 1Gbit/s
+  urls:
+  - http://mirrors.aliyun.com/alpine/
+  - https://mirrors.aliyun.com/alpine/


### PR DESCRIPTION
All mirrors is very slow or unable to access from China, aliyun and tuna mian a very good mirror of alpine, this will easy the pain to install alpine from China.