### PR TITLE
main/libgpg-error: upgrade to 1.30

### DIFF
--- a/main/libgpg-error/APKBUILD
+++ b/main/libgpg-error/APKBUILD
@@ -1,19 +1,15 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libgpg-error
-pkgver=1.29
+pkgver=1.30
 pkgrel=0
 pkgdesc="Support library for libgcrypt"
 url="http://www.gnupg.org"
 arch="all"
 license="GPL-2.0-or-later LGPL-2.1-or-later"
-depends=""
-depends_dev=""
-makedepends=""
-install=""
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lisp:lisp:noarch"
 source="https://gnupg.org/ftp/gcrypt/$pkgname/$pkgname-$pkgver.tar.bz2"
-builddir="$srcdir"/$pkgname-$pkgver
+
 build () {
 	cd "$builddir"
 	./configure \
@@ -41,4 +37,4 @@ lisp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr/share/
 }
 
-sha512sums="57b95a7ed0ed808f05a75d7ee700ed0317da06fde1f8c59f5a4f049d784c4598f3c693068ddd47cd8bb0efdb43b9b628b876d34211f8a3e67d5088110a15323b  libgpg-error-1.29.tar.bz2"
+sha512sums="ee07d3d3f30432b6a7ff68640c64ff42cc21510e1da43023d7b23571abcc54ee9f5db0c95a92745d8961e15664c4a54fcf024552af0f9de41d99ef716c2b48c4  libgpg-error-1.30.tar.bz2"


### PR DESCRIPTION
100% backwards compatibility - https://abi-laboratory.pro/tracker/timeline/libgpg-error/