### PR TITLE
main/upower: upgrade to 0.99.7

### DIFF
--- a/main/upower/APKBUILD
+++ b/main/upower/APKBUILD
@@ -1,17 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=upower
-pkgver=0.99.6
-pkgrel=2
+pkgver=0.99.7
+pkgrel=0
 pkgdesc="Power Management Services"
-url="http://upower.freedesktop.org"
+url="https://upower.freedesktop.org"
 arch="all"
 license="GPL-2.0-or-later"
-depends=""
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 makedepends="linux-headers gtk+-dev libgudev-dev libusb-dev polkit-dev
 	dbus-glib-dev libxslt gobject-introspection-dev docbook-xsl"
-source="http://upower.freedesktop.org/releases/upower-$pkgver.tar.xz
-	"
+source="https://upower.freedesktop.org/releases/upower-$pkgver.tar.xz"
 # XXX: tests are broken on alpine for some reason, but not on adelie
 options="!check"
 
@@ -39,4 +37,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="7e7256491ecb5d3f04abf41f05a761b79761c8868a1aedadfc5085c3b9cf15f6099c1494596e6a24b0951511bc7cac074e93ebb2b84abb9fb7a4374483052d3f  upower-0.99.6.tar.xz"
+sha512sums="a1ad200e715284eae815580bba3faad480f7f13401f6ff1a2e7446172796a2413990ce2b553de713ddc530849b2dff1f0ddc12fbd2fd9b55510bbb644d2340a4  upower-0.99.7.tar.xz"


### PR DESCRIPTION
100% backwards compatible - https://abi-laboratory.pro/tracker/timeline/upower/