### PR TITLE
main/libvncserver: fix CVE-2018-7225

### DIFF
--- a/main/libvncserver/APKBUILD
+++ b/main/libvncserver/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: A. Wilcox <awilfox@adelielinux.org>
 pkgname=libvncserver
 pkgver=0.9.11
-pkgrel=1
+pkgrel=2
 pkgdesc="Library to make writing a vnc server easy"
 url="http://libvncserver.sourceforge.net/"
 arch="all"
@@ -16,15 +16,17 @@ makedepends="$depends_dev autoconf automake libtool"
 install=""
 subpackages="$pkgname-dev"
 source="https://github.com/LibVNC/libvncserver/archive/LibVNCServer-$pkgver.tar.gz
-	"
+	CVE-2018-7225.patch"
+
 # secfixes:
+#   0.9.11-r2:
+#     - CVE-2018-7225
 #   0.9.11-r0:
 #     - CVE-2016-9941
 #     - CVE-2016-9942
 
 builddir="$srcdir"/libvncserver-LibVNCServer-$pkgver
 prepare() {
-	cd "$builddir"
 	default_prepare
 	./autogen.sh
 }
@@ -50,6 +52,5 @@ package() {
 	make install DESTDIR="$pkgdir"
 }
 
-md5sums="7f06104d5c009813e95142932c4ddb06  LibVNCServer-0.9.11.tar.gz"
-sha256sums="193d630372722a532136fd25c5326b2ca1a636cbb8bf9bb115ef869c804d2894  LibVNCServer-0.9.11.tar.gz"
-sha512sums="e473c081b68dd3cdd96a1756b4f4945ece79d3c8e4cef62140be1699671555fc16d3080e81d764197a14ea83203ffcd0e18c3cc182e012d036e3faae943003fb  LibVNCServer-0.9.11.tar.gz"
+sha512sums="e473c081b68dd3cdd96a1756b4f4945ece79d3c8e4cef62140be1699671555fc16d3080e81d764197a14ea83203ffcd0e18c3cc182e012d036e3faae943003fb  LibVNCServer-0.9.11.tar.gz
+1704254e74aa0adca48669c28ff475bf82a9468cf31edf43c3e0d10178307a7c8ecd8a8f11c061931318a6e529922d4adc188347da1e632dc2ade604a4388706  CVE-2018-7225.patch"

--- a/main/libvncserver/CVE-2018-7225.patch
+++ b/main/libvncserver/CVE-2018-7225.patch
@@ -1,0 +1,63 @@
+From 28afb6c537dc82ba04d5f245b15ca7205c6dbb9c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <ppisar@redhat.com>
+Date: Mon, 26 Feb 2018 13:48:00 +0100
+Subject: [PATCH] Limit client cut text length to 1 MB
+
+This patch constrains a client cut text length to 1 MB. Otherwise
+a client could make server allocate 2 GB of memory and that seems to
+be to much to classify it as a denial of service.
+
+The limit also prevents from an integer overflow followed by copying
+an uninitilized memory when processing msg.cct.length value larger
+than SIZE_MAX or INT_MAX - sz_rfbClientCutTextMsg.
+
+This patch also corrects accepting length value of zero (malloc(0) is
+interpreted on differnet systems differently).
+
+CVE-2018-7225
+<https://github.com/LibVNC/libvncserver/issues/218>
+---
+ libvncserver/rfbserver.c | 20 +++++++++++++++++++-
+ 1 file changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/libvncserver/rfbserver.c b/libvncserver/rfbserver.c
+index 116c488..4fc4d9d 100644
+--- a/libvncserver/rfbserver.c
++++ b/libvncserver/rfbserver.c
+@@ -85,6 +88,8 @@
+ #include <errno.h>
+ /* strftime() */
+ #include <time.h>
++/* PRIu32 */
++#include <inttypes.h>
+ 
+ #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
+ #include "rfbssl.h"
+@@ -2577,7 +2577,23 @@ rfbProcessClientNormalMessage(rfbClientPtr cl)
+ 
+ 	msg.cct.length = Swap32IfLE(msg.cct.length);
+ 
+-	str = (char *)malloc(msg.cct.length);
++	/* uint32_t input is passed to malloc()'s size_t argument,
++	 * to rfbReadExact()'s int argument, to rfbStatRecordMessageRcvd()'s int
++	 * argument increased of sz_rfbClientCutTextMsg, and to setXCutText()'s int
++	 * argument. Here we impose a limit of 1 MB so that the value fits
++	 * into all of the types to prevent from misinterpretation and thus
++	 * from accessing uninitialized memory (CVE-2018-7225) and also to
++	 * prevent from a denial-of-service by allocating to much memory in
++	 * the server. */
++	if (msg.cct.length > 1<<20) {
++	    rfbLog("rfbClientCutText: too big cut text length requested: %" PRIu32 "\n",
++		    msg.cct.length);
++	    rfbCloseClient(cl);
++	    return;
++	}
++
++	/* Allow zero-length client cut text. */
++	str = (char *)calloc(msg.cct.length ? msg.cct.length : 1, 1);
+ 	if (str == NULL) {
+ 		rfbLogPerror("rfbProcessClientNormalMessage: not enough memory");
+ 		rfbCloseClient(cl);
+-- 
+2.17.0
+


### PR DESCRIPTION
Patch for CVE-2018-7225 sourced from [upstream](https://github.com/LibVNC/libvncserver/commit/28afb6c537dc82ba04d5f245b15ca7205c6dbb9c).