### PR TITLE
community/irssi-xmpp: bump pkgrel

### DIFF
--- a/community/irssi-xmpp/APKBUILD
+++ b/community/irssi-xmpp/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stefan Wagner <stw@bit-strickerei.de>
 pkgname=irssi-xmpp
 pkgver=0.54
-pkgrel=0
+pkgrel=1
 pkgdesc="An irssi plugin to connect to the Jabber network"
 url="https://cybione.org/~irssi-xmpp/"
 arch="all"


### PR DESCRIPTION
Necessary since modern irssi needs a freshly built irssi-xmpp