### PR TITLE
community/phpmyadmin: upgrade to 4.8.0

### DIFF
--- a/community/phpmyadmin/APKBUILD
+++ b/community/phpmyadmin/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Matt Smith <mcs@darkregion.net>
 _php=php5
 pkgname=phpmyadmin
-pkgver=4.7.8
+pkgver=4.8.0
 pkgrel=0
 pkgdesc="A Web-based PHP tool for administering MySQL"
 url="https://www.phpmyadmin.net/"
@@ -100,5 +100,5 @@ doc() {
 	done
 }
 
-sha512sums="ae6edcfba72413a6e0af0b120a99809320a840ab332ae77263f21e14f3b34a38cca70591628ba5818d6732ff6d23551ea51cbf6a75012d2326d0fab1c2a1b9ae  phpMyAdmin-4.7.8-all-languages.tar.xz
+sha512sums="50d69ebc1e0a814d1a348a59e6cb42931dbd1d8a9b16e542293b8e30e2ed0ec45ccd993c4388733ce3b099536db39accbc86941554710a4b4b4de8368f9dac02  phpMyAdmin-4.8.0-all-languages.tar.xz
 c6af2960b95924c31cc05d90e7282ba9be6cb6eabb134b8bb627230a4253c017eca75132420a356acd6aecdce146e29666ed90fc90749820060a64478d3e2105  phpmyadmin.apache2.conf"


### PR DESCRIPTION
Ref https://www.phpmyadmin.net/news/2018/4/7/phpmyadmin-480-released/