### PR TITLE
testing/linux-tools: Add gpio-tools subpackage

### DIFF
--- a/testing/linux-tools/APKBUILD
+++ b/testing/linux-tools/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=linux-tools
 pkgver=4.14.34
 _kernver=${pkgver%.*}
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux kernel tools meta package"
 url="http://www.kernel.org"
 arch="all"
@@ -13,10 +13,11 @@ depends_dev="pciutils-dev readline-dev gettext-dev"
 makedepends="$depends_dev elfutils-dev bash linux-headers flex bison diffutils
 	zlib-dev"
 install=""
-subpackages="perf perf-bash-completions:perf_completions cpupower $pkgname-doc $pkgname-dev"
+subpackages="perf perf-bash-completions:perf_completions cpupower gpio-tools:gpio_tools $pkgname-doc $pkgname-dev"
 source="https://kernel.org/pub/linux/kernel/v4.x/linux-$_kernver.tar.xz
         https://kernel.org/pub/linux/kernel/v4.x/patch-$pkgver.xz
 	cpupower-libs.patch
+	gpio-stdint.patch
 	"
 
 builddir="$srcdir"/linux-$_kernver
@@ -47,7 +48,7 @@ package() {
 	cd "$builddir"
 	mkdir -p "$pkgdir"
 	_make_tools DESTDIR="$pkgdir" \
-		perf_install cpupower_install
+		perf_install cpupower_install gpio_install
 }
 
 cpupower() {
@@ -81,6 +82,13 @@ perf_completions() {
 	mv "$pkgdir"/etc/bash_completion.d "$subpkgdir"/etc/
 }
 
+gpio_tools() {
+	pkgdesg="Linux kernel tools for GPIO access"
+	mkdir -p "$subpkgdir"/usr/bin/
+	mv "$pkgdir"/usr/bin/*gpio* "$subpkgdir"/usr/bin/
+}
+
 sha512sums="77e43a02d766c3d73b7e25c4aafb2e931d6b16e870510c22cef0cdb05c3acb7952b8908ebad12b10ef982c6efbe286364b1544586e715cf38390e483927904d8  linux-4.14.tar.xz
 1aff1ad1294e0d22ae1de0bbcb1d05269a9cc7bfeb6bc885bd9ee445198b30951d7d7918bf33152579415db2a4afe018d4b21c1fea5dd4d5e5014662fd870acf  patch-4.14.34.xz
-a46e3a84b00a39a356618831d0ddfb7f0d10f0a3799d1307ba2cc832e73c01f8d637a4e801a6dd25025f6f13155c6ad8b836422ff72d365e51063ac0bf907f52  cpupower-libs.patch"
+a46e3a84b00a39a356618831d0ddfb7f0d10f0a3799d1307ba2cc832e73c01f8d637a4e801a6dd25025f6f13155c6ad8b836422ff72d365e51063ac0bf907f52  cpupower-libs.patch
+dba8e9ee4b688a7e80637268edc9e749addcae9fa1cda782ba729c28eb48240218986f9c9db7da6ea6721a9c201f88b3b74f12df7640f17f8d0d9b475eaa0395  gpio-stdint.patch"

--- a/testing/linux-tools/gpio-stdint.patch
+++ b/testing/linux-tools/gpio-stdint.patch
@@ -1,0 +1,46 @@
+commit 92e70b83c0fef79dea9b8be06944b1eaffa4a9ba
+Author: Jonathan Neuschäfer <j.neuschaefer@gmx.net>
+Date:   Thu Dec 14 21:26:08 2017 +0100
+
+    tools/gpio: Don't use u_int32_t
+    
+    u_int32_t is a non-standard version of uint32_t, that was apparently
+    introduced by BSD. Use uint32_t from stdint.h instead.
+    
+    Signed-off-by: Jonathan Neuschäfer <j.neuschaefer@gmx.net>
+    Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+
+diff --git a/tools/gpio/gpio-event-mon.c b/tools/gpio/gpio-event-mon.c
+index 1c14c2595158..be6768e21b09 100644
+--- a/tools/gpio/gpio-event-mon.c
++++ b/tools/gpio/gpio-event-mon.c
+@@ -14,6 +14,7 @@
+ #include <unistd.h>
+ #include <stdlib.h>
+ #include <stdbool.h>
++#include <stdint.h>
+ #include <stdio.h>
+ #include <dirent.h>
+ #include <errno.h>
+@@ -27,8 +28,8 @@
+ 
+ int monitor_device(const char *device_name,
+ 		   unsigned int line,
+-		   u_int32_t handleflags,
+-		   u_int32_t eventflags,
++		   uint32_t handleflags,
++		   uint32_t eventflags,
+ 		   unsigned int loops)
+ {
+ 	struct gpioevent_request req;
+@@ -145,8 +146,8 @@ int main(int argc, char **argv)
+ 	const char *device_name = NULL;
+ 	unsigned int line = -1;
+ 	unsigned int loops = 0;
+-	u_int32_t handleflags = GPIOHANDLE_REQUEST_INPUT;
+-	u_int32_t eventflags = 0;
++	uint32_t handleflags = GPIOHANDLE_REQUEST_INPUT;
++	uint32_t eventflags = 0;
+ 	int c;
+ 
+ 	while ((c = getopt(argc, argv, "c:n:o:dsrf?")) != -1) {


### PR DESCRIPTION
This new package contains the tools lsgpio, gpio-event-mon, and gpio-hammer
from tools/gpio/ in the kernel source code. They are mainly useful for the
interactive testing of GPIOs.

(cc @ncopa)