### PR TITLE
testing/wireguard: upgrade to 0.0.20180413

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20180304
-_mypkgrel=2
+_ver=0.0.20180413
+_mypkgrel=1
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="dc7ad4c366625bc614f95abe163459804fa3b6a4dd9e1c7eee1571d3dab5a5bc88dbdc6cc79b9ec48f471ba71da54050f1bce8874ed130f15234a8353d276e50  WireGuard-0.0.20180304.tar.xz"
+sha512sums="e9227c57250af8040a18e210f9741e1ca93411caf48f2325694e8d8a8699b78bd60244534c39e3ab372deae7059922b3ceb519eb8bf8737472cc3568f7577681  WireGuard-0.0.20180413.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180304
+pkgver=0.0.20180413
 pkgrel=3
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="dc7ad4c366625bc614f95abe163459804fa3b6a4dd9e1c7eee1571d3dab5a5bc88dbdc6cc79b9ec48f471ba71da54050f1bce8874ed130f15234a8353d276e50  WireGuard-0.0.20180304.tar.xz"
+sha512sums="e9227c57250af8040a18e210f9741e1ca93411caf48f2325694e8d8a8699b78bd60244534c39e3ab372deae7059922b3ceb519eb8bf8737472cc3568f7577681  WireGuard-0.0.20180413.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,7 +4,7 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180304
+_ver=0.0.20180413
 _rel=0
 _toolsrel=0
 
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="dc7ad4c366625bc614f95abe163459804fa3b6a4dd9e1c7eee1571d3dab5a5bc88dbdc6cc79b9ec48f471ba71da54050f1bce8874ed130f15234a8353d276e50  WireGuard-0.0.20180304.tar.xz"
+sha512sums="e9227c57250af8040a18e210f9741e1ca93411caf48f2325694e8d8a8699b78bd60244534c39e3ab372deae7059922b3ceb519eb8bf8737472cc3568f7577681  WireGuard-0.0.20180413.tar.xz"


### PR DESCRIPTION
```
  * wg-quick.8: fix typo
  * wg-quick: hide errors on save
  
  This fixes a small regression in the resolvconf save handling on Debian.
  
  * compat: stable kernels are now receiving b87b619
  * compat: silence warning on frankenkernels
  * compat: support OpenSUSE 15
  
  Usual set of fixes for weird kernels.
  
  * curve25519: use precomp implementation instead of sandy2x
  * curve25519: use cmov instead of xor for cswap
  * curve25519: memzero in batches
  * curve25519: precomp const correctness
  
  Rather than using sandy2x, which requires use of the vector registers and simd
  instructions (and therefore thermal throttling and register save/restores), we
  instead use BMI2 and ADX instructions to achieve better performance, using:
    - https://eprint.iacr.org/2017/264
    - https://github.com/armfazh/rfc7748_precomputed
  
  * curve25519: add self tests from wycheproof
  * chacha20poly1305: add self tests from wycheproof
  
  Wycheproof now provides sneaky test vectors, so we've imported them into our
  self-tests to mitigate regressions. More info can be found at:
    - https://github.com/google/wycheproof
```