### PR TITLE
testing/bird: don't use git repo as version number

### DIFF
--- a/testing/bird/APKBUILD
+++ b/testing/bird/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Francesco Zanini <francesco@zanini.me>
 pkgname=bird
 pkgver=2.0.2
-pkgrel=0
+pkgrel=1
 pkgdesc="BIRD Internet Routing Daemon"
 url="http://bird.network.cz/"
 arch="all"
@@ -13,6 +13,7 @@ makedepends="bison flex ncurses-dev readline-dev linux-headers"
 install=""
 source="
 	ftp://bird.network.cz/pub/bird/bird-$pkgver.tar.gz
+	bird-correct-version.patch
 	bird-make-test-bsprintf.patch
 	bird.initd
 	"
@@ -45,5 +46,6 @@ package() {
 }
 
 sha512sums="aef96f246484a52269b44963df033ccc584e62d50d1ae31a97a97b9c7375e576d70d00f61a0f6da336e60cefc4c921945df0cc821d5fd1c737b19f508e65d30b  bird-2.0.2.tar.gz
+ca6011e1a828f5a1d48d8c18f178f1259b623f42aebcce6bb49582a91303520d48c7467d7a31e467ce04af865da4f91ae5a5ada8892fa86717fbc048a59bfb74  bird-correct-version.patch
 e0a9bab1bb84ab4efbf51c4c015bf35196d146560f737979d3a17c44dc2397d9578e61a3bba0c58f3cdbb108074f17288bf536db5d8d4dce87c91f1be3dc6282  bird-make-test-bsprintf.patch
 59245af3fd514421d0babcefed556597022a36d14615d596bb5c08c7dd0a6ed4519928e35a0b7ff14fe27ecfa50fa8011283c92bfc9b8355b15b3263df189d5d  bird.initd"

--- a/testing/bird/bird-correct-version.patch
+++ b/testing/bird/bird-correct-version.patch
@@ -1,0 +1,15 @@
+diff -urp a/Makefile.in b/Makefile.in
+--- a/Makefile.in	1970-01-01 00:00:00.000000000 +0000
++++ b/Makefile.in	1970-01-01 00:00:00.000000000 +0000
+@@ -21,11 +21,6 @@ INSTALL=@INSTALL@
+ INSTALL_PROGRAM=@INSTALL_PROGRAM@
+ INSTALL_DATA=@INSTALL_DATA@
+ 
+-git-label:=$(strip $(shell git describe --always --dirty=-x 2>/dev/null))
+-ifneq ($(git-label),)
+-        CFLAGS += -DGIT_LABEL="$(git-label)"
+-endif
+-
+ client=$(addprefix $(exedir)/,@CLIENT@)
+ daemon=$(exedir)/bird
+ protocols=@protocols@


### PR DESCRIPTION
Makefile.in (used by `make`) contains a shell execution line to read the current git tags and uses that value in the resulting binary. However, since we're not building from a git repository but from a tar file, this results in `bird --version` reporting a version of `v3.7.0-3239-gc13b5c993b` instead of `2.0.2`. The added patch makes sure that bird uses the `BIRD_VERSION` from `sysdep/config.h`