### PR TITLE
main/libva: Remove mesa-dev from depends_dev

### DIFF
--- a/main/libva/APKBUILD
+++ b/main/libva/APKBUILD
@@ -2,16 +2,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libva
 pkgver=2.1.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Video Acceleration (VA) API for Linux"
 url="http://freedesktop.org/wiki/Software/vaapi"
 arch="all"
 options="!check"  # No test suite.
 license="MIT"
-depends=""
-depends_dev="mesa-dev"
-makedepends="$depends_dev autoconf automake libtool"
-install=""
+makedepends="mesa-dev autoconf automake libtool"
 subpackages="$pkgname-dev"
 source="https://github.com/01org/${pkgname}/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.bz2"
 


### PR DESCRIPTION
Which will cause circular dependency when libva enabled in mesa.