### PR TITLE
testing/wireguard*: _toolsrel fixes

### DIFF
--- a/testing/wireguard-hardened/APKBUILD
+++ b/testing/wireguard-hardened/APKBUILD
@@ -10,7 +10,7 @@ _kpkgrel=0
 # we must also match up _toolsrel with wireguard-tools
 _ver=0.0.20180420
 _mypkgrel=2
-_toolsrel=0
+_toolsrel=3
 _name=wireguard
 
 # verify the kernel version before entering chroot

--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -1,6 +1,7 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
+# NOTE: pkgrel must match _toolsrel in wireguard-{vanilla,hardened}
 pkgname=wireguard-tools
 pkgver=0.0.20180420
 pkgrel=3

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -5,7 +5,7 @@
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
 _ver=0.0.20180420
-_rel=0
+_rel=1
 _toolsrel=3
 
 _flavor=${FLAVOR:-vanilla}
@@ -26,7 +26,7 @@ url='https://www.wireguard.com'
 license="GPL-2.0"
 depends="$_kpkg=$_kpkgver"
 makedepends="$_kpkg-dev=$_kpkgver libmnl-dev"
-install_if="wireguard-tools=$_ver-r$toolsrel $_kpkg=$_kpkgver"
+install_if="wireguard-tools=$_ver-r$_toolsrel $_kpkg=$_kpkgver"
 options="!check"
 source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$_ver.tar.xz"
 builddir="$srcdir"/WireGuard-$_ver

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -6,7 +6,7 @@
 _name=wireguard
 _ver=0.0.20180420
 _rel=0
-_toolsrel=0
+_toolsrel=3
 
 _flavor=${FLAVOR:-vanilla}
 _kpkg=linux-$_flavor


### PR DESCRIPTION
- The first patch documents the requirement to keep `_toolsrel` in sync with wireguard-tools' `pkgrel`
- The second patch fixes a typo in wireguard-vanilla, where `toolsrel` was used instead of `_toolsrel`

(cc @itoffshore @zx2c4)