### PR TITLE
main/busybox: Backport nsenter option parser fixes

### DIFF
--- a/main/busybox/0001-nsenter-Rename-network-option-to-net.patch
+++ b/main/busybox/0001-nsenter-Rename-network-option-to-net.patch
@@ -1,0 +1,36 @@
+From 40394cb1c963c35d2daa9570ba968afa981cf1fc Mon Sep 17 00:00:00 2001
+From: Euan Harris <euan.harris@docker.com>
+Date: Thu, 3 May 2018 13:34:46 +0100
+Subject: [PATCH 1/2] nsenter: Rename --network option to --net
+
+In nsenter from util-linux, the long version of the -n option is
+--net=<path>.   BusyBox's version expects --network=<path>, so scripts
+and examples written for util-linux's version cause BusyBox's version
+to exit with the usage message.
+
+Confusingly, until commit 036585a911a5f, the usage message erroneously
+claimed that the long option was indeed called --net; after that commit
+long options are not listed at all.
+
+Signed-off-by: Euan Harris <euan.harris@docker.com>
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+---
+ util-linux/nsenter.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/util-linux/nsenter.c b/util-linux/nsenter.c
+index c6933c8..35439a2 100644
+--- a/util-linux/nsenter.c
++++ b/util-linux/nsenter.c
+@@ -112,7 +112,7 @@ static const char nsenter_longopts[] ALIGN1 =
+ 	"user\0"			Optional_argument	"U"
+ 	"ipc\0"				Optional_argument	"i"
+ 	"uts\0"				Optional_argument	"u"
+-	"network\0"			Optional_argument	"n"
++	"net\0"				Optional_argument	"n"
+ 	"pid\0"				Optional_argument	"p"
+ 	"mount\0"			Optional_argument	"m"
+ 	"target\0"			Required_argument	"t"
+-- 
+2.7.4
+

