### PR TITLE
community/php7: security upgrade to 7.2.5

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -25,8 +25,8 @@
 
 pkgname=php7
 _pkgreal=php
-pkgver=7.2.4
-pkgrel=2
+pkgver=7.2.5
+pkgrel=0
 _apiver=20170718
 _suffix=${pkgname#php}
 # Is this package the default (latest) PHP version?
@@ -181,18 +181,8 @@ s390x) options="$options !check";;
 esac
 
 # secfixes:
-#   7.1.13-r0:
-#     - CVE-2018-5711
+#   7.2.5-r0:
 #     - CVE-2018-5712
-#   7.1.11-r0:
-#     - CVE-2016-1283
-#   7.1.7-r0:
-#     - CVE-2017-7890
-#     - CVE-2017-9224
-#     - CVE-2017-9226
-#     - CVE-2017-9227
-#     - CVE-2017-9228
-#     - CVE-2017-9229
 
 prepare() {
 	cd "$builddir"
@@ -648,7 +638,7 @@ _mv() {
 	mv $@
 }
 
-sha512sums="036348c7dd1b14cb8d843682a800c396a2a712db3113fb1443826171d4fc75e326b1e239807cd59cbc3c703ffdba3e2a48033052c01552dd1c9454c6abf20fe0  php-7.2.4.tar.bz2
+sha512sums="af9a77a9a642470867ea8a14a0d4bc34bbcfc87e2a2155a7121cea98909118c4577f0413e74f02c883c0ef64ba21c15712b673f4b84b2e2d190a60dbd7780f24  php-7.2.5.tar.bz2
 1c708de82d1086f272f484faf6cf6d087af7c31750cc2550b0b94ed723961b363f28a947b015b2dfc0765caea185a75f5d2c2f2b099c948b65c290924f606e4f  php7-fpm.initd
 cacce7bf789467ff40647b7319e3760c6c587218720538516e8d400baa75651f72165c4e28056cd0c1dc89efecb4d00d0d7823bed80b29136262c825ce816691  php7-fpm.logrotate
 274bd7b0b2b7002fa84c779640af37b59258bb37b05cb7dd5c89452977d71807f628d91b523b5039608376d1f760f3425d165242ca75ee5129b2730e71c4e198  php7-module.conf


### PR DESCRIPTION
CVE-2018-5712

for older releases https://github.com/alpinelinux/aports/pull/4136