### PR TITLE
main/libwebp: upgrade to 1.0.0

### DIFF
--- a/main/libwebp/APKBUILD
+++ b/main/libwebp/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Kiyoshi Aman <kiyoshi.aman@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libwebp
-pkgver=0.6.1
+pkgver=1.0.0
 pkgrel=0
 pkgdesc="Libraries for working with WebP images"
 url="https://developers.google.com/speed/webp/"
@@ -45,4 +45,4 @@ tools() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="fece551d8fabdd8d7ba6807baa54a69a345f8690be4415dd0c0dea54002d78fe893a5d5aacfc13800300edd462b969d596709ac3213f6bc90f8e3698b2490d5f  libwebp-0.6.1.tar.gz"
+sha512sums="2af7036957722a3f1533fa2da0da15c76d7eb8ac98ec4ad5cf71dd4262f3d7c9897fb6b50befab83b7de22f0abceeb2c0ff52d60927513d40f8a41aa6a9abd99  libwebp-1.0.0.tar.gz"

--- a/main/libwebp/APKBUILD
+++ b/main/libwebp/APKBUILD
@@ -4,18 +4,21 @@ pkgname=libwebp
 pkgver=1.0.0
 pkgrel=0
 pkgdesc="Libraries for working with WebP images"
-url="https://developers.google.com/speed/webp/"
+url="https://developers.google.com/speed/webp"
 arch="all"
-license="BSD"
-makedepends="libpng-dev libjpeg-turbo-dev tiff-dev giflib-dev
-	automake autoconf libtool"
+license="BSD-3-Clause"
+makedepends="autoconf automake giflib-dev libjpeg-turbo-dev libpng-dev libtool
+	tiff-dev"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-tools"
-source="http://downloads.webmproject.org/releases/webp/libwebp-$pkgver.tar.gz"
-builddir="$srcdir/$pkgname-$pkgver"
+source="https://downloads.webmproject.org/releases/webp/$pkgname-$pkgver.tar.gz"
+
+prepare() {
+	default_prepare
+	./autogen.sh
+}
 
 build() {
 	cd "$builddir"
-	sh autogen.sh
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \


### PR DESCRIPTION
`libwebp` releases 0.6.1 and 1.0.0 [are binary compatible](https://chromium.googlesource.com/webm/libwebp/+/v1.0.0/NEWS)