### PR TITLE
community/libcouchbase: upgrade to 2.8.7

### DIFF
--- a/community/libcouchbase/APKBUILD
+++ b/community/libcouchbase/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Nathan Johnson <nathan@nathanjohnson.info>
 # Maintainer: Nathan Johnson <nathan@nathanjohnson.info>
 pkgname=libcouchbase
-pkgver=2.8.5
-pkgrel=2
+pkgver=2.8.7
+pkgrel=0
 pkgdesc="C client library for Couchbase"
 url="https://developer.couchbase.com/community"
 arch="all"
@@ -73,6 +73,6 @@ bin() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="82f9c45ea1f79fc53b54badd7de2f9ca69e0a941d09664ce80547135b36d425197f2e37d88710cef2d92c31f91718ef752fa87223214e549075c4427ae2f7d24  libcouchbase-2.8.5.tar.gz
+sha512sums="e83bf3e2330f320c735b24466ec46f33d3f2c31c180c3d02cbd4c276623e4b10def46e0160c1f461a7d5b234ffdac6638f5ab864048b48f39a3e7983307b2e24  libcouchbase-2.8.7.tar.gz
 987b76b9c8a38a1f144bcada3c24192b30b352c993c433f4a2a1e381b765ae6bb845ebc6393c794da1b4efbb68fd1d34b027104fecf5c9bcc29b0f58c7f6a474  disable_git_version_check.patch
 72319b86fdd91728723ccb091e72199788a84e2ec9ea12c0fcd1ed686eb155ec11e0addbff96735f83e7f31764a85650f0483b6e76d3a8bee16f71b2751fe4a9  fix_socktest.patch"


### PR DESCRIPTION
Upgrade of `php7-couchbase` require upgrade of `libcouchbase` to **2.8.6** at least
* https://github.com/couchbase/libcouchbase/releases/tag/2.8.7
* https://pecl.php.net/package-changelog.php?package=couchbase&release=2.4.6