### PR TITLE
testing/meek: fix split package

### DIFF
--- a/testing/meek/APKBUILD
+++ b/testing/meek/APKBUILD
@@ -2,15 +2,14 @@
 # Maintainer: kpcyrd <git@rxv.cc>
 pkgname=meek
 pkgver=0.30
-pkgrel=0
+pkgrel=1
 pkgdesc="A pluggable transport proxy written in Go"
 url="https://trac.torproject.org/projects/tor/wiki/doc/meek"
 arch="all"
 license="CC0-1.0"
-depends="meek-server meek-client"
+depends="ca-certificates"
 makedepends="glide go libcap"
 subpackages="$pkgname-doc
-	$pkgname-client
 	$pkgname-server
 	"
 # no test suite available
@@ -43,8 +42,6 @@ build() {
 package() {
 	cd "$builddir"
 	install -Dm 755 meek-client/meek-client "$pkgdir/usr/bin/meek-client"
-	install -Dm 755 meek-server/meek-server "$pkgdir/usr/bin/meek-server"
-	setcap 'cap_net_bind_service=+ep' "$pkgdir/usr/bin/meek-server"
 
 	mkdir -p "$pkgdir/usr/share/man/man1"
 	install -Dm644 doc/*.1 -t "$pkgdir/usr/share/man/man1"
@@ -55,13 +52,6 @@ package() {
 		"$pkgdir/usr/share/doc/$pkgname/torrc.meek-client"
 	install -Dm644 meek-server/torrc \
 		"$pkgdir/usr/share/doc/$pkgname/torrc.meek-server"
-}
-
-client() {
-	pkgdesc="meek pluggable transport proxy client"
-	depends=ca-certificates
-	install -Dm755 "$builddir"/meek-client/meek-client \
-		"$subpkgdir"/usr/bin/meek-client
 }
 
 server() {


### PR DESCRIPTION
This resolves a dumb mistake from my initial PR, `meek` was supposed to be a meta package, but it still contained both the meek-server and meek-client binary. I've split the package differently, `meek` contains `meek-client`; which is the binary most users need, while `meek-server` is only needed when a user wants to setup their own bridge (and is therefore split into it's own package).

Sorry for the inconvenience.