### PR TITLE
community/riot-web: upgrade to 0.14.1

### DIFF
--- a/community/riot-web/APKBUILD
+++ b/community/riot-web/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
 # Maintainer: Carlo Landmeter <clandmeter@alpinelinux.org>
 pkgname=riot-web
-pkgver=0.13.5
+pkgver=0.14.1
 pkgrel=0
 pkgdesc="A glossy Matrix collaboration client for the web"
 url="http://riot.im/"
@@ -25,4 +25,4 @@ package() {
 		"$pkgdir"/usr/share/webapps/riot-web/config.json
 }
 
-sha512sums="d892ea9871bcb7df08702b1f2d57f1126e59167aa23941501e0f9af70dc725235d6df3d319ebe46b549de86bb8b4b83d3b01da094a07d781cb6ecd580a4daab2  riot-v0.13.5.tar.gz"
+sha512sums="2121c8e7269ef7b83968e3c65fd9a905e8ffbd757c571cbf1e7238fbed18dbb23394192db27baf82a4f6d4042b9754b7a71b9c1a7bcf485e23f53850f6d2fa04  riot-v0.14.1.tar.gz"


### PR DESCRIPTION
Ref https://github.com/vector-im/riot-web/releases/tag/v0.14.1