### PR TITLE
community/fuse-exfat: upgrade to 1.2.8

### DIFF
--- a/community/fuse-exfat/APKBUILD
+++ b/community/fuse-exfat/APKBUILD
@@ -2,12 +2,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=fuse-exfat
 _pkgreal=exfat
-pkgver=1.2.7
+pkgver=1.2.8
 pkgrel=0
 pkgdesc="Free exFAT file system implementation"
 url="https://github.com/relan/exfat"
 arch="all"
 license="GPL-2.0-or-later"
+options="!check" # No test suite
 provides="$_pkgreal"
 depends="fuse"
 makedepends="autoconf automake fuse-dev"
@@ -36,4 +37,4 @@ utils() {
 	done
 }
 
-sha512sums="f90b1eff5c51ff93377f82f2838d214e0670a4a8c54fb7c0ec8ce743971b35867975568b8886e8fae8e320706419cf4e39d0852e68350c9b999cf0be4c5f88fc  exfat-1.2.7.tar.gz"
+sha512sums="2805d8a59c53db348265943bfd5537aa1dfc87582fb1a3e9cba6ab112b93632be3c0932f72b57c7839d60faf1d455f56fd7d7a7f49e3e9419f4b6715332e939a  exfat-1.2.8.tar.gz"


### PR DESCRIPTION
These two packages are duplicates:
https://pkgs.alpinelinux.org/contents?branch=edge&name=fuse-exfat-utils&arch=aarch64&repo=community
https://pkgs.alpinelinux.org/contents?branch=edge&name=exfat-utils&arch=aarch64&repo=community