--- a/main/busybox/0002-nsenter-fix-parsing-of-t-S-and-G-options.patch
+++ b/main/busybox/0002-nsenter-fix-parsing-of-t-S-and-G-options.patch
@@ -1,0 +1,61 @@
+From 254e47372f77ea1070be6dbb44b5c45770115a07 Mon Sep 17 00:00:00 2001
+From: Euan Harris <euan.harris@docker.com>
+Date: Fri, 4 May 2018 16:18:47 +0100
+Subject: [PATCH 2/2] nsenter: fix parsing of -t, -S and -G options
+
+-t, -S and -G each take mandatory integer arguments.   getopt32long()'s
+option string syntax for this type of argument is 'c:+', however nsenter's
+opt_str uses 'c+', which specifies two options 'c' and '+' which do not
+take arguments.   This means that giving a target PID causes nsenter to
+exit and print the usage string:
+
+  # nsenter -t1 sh
+  nsenter: unrecognized option: 1
+  BusyBox v1.27.2 (2017-12-12 10:41:50 GMT) multi-call binary.
+  ...
+
+The long form options are also broken:
+
+  # nsenter --setuid=1000 --setgid=1000 sh
+  BusyBox v1.29.0.git (2018-05-04 13:56:49 UTC) multi-call binary.
+  ...
+
+`nsenter --target=<pid> sh` parses correctly and appears to work, but
+<pid> is ignored and set to 0.   This doesn't raise an error unless one
+of the namespace arguments is also given:
+
+  # ./busybox_unstripped nsenter --target=42 sh
+  # exit
+
+  # ./busybox_unstripped nsenter -n --target=42 sh
+  BusyBox v1.29.0.git (2018-05-04 13:56:49 UTC) multi-call binary.
+  ...
+
+This has caused problems in a couple of places:
+
+  https://github.com/linuxkit/linuxkit/issues/567
+  https://github.com/gliderlabs/docker-alpine/issues/359
+  https://github.com/kontena/pharos-cluster/pull/81
+
+Signed-off-by: Euan Harris <euan.harris@docker.com>
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+---
+ util-linux/nsenter.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/util-linux/nsenter.c b/util-linux/nsenter.c
+index 35439a2..ae8103a 100644
+--- a/util-linux/nsenter.c
++++ b/util-linux/nsenter.c
+@@ -105,7 +105,7 @@ static const struct namespace_descr ns_list[] = {
+ /*
+  * Upstream nsenter doesn't support the short option for --preserve-credentials
+  */
+-static const char opt_str[] ALIGN1 = "U::i::u::n::p::m::""t+S+G+r::w::F";
++static const char opt_str[] ALIGN1 = "U::i::u::n::p::m::""t:+S:+G:+r::w::F";
+ 
+ #if ENABLE_LONG_OPTS
+ static const char nsenter_longopts[] ALIGN1 =
+-- 
+2.7.4
+

--- a/main/busybox/APKBUILD
+++ b/main/busybox/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=busybox
 pkgver=1.28.2
-pkgrel=3
+pkgrel=4
 pkgdesc="Size optimized toolbox of many common UNIX utilities"
 url=http://busybox.net
 arch="all"
@@ -39,6 +39,9 @@ source="http://busybox.net/downloads/$pkgname-$pkgver.tar.bz2
 
 	fix-cpio-symlinks.patch
 	0001-grep-fix-echo-aa-busybox-grep-F-w-a-should-not-match.patch
+
+	0001-nsenter-Rename-network-option-to-net.patch
+	0002-nsenter-fix-parsing-of-t-S-and-G-options.patch
 
 	acpid.logrotate
 	busyboxconfig
@@ -202,6 +205,8 @@ a96aa81d2f0104b5c28f02e80b3f77dbce77af93c174c09015a34850474d69e42c160fc8061c62f0
 d90d6b3406760fe3df6dbed46a0f4d1c02a69d5184ebc86d8c1692bc4576532127283ba3ff9a81e64f3660c279b8ee324dac7a426350873c45957067648651c6  0017-ifupdown-do-not-fail-if-interface-disappears-during-.patch
 65c11538056b6bd782b6195252a2a49f3b374e285a04f3296f708bb7da02b87435c34d43eaf80f1961167f55106fc2e4d5843d0c27cf06e6156ff8fabe642ac8  fix-cpio-symlinks.patch
 bc16f8ee0369274aa145d050cf45d7b0f7e9cd569b40e327b634f442851fff23a7decee0ba7822535bb6e195a0f8ab8a29fe5899cd909abda8d60e4247b462d9  0001-grep-fix-echo-aa-busybox-grep-F-w-a-should-not-match.patch
+d2364e20b12c5215c4baecc3c6faf903e6e1e2bee95d697af047d680e9d57e7aeea54c8584d062d92daa0ea64898b502fbae010b22ab236ec4018966b74deeec  0001-nsenter-Rename-network-option-to-net.patch
+0dbffae82b62317fc4144a01940ebc601e58b0e14eb8338bc42db79407d0b74dbe9f0f44758b9a5baa399eb90f8e8ee8f9c344bebd1b03bdd2ce520cb2b28d5e  0002-nsenter-fix-parsing-of-t-S-and-G-options.patch
 a9b1403c844c51934637215307dd9e2adb9458921047acff0d86dcf229b6e0027f4b2c6cdaa25a58407aad9d098fb5685d58eb5ff8d2aa3de4912cdea21fe54c  acpid.logrotate
 035f2a28719971d9ff805d208d70bc1144fd3701235dc46ef581a559e696ef92265f28f7debf0248a2cee004a773dcd07828bcc088716f5aff944ccdce15d30f  busyboxconfig
 0efbe22e2fd56993d92b6542d4ccffb2b42d50495be085c98f417a71f503b4071e2f092afcec77f78064d33ffb0922c28daa3cb9958e6d7fb26d5a660abd90f4  busyboxconfig-extras


### PR DESCRIPTION
* Rename --network to --net, to match util-linux and the help text
* -t, -S and -G should take mandatory integer options, but are defined
  as simple flags, causing problems such as:

    https://github.com/linuxkit/linuxkit/issues/567
    https://github.com/gliderlabs/docker-alpine/issues/359
    https://github.com/kontena/pharos-cluster/pull/81

These patches have been accepted upstream by Busybox.

Signed-off-by: Euan Harris <euan.harris@docker.com>