### PR TITLE
testing/weston: fix build

### DIFF
--- a/testing/weston/APKBUILD
+++ b/testing/weston/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=weston
 pkgver=3.0.0
-pkgrel=1
+pkgrel=2
 _libname=lib$pkgname
 _libdir=$_libname-${pkgver%%.*}
 pkgdesc="The reference Wayland server"
@@ -12,14 +12,14 @@ license="MIT"
 depends=""
 makedepends="wayland-protocols libxkbcommon-dev xkeyboard-config
 	libinput-dev libunwind-dev mtdev-dev libxcursor-dev glu-dev
-	pango-dev colord-dev freerdp-dev libwebp-dev libva-dev dbus-dev
-	linux-pam-dev
+	pango-dev colord-dev libwebp-dev libva-dev dbus-dev
+	linux-pam-dev wayland-libs-egl wayland-dev
 	"
 _cms="cms-colord cms-static"
 _shell="shell-desktop shell-fullscreen shell-ivi"
 _client="info terminal wcap-decode"
 _backend="backend-drm backend-fbdev backend-headless
-	backend-rdp backend-x11 backend-wayland
+	backend-x11 backend-wayland
 	"
 for _sub in $_cms $_shell $_client $_backend; do
 	subpackages="$subpackages $pkgname-$_sub:_sub"
@@ -46,7 +46,6 @@ build() {
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
 		--libexecdir=/usr/lib/$pkgname \
-		--enable-rdp-compositor \
 		--enable-screen-sharing \
 		--enable-vaapi-recorder \
 		--enable-clients \


### PR DESCRIPTION
1. New makedepends needed, because `mesa-libwayland-egl` does not exist anymore (see 257a236 and 4f8b36b): `wayland-libs-egl wayland-dev`
   This fixes configure errors:
```
checking for EGL_TESTS... no
configure: error: Package requirements (egl glesv2 wayland-client wayland-egl) were not met:

Package 'wayland-client', required by 'virtual:world', not found
Package 'wayland-egl', required by 'virtual:world', not found
```
2. Disable RDP backend, because Weston source is incompatible with freerdp 2.0.0. This avoids compilation errors like this one:
```
libweston/compositor-rdp.c:193:5: error: 'SURFACE_BITS_COMMAND {aka struct _SURFACE_BITS_COMMAND}' has no member named 'bpp';
```