### PR TITLE
main/opusfile: fix dependency conflict

### DIFF
--- a/main/opusfile/APKBUILD
+++ b/main/opusfile/APKBUILD
@@ -1,20 +1,18 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=opusfile
 pkgver=0.10
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level API for decoding and seeking within .opus files"
-url="http://www.opus-codec.org/"
+url="https://www.opus-codec.org/"
 arch="all"
 license="BSD"
-depends=""
-depends_dev="libogg-dev libressl-dev opus-dev"
-makedepends="$depends_dev"
-install=""
+depends_dev="libressl-dev"
+makedepends="$depends_dev libogg-dev opus-dev"
 subpackages="$pkgname-dev $pkgname-doc"
-source="http://downloads.xiph.org/releases/opus/$pkgname-$pkgver.tar.gz
+source="https://downloads.xiph.org/releases/opus/$pkgname-$pkgver.tar.gz
 	libressl.patch
+	fix-conflict.patch
 	"
-builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
 	cd "$builddir"
@@ -45,4 +43,5 @@ package() {
 }
 
 sha512sums="302601c31ca28bff175cefa99ac16177122a786d043be229616e2c98b7ffaf4a96b8bb17ca16e31240325a92763f417315b54d8f1b2f4f63f445cb7ad43c4a37  opusfile-0.10.tar.gz
-4a5572bb0671e8bf38d70883d61257e182e4e417828c65461351649728ab5560c7da0d5d4560a30bbad256bfcafa874322a8f1470a796f4948af93d50dd4a74e  libressl.patch"
+4a5572bb0671e8bf38d70883d61257e182e4e417828c65461351649728ab5560c7da0d5d4560a30bbad256bfcafa874322a8f1470a796f4948af93d50dd4a74e  libressl.patch
+b902b8c25506d3730a2a3bafcc5542671df8f35c588d05e54e883071c853c2e6e572dde80a8f7f39a58780a509c2d14b963040a3cab633edfc400cfca08060de  fix-conflict.patch"

--- a/main/opusfile/fix-conflict.patch
+++ b/main/opusfile/fix-conflict.patch
@@ -1,0 +1,9 @@
+--- a/opusurl.pc.in
++++ b/opusurl.pc.in
+@@ -9,6 +9,5 @@
+ Description: High-level Opus decoding library, URL support
+ Version: @PACKAGE_VERSION@
+ Requires: opusfile
+-Requires.private: @openssl@
+ Conflicts:
+ Libs: -L${libdir} -lopusurl


### PR DESCRIPTION
Bug report: https://bugs.alpinelinux.org/issues/8666

Proof - https://pkgs.alpinelinux.org/package/edge/main/s390x/opusfile-dev:
![image](https://user-images.githubusercontent.com/858296/39499477-865bb69a-4dae-11e8-9c80-95cc11458037.png)

Before changes:
![image](https://user-images.githubusercontent.com/858296/39499593-415ce158-4daf-11e8-9cf6-7f033111d44a.png)

After changes:
![image](https://user-images.githubusercontent.com/858296/39499580-2a838112-4daf-11e8-8aef-6125dec26a5e.png)


@ncopa Please review this PR.