### PR TITLE
main/wavpack: add secfixes

### DIFF
--- a/main/wavpack/APKBUILD
+++ b/main/wavpack/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer:  Natanael Copa <ncopa@alpinelinux.org>
 pkgname=wavpack
 pkgver=5.1.0
-pkgrel=5
+pkgrel=6
 pkgdesc="Audio compression format with lossless, lossy, and hybrid compression modes"
 url="http://www.wavpack.com/"
 arch="all"
@@ -14,9 +14,17 @@ source="http://www.wavpack.com/${pkgname}-${pkgver}.tar.bz2
 	CVE-2018-6767.patch
 	CVE-2018-7253.patch
 	CVE-2018-7254.patch
+	CVE-2018-10536_10537.patch
+	CVE-2018-10538_10539_10540.patch
 	"
 
 # secfixes:
+#   5.1.0-r6:
+#     - CVE-2018-10536
+#     - CVE-2018-10537
+#     - CVE-2018-10538
+#     - CVE-2018-10539
+#     - CVE-2018-10340
 #   5.1.0-r3:
 #     - CVE-2018-6767
 #     - CVE-2018-7253
@@ -48,4 +56,6 @@ package() {
 sha512sums="4c31616ae63c3a875afa20f26ce935f7a8f9921e2892b4b8388eca3ccd83b2d686f43eed8b9ec1dead934a1148401b9dced3b05f509b7942c48d7af31cf80a54  wavpack-5.1.0.tar.bz2
 9a4d0da20398c3500f2308abae921bda2149e46270e0424b83b06bf9a15ff16b5b89c000a7633a6b454f09f7e2ffd5a88de37cd7504f633108e50c0d954c883c  CVE-2018-6767.patch
 6e8bdb2a1fa1445de7778226bf4db35efa96f6455be3f2c52bd56dc567eba8eeba9a0140965816c2dc340abcdcb966dc6fd647345e419fde3dceba2a512e5395  CVE-2018-7253.patch
-8745e1d3b97df6bdc2844c6731c1079afce8aee6cd3ad39557c8442687f80d2e2b278fd5277e35f7793de3035a7923be69a248dd7ab2cae66d92ea43905dae60  CVE-2018-7254.patch"
+8745e1d3b97df6bdc2844c6731c1079afce8aee6cd3ad39557c8442687f80d2e2b278fd5277e35f7793de3035a7923be69a248dd7ab2cae66d92ea43905dae60  CVE-2018-7254.patch
+fd7ff58c53f9b4cec335e36017c5b1709c5526a2d44a54dfbeb050ea303997418d1fa312ebe39f521a35a6f2151b8a0f5845ee9bf6bbda22bef036e9fc0166a5  CVE-2018-10536_10537.patch
+a59eff2a8f47d4383f33667e7737f5e2e639778b367340169f1c5d6335c8948cfd8e1a7554e8b6c05a59d80a04048cf137c0f4fdfd88d2d88757404d3dac31ee  CVE-2018-10538_10539_10540.patch"

--- a/main/wavpack/CVE-2018-10536_10537.patch
+++ b/main/wavpack/CVE-2018-10536_10537.patch
@@ -1,0 +1,60 @@
+From 26cb47f99d481ad9b93eeff80d26e6b63bbd7e15 Mon Sep 17 00:00:00 2001
+From: David Bryant <david@wavpack.com>
+Date: Tue, 24 Apr 2018 22:18:07 -0700
+Subject: [PATCH] issue #30 issue #31 issue #32: no multiple format chunks in
+ WAV or W64
+
+---
+ cli/riff.c   | 7 ++++++-
+ cli/wave64.c | 6 ++++++
+ 2 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/cli/riff.c b/cli/riff.c
+index 7bddf63..5d6452e 100644
+--- a/cli/riff.c
++++ b/cli/riff.c
+@@ -53,7 +53,7 @@ extern int debug_logging_mode;
+ 
+ int ParseRiffHeaderConfig (FILE *infile, char *infilename, char *fourcc, WavpackContext *wpc, WavpackConfig *config)
+ {
+-    int is_rf64 = !strncmp (fourcc, "RF64", 4), got_ds64 = 0;
++    int is_rf64 = !strncmp (fourcc, "RF64", 4), got_ds64 = 0, format_chunk = 0;
+     int64_t total_samples = 0, infilesize;
+     RiffChunkHeader riff_chunk_header;
+     ChunkHeader chunk_header;
+@@ -140,6 +140,11 @@ int ParseRiffHeaderConfig (FILE *infile, char *infilename, char *fourcc, Wavpack
+         else if (!strncmp (chunk_header.ckID, "fmt ", 4)) {     // if it's the format chunk, we want to get some info out of there and
+             int supported = TRUE, format;                        // make sure it's a .wav file we can handle
+ 
++            if (format_chunk++) {
++                error_line ("%s is not a valid .WAV file!", infilename);
++                return WAVPACK_SOFT_ERROR;
++            }
++
+             if (chunk_header.ckSize < 16 || chunk_header.ckSize > sizeof (WaveHeader) ||
+                 !DoReadFile (infile, &WaveHeader, chunk_header.ckSize, &bcount) ||
+                 bcount != chunk_header.ckSize) {
+diff --git a/cli/wave64.c b/cli/wave64.c
+index fa928a0..0388dc7 100644
+--- a/cli/wave64.c
++++ b/cli/wave64.c
+@@ -53,6 +53,7 @@ int ParseWave64HeaderConfig (FILE *infile, char *infilename, char *fourcc, Wavpa
+     Wave64ChunkHeader chunk_header;
+     Wave64FileHeader filehdr;
+     WaveHeader WaveHeader;
++    int format_chunk = 0;
+     uint32_t bcount;
+ 
+     infilesize = DoGetFileSize (infile);
+@@ -104,6 +105,11 @@ int ParseWave64HeaderConfig (FILE *infile, char *infilename, char *fourcc, Wavpa
+         if (!memcmp (chunk_header.ckID, fmt_guid, sizeof (fmt_guid))) {
+             int supported = TRUE, format;
+ 
++            if (format_chunk++) {
++                error_line ("%s is not a valid .W64 file!", infilename);
++                return WAVPACK_SOFT_ERROR;
++            }
++
+             chunk_header.ckSize = (chunk_header.ckSize + 7) & ~7L;
+ 
+             if (chunk_header.ckSize < 16 || chunk_header.ckSize > sizeof (WaveHeader) ||

--- a/main/wavpack/CVE-2018-10538_10539_10540.patch
+++ b/main/wavpack/CVE-2018-10538_10539_10540.patch
@@ -1,0 +1,71 @@
+From 6f8bb34c2993a48ab9afbe353e6d0cff7c8d821d Mon Sep 17 00:00:00 2001
+From: David Bryant <david@wavpack.com>
+Date: Tue, 24 Apr 2018 17:27:01 -0700
+Subject: [PATCH] issue #33, sanitize size of unknown chunks before malloc()
+
+---
+ cli/dsdiff.c | 9 ++++++++-
+ cli/riff.c   | 9 ++++++++-
+ cli/wave64.c | 9 ++++++++-
+ 3 files changed, 24 insertions(+), 3 deletions(-)
+
+diff --git a/cli/dsdiff.c b/cli/dsdiff.c
+index c016df9..fa56bbb 100644
+--- a/cli/dsdiff.c
++++ b/cli/dsdiff.c
+@@ -279,7 +279,14 @@ int ParseDsdiffHeaderConfig (FILE *infile, char *infilename, char *fourcc, Wavpa
+         else {          // just copy unknown chunks to output file
+ 
+             int bytes_to_copy = (int)(((dff_chunk_header.ckDataSize) + 1) & ~(int64_t)1);
+-            char *buff = malloc (bytes_to_copy);
++            char *buff;
++
++            if (bytes_to_copy < 0 || bytes_to_copy > 4194304) {
++                error_line ("%s is not a valid .DFF file!", infilename);
++                return WAVPACK_SOFT_ERROR;
++            }
++
++            buff = malloc (bytes_to_copy);
+ 
+             if (debug_logging_mode)
+                 error_line ("extra unknown chunk \"%c%c%c%c\" of %d bytes",
+diff --git a/cli/riff.c b/cli/riff.c
+index de98c1e..7bddf63 100644
+--- a/cli/riff.c
++++ b/cli/riff.c
+@@ -286,7 +286,14 @@ int ParseRiffHeaderConfig (FILE *infile, char *infilename, char *fourcc, Wavpack
+         else {          // just copy unknown chunks to output file
+ 
+             int bytes_to_copy = (chunk_header.ckSize + 1) & ~1L;
+-            char *buff = malloc (bytes_to_copy);
++            char *buff;
++
++            if (bytes_to_copy < 0 || bytes_to_copy > 4194304) {
++                error_line ("%s is not a valid .WAV file!", infilename);
++                return WAVPACK_SOFT_ERROR;
++            }
++
++            buff = malloc (bytes_to_copy);
+ 
+             if (debug_logging_mode)
+                 error_line ("extra unknown chunk \"%c%c%c%c\" of %d bytes",
+diff --git a/cli/wave64.c b/cli/wave64.c
+index 591d640..fa928a0 100644
+--- a/cli/wave64.c
++++ b/cli/wave64.c
+@@ -241,7 +241,14 @@ int ParseWave64HeaderConfig (FILE *infile, char *infilename, char *fourcc, Wavpa
+         }
+         else {          // just copy unknown chunks to output file
+             int bytes_to_copy = (chunk_header.ckSize + 7) & ~7L;
+-            char *buff = malloc (bytes_to_copy);
++            char *buff;
++
++            if (bytes_to_copy < 0 || bytes_to_copy > 4194304) {
++                error_line ("%s is not a valid .W64 file!", infilename);
++                return WAVPACK_SOFT_ERROR;
++            }
++
++            buff = malloc (bytes_to_copy);
+ 
+             if (debug_logging_mode)
+                 error_line ("extra unknown chunk \"%c%c%c%c\" of %d bytes",


### PR DESCRIPTION
fixes for:
-[CVE-2018-10536](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10536)
-[CVE-2018-10537](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10537)
-[CVE-2018-10538](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10538)
-[CVE-2018-10539](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10539)
-[CVE-2018-10540](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10540)