### PR TITLE
main/openssh: fix flavour split function, add kerberos

### DIFF
--- a/main/openssh/APKBUILD
+++ b/main/openssh/APKBUILD
@@ -4,19 +4,19 @@
 pkgname=openssh
 pkgver=7.7_p1
 _myver=${pkgver%_*}${pkgver#*_}
-pkgrel=2
+pkgrel=3
 pkgdesc="Port of OpenBSD's free SSH release"
 url="http://www.openssh.org/portable.html"
 arch="all"
 license="BSD"
 options="suid"
 depends="openssh-client openssh-sftp-server openssh-server"
-makedepends_build="linux-pam-dev"
+makedepends_build="linux-pam-dev krb5-dev"
 makedepends_host="libressl-dev zlib-dev linux-headers"
 makedepends="$makedepends_build $makedepends_host"
 # Add more packages support here e.g. kerberos
 _pkgsupport=""
-[ -z "$BOOTSTRAP" ] && _pkgsupport="pam"
+[ -z "$BOOTSTRAP" ] && _pkgsupport="pam kerberos5 kerberos5+pam"
 subpackages="$pkgname-doc
 	$pkgname-keygen
 	$pkgname-client
@@ -81,18 +81,23 @@ build() {
 	# now we build "vanilla" openssh
 	_configure="$_configure_vanilla"
 	for _flavour in $_pkgsupport; do
-		_configure="$_configure --without-$_flavour"
+		for _flavour_pkg in ${_flavour//+/$' '}; do
+			_configure="$_configure --without-$_flavour_pkg"
+		done
 	done
 	msg "Building openssh..."
 	eval "$_configure"
 	make
 
 	# now we build other openssh-$_flavour
-	_configure="$_configure_vanilla"
 	for _flavour in $_pkgsupport; do
+		_configure_flavour="$_configure"
 		cd "$builddir-$_flavour"
 		msg "Building openssh with $_flavour support..."
-		eval "$_configure --with-$_flavour"
+		for _flavour_pkg in ${_flavour//+/$' '}; do
+			_configure_flavour="$_configure_flavour --with-$_flavour_pkg"
+		done
+		eval "$_configure_flavour"
 		make
 	done
 }
@@ -178,18 +183,17 @@ server() {
 }
 
 _server() {
-	cd "$builddir"
+	cd "$1"
 	install -d "$subpkgdir"/usr/sbin
 	mv "$1"/sshd "$subpkgdir"/usr/sbin/
 }
 
 _pkg_flavour() {
+	_subpkg_name=$(basename $subpkgdir)
+	_flavour="${_subpkg_name/$pkgname-server-/}"
 	pkgdesc="OpenSSH server with $_flavour support"
 	depends="openssh-keygen openssh-server-common"
-	for _flavour in $_pkgsupport; do
-		cd "${builddir}"-$_flavour
-		_server "${builddir}"-$_flavour
-	done
+	_server "${builddir}-${_flavour}"
 }
 
 sha512sums="597252cb48209a0cb98ca1928a67e8d63e4275252f25bc37269204c108f034baade6ba0634e32ae63422fddd280f73096a6b31ad2f2e7a848dde75ca30e14261  openssh-7.7p1.tar.gz


### PR DESCRIPTION
The support for different flavours of openssh-server packages
was broken, effectively only supporting a single additional
flavour. The changes now support multiple flavours as
subpackages and also use the '+' sign in the flavour name
as a separator for indicating multiple packages which need
to be enabled in the openssh build. E.g. the "kerberos5+pam"
flavour enables both kerberos and pam support in a single
subpackage named openssh-server-kerberos5+pam.