### PR TITLE
main/freetype: fix CVE-2018-6942

### DIFF
--- a/main/freetype/0001-src-truetype-ttinterp.c-Ins_GETVARIATION-Avoid-NULL-.patch
+++ b/main/freetype/0001-src-truetype-ttinterp.c-Ins_GETVARIATION-Avoid-NULL-.patch
@@ -1,0 +1,50 @@
+From 8c0f9b94e3aa99cf63e06fda93c10ea0ad86eb09 Mon Sep 17 00:00:00 2001
+From: prspkt <prspkt@protonmail.com>
+Date: Tue, 12 Jun 2018 16:27:48 +0000
+Subject: [PATCH] main/freetype: fix CVE-2018-6942
+
+diff --git a/0001-src-truetype-ttinterp.c-Ins_GETVARIATION-Avoid-NULL-.patch b/0001-src-truetype-ttinterp.c-Ins_GETVARIATION-Avoid-NULL-.patch
+new file mode 100644
+index 0000000..07c8c88
+--- /dev/null
++++ b/0001-src-truetype-ttinterp.c-Ins_GETVARIATION-Avoid-NULL-.patch
+@@ -0,0 +1,39 @@
++From 29c759284e305ec428703c9a5831d0b1fc3497ef Mon Sep 17 00:00:00 2001
++From: Werner Lemberg <wl@gnu.org>
++Date: Sat, 27 Jan 2018 14:43:43 +0100
++Subject: [PATCH] * src/truetype/ttinterp.c (Ins_GETVARIATION): Avoid NULL
++ reference.
++
++Reported as
++
++  https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=5736
++---
++ src/truetype/ttinterp.c | 12 ++++++++++--
++ 1 file changed, 10 insertions(+), 2 deletions(-)
++
++diff --git a/src/truetype/ttinterp.c b/src/truetype/ttinterp.c
++index d855aaaa9..551f14a2e 100644
++--- a/src/truetype/ttinterp.c
+++++ b/src/truetype/ttinterp.c
++@@ -7532,8 +7532,16 @@
++       return;
++     }
++ 
++-    for ( i = 0; i < num_axes; i++ )
++-      args[i] = coords[i] >> 2; /* convert 16.16 to 2.14 format */
+++    if ( coords )
+++    {
+++      for ( i = 0; i < num_axes; i++ )
+++        args[i] = coords[i] >> 2; /* convert 16.16 to 2.14 format */
+++    }
+++    else
+++    {
+++      for ( i = 0; i < num_axes; i++ )
+++        args[i] = 0;
+++    }
++   }
++ 
++ 
++-- 
++2.17.1
++

--- a/main/freetype/APKBUILD
+++ b/main/freetype/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=freetype
 pkgver=2.9
-pkgrel=0
+pkgrel=1
 pkgdesc="TrueType font rendering library"
 url="https://www.freetype.org/"
 arch="all"
@@ -17,11 +17,14 @@ source="http://download.savannah.gnu.org/releases/freetype/freetype-$pkgver.tar.
 	0001-Enable-table-validation-modules.patch
 	0003-Enable-infinality-subpixel-hinting.patch
 	0004-Enable-long-PCF-family-names.patch
+	0001-src-truetype-ttinterp.c-Ins_GETVARIATION-Avoid-NULL-.patch
 
 	freetype-profile.sh
 	"
 
 # secfixes:
+#   2.9-r1:
+#     - CVE-2018-6942
 #   2.7.1-r1:
 #     - CVE-2017-8105
 #     - CVE-2017-8287
@@ -56,4 +59,5 @@ sha512sums="28465f3453baf9a187529432118389de8f1b85273c9fb787d2c8f0feee8ab64b387d
 41a84be2631b53072a76b78c582575aa48b650ee7b00017d018381002bc25df10cf33da4954c95ef50db39f1fa566678e3b4ae9bfee1dfd705423fb53e53e494  0001-Enable-table-validation-modules.patch
 7b52a3d67750d59b2c98e83dab4e0a0ab263142c2ca7bd5f8be5f8fe9cd1dc1f4debad44111c7886665329d8d2a3163756455618a6615df8f85d82bb0372d4dd  0003-Enable-infinality-subpixel-hinting.patch
 64c20fbcbf48372ea35fe2e0dae8fec4be8c601c899a4a71913060c6ea4082a2f41d69701da511e09fee126bf198d560986469e2356bd088d2dd5961f437df63  0004-Enable-long-PCF-family-names.patch
+a4a484478bbc5079abd72e643c8fac2efe17d1641e72590e687636541b1abae9eb900efc9e3dda6f850c377c13cee68aeb77ec7c0686ffe0e4814bd00ea6535e  0001-src-truetype-ttinterp.c-Ins_GETVARIATION-Avoid-NULL-.patch
 829dff39fc98e341cf88433758d9288fe9f824c1a1644ac7777ed274133df0fd0ee65606b7dab69acdb12ebf516d89da063df8850114e0c4e16a28bcc5de215d  freetype-profile.sh"


### PR DESCRIPTION
[Upstream patch](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/commit/?id=29c759284e305ec428703c9a5831d0b1fc3497ef) fixes:
- [CVE-2018-6942](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6942)