### PR TITLE
main/flashrom: replace deprecated libusb_set_debug call to fix build

### DIFF
--- a/main/flashrom/APKBUILD
+++ b/main/flashrom/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Nathan Angelacos <nangel@alpinelinux.org>
 pkgname=flashrom
 pkgver=0.9.9
-pkgrel=2
+pkgrel=3
 pkgdesc="A utility for identifying, reading, writing, verifying and erasing flash chips"
 url="https://www.flashrom.org/Flashrom"
 arch="all"
@@ -14,6 +14,7 @@ install="$pkgname.post-install"
 source="http://download.flashrom.org/releases/flashrom-$pkgver.tar.bz2
 	sst26.patch
 	musl-ffs.patch
+	libusb_set_option.patch
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver
@@ -30,4 +31,5 @@ package() {
 
 sha512sums="155445ce7acab97f91596aad704aa2211da1c3f71fb463fc65c621dfea41e44b5de7db801c5b5cfc37450e8a8cfed5b202553715d999710422c830a0c38ae153  flashrom-0.9.9.tar.bz2
 545dfadf8d0c53c9b0116af29eb4454b09ec74b2e906258aa7fcedb472957941a405273fae8ccd1e2f2ec5a848780a8191fcde80e2714573c76b3cd35ab279fa  sst26.patch
-371131e37ee0f2ce31b5dd264707b91817a2f0a3654943e6b3430df862d4bb64f27117c1c94276cb447f5b45f1771b9997f9c96423d68c6dd4565c1e1f442a5e  musl-ffs.patch"
+371131e37ee0f2ce31b5dd264707b91817a2f0a3654943e6b3430df862d4bb64f27117c1c94276cb447f5b45f1771b9997f9c96423d68c6dd4565c1e1f442a5e  musl-ffs.patch
+1b50b760cfc5fc272b8fd87672308737641cca99cbdb79b73005e5d5ac37f371639990eb9573e31b23ccf63d364d044e16d9db6f6149203843b1aed91d69f3ab  libusb_set_option.patch"

--- a/main/flashrom/libusb_set_option.patch
+++ b/main/flashrom/libusb_set_option.patch
@@ -1,0 +1,11 @@
+--- a/ch341a_spi.c
++++ b/ch341a_spi.c
+@@ -444,7 +444,7 @@
+ 		return -1;
+ 	}
+ 
+-	libusb_set_debug(NULL, 3); // Enable information, warning and error messages (only).
++	libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);  // Enable information, warning and error messages (only).
+ 
+ 	uint16_t vid = devs_ch341a_spi[0].vendor_id;
+ 	uint16_t pid = devs_ch341a_spi[0].device_id;


### PR DESCRIPTION
deprecated libusb_set_debug(NULL, 3) call replaced with new libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO)