### PR TITLE
testing/rakudo: upgrade to 2018.04

### DIFF
--- a/testing/moarvm/APKBUILD
+++ b/testing/moarvm/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=moarvm
-pkgver=2018.03
+pkgver=2018.04
 pkgrel=0
 pkgdesc="A VM for NQP And Rakudo Perl 6"
 url="http://moarvm.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="be613e038747d771de03129e52d6e65712ddf6f73ed87eb008ae78968f2d516b4fded792a67e1ce031378c223408101ceaf25f90abf9ba35ee20c6e8401b46f1  MoarVM-2018.03.tar.gz"
+sha512sums="cbcceabc2f3d3d3ac73655bf16246f714923abbe909f2bfa6b1f2456801a4bebfe246f552e2704da254609e1edb66b564ef5b845c88af3761a6d552b2364fc51  MoarVM-2018.04.tar.gz"

--- a/testing/nqp/APKBUILD
+++ b/testing/nqp/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=nqp
-pkgver=2018.03
+pkgver=2018.04
 pkgrel=0
 pkgdesc="Not Quite Perl"
 url="https://github.com/perl6/nqp"
@@ -42,4 +42,4 @@ doc() {
 	done
 }
 
-sha512sums="2f6ac6a3be173ef92d80b80b5557aa49028c04b89fda5465a0c69e6a6253bce9d39662919f60867e7ededa499b81e4d2cd8f5fb0d7edfd022833c1f64f492440  nqp-2018.03.tar.gz"
+sha512sums="30ee26176f1834c528c0b4bdddc8df08c50f6504cb1626b912a050ab5199f3c1000eb9c884c4031771d6f88429c8fbd23457b73aaa8ee7d937c9f29ad1a46429  nqp-2018.04.tar.gz"

--- a/testing/rakudo/APKBUILD
+++ b/testing/rakudo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=rakudo
-pkgver=2018.03
+pkgver=2018.04
 pkgrel=0
 pkgdesc="A compiler for the Perl 6 programming language"
 url="http://rakudo.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="7e0162ccd818e6a9e64c3d2787bab2e1772471d066d050fa4dcb913d3663a66e23ebe11d42f061c782b113c99fd99437d9b048d4dd55b5c9effc1a6a69fda50d  rakudo-2018.03.tar.gz"
+sha512sums="d3e50fd1378bffbe6a56e948c44128e68fe070c6eba13a0fc4ca70d40d09cd47fd2902586a5f1af70b3c81caa90bdeb86a4e277a5d8fbf9e48e91c05906a801b  rakudo-2018.04.tar.gz"


### PR DESCRIPTION
Upgrade moarvm, nqp, and rakudo to version 2018.04, must upgrade all three together.
