### PR TITLE
community/php7: security upgrade to 7.0.30 (3.5)

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=php7
 _pkgreal=php
-pkgver=7.0.29
+pkgver=7.0.30
 pkgrel=0
 pkgdesc="The PHP language runtime engine - 7th branch"
 url="http://www.php.net/"
@@ -55,6 +55,8 @@ subpackages="$subpackages $pkgname-common::noarch"
 _apiver="20151012"
 
 # secfixes:
+#   7.0.30-r0:
+#     - CVE-2018-5712
 #   7.0.28-r0:
 #     - CVE-2018-7584
 #   7.0.27-r0:
@@ -352,7 +354,7 @@ _package_ext() {
 		> "$subpkgdir"/etc/$pkgname/conf.d/${elo}_${extname}.ini
 }
 
-md5sums="f634a3e42fb8cc6da6be06e7d5601a55  php-7.0.29.tar.bz2
+md5sums="8a9e3bc1a26dbaf0aecf35bede54c39a  php-7.0.30.tar.bz2
 4115cbd0843c72adc3bd42fecd6d4540  php7-fpm.initd
 25bde13e7894c2930d97fad68d5dd3b3  php7-fpm.logrotate
 47be6cd1ed92f21579e15bf2003a709f  php7-module.conf
@@ -360,7 +362,7 @@ md5sums="f634a3e42fb8cc6da6be06e7d5601a55  php-7.0.29.tar.bz2
 66f0037a029f9eed2b31d2e1d50f1860  tidy-buffio.patch
 d872e633c9b33c3c9f629dd2edd2e5c5  includedir.patch
 6ba762ab7a105163b8e5b3913deae109  pid_log.patch"
-sha256sums="989142d5c5ff7a11431254f9c1995235bad61a3364b99c966e11e06aa10d3fbc  php-7.0.29.tar.bz2
+sha256sums="213f38400c239b8fab2f6f59d6f4d4bd463d0a75bd4edf723dd4d5fea8850b50  php-7.0.30.tar.bz2
 a7e4fc0eeba18aec019f62ed966915afd82b6b5fb1e1af93b59f964b5bd66172  php7-fpm.initd
 6e4406f21b69085714cdb9d9a67c08e27a1c737ab353f9813cb2fc268352d2c6  php7-fpm.logrotate
 276c823ee666ea73b36d4e97174eeea05713125b61f7f8681e350453c4123143  php7-module.conf
@@ -368,7 +370,7 @@ f739ca427a1dd53a388bad0823565299c5d4a5796b1171b892884e4d7d099bab  install-pear.p
 5dc8f32e5e2b1cd6317ada5a5adb9b5f0802ed6e0dbe065d7bfcc0f55d47e0d5  tidy-buffio.patch
 ea74966a23b1b54548ee35e9ccc2fc8d2b7c2285c385c44d6b23d9e2f25ea1a7  includedir.patch
 0cca8729c64682387a8c44ed74f0966da697f2817152d8d05bb25bedc7eaafec  pid_log.patch"
-sha512sums="05a934d38815505ba2cb3dfbaffd98b682038ed279092e53760a0a91b688b484644c3114df402a8fa03e200b42d3eee9fc451270e27736975fc7bf40e7d2d64a  php-7.0.29.tar.bz2
+sha512sums="37b39b3163ad5c5f7d42e22bb5fe9d8708a0559add4f29624c4640c11ef0cbcdfe010cbf69032b741099c9d4f87c9878c19c1d2f3f98817271686aa177956002  php-7.0.30.tar.bz2
 1c708de82d1086f272f484faf6cf6d087af7c31750cc2550b0b94ed723961b363f28a947b015b2dfc0765caea185a75f5d2c2f2b099c948b65c290924f606e4f  php7-fpm.initd
 cacce7bf789467ff40647b7319e3760c6c587218720538516e8d400baa75651f72165c4e28056cd0c1dc89efecb4d00d0d7823bed80b29136262c825ce816691  php7-fpm.logrotate
 fbf9a1572d37370ec0d126502e1d066e045a992484d8fc4f1e2ede330134c1a15f4029f29fa4daebd48eed78b045dc051ced69fbf1f11efc7ad81d884a639a99  php7-module.conf


### PR DESCRIPTION
CVE-2018-5712