### PR TITLE
testing/wireguard: upgrade to 0.0.20180513

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180420
-pkgrel=3
+pkgver=0.0.20180513
+pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
 url='https://www.wireguard.com'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="19740c6678d13bbe156520d6121db2bd95c8f30891b9acbbc6af1d49079f144598f8062131ac1dfd14b830e32306bc54f2ae9608ceeec762ffde65495413a0ac  WireGuard-0.0.20180420.tar.xz"
+sha512sums="82f46fc50f47ac94948a7984a209ec55506c2bf1c41edf3a89f8043a0c770d6e88fdd7888b01ea41b227d316f53606a354f4d5d184ab2f1ecef80e0b376270b1  WireGuard-0.0.20180513.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180420
-_rel=0
+_ver=0.0.20180513
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -26,7 +26,7 @@ url='https://www.wireguard.com'
 license="GPL-2.0"
 depends="$_kpkg=$_kpkgver"
 makedepends="$_kpkg-dev=$_kpkgver libmnl-dev"
-install_if="wireguard-tools=$_ver-r$toolsrel $_kpkg=$_kpkgver"
+install_if="wireguard-tools=$_ver-r$_toolsrel $_kpkg=$_kpkgver"
 options="!check"
 source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$_ver.tar.xz"
 builddir="$srcdir"/WireGuard-$_ver
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="19740c6678d13bbe156520d6121db2bd95c8f30891b9acbbc6af1d49079f144598f8062131ac1dfd14b830e32306bc54f2ae9608ceeec762ffde65495413a0ac  WireGuard-0.0.20180420.tar.xz"
+sha512sums="82f46fc50f47ac94948a7984a209ec55506c2bf1c41edf3a89f8043a0c770d6e88fdd7888b01ea41b227d316f53606a354f4d5d184ab2f1ecef80e0b376270b1  WireGuard-0.0.20180513.tar.xz"


### PR DESCRIPTION
```
  * keygen-html: add zip file example
  
  The alpha Android app now supports importing from .zip files, so the example
  contrib code has been updated to show people how to trivially generate .zip
  files from ... javascript. That's right, the WireGuard repo now contains some
  more demo javascript.
  
  * qemu: retry on 404 in wget for kernel.org race
  
  Simple fix for build.wireguard.com's handling of new kernels.
  
  * embeddable-wg-library: zero attribute padding
  
  This imports 37c876b55a2c00424ccda5a300ab5fdec1d88b22 from upstream libmnl.
  
  * allowedips: add selftest for allowedips_walk_by_peer
  * allowedips: use native endian on lookup
  * allowedips: produce better assembly with unsigned arithmetic
  * allowedips: simplify arithmetic
  
  A series of bitmath improvements make allowedips lookups sleeker and faster.
  
  * socket: use skb_put_data
  
  This follows 59ae1d127ac0ae404baf414c434ba2651b793f46 in the kernel.
  
  * chacha20poly1305: make gcc 8.1 happy
  
  GCC 8.1 does not know about the invariant `0 <= ctx->num < POLY1305_BLOCK_SIZE`.
  This results in a warning that `memcpy(ctx->data + num, inp, len);` may
  overflow the `data` field, which is correct for arbitrary values of `num`.
  
  To make the invariant explicit we ensure that `num` is in the required range.
  An alternative would be to change `ctx->num` to a 4-bit bitfield at the point
  of declaration.
  
  This changes the code from `test ebp, ebp; jz end` to `and ebp, 15; jz
  end`, which have identical performance characteristics.
  
  * queueing: preserve pfmemalloc header bit
  
  Precautionary measure. Further work on this function goes on in the netdev
  thread: https://marc.info/?l=linux-netdev&m=152607982125178&w=2
  
  * compat: handle RHEL 7.5's recent backports
  * compat: don't clear header bits on RHEL
  
  WireGuard now supports RHEL's latest kernel, which involved fixing some pretty
  major crashes and clashes with RHEL's backports.
```