### PR TITLE
testing/sacc: clean up

### DIFF
--- a/testing/sacc/APKBUILD
+++ b/testing/sacc/APKBUILD
@@ -13,14 +13,14 @@ source="ftp://bitreich.org/releases/$pkgname/$pkgname-v$pkgver.tgz"
 builddir="$srcdir/$pkgname-v$pkgver"
 
 build() {
-	make -C "$builddir"
+	cd "$builddir"
+	make
 }
 
 package() {
 	cd "$builddir"
 
 	make install PREFIX=/usr DESTDIR="$pkgdir"
-	install -Dm644 $pkgname.1 "$pkgdir"/usr/share/man/man1/$pkgname.1
 }
 
 sha512sums="9bc45264246f1b3fbc54b621963d8eeec6dd45b3c0e3a329e0755189b69fdafd385689f75bc2ec2ff85960d96cf7bba9816e6dc1aa43c5750d093719806dc2c2  sacc-v1.00.tgz"


### PR DESCRIPTION
Removed the unportable `make -C`, also removed the unneeded `install`
directive, as make install takes care of installing the man page.

Thanks to quinq on #suckless.