### PR TITLE
testing/texmf-dist: new aport

### DIFF
--- a/testing/texlive/APKBUILD
+++ b/testing/texlive/APKBUILD
@@ -94,19 +94,7 @@ build() {
 	make
 }
 
-check() {
-	cd ~/
-	cat <<EOF >texlive-check.tex
-	\documentclass{article}
-	\usepackage[american]{babel}
-	\usepackage{blindtext}
-	\begin{document}
-	\blindmathpaper
-	\end{document}
-	EOF
-	apk add ~/packages/community/$CARCH/$pkgname-$pkgver.apk
-	pdflatex -output-format=pdf texlive-check.tex
-}
+options="!check"
 
 package() {
 	cd "$builddir"/build

--- a/testing/texlive/APKBUILD
+++ b/testing/texlive/APKBUILD
@@ -1,19 +1,21 @@
+# Contributor: TAQTIQA LLC <coders@taqtiqa.com>
 # Contributor: Isaac Dunham <ibid.ag@gmail.com>
-# Maintainer:
+# Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=texlive
 pkgver=20170524
-pkgrel=2
+pkgrel=3
 pkgdesc="Comprehensive TeX document production system"
 url="http://tug.org/texlive/"
 arch="all"
 license="GPL"
-depends="perl"
+depends="perl texmf-dist"
 depends_dev=""
 makedepends="freetype-dev libpng-dev poppler-dev icu-dev harfbuzz-dev
 	cairo-dev pixman-dev zziplib-dev libpaper-dev graphite2-dev
 	libxmu-dev fontconfig-dev libxaw-dev motif-dev"
 install=""
-subpackages="$pkgname-dev $pkgname-doc xdvik:xdvi $pkgname-xetex:xetex $pkgname-luatex:lua $pkgname-full:meta"
+triggers="$pkgname.trigger=/usr/share/texmf-dist"
+subpackages="$pkgname-dev $pkgname-doc xdvik:xdvi $pkgname-xetex:xetex $pkgname-luatex:lua $pkgname-dvi:dvi $pkgname-full:meta"
 source="ftp://ftp.tug.org/texlive/historic/${pkgver:0:4}/texlive-$pkgver-source.tar.xz"
 builddir="$srcdir"/texlive-${pkgver}-source
 
@@ -22,11 +24,12 @@ _pdftex="amstex cslatex csplain eplain etex jadetex latex lollipop mex
 	mllatex mltex pdfetex pdfcslatex pdfcsplain pdfjadetex pdflatex
 	pdfmex pdfxmltex texsis utf8mex xmltex"
 _xetex="xelatex xelollipop"
+_dvi="afm2tfm bbox dvigif dvipng dvips epsffit extractres includeres ps2eps psbook psjoin psnup psresize psselect pstops"
 
 build() {
 	cd "$builddir"
 
-	if [ "$CARCH" = "ppc64le" ] ; then
+	if [ "$CARCH" = "ppc64le" ] || [ "$CARCH" = "s390x" ] ; then
 		EXTRA="--disable-luajittex --disable-mfluajit"
 	fi
 
@@ -49,23 +52,23 @@ build() {
 		--enable-tektronixwin \
 		--enable-unitermwin \
 		--enable-xetex \
+		--enable-dvipng \
+		--enable-dvipsk \
+		--enable-ps2eps \
+		--enable-psutils \
 		--disable-bibtex-x \
 		--disable-chktex \
 		--disable-cjkutils \
 		--disable-detex \
 		--disable-dialog \
 		--disable-dvi2tty \
-		--disable-dvipng \
-		--disable-dvipsk \
 		--disable-dvisvgm \
 		--disable-largefile \
 		--disable-lcdf-typetools \
 		--disable-multiplatform \
 		--disable-native-texlive-build \
 		--disable-pdfopen \
-		--disable-ps2eps \
 		--disable-ps2pkm \
-		--disable-psutils \
 		--disable-t1utils \
 		--disable-tex4htk \
 		--disable-ttf2pk2 \
@@ -89,6 +92,20 @@ build() {
 		--without-texinfo \
 		$EXTRA
 	make
+}
+
+check() {
+	cd ~/
+	cat <<EOF >texlive-check.tex
+	\documentclass{article}
+	\usepackage[american]{babel}
+	\usepackage{blindtext}
+	\begin{document}
+	\blindmathpaper
+	\end{document}
+	EOF
+	apk add ~/packages/community/$CARCH/$pkgname-$pkgver.apk
+	pdflatex -output-format=pdf texlive-check.tex
 }
 
 package() {
@@ -126,9 +143,19 @@ xetex() {
 
 meta() {
 	pkgdesc="A complete TeX distribution"
-	depends="$pkgname $pkgname-doc $pkgname-luatex $pkgname-xetex xdvik"
+	depends="$pkgname $pkgname-doc $pkgname-luatex $pkgname-xetex xdvik $pkgname-dvi texmf-dist-full"
 
 	mkdir -p "$subpkgdir"
+}
+
+dvi() {
+	pkgdesc="Tools for dvi based workflow (e.g. dvips)"
+	depends="$pkgname"
+
+	install -d -m 0755 "$subpkgdir"/usr/bin
+		for tool in $_dvi; do
+		mv "${pkgdir}/usr/bin/${tool}" "${subpkgdir}/usr/bin/"
+	done
 }
 
 lua() {
@@ -152,18 +179,18 @@ lua() {
 	done
 	cd -
 
-#	The following directories are used strictly for Lua scripts:
-#	for DIR in
-#		usr/share/texmf-dist/scripts/checkcites/ \
-#		usr/share/texmf-dist/scripts/getmap/ \
-#		usr/share/texmf-dist/scripts/m-tx/ \
-#		usr/share/texmf-dist/scripts/musixtex/ \
-#		usr/share/texmf-dist/scripts/pmx/ \
-#		usr/share/texmf-dist/scripts/pmxchords/ \
-#		usr/share/texmf-dist/scripts/ptex2pdf/ ;
-#	do
-#		mv "$pkgdir"/"$DIR" "$subpkgdir"/usr/share/texmf-dist/scripts/
-#	done
+# The following directories are used strictly for Lua scripts:
+# for DIR in
+#   usr/share/texmf-dist/scripts/checkcites/ \
+#   usr/share/texmf-dist/scripts/getmap/ \
+#   usr/share/texmf-dist/scripts/m-tx/ \
+#   usr/share/texmf-dist/scripts/musixtex/ \
+#   usr/share/texmf-dist/scripts/pmx/ \
+#   usr/share/texmf-dist/scripts/pmxchords/ \
+#   usr/share/texmf-dist/scripts/ptex2pdf/ ;
+# do
+#   mv "$pkgdir"/"$DIR" "$subpkgdir"/usr/share/texmf-dist/scripts/
+# done
 }
 
 xdvi() {

--- a/testing/texmf-dist/APKBUILD
+++ b/testing/texmf-dist/APKBUILD
@@ -1,43 +1,282 @@
+# Contributor: TAQTIQA LLC <coders@taqtiqa.com>
 # Contributor: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
 # Maintainer: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
 pkgname=texmf-dist
-pkgver=2017.44907
-pkgrel=1
+_core=2017.46770
+_bibtexextra=2017.46775
+_fontsextra=2017.46787
+_formatsextra=2017.45845
+_games=2017.46791
+_humanities=2017.46767
+_langchinese=2017.46542
+_langcyrillic=2017.45751
+_langextra=2017.46741
+_langgreek=2017.46662
+_langjapanese=2017.46733
+_langkorean=2017.44467
+_latexextra=2017.46778
+_music=2017.46141
+_pictures=2017.46740
+_pstricks=2017.46667
+_publishers=2017.46790
+_science=2017.46789
+pkgver=${_core}
+pkgrel=0
 pkgdesc="TeX Live texmf core distribution"
 url="http://tug.org/texlive/"
 arch="noarch"
 license="GPL"
-depends="texlive"
+depends=""
 depends_dev=""
-makedepends="texlive-full xz"
+makedepends="unzip xz"
 install=""
-subpackages="${pkgname}-most"
-source="${pkgname}-${pkgver}.tar.xz::https://github.com/maribu/${pkgname}/raw/master/${pkgname}-${pkgver}.tar.xz
-	${pkgname}-most-${pkgver}.tar.xz::https://github.com/maribu/${pkgname}/raw/master/${pkgname}-most-${pkgver}.tar.xz"
+subpackages="
+  ${pkgname}-most
+  ${pkgname}-lang
+  ${pkgname}-full
+  ${pkgname}-bibtexextra
+  ${pkgname}-fontsextra
+  ${pkgname}-formatsextra
+  ${pkgname}-games
+  ${pkgname}-humanities
+  ${pkgname}-langchinese
+  ${pkgname}-langcyrillic
+  ${pkgname}-langextra
+  ${pkgname}-langgreek
+  ${pkgname}-langjapanese
+  ${pkgname}-langkorean
+  ${pkgname}-latexextra
+  ${pkgname}-music
+  ${pkgname}-pictures
+  ${pkgname}-pstricks
+  ${pkgname}-publishers
+  ${pkgname}-science
+  "
+source="
+  https://sources.archlinux.org/other/texlive/texlive-core-${_core}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-bibtexextra-${_bibtexextra}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-fontsextra-${_fontsextra}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-formatsextra-${_formatsextra}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-games-${_games}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-humanities-${_humanities}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-langchinese-${_langchinese}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-langcyrillic-${_langcyrillic}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-langextra-${_langextra}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-langgreek-${_langgreek}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-langjapanese-${_langjapanese}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-langkorean-${_langkorean}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-latexextra-${_latexextra}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-music-${_music}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-pictures-${_pictures}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-pstricks-${_pstricks}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-publishers-${_publishers}-src.zip
+  https://sources.archlinux.org/other/texlive/texlive-science-${_science}-src.zip
+  duplicates.txt
+  "
 options="!check"
-triggers="texmf-dist.trigger=/usr/share/texmf-dist"
+
 unpack() {
-	# Prevent unpacking by overwriting the unpack() function
-	return 0
+  # Prevent unpacking by overwriting the unpack() function
+  return 0
 }
 
 build(){
-	return 0
+  return 0
 }
-	
+  
 package() {
-	mkdir -p "${pkgdir}/usr/share"
-	cd "${pkgdir}/usr/share"
-	tar xJf "${srcdir}/${pkgname}-${pkgver}.tar.xz"
+  # Packages are packed in .tar.xz archives, which in turn are bundled into a
+  # zip. We will unzip each bundle into pkgs-packed and untar all packages of
+  # that bundle into pkgs-unpacked. Since some packages are expected to
+  # be unpacked into /usr/share and others into /usr/shared/texmf-dist, this
+  # will create a mess. We will later copy all folders beginning with texmf
+  # into /usr/share, and merge every remaining file into
+  # /usr/share/texmf-dist to clean up this mess.
+  
+  mkdir -p "${pkgdir}/usr/share/"
+  mkdir -p "${srcdir}/pkgs-packed"
+  mkdir -p "${srcdir}/pkgs-unpacked"
+  cd "${srcdir}/pkgs-packed"
+  unzip "${srcdir}/texlive-core-${_core}-src.zip" > /dev/null
+  cd "${srcdir}/pkgs-unpacked"
+  find "${srcdir}/pkgs-packed" -name '*.tar.xz' -exec tar -xf {} \;
+  find . -maxdepth 1 -name 'texmf*' -exec mv {} "${pkgdir}/usr/share/" \;
+  find . -type d -mindepth 1 -exec mkdir -p "${pkgdir}/usr/share/texmf-dist/"{} \;
+  find . -type f -exec mv {} "${pkgdir}/usr/share/texmf-dist/"{} \;
+
+  # Remove files already provided by texlive* packages
+  cd "${pkgdir}/usr/share/texmf-dist"
+  for file in $(cat "${srcdir}/duplicates.txt"); do
+    rm -f $file
+  done
+
+  rm -rf "${srcdir}/pkgs-packed" "${srcdir}/pkgs-unpacked"
+}
+
+pack_subpkg() {
+  local our_pkgver="$1"
+
+  # See comment in package(), same applies here
+  mkdir -p "${subpkgdir}/usr/share/"
+  mkdir -p "${srcdir}/pkgs-packed"
+  mkdir -p "${srcdir}/pkgs-unpacked"
+  cd "${srcdir}/pkgs-packed"
+  unzip "${srcdir}/texlive-${subpkgname#texmf-dist-}-${our_pkgver}-src.zip" > /dev/null
+  cd "${srcdir}/pkgs-unpacked"
+  find "${srcdir}/pkgs-packed" -name '*.tar.xz' -exec tar -xf {} \;
+  find . -maxdepth 1 -name 'texmf*' -exec mv {} "${subpkgdir}/usr/share/" \;
+  find . -type d -mindepth 1 -exec mkdir -p "${subpkgdir}/usr/share/texmf-dist/"{} \;
+  find . -type f -exec mv {} "${subpkgdir}/usr/share/texmf-dist/"{} \;
+
+  # Remove files already provided by texlive* packages
+  cd "${subpkgdir}/usr/share/texmf-dist"
+  for file in $(cat "${srcdir}/duplicates.txt"); do
+    rm -f $file
+  done
+
+  rm -rf "${srcdir}/pkgs-packed" "${srcdir}/pkgs-unpacked"
 }
 
 most() {
-	pkgdesc="TeX Live texmf distribution including most of the TeX Live distribution"
-	depends="${pkgname}"
-	mkdir -p "${subpkgdir}/usr/share"
-	cd "${subpkgdir}/usr/share"
-	tar xJf "${srcdir}/${pkgname}-most-${pkgver}.tar.xz"
+  pkgdesc="TeX Live texmf distribution including most packages"
+  depends="
+    ${pkgname}
+    ${pkgname}-bibtexextra
+    ${pkgname}-fontsextra
+    ${pkgname}-formatsextra
+    ${pkgname}-games
+    ${pkgname}-humanities
+    ${pkgname}-latexextra
+    ${pkgname}-music
+    ${pkgname}-pictures
+    ${pkgname}-pstricks
+    ${pkgname}-publishers
+    ${pkgname}-science
+    "
+  mkdir -p "${subpkgdir}"
 }
 
-sha512sums="9d08aa5850f89bd7a1327a0a2e4aef117ea05cc71d074fc95d3cba4494414426124976703b85c5a2d58b4358d74e9f23bd97b5668c6fa872acf4daf9fb92be27  texmf-dist-2017.44907.tar.xz
-c53926b9a9c1092a35cc1d32593ab46828877ab2faf4f582910a62bda7de6f81d9db61b5c508e768c68a80fa7a0c6470b05f3114a8ff98512fe811198230a8cd  texmf-dist-most-2017.44907.tar.xz"
+lang() {
+  pkgdesc="TeX Live texmf distribution: Additional languages"
+  depends="
+    ${pkgname}
+    ${pkgname}-langchinese
+    ${pkgname}-langcyrillic
+    ${pkgname}-langextra
+    ${pkgname}-langgreek
+    ${pkgname}-langjapanese
+    ${pkgname}-langkorean
+    "
+  mkdir -p "${subpkgdir}"
+}
+
+full() {
+  pkgdesc="Full TeX Live texmf distribution"
+  depends="${pkgname}-most ${pkgname}-lang"
+  mkdir -p "${subpkgdir}"
+}
+
+bibtexextra() {
+  pkgdesc="TeX Live texmf distribution: Additional BibTeX styles and bibliography DBs"
+  pack_subpkg "$_bibtexextra"
+}
+
+fontsextra() {
+  pkgdesc="TeX Live texmf distribution: Additional fonts"
+  pack_subpkg "$_fontsextra"
+}
+
+formatsextra() {
+  pkgdesc="TeX Live texmf distribution: Additional TeX formats"
+  pack_subpkg "$_formatsextra"
+}
+
+games() {
+  pkgdesc="TeX Live texmf distribution: Typesetting board games including chess"
+  pack_subpkg "$_games"
+}
+
+humanities() {
+  pkgdesc="TeX Live texmf distribution: Packages for humanities, law, linguistics, ..."
+  pack_subpkg "$_humanities"
+}
+
+langchinese() {
+  pkgdesc="TeX Live texmf distribution: Support for Chinese"
+  pack_subpkg "$_langchinese"
+}
+
+langcyrillic() {
+  pkgdesc="TeX Live texmf distribution: Support for Cyrillic languages"
+  pack_subpkg "$_langcyrillic"
+}
+
+langextra() {
+  pkgdesc="TeX Live texmf distribution: Additional languages"
+  pack_subpkg "$_langextra"
+}
+
+langgreek() {
+  pkgdesc="TeX Live texmf distribution: Support for Greek"
+  pack_subpkg "$_langgreek"
+}
+
+langjapanese() {
+  pkgdesc="TeX Live texmf distribution: Support for Japanese"
+  pack_subpkg "$_langjapanese"
+}
+
+langkorean() {
+  pkgdesc="TeX Live texmf distribution: Support for Korean"
+  pack_subpkg "$_langkorean"
+}
+
+latexextra() {
+  pkgdesc="TeX Live texmf distribution: Add-onpackages for LaTeX"
+  pack_subpkg "$_latexextra"
+}
+
+music() {
+  pkgdesc="TeX Live texmf distribution: Music typesetting packages"
+  pack_subpkg "$_music"
+}
+
+pictures() {
+  pkgdesc="TeX Live texmf distribution: Packages for drawing graphics"
+  pack_subpkg "$_pictures"
+}
+
+pstricks() {
+  pkgdesc="TeX Live texmf distribution: Additional PSTricks packages"
+  pack_subpkg "$_pstricks"
+}
+
+publishers() {
+  pkgdesc="TeX Live texmf distribution: LaTeX packages for specific publishers"
+  pack_subpkg "$_publishers"
+}
+
+science() {
+  pkgdesc="TeX Live texmf distribution: Typesetting for math and sciences"
+  pack_subpkg "$_science"
+}
+
+sha512sums="7826b0d0486d620971e2d84087e6688fb99ea3778dd90d099d7333de10986a7746683dc36d9ca0b93906807ca502315f6dcf2462f13ea498a761e029bec14e24  texlive-core-2017.46770-src.zip
+f3886ef7e875b6e4a62ffe8afb34da31e02ceb8adbe67965a2a29f42fa92cac11baa81a89aa20e12bb1110c7dbf949dffdb4815e0b6da4cb97985648209598e2  texlive-bibtexextra-2017.46775-src.zip
+266a943cf88d0948061a12cdfbf25ce44aa97425fe379dd17941e37e28e1040f642ff734f3be8ac29a6a76a7b6ce9c1da8f5fff0c6bd55c5ecc044c1a889e907  texlive-fontsextra-2017.46787-src.zip
+adf2c5ad4bc131749349a69a8429cdfca7d44cc221b4c0ebceb38d59440183e7d888631fb2a7faa7f3ce806e65b9e4f433fbd289ec9fd0e7f4d0248c5f48930f  texlive-formatsextra-2017.45845-src.zip
+87579c98c31e6dfae05b78330f72f6113f44704253f5c2e41855898e1b650ee08fdfc4dbace026f03ccfab7c262526e53158c65bae9e743c1d525f58eb8466da  texlive-games-2017.46791-src.zip
+e7487b8b73d32ae5570d64bcbe8b07d6ab4d0822d35e4042864c9ccbaa36a56f6fb0d65facae3bf64b0f382c5c72ebb313e25918df11d3882af59de67d0d9d60  texlive-humanities-2017.46767-src.zip
+fdce0505245ca77e5b04761c4dff41cdbab958c6a9cc4fa2bedaf33a7bf523ad9341ff91e1ba9e1e4925e76b618155685699f8ce1db3c3d1baaa7433456feb0c  texlive-langchinese-2017.46542-src.zip
+e9a3f457769f5690bef1d09a435587914534fb8c0a7c2d72ae26e0421753ff1e1a6a5ea2b2767e9546cb092a268a19edf8d3f03b88bc0af1cbd871f12044b12e  texlive-langcyrillic-2017.45751-src.zip
+47176f9686c65138c3d9aa31a0baff6dc10bb363150e951212d1b9ead2a79899c28897e83e854fe50f1925c9dd150116cc1ec82c462fa048efc9c6e982916592  texlive-langextra-2017.46741-src.zip
+57fd9b8e0219fec0b88638fdb1cca89045c9cb6d66ae43dd687cb301e39c90d320d1bb0a7a64e90b3a04a1e67aea2e12dc5252227ec2555a59900be121e9d00e  texlive-langgreek-2017.46662-src.zip
+c94c5922289d286df8c5800943d92c44dfae0f62c6ee76fe863e480ec734a40218dcabc5f000cbd77f65418da25e6a44d4907987d2cbcb5fd8888a3b1bc27c31  texlive-langjapanese-2017.46733-src.zip
+cca9fba7cd3b0888949e0ed9799052be9c8957ff6784ea65f26306bce0c6812f15b94a919b3f2ecb197650a976bca2d41b52d74ddbfecdecfa4b61aed33516a0  texlive-langkorean-2017.44467-src.zip
+34580ad4d7579c7a3d03e55446a23ef4e0c10df15e414b7e067b38cb0010cc46ccbe4421fb7076939f9c5f5c2933717fc2b016727180f1e38ae5ebfb6aa39dbf  texlive-latexextra-2017.46778-src.zip
+5360a2a4057ce04775995224d76acd7204234707bfb66cdc4a1140e32e7907aaba0a09634223035658f70496f1b33f7528b29bcc198791ad3c4eb32d45e9b4fd  texlive-music-2017.46141-src.zip
+755f47a3a0a734d79bd76495f3c6b0b76a3a2fb186742892ea1ad5689a467713e2fa7a22dff50850f13b332bc9ae43e8455dba3c8a82aa0198b8641788dd2fbc  texlive-pictures-2017.46740-src.zip
+ee1e74c265b28356510408d4a3fbc002d1f0e63621c24ce3b3ec4ff83032efbaea49280bbd35d5d07ef4677619f4f411b8db6dcb4ffbbb189a0b323deccde5e3  texlive-pstricks-2017.46667-src.zip
+3b401690741360aa73d2204563ad3e18034d586cfbe7bca8acca64e8519d5bcaacdcd974c94c827b7d8f1851cfa9fc58b6d70ece3d50dde2eb2c04aea7e30866  texlive-publishers-2017.46790-src.zip
+5d620c6686bb4be1ba41bced1c19a6ed9f21a7b1f88c8d942c7619e867909aead7afd5aa2510c396d5ca3d9313211abecfd0fff83a25c170756dff201b423c94  texlive-science-2017.46789-src.zip
+795df101ccb6708cb197df3785f033140bfe47ff041a375d469826e0d6217775a40e58e7c5a752229d40bb7b3fd36a297617137089752d24b7999d2d17d15339  duplicates.txt"


### PR DESCRIPTION
http://tug.org/texlive/
TeX Live texmf core distribution

This is largely a port of the master/edge APKBUILD files.
Each package builds in a 3.7 container and the following **texlive** check passes when I run it in the container.  I've added it to `check()` in texlive.  There is little documentation on writing `check()`s so I'm largely guessing at the correct syntax and approach.

  cd ~/
  cat << EOF >texlive-check.tex
	\documentclass{article}
	\usepackage[american]{babel}
	\usepackage{blindtext}
	\begin{document}
	\blindmathpaper
	\end{document}
  EOF
  apk add ~/packages/community/$CARCH/$pkgname-$pkgver.apk
  pdflatex -output-format=pdf texlive-check.tex
