### PR TITLE
main/linux-vanilla: enable VESA framebuffer driver

### DIFF
--- a/main/linux-vanilla/APKBUILD
+++ b/main/linux-vanilla/APKBUILD
@@ -7,7 +7,7 @@ case $pkgver in
 	*.*.*)	_kernver=${pkgver%.*};;
 	*.*) _kernver=$pkgver;;
 esac
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux vanilla kernel"
 url="http://kernel.org"
 depends="mkinitfs"


### PR DESCRIPTION
I have a Thinkpad x220 with Coreboot + SeaBIOS instead of the original vendor BIOS.
In this specific configuration, VESA support is necessary to have graphics (or text output) in early boot (before the KMS driver is initialized), since there is no complete VGA BIOS anymore handling the other legacy display methods.

CONFIG_FB_VESA is recommended as a default, and i couldn't any find commits that tell why it should be deactivated, so i hope it's safe to enable this for everyone.