### PR TITLE
community/go: upgrade to 1.10.3

### DIFF
--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=go
-pkgver=1.10.1
+pkgver=1.10.3
 # This should be the latest commit on the corresponding release branch
 # https://github.com/golang/tools/commits/release-branch.go1.10
-_toolsver="25101aadb97aa42907eee6a238d6d26a6cb3c756"
+_toolsver="e9928cbe4ab476eebf6ff177f77b344773acfa9b"
 pkgrel=0
 pkgdesc="Go programming language compiler"
 url="http://www.golang.org/"
@@ -156,7 +156,7 @@ tools() {
 	done
 }
 
-sha512sums="13f6b0643a4f92eeca04444b9fa10de38fc3427daea9aa3227cf9a5738ffee1a3f2e355ba5faf711b8506f7de118bdcd3b9064b65407a22613523e29ffd73415  go1.10.1.src.tar.gz
-bb44f4941cc49f8271c1fd46d94c6c165796d919f156a4fd608158247f3f31c4d170e0d5ae67766ee22cb0eb844a106c7fe101fb7d20a2b6414e43e68ffbd6b1  go-tools-1.10.1-25101aadb97aa42907eee6a238d6d26a6cb3c756.tar.gz
+sha512sums="fd2bd5fcb5c6d0a5336c4b1d2cacb368edbb01359297a83bdedc53f6018642598232f00633fc60fde879050f5f26a810c828d46b5d6626cbcc0702d93ad33fbb  go1.10.3.src.tar.gz
+3b0bf5d4dc60bae92b04b9be9d193a36a35d4abbfce39480a02066ad5557f7529a088b233395c82727e2ebc312aff2fd5e3c9f00cca491e2a8db48e5c31657a4  go-tools-1.10.3-e9928cbe4ab476eebf6ff177f77b344773acfa9b.tar.gz
 a8f3afd97992f03ccf2680cde214eefccac47daeb9eeb689b5e0b206ea3c19cfb23d448a4eb532894d830d4b91cd97b249e88f04c17feba02d9e243b40243bd0  default-buildmode-pie.patch
 6abfdd8521b61ce1e823465f9b950a75dc235d7d58cc4c641c4e7830f7da28b8c57be53aef85641ff79bc95d7bd47bb0796659309d9d8e7907e29df520b150b0  set-external-linker.patch"


### PR DESCRIPTION
https://golang.org/doc/devel/release.html#go1.10.minor