### PR TITLE
main/tiff: add secfixes

### DIFF
--- a/main/tiff/APKBUILD
+++ b/main/tiff/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Michael Mason <ms13sp@gmail.com>
 pkgname=tiff
 pkgver=4.0.9
-pkgrel=4
+pkgrel=5
 pkgdesc="Provides support for the Tag Image File Format or TIFF"
 url="http://www.libtiff.org"
 arch="all"
@@ -17,8 +17,11 @@ source="http://download.osgeo.org/libtiff/$pkgname-$pkgver.tar.gz
 	CVE-2017-18013.patch
 	CVE-2018-5784.patch
 	CVE-2018-7456.patch
+	CVE-2018-8905.patch
 	"
 # secfixes:
+#   4.0.9-r5:
+#     - CVE-2018-8905
 #   4.0.9-r4:
 #     - CVE-2018-7456
 #   4.0.9-r2:
@@ -80,4 +83,5 @@ tools() {
 sha512sums="04f3d5eefccf9c1a0393659fe27f3dddd31108c401ba0dc587bca152a1c1f6bc844ba41622ff5572da8cc278593eff8c402b44e7af0a0090e91d326c2d79f6cd  tiff-4.0.9.tar.gz
 3a31e4315ecc5c5bf709e2ca0fefb5bc7ff50c79f911b8b8366be38d007d3f79e89982700a620b2d82739313fbd79041428dbf3ecf0a790c9ec3bc2e211d6fce  CVE-2017-18013.patch
 c9cb1f712241c5bbd01910d4f4becf50ba8498bb04393f45451af4ace948b6a41b3d887adc9fbce1a53edeb0aeba03868f4d31428f3c5813ed14bb4b6f4c0f96  CVE-2018-5784.patch
-8f3ad4065f6ef349c4bd0fe9161cbe19744fbbc89f17c52eb4e43548ca4816f09c7f7e270cb77ced820a95ca009b5f7ad65ee79e7b23ffe1d31c137e3b2bef47  CVE-2018-7456.patch"
+8f3ad4065f6ef349c4bd0fe9161cbe19744fbbc89f17c52eb4e43548ca4816f09c7f7e270cb77ced820a95ca009b5f7ad65ee79e7b23ffe1d31c137e3b2bef47  CVE-2018-7456.patch
+ba283d0def89bf7caee753f39b5717780e9aec2ba32b8ce400b3d86b50eb1414a92bd56ebcf5e9550436a71aa18c55e31c6b5966f24dc5ec1863f28ca769d887  CVE-2018-8905.patch"

--- a/main/tiff/CVE-2018-8905.patch
+++ b/main/tiff/CVE-2018-8905.patch
@@ -1,0 +1,51 @@
+From 58a898cb4459055bb488ca815c23b880c242a27d Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 12 May 2018 15:32:31 +0200
+Subject: [PATCH] LZWDecodeCompat(): fix potential index-out-of-bounds write. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2780 / CVE-2018-8905
+
+The fix consists in using the similar code LZWDecode() to validate we
+don't write outside of the output buffer.
+---
+ libtiff/tif_lzw.c | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/libtiff/tif_lzw.c b/libtiff/tif_lzw.c
+index 4ccb443..94d85e3 100644
+--- a/libtiff/tif_lzw.c
++++ b/libtiff/tif_lzw.c
+@@ -602,6 +602,7 @@ LZWDecodeCompat(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
+ 	char *tp;
+ 	unsigned char *bp;
+ 	int code, nbits;
++	int len;
+ 	long nextbits, nextdata, nbitsmask;
+ 	code_t *codep, *free_entp, *maxcodep, *oldcodep;
+ 
+@@ -753,13 +754,18 @@ LZWDecodeCompat(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
+ 				}  while (--occ);
+ 				break;
+ 			}
+-			assert(occ >= codep->length);
+-			op += codep->length;
+-			occ -= codep->length;
+-			tp = op;
++			len = codep->length;
++			tp = op + len;
+ 			do {
+-				*--tp = codep->value;
+-			} while( (codep = codep->next) != NULL );
++				int t;
++				--tp;
++				t = codep->value;
++				codep = codep->next;
++				*tp = (char)t;
++			} while (codep && tp > op);
++			assert(occ >= len);
++			op += len;
++			occ -= len;
+ 		} else {
+ 			*op++ = (char)code;
+ 			occ--;
+--
+libgit2 0.27.0
+


### PR DESCRIPTION
fix for:
- [CVE-2018-8905](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8905)
sourced from [upstream](https://gitlab.com/libtiff/libtiff/commit/58a898cb4459055bb488ca815c23b880c242a27d).