### PR TITLE
testing/wireguard: upgrade to 0.0.20180420

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -8,8 +8,8 @@ _kpkgrel=0
 
 # when changing _ver we *must* bump _mypkgrel
 # we must also match up _toolsrel with wireguard-tools
-_ver=0.0.20180413
-_mypkgrel=1
+_ver=0.0.20180420
+_mypkgrel=2
 _toolsrel=0
 _name=wireguard
 
@@ -59,4 +59,4 @@ package() {
 	done
 }
 
-sha512sums="e9227c57250af8040a18e210f9741e1ca93411caf48f2325694e8d8a8699b78bd60244534c39e3ab372deae7059922b3ceb519eb8bf8737472cc3568f7577681  WireGuard-0.0.20180413.tar.xz"
+sha512sums="19740c6678d13bbe156520d6121db2bd95c8f30891b9acbbc6af1d49079f144598f8062131ac1dfd14b830e32306bc54f2ae9608ceeec762ffde65495413a0ac  WireGuard-0.0.20180420.tar.xz"

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180413
+pkgver=0.0.20180420
 pkgrel=3
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="e9227c57250af8040a18e210f9741e1ca93411caf48f2325694e8d8a8699b78bd60244534c39e3ab372deae7059922b3ceb519eb8bf8737472cc3568f7577681  WireGuard-0.0.20180413.tar.xz"
+sha512sums="19740c6678d13bbe156520d6121db2bd95c8f30891b9acbbc6af1d49079f144598f8062131ac1dfd14b830e32306bc54f2ae9608ceeec762ffde65495413a0ac  WireGuard-0.0.20180420.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,7 +4,7 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180413
+_ver=0.0.20180420
 _rel=0
 _toolsrel=0
 
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="e9227c57250af8040a18e210f9741e1ca93411caf48f2325694e8d8a8699b78bd60244534c39e3ab372deae7059922b3ceb519eb8bf8737472cc3568f7577681  WireGuard-0.0.20180413.tar.xz"
+sha512sums="19740c6678d13bbe156520d6121db2bd95c8f30891b9acbbc6af1d49079f144598f8062131ac1dfd14b830e32306bc54f2ae9608ceeec762ffde65495413a0ac  WireGuard-0.0.20180420.tar.xz"


### PR DESCRIPTION
```

  * wg-quick: account for specified fwmark in auto routing mode
  
  If we're doing automatic routing with default routes, but the config has
  also specified an explicit fwmark, then use that explicit fwmark, even
  if it's conflicting, since the administrator has explicitly opted into
  using it. Also, when shutting down the interface, we only now remove the
  fancy rules if we're in automatic routing mode with default routes.
  
  * send: account for route-based MTU
  
  It might be that a particular route has a different MTU than the
  interface, via `ip route add ... dev wg0 mtu 1281`, for example. In this
  case, it's important that we don't accidently pad beyond the end of the
  MTU. We accomplish that in this patch by carrying forward the MTU from
  the dst if it exists. We also add a unit test for this issue.
  
  * send: simplify skb_padding with nice macro
  * blake2s: remove unused helper
  * compat: remove unused dev_recursion_level backport
  
  Cleanups.
  
  * poly1305: do not place constants in different sections
  
  We're referencing these constants as one contiguous blob, so if there's
  any merging that goes on with other constants elsewhere (such as the
  kernel's current poly1305 implementation that we hope to replace), then
  these will be reordered and have the wrong values.
```