### PR TITLE
testing/wireguard-tools: Document pkgrel/_toolsrel requirement

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -1,6 +1,7 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
+# NOTE: pkgrel must match _toolsrel in wireguard-vanilla
 pkgname=wireguard-tools
 pkgver=0.0.20180513
 pkgrel=0


### PR DESCRIPTION
This is the remaining part of #4235, just a small comment to help contributors who change the pkgrel variable in wireguard-tools.

cc @zx2c4 