### PR TITLE
community/pulseaudio: Upgrade to 11.1

### DIFF
--- a/community/pulseaudio/0002-fake-desktop-file.patch
+++ b/community/pulseaudio/0002-fake-desktop-file.patch
@@ -1,0 +1,17 @@
+diff --git a/src/daemon/pulseaudio.desktop b/src/daemon/pulseaudio.desktop
+new file mode 100644
+index 0000000..06cde27
+--- /dev/null
++++ b/src/daemon/pulseaudio.desktop
+@@ -0,0 +1,11 @@
++[Desktop Entry]
++Version=1.0
++_Name=PulseAudio Sound System
++_Comment=Start the PulseAudio Sound System
++Exec=start-pulseaudio-x11
++Terminal=false
++Type=Application
++Categories=
++GenericName=
++X-GNOME-Autostart-Phase=Initialization
++X-KDE-autostart-phase=1

--- a/community/pulseaudio/APKBUILD
+++ b/community/pulseaudio/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=pulseaudio
-pkgver=9.0
-pkgrel=5
+pkgver=11.1
+pkgrel=0
 pkgdesc="A featureful, general-purpose sound server"
 url="http://www.freedesktop.org/wiki/Software/PulseAudio"
 arch="all !s390x"
@@ -17,6 +17,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-libs $pkgname-bluez
 	$pkgname-bash-completion:bashcomp $pkgname-zsh-completion:zshcomp"
 source="http://freedesktop.org/software/pulseaudio/releases/pulseaudio-$pkgver.tar.xz
 	0001-padsp-Make-it-compile-on-musl.patch
+	0002-fake-desktop-file.patch
 	$pkgname.initd
 	$pkgname.confd"
 
