### PR TITLE
Fix VPNC not working

### DIFF
--- a/testing/vpnc/APKBUILD
+++ b/testing/vpnc/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=vpnc
 pkgver=0.5.3
-pkgrel=1
+pkgrel=2
 pkgdesc="IPSec VPN client compatible with Cisco equipment"
 url="http://www.unix-ag.uni-kl.de/~massar/vpnc/"
 arch="all"
 license="GPL-2.0-or-later"
-makedepends="libgcrypt-dev perl"
+makedepends="libgcrypt-dev perl linux-headers"
 subpackages="$pkgname-doc"
 source="http://www.unix-ag.uni-kl.de/~massar/vpnc/vpnc-$pkgver.tar.gz
 	working.patch
@@ -35,6 +35,6 @@ package() {
 }
 
 sha512sums="fd1251d200c3826ebfd7022683e38912f30c2a95fbc51259bcd1fdf0570ef3c53cd842003c117a770657f7f8ebb00ceffeea91ced0c3f83dd9c1ca0488519ea3  vpnc-0.5.3.tar.gz
-6c3eb976d3877b02c751c310f835bc864e4868d167bbaf9f365b9b728d732cc018591e9a8dfc5a4277b01daf070b74f3bb7e67e175b90ee495fecec1a049e29f  working.patch
+7bb2334085d98dc206853fa92368684492f5bfd62b6dee54acebd5d114bfa3b2fb5ac3d65450a102b53da9b15de84182176705031fa97e61042c4144aa8d1e45  working.patch
 d20091a67ccd3b8e9f31ca47c49577ff3cd5bf6ba9ef7bcd9f03231d87fa64d978c60ab69c67bbafdc18d6474d932d6ec68de02d13bea41ae6a7d31b845635e9  vpnc.initd
 1254f687dcd9822becfcccabbb34d8343d715d70247dbf4b5e018835fff24b33f5272368f77199d697c8d11d913182b1f756d5e08a46b2057849779f09b19633  vpnc.confd"

--- a/testing/vpnc/working.patch
+++ b/testing/vpnc/working.patch
@@ -1,29 +1,45 @@
-diff --git a/sysdep.c b/sysdep.c
-index ff07753..43fdb74 100644
---- a/sysdep.c
-+++ b/sysdep.c
-@@ -59,7 +59,7 @@
+Author: Rien Maertens <maertensrien@gmail.com>
+Description: Fixes VPNC not working. Patch taken and modified from OpenWRT.
+URL: https://github.com/openwrt/packages/blob/master/net/vpnc/patches/100-musl-compat.patch
+--- orig/config.c
++++ patched/config.c
+@@ -26,7 +26,10 @@
+ #include <unistd.h>
+ #include <string.h>
+ #include <errno.h>
++#include <sys/ttydefaults.h>
++#include <sys/types.h>
+ #include <sys/utsname.h>
++#include <sys/wait.h>
+
+ #include <gcrypt.h>
+
+--- orig/sysdep.c
++++ patched/sysdep.c
+@@ -59,6 +59,10 @@
  #if defined(__DragonFly__)
  #include <net/tun/if_tun.h>
  #elif defined(__linux__)
--#include <linux/if_tun.h>
-+/*#include <linux/if_tun.h>*/
++# if !defined(__GLIBC__) && !defined(__UCLIBC__)
++#  define _LINUX_IF_ETHER_H
++#  include <net/ethernet.h>
++# endif
+ #include <linux/if_tun.h>
  #elif defined(__APPLE__)
  /* no header for tun */
- #elif defined(__CYGWIN__)
-diff --git a/sysdep.h b/sysdep.h
-index a5eafd6..af34e94 100644
---- a/sysdep.h
-+++ b/sysdep.h
-@@ -38,11 +38,13 @@ int tun_get_hwaddr(int fd, char *dev, uint8_t *hwaddr);
- 
+--- orig/sysdep.h
++++ patched/sysdep.h
+@@ -37,12 +37,14 @@
+ int tun_get_hwaddr(int fd, char *dev, uint8_t *hwaddr);
+
  /***************************************************************************/
- #if defined(__linux__) || defined(__GLIBC__)
-+#ifdef __GLIBC__
+-#if defined(__linux__) || defined(__GLIBC__)
++#if defined(__GLIBC__) || defined(__UCLIBC__)
  #include <error.h>
 +#define HAVE_ERROR     1
 +#endif
- 
+
++#if defined(__linux__) || defined(__GLIBC__)
  #define HAVE_VASPRINTF 1
  #define HAVE_ASPRINTF  1
 -#define HAVE_ERROR     1


### PR DESCRIPTION
VPNC did not work on my raspberry pi installation with the following message:
```
tilde:~# vpnc --debug 99                         
WARNING! active debug level is >= 99, output includes username and password (hex encoded)
WARNING! active debug level is >= 99, output includes username and password (hex encoded)

vpnc version 0.5.3
   hex_test: 00010203

S1 init_sockaddr
 [2018-04-14 14:47:48]

S2 make_socket
 [2018-04-14 14:47:48]

S3 setup_tunnel
 [2018-04-14 14:47:48]
   using interface
can't initialise tunnel interface: No such file or directory
```
I modified [OpenWRT's patch](https://github.com/openwrt/packages/blob/master/net/vpnc/patches/100-musl-compat.patch) and now it works on my system:
```
tilde:~# vpnc
VPNC started in background (pid: 2617)...
```