### PR TITLE
scripts/mkimg*: allow building s390x standard image

### DIFF
--- a/scripts/mkimg.base.sh
+++ b/scripts/mkimg.base.sh
@@ -256,6 +256,10 @@ create_image_iso() {
 		grub-mkrescue --output ${ISO} ${DESTDIR} -follow-links \
 			-sysid LINUX \
 			-volid "alpine-$PROFILE $RELEASE $ARCH"
+	elif [ "$ARCH" = "s390x" ]; then
+		for _image in vmlinuz initramfs modloop; do
+			cp ${DESTDIR}/boot/$_image-$kernel_flavors ${OUTDIR}
+		done
 	else
 		xorrisofs \
 			-quiet \


### PR DESCRIPTION
s390x standard media consist of a kernel, an initramfs, a parm file.
Users can tweak parameters for their needs in the example parm file.