### PR TITLE
main/weston: fix build

### DIFF
--- a/testing/weston/APKBUILD
+++ b/testing/weston/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=weston
 pkgver=3.0.0
-pkgrel=1
+pkgrel=2
 _libname=lib$pkgname
 _libdir=$_libname-${pkgver%%.*}
 pkgdesc="The reference Wayland server"
@@ -13,7 +13,7 @@ depends=""
 makedepends="wayland-protocols libxkbcommon-dev xkeyboard-config
 	libinput-dev libunwind-dev mtdev-dev libxcursor-dev glu-dev
 	pango-dev colord-dev freerdp-dev libwebp-dev libva-dev dbus-dev
-	linux-pam-dev
+	linux-pam-dev wayland-dev
 	"
 _cms="cms-colord cms-static"
 _shell="shell-desktop shell-fullscreen shell-ivi"
@@ -30,7 +30,8 @@ subpackages="$pkgname-dev $pkgname-doc $subpackages
 	"
 source="http://wayland.freedesktop.org/releases/$pkgname-$pkgver.tar.xz
 	timespec.patch
-	weston-launch-custom-error-function.patch"
+	weston-launch-custom-error-function.patch
+	freerdp-2.0.0_rc2.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 # weston-launch requires suid
 options="!check suid"
@@ -131,4 +132,5 @@ _sub() {
 
 sha512sums="b824c39f2a884f6d50d607613f447090621f684c96f7d905f25f6e500dabd03ecb2b1cd1030babc193c3417223cb220103abb792437e1a5ead7229a76b5c7a58  weston-3.0.0.tar.xz
 3e596af4bf0a6b06a5d28376043db111fe1c161ead04501fa6d2c667b5a21889cca3354d1bdc4ac794841bef68ed5e1a7a84e44e7d510e947e3673195706caed  timespec.patch
-3f742a29075fd447995cdda283d12655910925811b22a28fc279bcc7cf5c7c1a888cd391bec42d934b3bad24578504c642882100f15647178f6f6f89a8405916  weston-launch-custom-error-function.patch"
+3f742a29075fd447995cdda283d12655910925811b22a28fc279bcc7cf5c7c1a888cd391bec42d934b3bad24578504c642882100f15647178f6f6f89a8405916  weston-launch-custom-error-function.patch
+fb1f97058723bca27fc80b41e97d6f30987ab5fa2861d07bc41df4755fe431e0900fb82fbd92fd235db30cbca7869b624ffb95a07c0dfe752379a3ff8690c4ef  freerdp-2.0.0_rc2.patch"

--- a/testing/weston/freerdp-2.0.0_rc2.patch
+++ b/testing/weston/freerdp-2.0.0_rc2.patch
@@ -1,0 +1,121 @@
+From 8fad15621a4cc5858edd240987a8b3a3b90895a3 Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca@z3ntu.xyz>
+Date: Thu, 10 May 2018 18:36:41 +0200
+Subject: [PATCH] Fix compositor-rdp compilation with freerdp 2.0.0-rc2
+
+See https://github.com/FreeRDP/FreeRDP/commit/1f7d33a2f22a372c124ce985a394619e186e06b9
+---
+ libweston/compositor-rdp.c | 50 +++++++++++++++++++-------------------
+ 1 file changed, 25 insertions(+), 25 deletions(-)
+
+diff --git a/libweston/compositor-rdp.c b/libweston/compositor-rdp.c
+index 091472b0..79b7f68d 100644
+--- a/libweston/compositor-rdp.c
++++ b/libweston/compositor-rdp.c
+@@ -185,10 +185,10 @@ rdp_peer_refresh_rfx(pixman_region32_t *damage, pixman_image_t *image, freerdp_p
+ 	cmd->destTop = damage->extents.y1;
+ 	cmd->destRight = damage->extents.x2;
+ 	cmd->destBottom = damage->extents.y2;
+-	cmd->bpp = 32;
+-	cmd->codecID = peer->settings->RemoteFxCodecId;
+-	cmd->width = width;
+-	cmd->height = height;
++	cmd->bmp.bpp = 32;
++	cmd->bmp.codecID = peer->settings->RemoteFxCodecId;
++	cmd->bmp.width = width;
++	cmd->bmp.height = height;
+ 
+ 	ptr = pixman_image_get_data(image) + damage->extents.x1 +
+ 				damage->extents.y1 * (pixman_image_get_stride(image) / sizeof(uint32_t));
+@@ -211,8 +211,8 @@ rdp_peer_refresh_rfx(pixman_region32_t *damage, pixman_image_t *image, freerdp_p
+ 			pixman_image_get_stride(image)
+ 	);
+ 
+-	cmd->bitmapDataLength = Stream_GetPosition(context->encode_stream);
+-	cmd->bitmapData = Stream_Buffer(context->encode_stream);
++	cmd->bmp.bitmapDataLength = Stream_GetPosition(context->encode_stream);
++	cmd->bmp.bitmapData = Stream_Buffer(context->encode_stream);
+ 
+ 	update->SurfaceBits(update->context, cmd);
+ }
+@@ -242,19 +242,19 @@ rdp_peer_refresh_nsc(pixman_region32_t *damage, pixman_image_t *image, freerdp_p
+ 	cmd->destTop = damage->extents.y1;
+ 	cmd->destRight = damage->extents.x2;
+ 	cmd->destBottom = damage->extents.y2;
+-	cmd->bpp = 32;
+-	cmd->codecID = peer->settings->NSCodecId;
+-	cmd->width = width;
+-	cmd->height = height;
++	cmd->bmp.bpp = 32;
++	cmd->bmp.codecID = peer->settings->NSCodecId;
++	cmd->bmp.width = width;
++	cmd->bmp.height = height;
+ 
+ 	ptr = pixman_image_get_data(image) + damage->extents.x1 +
+ 				damage->extents.y1 * (pixman_image_get_stride(image) / sizeof(uint32_t));
+ 
+ 	nsc_compose_message(context->nsc_context, context->encode_stream, (BYTE *)ptr,
+-			cmd->width,	cmd->height,
++			cmd->bmp.width,	cmd->bmp.height,
+ 			pixman_image_get_stride(image));
+-	cmd->bitmapDataLength = Stream_GetPosition(context->encode_stream);
+-	cmd->bitmapData = Stream_Buffer(context->encode_stream);
++	cmd->bmp.bitmapDataLength = Stream_GetPosition(context->encode_stream);
++	cmd->bmp.bitmapData = Stream_Buffer(context->encode_stream);
+ 	update->SurfaceBits(update->context, cmd);
+ }
+ 
+@@ -291,16 +291,16 @@ rdp_peer_refresh_raw(pixman_region32_t *region, pixman_image_t *image, freerdp_p
+ 	update->SurfaceFrameMarker(peer->context, marker);
+ 
+ 	memset(cmd, 0, sizeof(*cmd));
+-	cmd->bpp = 32;
+-	cmd->codecID = 0;
++	cmd->bmp.bpp = 32;
++	cmd->bmp.codecID = 0;
+ 
+ 	for (i = 0; i < nrects; i++, rect++) {
+ 		/*weston_log("rect(%d,%d, %d,%d)\n", rect->x1, rect->y1, rect->x2, rect->y2);*/
+ 		cmd->destLeft = rect->x1;
+ 		cmd->destRight = rect->x2;
+-		cmd->width = rect->x2 - rect->x1;
++		cmd->bmp.width = rect->x2 - rect->x1;
+ 
+-		heightIncrement = peer->settings->MultifragMaxRequestSize / (16 + cmd->width * 4);
++		heightIncrement = peer->settings->MultifragMaxRequestSize / (16 + cmd->bmp.width * 4);
+ 		remainingHeight = rect->y2 - rect->y1;
+ 		top = rect->y1;
+ 
+@@ -308,21 +308,21 @@ rdp_peer_refresh_raw(pixman_region32_t *region, pixman_image_t *image, freerdp_p
+ 		subrect.x2 = rect->x2;
+ 
+ 		while (remainingHeight) {
+-			   cmd->height = (remainingHeight > heightIncrement) ? heightIncrement : remainingHeight;
++			   cmd->bmp.height = (remainingHeight > heightIncrement) ? heightIncrement : remainingHeight;
+ 			   cmd->destTop = top;
+-			   cmd->destBottom = top + cmd->height;
+-			   cmd->bitmapDataLength = cmd->width * cmd->height * 4;
+-			   cmd->bitmapData = (BYTE *)realloc(cmd->bitmapData, cmd->bitmapDataLength);
++			   cmd->destBottom = top + cmd->bmp.height;
++			   cmd->bmp.bitmapDataLength = cmd->bmp.width * cmd->bmp.height * 4;
++			   cmd->bmp.bitmapData = (BYTE *)realloc(cmd->bmp.bitmapData, cmd->bmp.bitmapDataLength);
+ 
+ 			   subrect.y1 = top;
+-			   subrect.y2 = top + cmd->height;
+-			   pixman_image_flipped_subrect(&subrect, image, cmd->bitmapData);
++			   subrect.y2 = top + cmd->bmp.height;
++			   pixman_image_flipped_subrect(&subrect, image, cmd->bmp.bitmapData);
+ 
+ 			   /*weston_log("*  sending (%d,%d, %d,%d)\n", subrect.x1, subrect.y1, subrect.x2, subrect.y2); */
+ 			   update->SurfaceBits(peer->context, cmd);
+ 
+-			   remainingHeight -= cmd->height;
+-			   top += cmd->height;
++			   remainingHeight -= cmd->bmp.height;
++			   top += cmd->bmp.height;
+ 		}
+ 	}
+ 
+-- 
+2.17.0
+


### PR DESCRIPTION
1. New makedepend `wayland-dev`, because `mesa-libwayland-egl` does not exist anymore (see 257a236 and 4f8b36b). This fixes configure errors:
```
checking for EGL_TESTS... no
configure: error: Package requirements (egl glesv2 wayland-client wayland-egl) were not met:

Package 'wayland-client', required by 'virtual:world', not found
Package 'wayland-egl', required by 'virtual:world', not found
```
2. Apply @z3ntu's patch to make the RDP backend work with freerdp-2.0.0_rc2. This avoids compilation errors like this one:
```
libweston/compositor-rdp.c:193:5: error: 'SURFACE_BITS_COMMAND {aka struct _SURFACE_BITS_COMMAND}' has no member named 'bpp';
```