### PR TITLE
main/flac: add secfixes

### DIFF
--- a/main/flac/APKBUILD
+++ b/main/flac/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=flac
 pkgver=1.3.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Free Lossless Audio Codec"
 url="http://flac.sourceforge.net/"
 arch="all"
@@ -11,7 +11,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 depends=
 makedepends="libogg-dev !libiconv"
 source="http://downloads.xiph.org/releases/flac/flac-${pkgver}.tar.xz
-	"
+	CVE-2017-6888.patch"
 
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -50,6 +50,5 @@ package() {
 	install -Dm0644 COPYING.Xiph \
 		"$pkgdir"/usr/share/licenses/$pkgname/COPYING.Xiph
 }
-md5sums="454f1bfa3f93cc708098d7890d0499bd  flac-1.3.2.tar.xz"
-sha256sums="91cfc3ed61dc40f47f050a109b08610667d73477af6ef36dcad31c31a4a8d53f  flac-1.3.2.tar.xz"
-sha512sums="63910e8ebbe508316d446ffc9eb6d02efbd5f47d29d2ea7864da9371843c8e671854db6e89ba043fe08aef1845b8ece70db80f1cce853f591ca30d56ef7c3a15  flac-1.3.2.tar.xz"
+sha512sums="63910e8ebbe508316d446ffc9eb6d02efbd5f47d29d2ea7864da9371843c8e671854db6e89ba043fe08aef1845b8ece70db80f1cce853f591ca30d56ef7c3a15  flac-1.3.2.tar.xz
+d2fedee94282a38fecd9c9e0a196966e2b23cc1df13290348bb7841a61aa9e95658e6dda6b8637f78d11a397f076388cbc2a0bf6f15e798882ccf42cc8c6f35c  CVE-2017-6888.patch"

--- a/main/flac/APKBUILD
+++ b/main/flac/APKBUILD
@@ -13,6 +13,10 @@ makedepends="libogg-dev !libiconv"
 source="http://downloads.xiph.org/releases/flac/flac-${pkgver}.tar.xz
 	CVE-2017-6888.patch"
 
+# secfixes:
+#   1.3.2-r2:
+#     - CVE-2017-6888
+
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {

--- a/main/flac/CVE-2017-6888.patch
+++ b/main/flac/CVE-2017-6888.patch
@@ -1,0 +1,27 @@
+From 4f47b63e9c971e6391590caf00a0f2a5ed612e67 Mon Sep 17 00:00:00 2001
+From: Erik de Castro Lopo <erikd@mega-nerd.com>
+Date: Sat, 8 Apr 2017 18:34:49 +1000
+Subject: [PATCH] stream_decoder.c: Fix a memory leak
+
+Leak reported by Secunia Research.
+---
+ src/libFLAC/stream_decoder.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/libFLAC/stream_decoder.c b/src/libFLAC/stream_decoder.c
+index 14d5fe7..a552751 100644
+--- a/src/libFLAC/stream_decoder.c
++++ b/src/libFLAC/stream_decoder.c
+@@ -1753,6 +1753,9 @@ FLAC__bool read_metadata_vorbiscomment_(FLAC__StreamDecoder *decoder, FLAC__Stre
+ 					}
+ 					memset (obj->comments[i].entry, 0, obj->comments[i].length) ;
+ 					if (!FLAC__bitreader_read_byte_block_aligned_no_crc(decoder->private_->input, obj->comments[i].entry, obj->comments[i].length)) {
++						/* Current i-th entry is bad, so we delete it. */
++						free (obj->comments[i].entry) ;
++						obj->comments[i].entry = NULL ;
+ 						obj->num_comments = i;
+ 						goto skip;
+ 					}
+-- 
+2.1.4
+


### PR DESCRIPTION
fix for:
-[CVE-2017-6888](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-6888) sourced from [upstream](https://git.xiph.org/?p=flac.git;a=commit;h=4f47b63e9c971e6391590caf00a0f2a5ed612e67)