### PR TITLE
libvpx: Update to 1.7.0

### DIFF
--- a/community/ffmpeg/APKBUILD
+++ b/community/ffmpeg/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=ffmpeg
 pkgver=3.4.4
-pkgrel=0
+pkgrel=1
 pkgdesc="Complete and free Internet live audio and video broadcasting solution for Linux/Unix"
 url="http://ffmpeg.org/"
 arch="all"

--- a/community/gst-plugins-good/APKBUILD
+++ b/community/gst-plugins-good/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gst-plugins-good
 pkgver=1.14.2
-pkgrel=0
+pkgrel=1
 pkgdesc="GStreamer Multimedia Framework Good Plugins"
 url="https://gstreamer.freedesktop.org"
 arch="all"

--- a/community/mplayer/APKBUILD
+++ b/community/mplayer/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=mplayer
 pkgver=1.3.0
 _ver=${pkgver/_/}
-pkgrel=6
+pkgrel=7
 pkgdesc="A movie player for linux"
 url="http://www.mplayerhq.hu/"
 arch="x86_64"

--- a/community/vlc/APKBUILD
+++ b/community/vlc/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=vlc
 pkgver=3.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A multi-platform MPEG, VCD/DVD, and DivX player"
 triggers="vlc-libs.trigger=/usr/lib/vlc/plugins"
 pkgusers="vlc"

--- a/community/xpra/APKBUILD
+++ b/community/xpra/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=xpra
 pkgver=2.3.4
-pkgrel=0
+pkgrel=1
 pkgdesc="Xpra is 'screen for X' & allows you to run X programs, usually on a remote host over SSH or encrypted tcp"
 url="https://xpra.org"
 # !armhf: fails to build

--- a/main/libvpx/APKBUILD
+++ b/main/libvpx/APKBUILD
@@ -1,17 +1,17 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libvpx
-pkgver=1.6.1
+pkgver=1.7.0
 pkgrel=0
 pkgdesc="Library for the vp8 codec"
 url="https://www.webmproject.org/"
 arch="all"
 license="GPL"
 depends=""
-makedepends="coreutils yasm bash perl"
+makedepends="coreutils diffutils yasm bash perl"
 subpackages="$pkgname-dev $pkgname-utils"
-source="https://storage.googleapis.com/downloads.webmproject.org/releases/webm/$pkgname-$pkgver.tar.bz2"
+source="$pkgname-$pkgver.tar.gz::https://github.com/webmproject/libvpx/archive/v$pkgver.tar.gz"
 
-builddir="$srcdir"/$pkgname-$pkgver
+builddir="$srcdir/$pkgname-$pkgver"
 build() {
 	cd "$builddir"
 	# build fix for arm
@@ -43,4 +43,4 @@ utils() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="1a4b009fe1737715c6563a79848126a5859394a5074b1e9cca9bc2e213df90890c15e708040d5f2c96c7c21e268f51e1352ac6911514bf891a4bf3eea154159d  libvpx-1.6.1.tar.bz2"
+sha512sums="8b3b766b550f8d86907628d7ed88035f9a2612aac21542e0fd5ad35b905eb82cbe1be02a1a24afce7a3bcc4766f62611971f72724761996b392136c40a1e7ff0  libvpx-1.7.0.tar.gz"

--- a/testing/firefox/APKBUILD
+++ b/testing/firefox/APKBUILD
@@ -4,7 +4,7 @@ pkgname=firefox
 pkgver=62.0.2
 _pkgver=$pkgver
 _xulver=$pkgver
-pkgrel=0
+pkgrel=1
 pkgdesc="Firefox web browser"
 url="http://www.firefox.com"
 # limited by rust and cargo

--- a/testing/seamonkey/APKBUILD
+++ b/testing/seamonkey/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Marc Vertes <mvertes@free.fr>
 pkgname=seamonkey
 pkgver=2.49.4
-pkgrel=1
+pkgrel=2
 pkgdesc="all-in-one internet application suite"
 url="http://www.seamonkey-project.org"
 arch="x86_64"


### PR DESCRIPTION
Version Bump, touch dependent packages, changed source URL to Github Release (because "official" tarball is kinda broken)
