### PR TITLE
scripts/mkimg: use -rational-rock to avoid uid pollution

### DIFF
--- a/scripts/mkimg.base.sh
+++ b/scripts/mkimg.base.sh
@@ -251,7 +251,7 @@ create_image_iso() {
 			-output ${ISO} \
 			-full-iso9660-filenames \
 			-joliet \
-			-rock \
+			-rational-rock \
 			-sysid LINUX \
 			-volid "alpine-$PROFILE $RELEASE $ARCH" \
 			$_isolinux \


### PR DESCRIPTION
ISO image should have files owned by root, not leaking the builder uid.