### PR TITLE
testing/nheko: upgrade to 0.3.0

### DIFF
--- a/testing/nheko/APKBUILD
+++ b/testing/nheko/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Kiyoshi Aman <kiyoshi.aman+adelie@gmail.com>
 # Maintainer: Kiyoshi Aman <kiyoshi.aman+adelie@gmail.com>
 pkgname=nheko
-pkgver=0.2.1
+pkgver=0.3.0
 pkgrel=0
 pkgdesc="Qt5-based client for Matrix protocol"
 url="https://github.com/mujx/nheko"
@@ -9,7 +9,7 @@ arch="all"
 license="GPL-3.0+"
 depends=""
 depends_dev=""
-makedepends="cmake qt5-qtbase-dev qt5-qttools-dev qt5-qtmultimedia-dev lmdb-dev $depends_dev"
+makedepends="clang cmake qt5-qtbase-dev qt5-qttools-dev qt5-qtmultimedia-dev lmdb-dev $depends_dev"
 install=""
 source="$pkgname-$pkgver.tar.gz::https://github.com/mujx/nheko/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
@@ -29,8 +29,10 @@ build() {
 		-DBUILD_SHARED_LIBS=True \
 		-DCMAKE_SKIP_RPATH=True \
 		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
-		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+		-DCMAKE_CXX_FLAGS="$CXXFLAGS -stdlib=libstdc++" \
 		-DCMAKE_C_FLAGS="$CFLAGS" \
+		-DCMAKE_CXX_COMPILER=clang++ \
+		-DCMAKE_C_COMPILER=clang \
 		${CMAKE_CROSSOPTS} ..
 	make
 }
@@ -53,4 +55,4 @@ package() {
 	done
 }
 
-sha512sums="7d08c5c561c0388756b663da98b209c3074b61f5743cefa8f1ad21e3184b0de3973a8a6b129a0f1f602e6dbb3c99d7f0cf47e394a4c9527086a250aff7ca5b85  nheko-0.2.1.tar.gz"
+sha512sums="303c5fae4ec6552da42e5a2386fc18ebd8fed62fbc5d559d321c8d8feef4e62d3f3ea16172b9751e7712597155f2ca878d1fcee469a5c944b75f122fb269be3d  nheko-0.3.0.tar.gz"


### PR DESCRIPTION
This upgrade necessitated a switch to clang, as gcc7 is the minimum required for gcc-based building.