### PR TITLE
main/cjdns: upgrade to 20.2

### DIFF
--- a/main/cjdns/APKBUILD
+++ b/main/cjdns/APKBUILD
@@ -1,24 +1,25 @@
-# Maintainer:
+# Maintainer: kpcyrd <git@rxv.cc>
+# Contributor: kpcyrd <git@rxv.cc>
 # Contributor: Bartłomiej Piotrowski <bpiotrowski@alpinelinux.org>
 
 pkgname=cjdns
-pkgver=20
-pkgrel=1
+pkgver=20.2
+pkgrel=0
 pkgdesc="A routing engine designed for security, scalability, speed and ease of use"
 url="https://github.com/cjdelisle/cjdns"
 arch="all !x86 !s390x"
 license="GPL-3.0"
 makedepends="nodejs python2 linux-headers libseccomp-dev"
 install="$pkgname.post-install"
-subpackages="$pkgname-doc"
-source="${pkgname}-${pkgver}.tar.gz::https://github.com/cjdelisle/${pkgname}/archive/cjdns-v${pkgver}.tar.gz"
+subpackages="$pkgname-doc $pkgname-openrc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/cjdelisle/$pkgname/archive/cjdns-v$pkgver.tar.gz"
 
 builddir="$srcdir/$pkgname-$pkgname-v$pkgver"
 
 build() {
 	cd "$builddir"
-	export CJDNS_RELEASE_VERSION="${pkgver}"
-	sh 'do'
+	export CJDNS_RELEASE_VERSION="$pkgver"
+	node ./node_build/make.js
 }
 
 check() {
@@ -32,8 +33,8 @@ package() {
 	install -Dm755 contrib/openrc/cjdns "$pkgdir/etc/init.d/cjdns"
 	install -Dm644 doc/man/cjdroute.conf.5 \
 		"${pkgdir}/usr/share/man/man5/cjdroute.conf.5"
-	install -Dm 644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
-	install -Dm644 -t "${pkgdir}/usr/share/doc/${pkgname}" \
+	install -Dm 644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+	install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname" \
 		doc/admin-api.md \
 		doc/configure.md \
 		doc/djc_layer_model.md \
@@ -45,4 +46,4 @@ package() {
 		doc/tunnel.md
 }
 
-sha512sums="afa63daea3c3bd3e16dd0a326ebdc2afcb411c595e66552c3156c59c36af21c0b2278b3299b1053b98d381790311beeb14547afdf3d182170c446867d2199a94  cjdns-20.tar.gz"
+sha512sums="31edd3ff7e62bfe2ab555da1e34d4b900829180d9558eecdd93a3d726126067c8094419683f047abdcabc444e3b2ae933a68ca4fa1b535731f977e07983b7d39  cjdns-20.2.tar.gz"


### PR DESCRIPTION
I've also changed the build script to bypass `./do`, which is a wrapper that ensures a recent nodejs is installed, this is not needed when building for a distro.