### PR TITLE
testing/softhsm: fix test failure on x86

### DIFF
--- a/testing/softhsm/APKBUILD
+++ b/testing/softhsm/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Frank Felhoffer <silveraid@hackme.ca>
 pkgname=softhsm
 pkgver=2.4.0
-pkgrel=0
+pkgrel=1
 pkgdesc="cryptographic store accessible through a PKCS #11"
 url="https://www.opendnssec.org/softhsm/"
 arch="all"
@@ -12,7 +12,8 @@ checkdepends="cppunit-dev"
 makedepends="autoconf automake botan-dev libtool p11-kit-dev sqlite-dev"
 install=""
 subpackages="$pkgname-doc"
-source="https://dist.opendnssec.org/source/$pkgname-$pkgver.tar.gz"
+source="https://dist.opendnssec.org/source/$pkgname-$pkgver.tar.gz
+        fix-objstoretest.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -42,5 +43,7 @@ package() {
         make -j1 DESTDIR="$pkgdir/" install
 }
 
-sha256sums="26aac12bdeaacd15722dc0a24a5a1981a3b711e61d10ac687a23ff0b7075da07  softhsm-2.4.0.tar.gz"
-sha512sums="f14f65de32206500f708523ee88d8d5e3d1fd40175f1a9cd24c7760c829e2de9dbcb05453022df8186836c49a57e4eae7f2e75ce6a5346a426114f4d610a8a84  softhsm-2.4.0.tar.gz"
+sha256sums="26aac12bdeaacd15722dc0a24a5a1981a3b711e61d10ac687a23ff0b7075da07  softhsm-2.4.0.tar.gz
+bc1744ee8d1b64538bc0e12cf8cd3d8d39fe2fc2b6dbdf7c7f0e07991047a0ef  fix-objstoretest.patch"
+sha512sums="f14f65de32206500f708523ee88d8d5e3d1fd40175f1a9cd24c7760c829e2de9dbcb05453022df8186836c49a57e4eae7f2e75ce6a5346a426114f4d610a8a84  softhsm-2.4.0.tar.gz
+5c16c1c7cf6bd609d3355ac036e392abd243b710c90212247f48849f1ee87347725d7c835a5a286e0948248b43d031a15f0c21f962f1690dd8e6d3c0fa62632b  fix-objstoretest.patch"

--- a/testing/softhsm/fix-objstoretest.patch
+++ b/testing/softhsm/fix-objstoretest.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib/object_store/test/DBTests.cpp b/src/lib/object_store/test/DBTests.cpp
+index d787a83..0e68358 100644
+--- a/src/lib/object_store/test/DBTests.cpp
++++ b/src/lib/object_store/test/DBTests.cpp
+@@ -348,7 +348,7 @@ void test_a_db_with_a_connection_with_tables::can_update_integer_attribute_bound
+ 
+ 	// insert integer attribute
+ 	statement = connection->prepare(
+-				"insert into attribute_integer (value,type,object_id) values (%lld,%d,%lld)",
++				"insert into attribute_integer (value,type,object_id) values (%d,%d,%lld)",
+ 				1111,
+ 				1235,
+ 				object_id);


### PR DESCRIPTION
The conversion of an int to long long for some reason caused this test
failure. Why this is not also a problem on x86_64 is still a mystery to me.