### PR TITLE
community/hugo: upgrade to 0.39

### DIFF
--- a/community/hugo/APKBUILD
+++ b/community/hugo/APKBUILD
@@ -1,40 +1,41 @@
 # Contributor: Thomas Boerger <thomas@webhippie.de>
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=hugo
-pkgver=0.30.2
+pkgver=0.39
 pkgrel=0
 pkgdesc="A Fast and Flexible Static Site Generator built with love in GoLang"
 url="http://gohugo.io/"
 arch="all"
 license="Apache-2.0"
 depends=""
-makedepends="go govendor"
+makedepends="go dep"
 install=""
-source="${pkgname}-${pkgver}.tar.gz::https://github.com/gohugoio/hugo/archive/v$pkgver.tar.gz"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/gohugoio/hugo/archive/v$pkgver.tar.gz
+	drop-git-tests.patch"
 builddir="$srcdir/src/github.com/gohugoio/$pkgname"
 
 prepare() {
 	mkdir -p ${builddir%/*}
-	mv "$srcdir"/$pkgname-$pkgver "$builddir"/ || return 1
+	mv "$srcdir"/$pkgname-$pkgver "$builddir"/
 	default_prepare
 }
 
 build() {
 	cd "$builddir"
 	export GOPATH="$srcdir"
-	govendor sync -v || return 1
-	go build -v -o bin/$pkgname || return 1
+	dep ensure -v
+	go build -v -o bin/$pkgname
 }
 
 check() {
-	rm -f $builddir/releaser/git_test.go
 	cd "$builddir"
 	export GOPATH="$srcdir"
-	govendor test +local || return 1
+	go test ./...
 }
 
 package() {
 	install -Dm755 "$builddir"/bin/$pkgname "$pkgdir"/usr/bin/$pkgname
 }
 
-sha512sums="368e8b3def91454dd1d3eabd061a71dfcf8d0545dddd7d875342a6ec6a8c01e4651a8d6a3d64efbccd13b2c009b695642da3e9edb07ed267bb9a5b7880b83dbc  hugo-0.30.2.tar.gz"
+sha512sums="a4067b7feae024be7926869a5f0a9b30339e9b4426892e050f7a8d1ea332239fdeec6ab7b524a9e79c1443c71e8329a7fe9586d732ba2e3102de685c7f318c9a  hugo-0.39.tar.gz
+31f212a444998a582c5c71beb9522e665242cf973322a4cfce2f756a24fae03b194b8aa33fde233212b9624f311f6dc56f123183f61bf8cd7f3cbd695e7b86c5  drop-git-tests.patch"

--- a/community/hugo/drop-git-tests.patch
+++ b/community/hugo/drop-git-tests.patch
@@ -1,0 +1,127 @@
+--- hugo-0.39-original/hugolib/page_test.go
++++ hugo-0.39-patched/hugolib/page_test.go
+@@ -26,11 +26,6 @@
+ 	"testing"
+ 	"time"
+ 
+-	"github.com/gohugoio/hugo/hugofs"
+-	"github.com/spf13/afero"
+-
+-	"github.com/spf13/viper"
+-
+ 	"github.com/gohugoio/hugo/deps"
+ 	"github.com/gohugoio/hugo/helpers"
+ 	"github.com/spf13/cast"
+@@ -908,34 +903,6 @@
+ 	d, _ := time.Parse(time.RFC3339, "2013-05-17T16:59:30Z")
+ 
+ 	checkPageDate(t, p, d)
+-}
+-
+-func TestPageWithLastmodFromGitInfo(t *testing.T) {
+-	assrt := require.New(t)
+-
+-	// We need to use the OS fs for this.
+-	cfg := viper.New()
+-	fs := hugofs.NewFrom(hugofs.Os, cfg)
+-	fs.Destination = &afero.MemMapFs{}
+-
+-	cfg.Set("frontmatter", map[string]interface{}{
+-		"lastmod": []string{":git", "lastmod"},
+-	})
+-
+-	cfg.Set("enableGitInfo", true)
+-
+-	assrt.NoError(loadDefaultSettingsFor(cfg))
+-
+-	wd, err := os.Getwd()
+-	assrt.NoError(err)
+-	cfg.Set("workingDir", filepath.Join(wd, "testsite"))
+-
+-	s := buildSingleSite(t, deps.DepsCfg{Fs: fs, Cfg: cfg}, BuildCfg{SkipRender: true})
+-
+-	assrt.Len(s.RegularPages, 1)
+-
+-	// 2018-03-11 is the Git author date for testsite/content/first-post.md
+-	assrt.Equal("2018-03-11", s.RegularPages[0].Lastmod.Format("2006-01-02"))
+ }
+ 
+ func TestPageWithFrontMatterConfig(t *testing.T) {
+--- hugo-0.39-original/releaser/git_test.go
++++ /dev/null
+@@ -1,75 +0,0 @@
+-// Copyright 2017-present The Hugo Authors. All rights reserved.
+-//
+-// Licensed under the Apache License, Version 2.0 (the "License");
+-// you may not use this file except in compliance with the License.
+-// You may obtain a copy of the License at
+-// http://www.apache.org/licenses/LICENSE-2.0
+-//
+-// Unless required by applicable law or agreed to in writing, software
+-// distributed under the License is distributed on an "AS IS" BASIS,
+-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-// See the License for the specific language governing permissions and
+-// limitations under the License.
+-
+-package releaser
+-
+-import (
+-	"testing"
+-
+-	"github.com/stretchr/testify/require"
+-)
+-
+-func TestGitInfos(t *testing.T) {
+-	skipIfCI(t)
+-	infos, err := getGitInfos("v0.20", "hugo", "", false)
+-
+-	require.NoError(t, err)
+-	require.True(t, len(infos) > 0)
+-
+-}
+-
+-func TestIssuesRe(t *testing.T) {
+-
+-	body := `
+-This is a commit message.
+-
+-Updates #123
+-Fix #345
+-closes #543
+-See #456
+-	`
+-
+-	issues := extractIssues(body)
+-
+-	require.Len(t, issues, 4)
+-	require.Equal(t, 123, issues[0])
+-	require.Equal(t, 543, issues[2])
+-
+-}
+-
+-func TestGitVersionTagBefore(t *testing.T) {
+-	skipIfCI(t)
+-	v1, err := gitVersionTagBefore("v0.18")
+-	require.NoError(t, err)
+-	require.Equal(t, "v0.17", v1)
+-}
+-
+-func TestTagExists(t *testing.T) {
+-	skipIfCI(t)
+-	b1, err := tagExists("v0.18")
+-	require.NoError(t, err)
+-	require.True(t, b1)
+-
+-	b2, err := tagExists("adfagdsfg")
+-	require.NoError(t, err)
+-	require.False(t, b2)
+-
+-}
+-
+-func skipIfCI(t *testing.T) {
+-	if isCI() {
+-		// Travis has an ancient git with no --invert-grep: https://github.com/travis-ci/travis-ci/issues/6328
+-		// Also Travis clones very shallowly, making some of the tests above shaky.
+-		t.Skip("Skip git test on Linux to make Travis happy.")
+-	}
+-}


### PR DESCRIPTION
Updated to latest version, requires the `dep` package within `community` which have been moved my @clandmeter.