### PR TITLE
community/drupal7: security upgrade to 7.59 (3.5)

### DIFF
--- a/community/drupal7/APKBUILD
+++ b/community/drupal7/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 _php=php5
 pkgname=drupal7
-pkgver=7.52
+pkgver=7.59
 pkgrel=0
 pkgdesc="An open source content management platform"
 url="https://www.drupal.org/"
@@ -68,6 +68,6 @@ package() {
 		"$pkgdir"/var/lib/$pkgname/sites/default/files || return 1
 }
 
-md5sums="4963e68ca12918d3a3eae56054214191  drupal-7.52.tar.gz"
-sha256sums="ea09ec7c3555856591b7ac739dafbe7dbfba47d1ffe2a9a1f17fda490a91b8e8  drupal-7.52.tar.gz"
-sha512sums="4fd2721b87d7e160ccf202894c5ec11e836796be6dce3fbfe187eea826175822677c26079a3dae4567e0615e8f376a88c07a8979b619bb4ac1096c8ea5c8f802  drupal-7.52.tar.gz"
+md5sums="7e09c6b177345a81439fe0aa9a2d15fc  drupal-7.59.tar.gz"
+sha256sums="292c8741cd76b0baff33a36510e52fc8e189367498c8bcaae5da6ff15bdaaff6  drupal-7.59.tar.gz"
+sha512sums="68f02b39d1a4658adc0f0046c22cc1059b68f952f9cd753f5a3e379cf93705be308b4727519e90d77a42437442daebaa78d76745954be4d40e1a5105c319069c  drupal-7.59.tar.gz"


### PR DESCRIPTION
CVE-2018-7602

For 3.6 & 3.7 https://github.com/alpinelinux/aports/pull/4118