### PR TITLE
Revert "main/mesa: build fix for armhf"

### DIFF
--- a/main/mesa/APKBUILD
+++ b/main/mesa/APKBUILD
@@ -51,9 +51,6 @@ x86*)
 armhf|aarch64)
 	_gallium_drivers="${_gallium_drivers},vc4"
 	subpackages="$subpackages $pkgname-dri-vc4:_dri"
-	case "$CARCH" in
-	armhf) CFLAGS="$CFLAGS -mfpu=neon";;
-	esac
 	;;
 esac
 


### PR DESCRIPTION
This reverts commit 2b4535bd3025886a5237ecf385fe5f92b8c28da2.

It's not necessary anymore to apply CFLAGS -mfpu=neon globally.
mesa now applies target specific CFLAGS to enable neon for the vc4 driver.
https://cgit.freedesktop.org/mesa/mesa/commit/?id=bd5efbd70b33a9f7977e75799c3b7d293113ba4d