### PR TITLE
main/ntop: fix build break by reordering plugin dependancies

### DIFF
--- a/main/ntop/APKBUILD
+++ b/main/ntop/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=ntop
 pkgver=5.0.1
-pkgrel=12
+pkgrel=13
 pkgdesc="Network traffic probe"
 url="http://www.ntop.org"
 arch="all"
@@ -18,6 +18,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 source="https://sourceforge.net/projects/$pkgname/files/$pkgname/Stable/$pkgname-$pkgver.tar.gz
 	include-sys-types.h.patch
 	automake.patch
+	reorder_make_deps
 	ntop-rrdtool-1.6.0.patch
 	ntop.initd
 	ntop.confd
@@ -35,6 +36,7 @@ build() {
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--disable-snmp
+	patch -p1 < "$srcdir"/reorder_make_deps
 	make
 }
 
@@ -53,6 +55,7 @@ package() {
 sha512sums="f52c40e6c00c8d2f46b68078c5f9aef8ed78670f92a0a81f66f2f44c71d41bc4c001b4550f19b71c546f7c07cbbed15e0aa1ee13873ac63a11678bf2b8483f2a  ntop-5.0.1.tar.gz
 b67705152cd8723ba3e1c340ca55267134dddae04dd281fae262d07ce273a78d24bf40c297fe61ea7f70deb9cb7d59445e8a3ce360ed7810497e63052e1a9214  include-sys-types.h.patch
 ce284679f9ecf589139b6cfdba95a76df5205f5292a5ff88b7cdeb39fe01b4fef27fb097a6a594017aa015a2474fea6c5729917423398a911e1732329ec1504a  automake.patch
+ab1fb14317721a18d044145ddb552f827ec02c042ae591af6e7a738c28defcce53767493f01dcc31a6f4bfeb0d8032ceeca330a425a6c6e4efde0b22f8e1be9e  reorder_make_deps
 3532acc6e54a1abdefeba42b3adb68cba1a0d1d2d6422e5b33fb9823b48481bb83696f097e65288c5811a6dd65ce20bff6d285d152776156b0690610d4026245  ntop-rrdtool-1.6.0.patch
 22b61d88e1fc30106d07ee87701ff46b7f63f1ee2aa7bb5666d9cb5cb6251c583f793c80a5d799ac27fcb63650e7ecacb37e7992feb8aa8cbc2d326b36b05a8f  ntop.initd
 8693050cab03eeb29b59e0a7b173c7791625e8cd6bc33eaa5d74a50ab3ecf435577d7918626cfe3963a0d23d4522a737737b2b9fd8335df29784858a6191813d  ntop.confd

--- a/main/ntop/reorder_make_deps
+++ b/main/ntop/reorder_make_deps
@@ -1,0 +1,11 @@
+--- a/plugins/Makefile
++++ b/plugins/Makefile
+@@ -793,7 +793,7 @@
+ 	done
+ check-am: all-am
+ check: check-recursive
+-all-am: Makefile $(PROGRAMS) $(LTLIBRARIES)
++all-am: Makefile $(LTLIBRARIES) $(PROGRAMS)
+ installdirs: installdirs-recursive
+ installdirs-am:
+ 	for dir in "$(DESTDIR)$(libdir)"; do \


### PR DESCRIPTION
In 3.8 automake 1.16 invoked on ntop*/src/plugins/Makefile.am generates a Makefile with:
all-am: Makefile  $(PROGRAMS) $(LTLIBRARIES)
This results in a build error: 
gcc: error: netflowPlugin.o: No such file or directory
gcc: error: unrecognized command line option '-flat_namespace'; did you mean '-Wnamespaces'?
gcc: fatal error: no input files

In prior builds (3.7 and edge) with automake 1.15 the same Makefile.am generates a Makefile with:
all-am: Makefile $(LTLIBRARIES) $(PROGRAMS)
which builds without error.

This PR introduces a patch that changes the order of all-am dependencies to what had been generated in earlier versions of automake. It is not done as an ordinary patch since it must be applied after autogen.sh is run.