### PR TITLE
testing/knot-resolver: upgrade to 2.3.0

### DIFF
--- a/testing/knot-resolver/APKBUILD
+++ b/testing/knot-resolver/APKBUILD
@@ -1,20 +1,20 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=knot-resolver
-pkgver=2.2.0
+pkgver=2.3.0
 pkgrel=0
 pkgdesc="Minimalistic caching DNS resolver implementation"
 url="https://www.knot-resolver.cz/"
 # luajit is not available for disabled arches
 arch="all !s390x"
 license="GPL-3.0"
+pkgusers="kresd"
+pkggroups="kresd"
 depends="lua5.1-sec lua5.1-socket"
 depends_dev="knot-dev libedit-dev libuv-dev luajit-dev"
 makedepends="$depends_dev bash vim"
 checkdepends="cmocka-dev"
 install="$pkgname.pre-install"
-pkgusers="kresd"
-pkggroups="kresd"
 subpackages="$pkgname-mod-http:http:noarch $pkgname-dev $pkgname-doc"
 source="https://secure.nic.cz/files/$pkgname/$pkgname-$pkgver.tar.xz
 	$pkgname.initd
@@ -22,7 +22,10 @@ source="https://secure.nic.cz/files/$pkgname/$pkgname-$pkgver.tar.xz
 	$pkgname.logrotate
 	config
 	root.keys"
-builddir="$srcdir/$pkgname-$pkgver"
+
+# secfixes:
+#   2.3.0-r0:
+#     - CVE-2018-1110
 
 _flags="PREFIX=/usr
 	ETCDIR=/etc/$pkgname"
@@ -71,8 +74,7 @@ http() {
 	mv "$pkgdir"/$moddir/http* "$subpkgdir"/$moddir/
 }
 
-sha256sums="7bb7f0cd8bbb1d99706d56ed119bdffce094628479438896f3740644efe614fa  knot-resolver-2.2.0.tar.xz"
-sha512sums="397ae54cb5d1a838866175725b155862e54d5ff1191caab59641bcfd16cf4c965ea1b4f7f001d181c052941ff8df0d231be793a05383aa0abbd4a4130447e532  knot-resolver-2.2.0.tar.xz
+sha512sums="030594d6b096092962ce5f5c09a4d3a429433837f26b8bbdbaeba3ae201dd12ab8511e8314bd0f1d6f1b6f08d1d57e978425798fe31da4451f798e08610cff36  knot-resolver-2.3.0.tar.xz
 0e9b947ed0fe39a600ba8fe3cdeacf07521cdd6c371007dd15524f67c75ea024994a8c11820d70c57ef180c90f492eae69ef167152ad84c24a47c885710a7974  knot-resolver.initd
 9d0d629405df243dc0f782abd6fcaaaf13fbce78d881f7ce213cfd2a55cfbfd87af2ba976061bf7b5d3d055edec98b42632395390f2a469648c27f96124997a6  knot-resolver.confd
 688aeacb0c1f21c7e532533b402e67068897217713fb668636df7533000b493981ddfa0497f8dba7da7c804ee4ab8d587a4f52155b4e2bf1f4025d2588d314bb  knot-resolver.logrotate


### PR DESCRIPTION
Fixes CVE-2018-1110 - https://www.knot-resolver.cz/2018-04-23-knot-resolver-2.3.0.html