### PR TITLE
genrootfs improvements for cross-architecture bootstrapping

### DIFF
--- a/scripts/genrootfs.sh
+++ b/scripts/genrootfs.sh
@@ -29,7 +29,7 @@ fi
 
 ${APK:-apk} add --keys-dir "$keys_dir" --no-cache \
 	--repositories-file "$repositories_file" \
-	--no-script --root "$tmp" --initdb \
+	--no-script --root "$tmp" --initdb --arch "$arch" \
 	"$@"
 for link in $("$tmp"/bin/busybox --list-full); do
 	[ -e "$tmp"/$link ] || ln -s /bin/busybox "$tmp"/$link

--- a/scripts/genrootfs.sh
+++ b/scripts/genrootfs.sh
@@ -36,7 +36,7 @@ for link in $("$tmp"/bin/busybox --list-full); do
 done
 
 ${APK:-apk} fetch --keys-dir "$keys_dir" --no-cache \
-	--repositories-file "$repositories_file" \
+	--repositories-file "$repositories_file" --root "$tmp" \
 	--stdout --quiet alpine-base | tar -zx -C "$tmp" etc/
 
 branch=edge


### PR DESCRIPTION
These two commits make it possible to use genrootfs.sh for cross-architecture bootstrapping.

cc @ncopa 