### PR TITLE
main/perl-io-async: upgrade to 0.72

### DIFF
--- a/main/perl-io-async/APKBUILD
+++ b/main/perl-io-async/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Kiyoshi Aman <kiyoshi.aman@gmail.com>
 pkgname=perl-io-async
 _pkgreal=IO-Async
-pkgver=0.69
+pkgver=0.72
 pkgrel=0
 pkgdesc="Asynchronous event-driven programming"
 url="http://search.cpan.org/dist/IO-Async/"
@@ -35,6 +35,4 @@ package() {
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-md5sums="7585a39460c38e550f2037cc925a0374  IO-Async-0.69.tar.gz"
-sha256sums="05f1d64db02707eb933529870fe6ed95266d4226bc2297921debe21140c4880c  IO-Async-0.69.tar.gz"
-sha512sums="1c3ddb84511402d77ad62c22d10e79d4d805e6c8b27b7390c561dc293b076044eaeb3926fd2ec1d4408c0c60419821b917c6f0bceda9afea0bfba05a9f5fa588  IO-Async-0.69.tar.gz"
+sha512sums="4d1243e7904647d94bceb300d677ed2d28e58b7b57695b9de40b19f9b5d79418516837d5f6bead3836897956aad7027213b84c1244e46ddaa335b4916fe53804  IO-Async-0.72.tar.gz"


### PR DESCRIPTION
Version 0.69 is not available anymore