### PR TITLE
testin/aixlog: update to 1.2.0

### DIFF
--- a/testing/aixlog/APKBUILD
+++ b/testing/aixlog/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
 # Maintainer:
 pkgname=aixlog
-pkgver=1.1.0
+pkgver=1.2.0
 pkgrel=0
 pkgdesc="Header-only C++ logging library"
 url="https://github.com/badaix/aixlog"
@@ -33,4 +33,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="4fb4a7e4ab0a1a7ac005367b4935f34f8f5599c8f49db8e7696fd2759efdbd02606539e7b904c866d08fcd7ccb3666fb55c54ae5cb8ce890cf4297ca5993845e  aixlog-1.1.0.tar.gz"
+sha512sums="57f8f98377bf2ae8405244bb20eec0a408419da9545f15ef4357f8b7d9533c15fa65aa0f1a684b079319db2ad488956ff5251c24329a86afcf1661ca2dd3b5b9  aixlog-1.2.0.tar.gz"


### PR DESCRIPTION
Note that these packages are build-time dependencies of testing/snapcast (well, testing/snapcast-client and testing/snapcast-server), however they are not listed as such on https://pkgs.alpinelinux.org. Bug?