### PR TITLE
testing/acmetool: new aport

### DIFF
--- a/testing/acmetool/APKBUILD
+++ b/testing/acmetool/APKBUILD
@@ -1,0 +1,58 @@
+# Contributor: kpcyrd <git@rxv.cc>
+# Maintainer: kpcyrd <git@rxv.cc>
+pkgname=acmetool
+pkgver=0.0.67
+pkgrel=0
+pkgdesc="An easy-to-use command line tool for automatically acquiring certificates from ACME servers (such as Let's Encrypt)"
+url="https://github.com/hlandau/acme"
+arch="all"
+license="MIT"
+makedepends="glide go libcap-dev"
+subpackages="$pkgname-doc"
+# no test suite available
+options="!check"
+source="$pkgname-$pkgver.tar.gz::https://github.com/hlandau/acme/archive/v$pkgver.tar.gz
+	glide.lock
+	glide.yaml
+	"
+builddir="$srcdir/src/github.com/hlandau/acme"
+
+prepare() {
+	mkdir -p ${builddir%/*}
+	mv "$srcdir/acme-$pkgver" "$builddir"
+	cd "$builddir"
+	cp "$srcdir"/glide.yaml "$srcdir"/glide.lock .
+	export GOPATH="$srcdir"
+	glide install --skip-test
+	default_prepare
+}
+
+build() {
+	cd "$builddir"
+	export GOPATH="$srcdir"
+	go build -v -ldflags "-s -w -X github.com/hlandau/acme/hooks.DefaultPath=/etc/acme/hooks" \
+		./cmd/acmetool/...
+}
+
+package() {
+	cd "$builddir"
+	install -Dm 755 acmetool "$pkgdir/usr/bin/acmetool"
+
+	install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README"
+	install -Dm644 _doc/* -t "$pkgdir/usr/share/doc/$pkgname/"
+}
+
+glide_init() {
+	abuild clean deps unpack prepare
+	cd "$builddir"
+	export GOPATH="$srcdir"
+	rm -f glide.yaml glide.lock
+	glide init --non-interactive
+	glide update
+	cp glide.yaml glide.lock "$startdir"
+	cd "$startdir" && abuild checksum clean
+}
+
+sha512sums="c6f2bbdd97ced5ba4b5f7b466aaf1cc18d2930e43f9d3b6939e8abd05d622a177a84f2278af172c050733022b2d62fede7c40c1aedf6546d8da4021a621f1703  acmetool-0.0.67.tar.gz
+6ea636b99e3a2cab73e52a75bc92430fae6515d00c3287f5bbe942666e8fbba0883a3a89a6930021c7aae4451c4a9586eb034c35282d0e331d2f7b8456897bca  glide.lock
+108403fb50acdc3f74ad02d07b22665192206db8450a94156c57e129577835663f36c1a7fd40bd924bc84297c07417465b8013d9262bc497b74c000c268c7d42  glide.yaml"

--- a/testing/acmetool/glide.lock
+++ b/testing/acmetool/glide.lock
@@ -1,0 +1,114 @@
+hash: 68dde426608bc23d6537ee62c8ca73feaa28d8f541c638ed718e0cb1cbde9ba0
+updated: 2019-03-03T17:03:03.354765212Z
+imports:
+- name: github.com/alecthomas/template
+  version: a0175ee3bccc567396460bf5acd36800cb10c49c
+  subpackages:
+  - parse
+- name: github.com/alecthomas/units
+  version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
+- name: github.com/btcsuite/winsvc
+  version: f8fb11f83f7e860e3769a08e6811d1b399a43722
+  subpackages:
+  - mgr
+  - svc
+  - winapi
+- name: github.com/coreos/go-systemd
+  version: d1b7d058aa2adfc795ad17ff4aaa2bc64ec11c78
+  subpackages:
+  - dbus
+  - journal
+  - unit
+- name: github.com/erikdubbelboer/gspt
+  version: 2cac68f23d57e3e28a73b70d8d5d904749ec46e8
+- name: github.com/godbus/dbus
+  version: d41f4c66e71d091df57cfee7bf5978c0d612a174
+- name: github.com/hlandau/buildinfo
+  version: 337a29b5499734e584d4630ce535af64c5fe7813
+- name: github.com/hlandau/dexlogconfig
+  version: 244f29bd260884993b176cd14ef2f7631f6f3c18
+- name: github.com/hlandau/goutils
+  version: 0cdb66aea5b843822af6fdffc21286b8fe8379c4
+  subpackages:
+  - clock
+  - net
+  - os
+  - test
+  - text
+- name: github.com/hlandau/xlog
+  version: 197ef798aed28e08ed3e176e678fda81be993a31
+- name: github.com/jmhodges/clock
+  version: 880ee4c335489bc78d01e4d0a254ae880734bc15
+- name: github.com/mattn/go-isatty
+  version: 6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
+- name: github.com/mattn/go-runewidth
+  version: ce7b0b5c7b45a81508558cd1dba6bb1e4ddb51bb
+- name: github.com/mitchellh/go-wordwrap
+  version: ad45545899c7b13c020ea92b2072220eefad42b8
+- name: github.com/ogier/pflag
+  version: 45c278ab3607870051a2ea9040bb85fcb8557481
+- name: github.com/peterhellberg/link
+  version: 6d32b8d78d1e440948a1c461c5abcc6bf7881641
+- name: github.com/satori/go.uuid
+  version: 36e9d2ebbde5e3f13ab2e25625fd453271d6522e
+- name: github.com/shiena/ansicolor
+  version: a422bbe96644373c5753384a59d678f7d261ff10
+- name: golang.org/x/crypto
+  version: d6449816ce06963d9d136eee5a56fca5b0616e7e
+  subpackages:
+  - ocsp
+- name: golang.org/x/net
+  version: 8d16fa6dc9a85c1cd3ed24ad08ff21cf94f10888
+  subpackages:
+  - context
+  - context/ctxhttp
+  - idna
+- name: golang.org/x/sys
+  version: b126b21c05a91c856b027c16779c12e3bf236954
+  subpackages:
+  - unix
+- name: golang.org/x/text
+  version: 7922cc490dd5a7dbaa7fd5d6196b49db59ac042f
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
+- name: gopkg.in/alecthomas/kingpin.v2
+  version: 947dcec5ba9c011838740e680966fd7087a71d0d
+- name: gopkg.in/cheggaaa/pb.v1
+  version: 72b964305fba1230d3d818711138195f22b9ceea
+- name: gopkg.in/hlandau/configurable.v1
+  version: 41496864a1fe3e0fef2973f22372b755d2897402
+- name: gopkg.in/hlandau/easyconfig.v1
+  version: 7589cb96edce2f94f8c1e6eb261f8c2b06220fe7
+  subpackages:
+  - adaptflag
+  - cflag
+- name: gopkg.in/hlandau/service.v2
+  version: b64b3467ebd16f64faec1640c25e318efc0c0d7b
+  subpackages:
+  - daemon
+  - daemon/bansuid
+  - gsptcall
+- name: gopkg.in/hlandau/svcutils.v1
+  version: c25dac49e50cbbcbef8c81b089f56156f4067729
+  subpackages:
+  - caps
+  - chroot
+  - dupfd
+  - exepath
+  - passwd
+  - pidfile
+  - setuid
+  - systemd
+- name: gopkg.in/square/go-jose.v1
+  version: 6e50787b7338112747e64f32753fb4f9dbfb8f79
+  subpackages:
+  - cipher
+  - json
+- name: gopkg.in/tylerb/graceful.v1
+  version: 4654dfbb6ad53cb5e27f37d99b02e16c1872fbbb
+- name: gopkg.in/yaml.v2
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
+testImports: []

--- a/testing/acmetool/glide.yaml
+++ b/testing/acmetool/glide.yaml
@@ -1,0 +1,41 @@
+package: github.com/hlandau/acme
+import:
+- package: github.com/coreos/go-systemd
+  subpackages:
+  - dbus
+  - unit
+- package: github.com/hlandau/dexlogconfig
+- package: github.com/hlandau/goutils
+  subpackages:
+  - clock
+  - net
+  - os
+  - text
+- package: github.com/hlandau/xlog
+- package: github.com/jmhodges/clock
+- package: github.com/mitchellh/go-wordwrap
+- package: github.com/peterhellberg/link
+- package: github.com/satori/go.uuid
+- package: golang.org/x/crypto
+  subpackages:
+  - ocsp
+- package: golang.org/x/net
+  subpackages:
+  - context
+  - context/ctxhttp
+  - idna
+- package: gopkg.in/alecthomas/kingpin.v2
+- package: gopkg.in/cheggaaa/pb.v1
+- package: gopkg.in/hlandau/easyconfig.v1
+  subpackages:
+  - adaptflag
+- package: gopkg.in/hlandau/service.v2
+- package: gopkg.in/hlandau/svcutils.v1
+  subpackages:
+  - chroot
+  - exepath
+  - passwd
+  - systemd
+- package: gopkg.in/square/go-jose.v1
+- package: gopkg.in/tylerb/graceful.v1
+- package: gopkg.in/yaml.v2


### PR DESCRIPTION
https://github.com/hlandau/acme
An easy-to-use command line tool for automatically acquiring certificates from ACME servers (such as Let's Encrypt)