@@ -37,6 +38,12 @@ build() {
 		--disable-orc \
 		|| return 1
 	make || return 1
+}
+
+check() {
+	cd "$builddir"
+	# Don't do checks until https://bugs.freedesktop.org/show_bug.cgi?id=54658 is properly fixed
+	# make check || return 1
 }
 
 package() {
@@ -125,15 +132,8 @@ zshcomp() {
 	mv "$pkgdir"/usr/share/zsh "$subpkgdir"/usr/share
 }
 
-md5sums="da7162541b3a9bc20576dbd0d7d1489a  pulseaudio-9.0.tar.xz
-9c04ae15da7464e3d0003840b9025eed  0001-padsp-Make-it-compile-on-musl.patch
-884cb9a843361844904e8c85542e72fb  pulseaudio.initd
-bf7487ba2c48fc8a56bca41c97a18934  pulseaudio.confd"
-sha256sums="c3d3d66b827f18fbe903fe3df647013f09fc1e2191c035be1ee2d82a9e404686  pulseaudio-9.0.tar.xz
-bfa722e400ba820ee7013ceb050058b4e239b1ea8544be23767ceb70ee0bc332  0001-padsp-Make-it-compile-on-musl.patch
-bbd37d052962ddbf6ae633e4e3896da292d3e916a9123558a9b973096dda842d  pulseaudio.initd
-c03661e8cc902d27ff6b52f291207f2b008957571b942abdd92a873a52aae0dd  pulseaudio.confd"
-sha512sums="2177d4ab2ab7ded43d6eb5ece763504bdd614f9bdc27ab007894f8f7eed3fd0006a5b7550e5fd099d1877423524bc2baa22775372c8cefd9b772c28134d3e55a  pulseaudio-9.0.tar.xz
+sha512sums="8863d8d7aede0d9a4d158e84e7bece91747c335f9ac98c7b21fafe76b762f8817e1125307aa46e561e540d2c40525e91f51a55ec34ac55d58fd5980199856a7a  pulseaudio-11.1.tar.xz
 25b648681d9397631138635c024b5c6e289e32f11bf222afe4d853f62501555b5d75cc9058023d24ab8f97e442bcb37a647667e01582539d146762912a8ce08e  0001-padsp-Make-it-compile-on-musl.patch
+29fdd4a917ac09592d2fe085a4c848dc94880bf3dd2a3aacb0234849dc8c12dbc14c20e53ff3d296f3d365b0b78e2e405e2268b138aa84c81c2ced418284c591  0002-fake-desktop-file.patch
 34fe54ece5df60ce63a7955cd828a2716670fef71f40960698ae5518fdaf9cd599f4d8f8852e2c88d715600a9ad06a38984415e5eb320071012e5eb6e5c1b8b1  pulseaudio.initd
 75b54581591519d63a3362b155c0f9b0501a60763ab394693a456c44d0216138cf3a40bdd0f7442028663bc045e9ffee286f8f8eaf2ee3bb17379b43615fee0e  pulseaudio.confd"

--- a/community/pulseaudio/APKBUILD
+++ b/community/pulseaudio/APKBUILD
@@ -55,6 +55,7 @@ system() {
 	arch="noarch"
 	depends="$pkgname"
 	pkgdesc="Pulseaudio system-wide init scripts"
+	install="$subpkgname.pre-install"
 	install -D -m755 "$srcdir"/$pkgname.initd \
 		"$subpkgdir"/etc/init.d/$pkgname || return 1
 	install -D -m644 "$srcdir"/$pkgname.confd \

--- a/community/pulseaudio/APKBUILD
+++ b/community/pulseaudio/APKBUILD
@@ -1,5 +1,6 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
+# Contributor: Jonathan Sieber <mail@strfry.org>
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=pulseaudio
 pkgver=11.1
@@ -10,10 +11,11 @@ arch="all !s390x"
 license="LGPL"
 makedepends="m4 automake libtool intltool bash
 	dbus-dev libcap-dev alsa-lib-dev bluez-dev speexdsp-dev avahi-dev libressl-dev eudev-dev
-	libsndfile-dev gtk+3.0-dev json-c-dev fftw-dev gconf-dev sbc-dev jack-dev"
+	libsndfile-dev gtk+3.0-dev json-c-dev fftw-dev gconf-dev sbc-dev jack-dev webrtc-audio-processing-dev"
 install=""
 subpackages="$pkgname-dev $pkgname-doc $pkgname-libs $pkgname-bluez
 	$pkgname-alsa $pkgname-utils $pkgname-jack $pkgname-zeroconf $pkgname-system
+	$pkgname-webrtc
 	$pkgname-bash-completion:bashcomp $pkgname-zsh-completion:zshcomp"
 source="http://freedesktop.org/software/pulseaudio/releases/pulseaudio-$pkgver.tar.xz
 	0001-padsp-Make-it-compile-on-musl.patch
@@ -88,6 +90,14 @@ alsa() {
 	pkgdesc="Pulseaudio alsa support"
 	mkdir -p "$subpkgdir"/usr/lib/pulse-$pkgver/modules
 	mv "$pkgdir"/usr/lib/pulse-$pkgver/modules/*alsa*.so \
+		"$subpkgdir"/usr/lib/pulse-$pkgver/modules/ || return 1
+}
+
+webrtc() {
+	pkgdesc="Pulseaudio WebRTC Acoustic Echo Cancellation support"
+	mkdir -p "$subpkgdir"/usr/lib/pulse-$pkgver/modules
+	mv "$pkgdir"/usr/lib/pulse-$pkgver/modules/*webrtc*.so \
+		"$pkgdir"/usr/lib/pulse-$pkgver/modules/*echo-cancel*.so \
 		"$subpkgdir"/usr/lib/pulse-$pkgver/modules/ || return 1
 }
 

--- a/community/pulseaudio/pulseaudio-system.pre-install
+++ b/community/pulseaudio/pulseaudio-system.pre-install
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+addgroup -S pulse 2>/dev/null
+addgroup -S pulse-access 2>/dev/null
+adduser root pulse-access 2>/dev/null
+adduser -S -D -H \
+	-h /var/run/pulse \
+	-s /sbin/nologin \
+	-G pulse \
+	-g "Pulseaudio System User" \
+	pulse 2>/dev/null
+adduser pulse audio 2>/dev/null
+
+exit 0

--- a/community/webrtc-audio-processing/APKBUILD
+++ b/community/webrtc-audio-processing/APKBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Jonathan Sieber <mail@strfry.org>
+pkgname=webrtc-audio-processing
+pkgver=0.3
+pkgrel=1
+pkgdesc="Audio Processing Algorithms from Google's WebRTC Project"
+url="https://www.freedesktop.org/software/pulseaudio/webrtc-audio-processing/"
+arch="all"
+license="BSD"
+makedepends="linux-headers"
+subpackages="$pkgname-dev $pkgname-doc"
+source="http://freedesktop.org/software/pulseaudio/webrtc-audio-processing/$pkgname-$pkgver.tar.xz
+	fix-glibcxx-macro.patch"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+
+	CFLAGS="${CFLAGS/-Os/-O2}" ./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--localstatedir=/var \
+		--enable-custom-modes
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+
+	make DESTDIR="$pkgdir" install
+	install -Dm644 COPYING \
+		"$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+
+sha512sums="fac99ae0c28290afedce8745bb159af1d375bf17e448a4e020b3b04f4ade24929d1d110923c4363c06a963675a201135621f0d20e57edff42bbcfbaedf91b4d0  webrtc-audio-processing-0.3.tar.xz
+1c055f2a2d55ff885158f4c79fec5a9b29782dcfeb2c206f84ff52ce225ab593e5ad38e4d134d01534eb239364d83cf57bbfb5cc0f743d4b09d1c9519f64d70f  fix-glibcxx-macro.patch"

--- a/community/webrtc-audio-processing/fix-glibcxx-macro.patch
+++ b/community/webrtc-audio-processing/fix-glibcxx-macro.patch
@@ -1,0 +1,20 @@
+--- a/webrtc/base/checks.cc
++++ b/webrtc/base/checks.cc
+@@ -16,7 +16,7 @@
+ #include <cstdio>
+ #include <cstdlib>
+ 
+-#if defined(__GLIBCXX__) && !defined(__UCLIBC__)
++#if defined(__GLIBC__) && !defined(__UCLIBC__)
+ #include <cxxabi.h>
+ #include <execinfo.h>
+ #endif
+@@ -55,7 +55,7 @@
+ // to get usable symbols on Linux. This is copied from V8. Chromium has a more
+ // advanced stace trace system; also more difficult to copy.
+ void DumpBacktrace() {
+-#if defined(__GLIBCXX__) && !defined(__UCLIBC__)
++#if defined(__GLIBC__) && !defined(__UCLIBC__)
+   void* trace[100];
+   int size = backtrace(trace, sizeof(trace) / sizeof(*trace));
+   char** symbols = backtrace_symbols(trace, size);


### PR DESCRIPTION
This PR also adds features, besides upgrading the pulseaudio version:
- pulseaudio-system runs an install script, to adds and configures a user that PA needs for --system mode
- Echo Cancellation support through webrtc_audio_processing library. This requires introducing a new package for said library.