### PR TITLE
testing/php7-couchbase: upgrade to 2.4.6

### DIFF
--- a/testing/php7-couchbase/APKBUILD
+++ b/testing/php7-couchbase/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Nathan Johnson <nathan@nathanjohnson.info>
 pkgname=php7-couchbase
 _pkgreal=couchbase
-pkgver=2.4.5
-pkgrel=1
+pkgver=2.4.6
+pkgrel=0
 _phpver=${pkgname#php}
 _phpver=${_phpver%%-*}
 pkgdesc="PHP$_phpver extension for Couchbase"
@@ -39,4 +39,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$confdir"/$_pkgreal.ini
 }
 
-sha512sums="c1ee8f8dc58c1b79f8c3dd3ebb27be8436b76debde9c965758b5b8e5918b92f66a8f1afbf943f1f81ba8110e4a4bde089a4fc930a7d9240414102be9221471df  php7-couchbase-2.4.5.tgz"
+sha512sums="15dacbea0fb82101a5dfd20b5ed5d95d133af67c66fff95366af52eeb54f3c0eb928721bfa32b6a6dd1e258e80b5210f970999d9263f7a6172af4f851da812ab  php7-couchbase-2.4.6.tgz"


### PR DESCRIPTION
https://pecl.php.net/package-changelog.php?package=couchbase&release=2.4.6

Upgrade of `php7-couchbase` require upgrade of `libcouchbase` to *2.8.6* at least https://github.com/alpinelinux/aports/pull/4013