### PR TITLE
testing/toxcore: testing/toxic: New package for Tox messenger

### DIFF
--- a/testing/toxcore/APKBUILD
+++ b/testing/toxcore/APKBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Jonathan Sieber <mail@strfry.org>
+
+pkgname=toxcore
+pkgver=0.2.9
+pkgrel=0
+pkgdesc="Tox communication project - Core Library"
+url="https://tox.chat/"
+arch="all"
+license="GPL-3.0+"
+makedepends="linux-headers cmake libsodium-dev opus-dev libvpx-dev"
+subpackages="$pkgname-dev $pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/TokTok/c-toxcore/archive/v$pkgver.tar.gz"
+
+# Toxcore's tests do require networking and are not working properly in Travis-CI
+options="!check"
+
+builddir="$srcdir/c-$pkgname-$pkgver"
+
+build() {
+	cmake . \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_LIBDIR=lib
+
+	make
+}
+
+check() {
+	make test
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+	install -Dm644 LICENSE \
+		"$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+
+sha512sums="917826a906a9ca4f04f34494616b8e36ec9e74c6b0709c50e8fe2dd9da680d170013fef242a3fe1b834e8e54cd2dde6be1c14e5d977f8531436ef34280bc3966  toxcore-0.2.9.tar.gz"

--- a/testing/toxic/APKBUILD
+++ b/testing/toxic/APKBUILD
@@ -1,0 +1,25 @@
+# Maintainer: Jonathan Sieber <mail@strfry.org>
+pkgname=toxic
+pkgver=0.8.3
+pkgrel=0
+pkgdesc=" An ncurses-based Tox client"
+url="https://github.com/JFreegman/toxic"
+arch="all"
+license="GPL-3.0+"
+options="!check"
+subpackages="$pkgname-doc"
+makedepends="toxcore toxcore-dev libconfig-dev ncurses-dev openal-soft-dev linux-headers libvpx-dev opus-dev
+	libnotify-dev libqrencode-dev curl-dev libx11-dev"
+source="$pkgname-$pkgver.tar.gz::https://github.com/JFreegman/$pkgname/archive/v$pkgver.tar.gz"
+
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	make
+}
+
+package() {
+	make PREFIX="$pkgdir"/usr install
+}
+
+sha512sums="c8d746efcc055592dd990dfa57415cc1eacaaa3b66303d7583d9f9e7e98b8829c8f1ae849f36a243c8896e99787dd2e493c92367de719b20a4a160bc7daea76e  toxic-0.8.3.tar.gz"


### PR DESCRIPTION
This PR adds a package for the Tox Messenger console client 'toxic', and the underlying 'toxcore' library.