### PR TITLE
gcc: fix download URL

### DIFF
--- a/main/gcc/APKBUILD
+++ b/main/gcc/APKBUILD
@@ -143,8 +143,8 @@ if $LANG_ADA; then
 fi
 makedepends="$makedepends_build $makedepends_host"
 
-source="ftp://gcc.gnu.org/pub/gcc/releases/gcc-${_pkgbase:-$pkgver}/gcc-${_pkgbase:-$pkgver}.tar.xz
-	ftp://sourceware.org/pub/java/ecj-4.9.jar
+source="http://gcc.gnu.org/pub/gcc/releases/gcc-${_pkgbase:-$pkgver}/gcc-${_pkgbase:-$pkgver}.tar.xz
+	http://sourceware.org/pub/java/ecj-4.9.jar
 
 	001_all_default-ssp-strong.patch
 	002_all_default-relro.patch


### PR DESCRIPTION
This commit switches `ftp://` to `http://`, as the former link does not work anymore. Looks like GNU finally disabled their FTP service, as [announced here](https://ftp.gnu.org/):
> If you maintain scripts used to access ftp.gnu.org over FTP,
we strongly encourage you to change them to use HTTPS instead.

I've changed it to `http://` to match the binutils package.

EDIT: This is the second version, the first version still had the FTP link for the `ecj-4.9.jar` file hosted on sourceware.org. But they seem to [have disabled their FTP port](https://travis-ci.org/alpinelinux/aports/builds/375361469#L637) as well, the HTTP link still works.