### PR TITLE
main/smartmontools: metadata fixes

### DIFF
--- a/main/smartmontools/APKBUILD
+++ b/main/smartmontools/APKBUILD
@@ -1,13 +1,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=smartmontools
 pkgver=6.6
-pkgrel=0
-pkgdesc="Control and monitor S.M.A.R.T. enabled ATA and SCSI Hard Drives."
-url="http://smartmontools.sourceforge.net"
+pkgrel=1
+pkgdesc="Control and monitor S.M.A.R.T. enabled hard drives"
+url="https://www.smartmontools.org/"
 arch="all"
-license="GPL"
+license="GPL-2.0+"
 makedepends="linux-headers"
-subpackages="$pkgname-doc"
+subpackages="$pkgname-doc $pkgname-openrc"
 source="http://downloads.sourceforge.net/sourceforge/$pkgname/$pkgname-$pkgver.tar.gz
 	smartd.initd
 	smartd.confd


### PR DESCRIPTION
* The package can do SATA and NVMe, not just ATA and SCSI drives.

* Specify GPL version.

* Split OpenRC files.

* Add HTTPS site.