### PR TITLE
main/xen: security fixes XSA 260-262

### DIFF
--- a/main/xen/APKBUILD
+++ b/main/xen/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=xen
 pkgver=4.9.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Xen hypervisor"
 url="http://www.xen.org/"
 arch="x86_64 armhf aarch64"
@@ -115,6 +115,10 @@ options="!strip"
 #   4.9.2-r1:
 #     - CVE-2018-10472 XSA-258
 #     - CVE-2018-10471 XSA-259
+#   4.9.2-r2:
+#     - CVE-2018-8897  XSA-260 (needs x86-XPTI-reduce-.text.entry.patch)
+#     - CVE-2018-10982 XSA-261
+#     - CVE-2018-10981 XSA-262
 
 case "$CARCH" in
 x86*)
@@ -181,6 +185,14 @@ source="https://downloads.xenproject.org/release/$pkgname/$pkgver/$pkgname-$pkgv
 
 	xsa258.patch
 	xsa259.patch
+
+	x86-XPTI-reduce-.text.entry.patch
+	xsa260-1.patch
+	xsa260-2.patch
+	xsa260-3.patch
+	xsa260-4.patch
+	xsa261-4.9.patch
+	xsa262-4.9.patch
 
 	xenstored.initd
 	xenstored.confd
@@ -436,6 +448,13 @@ e76816c6ad0e91dc5f81947f266da3429b20e6d976c3e8c41202c6179532eec878a3f0913921ef3a
 2094ea964fa610b2bf72fd2c7ede7e954899a75c0f5b08030cf1d74460fb759ade84866176e32f8fe29c921dfdc6dafd2b31e23ab9b0a3874d3dceeabdd1913b  xenqemu-xattr-size-max.patch
 5be5befaf5c6a83bd1d02cf33e4bddc6d61d683ee4392e1a40b004c9026e785d62a8a6a80c94dba67150af1355ab141b8457589839c7d7beb4673fd302cc2470  xsa258.patch
 023b34174d059d1e22a070e9f48d0601b0a6e735acef5b74af7f8613d3267e66773e662790a8f2a5b7fda32b017bf654a059e4fecd94a82ff8502900e4b24b25  xsa259.patch
+dc0b706903da13025cc9fa3dde1ba8f0f774839704d9f3d3c6482b476f3cf1e85b9567fd4a6761e0322e55e0e9792944be6d23b2ef23db2844822a95d9491b8c  x86-XPTI-reduce-.text.entry.patch
+af38aae378414e88c2553dd61c499a7016e0be9bfc663d134b90fc4fba7eb792c34bfbbc5b52eb19339fea4e6d0bd8d629f150daadcd28ff13c2b1f5902496d5  xsa260-1.patch
+4796336af7505dc0b024d739f745483229a199dd5f7c91de52af0fc164b1951825c57faeb597bacf945ebfeafdcc3b2fd129b8dc9f01d852503d5124af49691f  xsa260-2.patch
+90f9283da362c25403c764db4eeb42cd329969e784d9685ef7691437e4589e4aec207cc24467b9971d552884be614f3f1aa5fd91095074cd26689e31bd9c6815  xsa260-3.patch
+34ad2d35f20f0be9b88ea93454497bd2e5539b91eac767f885257fef19d304e39bcc1ece5e06475208dafb8ca0cfe9941191ccb580037ae4bdb82b249e09bff9  xsa260-4.patch
+78c537f82b759bfbcec9d8e7f06b72501695978735a16d4f1ef71dbf5ea87a1e9b1d7fb9a3a56013e4aada33c1d9cb5de74a3b058946285485db20481a7317e1  xsa261-4.9.patch
+05dc19a710290b49ba6dbd1181dd0e69fc9ad524870c008813d22c8b0c2d6af573034e7a44b0b75dd2d112989caf1447b0d6b42d007f1bffc3442828a88ac8f3  xsa262-4.9.patch
 52c43beb2596d645934d0f909f2d21f7587b6898ed5e5e7046799a8ed6d58f7a09c5809e1634fa26152f3fd4f3e7cfa07da7076f01b4a20cc8f5df8b9cb77e50  xenstored.initd
 093f7fbd43faf0a16a226486a0776bade5dc1681d281c5946a3191c32d74f9699c6bf5d0ab8de9d1195a2461165d1660788e92a3156c9b3c7054d7b2d52d7ff0  xenstored.confd
 3c86ed48fbee0af4051c65c4a3893f131fa66e47bf083caf20c9b6aa4b63fdead8832f84a58d0e27964bc49ec8397251b34e5be5c212c139f556916dc8da9523  xenconsoled.initd

--- a/main/xen/x86-XPTI-reduce-.text.entry.patch
+++ b/main/xen/x86-XPTI-reduce-.text.entry.patch
@@ -1,0 +1,321 @@
+From 72ca5804d0d3297d527116aa1dc2b4f47f7079ee Mon Sep 17 00:00:00 2001
+From: Jan Beulich <jbeulich@suse.com>
+Date: Wed, 18 Apr 2018 16:41:16 +0200
+Subject: [PATCH] x86/XPTI: reduce .text.entry
+
+This exposes less code pieces and at the same time reduces the range
+covered from slightly above 3 pages to a little below 2 of them.
+
+The code being moved is unchanged, except for the removal of trailing
+blanks, insertion of blanks between operands, and a pointless q suffix
+from "retq".
+
+A few more small pieces could be moved, but it seems better to me to
+leave them where they are to not make it overly hard to follow code
+paths.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: Andrew Cooper <andrew.cooper3@citrix.com>
+master commit: 454efb2a31b64b98e3dd55c083ce41b87375faa6
+master date: 2018-04-05 15:48:23 +0100
+---
+ xen/arch/x86/x86_64/compat/entry.S |   9 +-
+ xen/arch/x86/x86_64/entry.S        | 209 ++++++++++++++++++-------------------
+ 2 files changed, 107 insertions(+), 111 deletions(-)
+
+diff --git a/xen/arch/x86/x86_64/compat/entry.S b/xen/arch/x86/x86_64/compat/entry.S
+index d1f900b66a..615bd884ed 100644
+--- a/xen/arch/x86/x86_64/compat/entry.S
++++ b/xen/arch/x86/x86_64/compat/entry.S
+@@ -11,8 +11,6 @@
+ #include <public/xen.h>
+ #include <irq_vectors.h>
+ 
+-        .section .text.entry, "ax", @progbits
+-
+ ENTRY(entry_int82)
+         ASM_CLAC
+         pushq $0
+@@ -197,6 +195,8 @@ ENTRY(compat_post_handle_exception)
+         movb  $0,TRAPBOUNCE_flags(%rdx)
+         jmp   compat_test_all_events
+ 
++        .section .text.entry, "ax", @progbits
++
+ /* See lstar_enter for entry register state. */
+ ENTRY(cstar_enter)
+         /* sti could live here when we don't switch page tables below. */
+@@ -251,6 +251,8 @@ UNLIKELY_END(compat_syscall_gpf)
+         movb  %cl,TRAPBOUNCE_flags(%rdx)
+         jmp   .Lcompat_bounce_exception
+ 
++        .text
++
+ ENTRY(compat_sysenter)
+         CR4_PV32_RESTORE
+         movq  VCPU_trap_ctxt(%rbx),%rcx
+@@ -270,9 +272,6 @@ ENTRY(compat_int80_direct_trap)
+         call  compat_create_bounce_frame
+         jmp   compat_test_all_events
+ 
+-        /* compat_create_bounce_frame & helpers don't need to be in .text.entry */
+-        .text
+-
+ /* CREATE A BASIC EXCEPTION FRAME ON GUEST OS (RING-1) STACK:            */
+ /*   {[ERRCODE,] EIP, CS, EFLAGS, [ESP, SS]}                             */
+ /* %rdx: trap_bounce, %rbx: struct vcpu                                  */
+diff --git a/xen/arch/x86/x86_64/entry.S b/xen/arch/x86/x86_64/entry.S
+index e8636c4a67..b0bd5fab17 100644
+--- a/xen/arch/x86/x86_64/entry.S
++++ b/xen/arch/x86/x86_64/entry.S
+@@ -12,8 +12,6 @@
+ #include <public/xen.h>
+ #include <irq_vectors.h>
+ 
+-        .section .text.entry, "ax", @progbits
+-
+ /* %rbx: struct vcpu */
+ ENTRY(switch_to_kernel)
+         leaq  VCPU_trap_bounce(%rbx),%rdx
+@@ -32,8 +30,111 @@ ENTRY(switch_to_kernel)
+         movb  %cl,TRAPBOUNCE_flags(%rdx)
+         call  create_bounce_frame
+         andl  $~X86_EFLAGS_DF,UREGS_eflags(%rsp)
++/* %rbx: struct vcpu */
++test_all_events:
++        ASSERT_NOT_IN_ATOMIC
++        cli                             # tests must not race interrupts
++/*test_softirqs:*/
++        movl  VCPU_processor(%rbx), %eax
++        shll  $IRQSTAT_shift, %eax
++        leaq  irq_stat+IRQSTAT_softirq_pending(%rip), %rcx
++        cmpl  $0, (%rcx, %rax, 1)
++        jne   process_softirqs
++        cmpb  $0, VCPU_mce_pending(%rbx)
++        jne   process_mce
++.Ltest_guest_nmi:
++        cmpb  $0, VCPU_nmi_pending(%rbx)
++        jne   process_nmi
++test_guest_events:
++        movq  VCPU_vcpu_info(%rbx), %rax
++        movzwl VCPUINFO_upcall_pending(%rax), %eax
++        decl  %eax
++        cmpl  $0xfe, %eax
++        ja    restore_all_guest
++/*process_guest_events:*/
++        sti
++        leaq  VCPU_trap_bounce(%rbx), %rdx
++        movq  VCPU_event_addr(%rbx), %rax
++        movq  %rax, TRAPBOUNCE_eip(%rdx)
++        movb  $TBF_INTERRUPT, TRAPBOUNCE_flags(%rdx)
++        call  create_bounce_frame
+         jmp   test_all_events
+ 
++        ALIGN
++/* %rbx: struct vcpu */
++process_softirqs:
++        sti
++        call do_softirq
++        jmp  test_all_events
++
++        ALIGN
++/* %rbx: struct vcpu */
++process_mce:
++        testb $1 << VCPU_TRAP_MCE, VCPU_async_exception_mask(%rbx)
++        jnz  .Ltest_guest_nmi
++        sti
++        movb $0, VCPU_mce_pending(%rbx)
++        call set_guest_machinecheck_trapbounce
++        test %eax, %eax
++        jz   test_all_events
++        movzbl VCPU_async_exception_mask(%rbx), %edx # save mask for the
++        movb %dl, VCPU_mce_old_mask(%rbx)            # iret hypercall
++        orl  $1 << VCPU_TRAP_MCE, %edx
++        movb %dl, VCPU_async_exception_mask(%rbx)
++        jmp  process_trap
++
++        ALIGN
++/* %rbx: struct vcpu */
++process_nmi:
++        testb $1 << VCPU_TRAP_NMI, VCPU_async_exception_mask(%rbx)
++        jnz  test_guest_events
++        sti
++        movb $0, VCPU_nmi_pending(%rbx)
++        call set_guest_nmi_trapbounce
++        test %eax, %eax
++        jz   test_all_events
++        movzbl VCPU_async_exception_mask(%rbx), %edx # save mask for the
++        movb %dl, VCPU_nmi_old_mask(%rbx)            # iret hypercall
++        orl  $1 << VCPU_TRAP_NMI, %edx
++        movb %dl, VCPU_async_exception_mask(%rbx)
++        /* FALLTHROUGH */
++process_trap:
++        leaq VCPU_trap_bounce(%rbx), %rdx
++        call create_bounce_frame
++        jmp  test_all_events
++
++/* No special register assumptions. */
++ENTRY(ret_from_intr)
++        GET_CURRENT(bx)
++        testb $3, UREGS_cs(%rsp)
++        jz    restore_all_xen
++        movq  VCPU_domain(%rbx), %rax
++        cmpb  $0, DOMAIN_is_32bit_pv(%rax)
++        je    test_all_events
++        jmp   compat_test_all_events
++
++/* Enable NMIs.  No special register assumptions. Only %rax is not preserved. */
++ENTRY(enable_nmis)
++        movq  %rsp, %rax /* Grab RSP before pushing */
++
++        /* Set up stack frame */
++        pushq $0               /* SS */
++        pushq %rax             /* RSP */
++        pushfq                 /* RFLAGS */
++        pushq $__HYPERVISOR_CS /* CS */
++        leaq  1f(%rip),%rax
++        pushq %rax             /* RIP */
++
++/* No op trap handler.  Required for kexec crash path. */
++GLOBAL(trap_nop)
++        iretq /* Disable the hardware NMI latch */
++1:
++        retq
++	.type enable_nmis, @function
++	.size enable_nmis, .-enable_nmis
++
++        .section .text.entry, "ax", @progbits
++
+ /* %rbx: struct vcpu, interrupts disabled */
+ restore_all_guest:
+         ASSERT_INTERRUPTS_DISABLED
+@@ -187,80 +288,8 @@ ENTRY(lstar_enter)
+ 
+         mov   %rsp, %rdi
+         call  pv_hypercall
+-
+-/* %rbx: struct vcpu */
+-test_all_events:
+-        ASSERT_NOT_IN_ATOMIC
+-        cli                             # tests must not race interrupts
+-/*test_softirqs:*/  
+-        movl  VCPU_processor(%rbx),%eax
+-        shll  $IRQSTAT_shift,%eax
+-        leaq  irq_stat+IRQSTAT_softirq_pending(%rip),%rcx
+-        cmpl  $0,(%rcx,%rax,1)
+-        jne   process_softirqs
+-        testb $1,VCPU_mce_pending(%rbx)
+-        jnz   process_mce
+-.Ltest_guest_nmi:
+-        testb $1,VCPU_nmi_pending(%rbx)
+-        jnz   process_nmi
+-test_guest_events:
+-        movq  VCPU_vcpu_info(%rbx),%rax
+-        movzwl VCPUINFO_upcall_pending(%rax),%eax
+-        decl  %eax
+-        cmpl  $0xfe,%eax
+-        ja    restore_all_guest
+-/*process_guest_events:*/
+-        sti
+-        leaq  VCPU_trap_bounce(%rbx),%rdx
+-        movq  VCPU_event_addr(%rbx),%rax
+-        movq  %rax,TRAPBOUNCE_eip(%rdx)
+-        movb  $TBF_INTERRUPT,TRAPBOUNCE_flags(%rdx)
+-        call  create_bounce_frame
+         jmp   test_all_events
+ 
+-        ALIGN
+-/* %rbx: struct vcpu */
+-process_softirqs:
+-        sti       
+-        call do_softirq
+-        jmp  test_all_events
+-
+-        ALIGN
+-/* %rbx: struct vcpu */
+-process_mce:
+-        testb $1 << VCPU_TRAP_MCE,VCPU_async_exception_mask(%rbx)
+-        jnz  .Ltest_guest_nmi
+-        sti
+-        movb $0,VCPU_mce_pending(%rbx)
+-        call set_guest_machinecheck_trapbounce
+-        test %eax,%eax
+-        jz   test_all_events
+-        movzbl VCPU_async_exception_mask(%rbx),%edx # save mask for the
+-        movb %dl,VCPU_mce_old_mask(%rbx)            # iret hypercall
+-        orl  $1 << VCPU_TRAP_MCE,%edx
+-        movb %dl,VCPU_async_exception_mask(%rbx)
+-        jmp  process_trap
+-
+-        ALIGN
+-/* %rbx: struct vcpu */
+-process_nmi:
+-        testb $1 << VCPU_TRAP_NMI,VCPU_async_exception_mask(%rbx)
+-        jnz  test_guest_events
+-        sti
+-        movb $0,VCPU_nmi_pending(%rbx)
+-        call set_guest_nmi_trapbounce
+-        test %eax,%eax
+-        jz   test_all_events
+-        movzbl VCPU_async_exception_mask(%rbx),%edx # save mask for the
+-        movb %dl,VCPU_nmi_old_mask(%rbx)            # iret hypercall
+-        orl  $1 << VCPU_TRAP_NMI,%edx
+-        movb %dl,VCPU_async_exception_mask(%rbx)
+-        /* FALLTHROUGH */
+-process_trap:
+-        leaq VCPU_trap_bounce(%rbx),%rdx
+-        call create_bounce_frame
+-        jmp  test_all_events
+-
+ ENTRY(sysenter_entry)
+         /* sti could live here when we don't switch page tables below. */
+         pushq $FLAT_USER_SS
+@@ -535,16 +564,6 @@ ENTRY(common_interrupt)
+         mov   %r15, STACK_CPUINFO_FIELD(xen_cr3)(%r14)
+         jmp ret_from_intr
+ 
+-/* No special register assumptions. */
+-ENTRY(ret_from_intr)
+-        GET_CURRENT(bx)
+-        testb $3,UREGS_cs(%rsp)
+-        jz    restore_all_xen
+-        movq  VCPU_domain(%rbx),%rax
+-        testb $1,DOMAIN_is_32bit_pv(%rax)
+-        jz    test_all_events
+-        jmp   compat_test_all_events
+-
+ ENTRY(page_fault)
+         movl  $TRAP_page_fault,4(%rsp)
+ /* No special register assumptions. */
+@@ -843,28 +862,6 @@ ENTRY(machine_check)
+         movl  $TRAP_machine_check,4(%rsp)
+         jmp   handle_ist_exception
+ 
+-/* Enable NMIs.  No special register assumptions. Only %rax is not preserved. */
+-ENTRY(enable_nmis)
+-        movq  %rsp, %rax /* Grab RSP before pushing */
+-
+-        /* Set up stack frame */
+-        pushq $0               /* SS */
+-        pushq %rax             /* RSP */
+-        pushfq                 /* RFLAGS */
+-        pushq $__HYPERVISOR_CS /* CS */
+-        leaq  1f(%rip),%rax
+-        pushq %rax             /* RIP */
+-
+-        iretq /* Disable the hardware NMI latch */
+-1:
+-        retq
+-
+-/* No op trap handler.  Required for kexec crash path. */
+-GLOBAL(trap_nop)
+-        iretq
+-
+-
+-
+         .pushsection .rodata, "a", @progbits
+ ENTRY(exception_table)
+         .quad do_trap
+-- 
+2.15.0
+

--- a/main/xen/xsa260-1.patch
+++ b/main/xen/xsa260-1.patch
@@ -1,0 +1,72 @@
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Subject: x86/traps: Fix %dr6 handing in #DB handler
+
+Most bits in %dr6 accumulate, rather than being set directly based on the
+current source of #DB.  Have the handler follow the manuals guidance, which
+avoids leaking hypervisor debugging activities into guest context.
+
+This is part of XSA-260 / CVE-2018-8897.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+--- a/xen/arch/x86/traps.c
++++ b/xen/arch/x86/traps.c
+@@ -3766,11 +3766,36 @@ static void ler_enable(void)
+ 
+ void do_debug(struct cpu_user_regs *regs)
+ {
++    unsigned long dr6;
+     struct vcpu *v = current;
+ 
++    /* Stash dr6 as early as possible. */
++    dr6 = read_debugreg(6);
++
+     if ( debugger_trap_entry(TRAP_debug, regs) )
+         return;
+ 
++    /*
++     * At the time of writing (March 2018), on the subject of %dr6:
++     *
++     * The Intel manual says:
++     *   Certain debug exceptions may clear bits 0-3. The remaining contents
++     *   of the DR6 register are never cleared by the processor. To avoid
++     *   confusion in identifying debug exceptions, debug handlers should
++     *   clear the register (except bit 16, which they should set) before
++     *   returning to the interrupted task.
++     *
++     * The AMD manual says:
++     *   Bits 15:13 of the DR6 register are not cleared by the processor and
++     *   must be cleared by software after the contents have been read.
++     *
++     * Some bits are reserved set, some are reserved clear, and some bits
++     * which were previously reserved set are reused and cleared by hardware.
++     * For future compatibility, reset to the default value, which will allow
++     * us to spot any bit being changed by hardware to its non-default value.
++     */
++    write_debugreg(6, X86_DR6_DEFAULT);
++
+     if ( !guest_mode(regs) )
+     {
+         if ( regs->eflags & X86_EFLAGS_TF )
+@@ -3803,7 +3828,8 @@ void do_debug(struct cpu_user_regs *regs
+     }
+ 
+     /* Save debug status register where guest OS can peek at it */
+-    v->arch.debugreg[6] = read_debugreg(6);
++    v->arch.debugreg[6] |= (dr6 & ~X86_DR6_DEFAULT);
++    v->arch.debugreg[6] &= (dr6 | ~X86_DR6_DEFAULT);
+ 
+     ler_enable();
+     do_guest_trap(TRAP_debug, regs);
+--- a/xen/include/asm-x86/debugreg.h
++++ b/xen/include/asm-x86/debugreg.h
+@@ -24,6 +24,8 @@
+ #define DR_STATUS_RESERVED_ZERO (~0xffffeffful) /* Reserved, read as zero */
+ #define DR_STATUS_RESERVED_ONE  0xffff0ff0ul /* Reserved, read as one */
+ 
++#define X86_DR6_DEFAULT 0xffff0ff0ul    /* Default %dr6 value. */
++
+ /* Now define a bunch of things for manipulating the control register.
+    The top two bytes of the control register consist of 4 fields of 4
+    bits - each field corresponds to one of the four debug registers,

--- a/main/xen/xsa260-2.patch
+++ b/main/xen/xsa260-2.patch
@@ -1,0 +1,110 @@
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Subject: x86/pv: Move exception injection into {,compat_}test_all_events()
+
+This allows paths to jump straight to {,compat_}test_all_events() and have
+injection of pending exceptions happen automatically, rather than requiring
+all calling paths to handle exceptions themselves.
+
+The normal exception path is simplified as a result, and
+compat_post_handle_exception() is removed entirely.
+
+This is part of XSA-260 / CVE-2018-8897.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+--- a/xen/arch/x86/x86_64/compat/entry.S
++++ b/xen/arch/x86/x86_64/compat/entry.S
+@@ -37,6 +37,12 @@ ENTRY(compat_test_all_events)
+         leaq  irq_stat+IRQSTAT_softirq_pending(%rip),%rcx
+         cmpl  $0,(%rcx,%rax,1)
+         jne   compat_process_softirqs
++
++        /* Inject exception if pending. */
++        lea   VCPU_trap_bounce(%rbx), %rdx
++        testb $TBF_EXCEPTION, TRAPBOUNCE_flags(%rdx)
++        jnz   .Lcompat_process_trapbounce
++
+         testb $1,VCPU_mce_pending(%rbx)
+         jnz   compat_process_mce
+ .Lcompat_test_guest_nmi:
+@@ -66,6 +72,15 @@ compat_process_softirqs:
+         call  do_softirq
+         jmp   compat_test_all_events
+ 
++        ALIGN
++/* %rbx: struct vcpu, %rdx: struct trap_bounce */
++.Lcompat_process_trapbounce:
++        sti
++.Lcompat_bounce_exception:
++        call  compat_create_bounce_frame
++        movb  $0, TRAPBOUNCE_flags(%rdx)
++        jmp   compat_test_all_events
++
+ 	ALIGN
+ /* %rbx: struct vcpu */
+ compat_process_mce:
+@@ -186,15 +201,6 @@ ENTRY(cr4_pv32_restore)
+         xor   %eax, %eax
+         ret
+ 
+-/* %rdx: trap_bounce, %rbx: struct vcpu */
+-ENTRY(compat_post_handle_exception)
+-        testb $TBF_EXCEPTION,TRAPBOUNCE_flags(%rdx)
+-        jz    compat_test_all_events
+-.Lcompat_bounce_exception:
+-        call  compat_create_bounce_frame
+-        movb  $0,TRAPBOUNCE_flags(%rdx)
+-        jmp   compat_test_all_events
+-
+         .section .text.entry, "ax", @progbits
+ 
+ /* See lstar_enter for entry register state. */
+--- a/xen/arch/x86/x86_64/entry.S
++++ b/xen/arch/x86/x86_64/entry.S
+@@ -40,6 +40,12 @@ test_all_events:
+         leaq  irq_stat+IRQSTAT_softirq_pending(%rip), %rcx
+         cmpl  $0, (%rcx, %rax, 1)
+         jne   process_softirqs
++
++        /* Inject exception if pending. */
++        lea   VCPU_trap_bounce(%rbx), %rdx
++        testb $TBF_EXCEPTION, TRAPBOUNCE_flags(%rdx)
++        jnz   .Lprocess_trapbounce
++
+         cmpb  $0, VCPU_mce_pending(%rbx)
+         jne   process_mce
+ .Ltest_guest_nmi:
+@@ -68,6 +74,15 @@ process_softirqs:
+         jmp  test_all_events
+ 
+         ALIGN
++/* %rbx: struct vcpu, %rdx struct trap_bounce */
++.Lprocess_trapbounce:
++        sti
++.Lbounce_exception:
++        call  create_bounce_frame
++        movb  $0, TRAPBOUNCE_flags(%rdx)
++        jmp   test_all_events
++
++        ALIGN
+ /* %rbx: struct vcpu */
+ process_mce:
+         testb $1 << VCPU_TRAP_MCE, VCPU_async_exception_mask(%rbx)
+@@ -664,15 +679,9 @@ handle_exception_saved:
+         mov   %r15, STACK_CPUINFO_FIELD(xen_cr3)(%r14)
+         testb $3,UREGS_cs(%rsp)
+         jz    restore_all_xen
+-        leaq  VCPU_trap_bounce(%rbx),%rdx
+         movq  VCPU_domain(%rbx),%rax
+         testb $1,DOMAIN_is_32bit_pv(%rax)
+-        jnz   compat_post_handle_exception
+-        testb $TBF_EXCEPTION,TRAPBOUNCE_flags(%rdx)
+-        jz    test_all_events
+-.Lbounce_exception:
+-        call  create_bounce_frame
+-        movb  $0,TRAPBOUNCE_flags(%rdx)
++        jnz   compat_test_all_events
+         jmp   test_all_events
+ 
+ /* No special register assumptions. */

--- a/main/xen/xsa260-3.patch
+++ b/main/xen/xsa260-3.patch
@@ -1,0 +1,138 @@
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Subject: x86/traps: Use an Interrupt Stack Table for #DB
+
+PV guests can use architectural corner cases to cause #DB to be raised after
+transitioning into supervisor mode.
+
+Use an interrupt stack table for #DB to prevent the exception being taken with
+a guest controlled stack pointer.
+
+This is part of XSA-260 / CVE-2018-8897.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+--- a/xen/arch/x86/cpu/common.c
++++ b/xen/arch/x86/cpu/common.c
+@@ -679,6 +679,7 @@ void load_system_tables(void)
+ 			[IST_MCE - 1] = stack_top + IST_MCE * PAGE_SIZE,
+ 			[IST_DF  - 1] = stack_top + IST_DF  * PAGE_SIZE,
+ 			[IST_NMI - 1] = stack_top + IST_NMI * PAGE_SIZE,
++			[IST_DB  - 1] = stack_top + IST_DB  * PAGE_SIZE,
+ 
+ 			[IST_MAX ... ARRAY_SIZE(tss->ist) - 1] =
+ 				0x8600111111111111ul,
+@@ -706,6 +707,7 @@ void load_system_tables(void)
+ 	set_ist(&idt_tables[cpu][TRAP_double_fault],  IST_DF);
+ 	set_ist(&idt_tables[cpu][TRAP_nmi],	      IST_NMI);
+ 	set_ist(&idt_tables[cpu][TRAP_machine_check], IST_MCE);
++	set_ist(&idt_tables[cpu][TRAP_debug],         IST_DB);
+ 
+ 	/*
+ 	 * Bottom-of-stack must be 16-byte aligned!
+--- a/xen/arch/x86/hvm/svm/svm.c
++++ b/xen/arch/x86/hvm/svm/svm.c
+@@ -1048,6 +1048,7 @@ static void svm_ctxt_switch_from(struct
+     set_ist(&idt_tables[cpu][TRAP_double_fault],  IST_DF);
+     set_ist(&idt_tables[cpu][TRAP_nmi],           IST_NMI);
+     set_ist(&idt_tables[cpu][TRAP_machine_check], IST_MCE);
++    set_ist(&idt_tables[cpu][TRAP_debug],         IST_DB);
+ }
+ 
+ static void svm_ctxt_switch_to(struct vcpu *v)
+@@ -1069,6 +1070,7 @@ static void svm_ctxt_switch_to(struct vc
+     set_ist(&idt_tables[cpu][TRAP_double_fault],  IST_NONE);
+     set_ist(&idt_tables[cpu][TRAP_nmi],           IST_NONE);
+     set_ist(&idt_tables[cpu][TRAP_machine_check], IST_NONE);
++    set_ist(&idt_tables[cpu][TRAP_debug],         IST_NONE);
+ 
+     svm_restore_dr(v);
+ 
+--- a/xen/arch/x86/smpboot.c
++++ b/xen/arch/x86/smpboot.c
+@@ -964,6 +964,7 @@ static int cpu_smpboot_alloc(unsigned in
+     set_ist(&idt_tables[cpu][TRAP_double_fault],  IST_NONE);
+     set_ist(&idt_tables[cpu][TRAP_nmi],           IST_NONE);
+     set_ist(&idt_tables[cpu][TRAP_machine_check], IST_NONE);
++    set_ist(&idt_tables[cpu][TRAP_debug],         IST_NONE);
+ 
+     for ( stub_page = 0, i = cpu & ~(STUBS_PER_PAGE - 1);
+           i < nr_cpu_ids && i <= (cpu | (STUBS_PER_PAGE - 1)); ++i )
+--- a/xen/arch/x86/traps.c
++++ b/xen/arch/x86/traps.c
+@@ -259,13 +259,13 @@ static void show_guest_stack(struct vcpu
+ /*
+  * Notes for get_stack_trace_bottom() and get_stack_dump_bottom()
+  *
+- * Stack pages 0, 1 and 2:
++ * Stack pages 0 - 3:
+  *   These are all 1-page IST stacks.  Each of these stacks have an exception
+  *   frame and saved register state at the top.  The interesting bound for a
+  *   trace is the word adjacent to this, while the bound for a dump is the
+  *   very top, including the exception frame.
+  *
+- * Stack pages 3, 4 and 5:
++ * Stack pages 4 and 5:
+  *   None of these are particularly interesting.  With MEMORY_GUARD, page 5 is
+  *   explicitly not present, so attempting to dump or trace it is
+  *   counterproductive.  Without MEMORY_GUARD, it is possible for a call chain
+@@ -286,12 +286,12 @@ unsigned long get_stack_trace_bottom(uns
+ {
+     switch ( get_stack_page(sp) )
+     {
+-    case 0 ... 2:
++    case 0 ... 3:
+         return ROUNDUP(sp, PAGE_SIZE) -
+             offsetof(struct cpu_user_regs, es) - sizeof(unsigned long);
+ 
+ #ifndef MEMORY_GUARD
+-    case 3 ... 5:
++    case 4 ... 5:
+ #endif
+     case 6 ... 7:
+         return ROUNDUP(sp, STACK_SIZE) -
+@@ -306,11 +306,11 @@ unsigned long get_stack_dump_bottom(unsi
+ {
+     switch ( get_stack_page(sp) )
+     {
+-    case 0 ... 2:
++    case 0 ... 3:
+         return ROUNDUP(sp, PAGE_SIZE) - sizeof(unsigned long);
+ 
+ #ifndef MEMORY_GUARD
+-    case 3 ... 5:
++    case 4 ... 5:
+ #endif
+     case 6 ... 7:
+         return ROUNDUP(sp, STACK_SIZE) - sizeof(unsigned long);
+@@ -3947,6 +3947,7 @@ void __init init_idt_traps(void)
+     set_ist(&idt_table[TRAP_double_fault],  IST_DF);
+     set_ist(&idt_table[TRAP_nmi],           IST_NMI);
+     set_ist(&idt_table[TRAP_machine_check], IST_MCE);
++    set_ist(&idt_table[TRAP_debug],         IST_DB);
+ 
+     /* CPU0 uses the master IDT. */
+     idt_tables[0] = idt_table;
+--- a/xen/arch/x86/x86_64/entry.S
++++ b/xen/arch/x86/x86_64/entry.S
+@@ -736,7 +736,7 @@ ENTRY(device_not_available)
+ ENTRY(debug)
+         pushq $0
+         movl  $TRAP_debug,4(%rsp)
+-        jmp   handle_exception
++        jmp   handle_ist_exception
+ 
+ ENTRY(int3)
+         pushq $0
+--- a/xen/include/asm-x86/processor.h
++++ b/xen/include/asm-x86/processor.h
+@@ -447,7 +447,8 @@ struct __packed __cacheline_aligned tss_
+ #define IST_DF   1UL
+ #define IST_NMI  2UL
+ #define IST_MCE  3UL
+-#define IST_MAX  3UL
++#define IST_DB   4UL
++#define IST_MAX  4UL
+ 
+ /* Set the interrupt stack table used by a particular interrupt
+  * descriptor table entry. */

--- a/main/xen/xsa260-4.patch
+++ b/main/xen/xsa260-4.patch
@@ -1,0 +1,72 @@
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Subject: x86/traps: Fix handling of #DB exceptions in hypervisor context
+
+The WARN_ON() can be triggered by guest activities, and emits a full stack
+trace without rate limiting.  Swap it out for a ratelimited printk with just
+enough information to work out what is going on.
+
+Not all #DB exceptions are traps, so blindly continuing is not a safe action
+to take.  We don't let PV guests select these settings in the real %dr7 to
+begin with, but for added safety against unexpected situations, detect the
+fault cases and crash in an obvious manner.
+
+This is part of XSA-260 / CVE-2018-8897.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+Reviewed-by: Jan Beulich <jbeulich@suse.com>
+
+--- a/xen/arch/x86/traps.c
++++ b/xen/arch/x86/traps.c
+@@ -3814,16 +3814,44 @@ void do_debug(struct cpu_user_regs *regs
+                 regs->eflags &= ~X86_EFLAGS_TF;
+             }
+         }
+-        else
++
++        /*
++         * Check for fault conditions.  General Detect, and instruction
++         * breakpoints are faults rather than traps, at which point attempting
++         * to ignore and continue will result in a livelock.
++         */
++        if ( dr6 & DR_GENERAL_DETECT )
++        {
++            printk(XENLOG_ERR "Hit General Detect in Xen context\n");
++            fatal_trap(regs, 0);
++        }
++
++        if ( dr6 & (DR_TRAP3 | DR_TRAP2 | DR_TRAP1 | DR_TRAP0) )
+         {
+-            /*
+-             * We ignore watchpoints when they trigger within Xen. This may
+-             * happen when a buffer is passed to us which previously had a
+-             * watchpoint set on it. No need to bump EIP; the only faulting
+-             * trap is an instruction breakpoint, which can't happen to us.
+-             */
+-            WARN_ON(!search_exception_table(regs));
++            unsigned int bp, dr7 = read_debugreg(7) >> DR_CONTROL_SHIFT;
++
++            for ( bp = 0; bp < 4; ++bp )
++            {
++                if ( (dr6 & (1u << bp)) && /* Breakpoint triggered? */
++                     ((dr7 & (3u << (bp * DR_CONTROL_SIZE))) == 0) /* Insn? */ )
++                {
++                    printk(XENLOG_ERR
++                           "Hit instruction breakpoint in Xen context\n");
++                    fatal_trap(regs, 0);
++                }
++            }
+         }
++
++        /*
++         * Whatever caused this #DB should be a trap.  Note it and continue.
++         * Guests can trigger this in certain corner cases, so ensure the
++         * message is ratelimited.
++         */
++        gprintk(XENLOG_WARNING,
++                "Hit #DB in Xen context: %04x:%p [%ps], stk %04x:%p, dr6 %lx\n",
++                regs->cs, _p(regs->rip), _p(regs->rip),
++                regs->ss, _p(regs->rsp), dr6);
++
+         goto out;
+     }
+ 

--- a/main/xen/xsa261-4.9.patch
+++ b/main/xen/xsa261-4.9.patch
@@ -1,0 +1,269 @@
+From: Xen Project Security Team <security@xenproject.org>
+Subject: x86/vpt: add support for IO-APIC routed interrupts
+
+And modify the HPET code to make use of it. Currently HPET interrupts
+are always treated as ISA and thus injected through the vPIC. This is
+wrong because HPET interrupts when not in legacy mode should be
+injected from the IO-APIC.
+
+To make things worse, the supported interrupt routing values are set
+to [20..23], which clearly falls outside of the ISA range, thus
+leading to an ASSERT in debug builds or memory corruption in non-debug
+builds because the interrupt injection code will write out of the
+bounds of the arch.hvm_domain.vpic array.
+
+Since the HPET interrupt source can change between ISA and IO-APIC
+always destroy the timer before changing the mode, or else Xen risks
+changing it while the timer is active.
+
+Note that vpt interrupt injection is racy in the sense that the
+vIO-APIC RTE entry can be written by the guest in between the call to
+pt_irq_masked and hvm_ioapic_assert, or the call to pt_update_irq and
+pt_intr_post. Those are not deemed to be security issues, but rather
+quirks of the current implementation. In the worse case the guest
+might lose interrupts or get multiple interrupt vectors injected for
+the same timer source.
+
+This is part of XSA-261.
+
+Address actual and potential compiler warnings. Fix formatting.
+
+Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+
+--- a/xen/arch/x86/hvm/hpet.c
++++ b/xen/arch/x86/hvm/hpet.c
+@@ -264,13 +264,20 @@ static void hpet_set_timer(HPETState *h,
+         diff = (timer_is_32bit(h, tn) && (-diff > HPET_TINY_TIME_SPAN))
+             ? (uint32_t)diff : 0;
+ 
++    destroy_periodic_time(&h->pt[tn]);
+     if ( (tn <= 1) && (h->hpet.config & HPET_CFG_LEGACY) )
++    {
+         /* if LegacyReplacementRoute bit is set, HPET specification requires
+            timer0 be routed to IRQ0 in NON-APIC or IRQ2 in the I/O APIC,
+            timer1 be routed to IRQ8 in NON-APIC or IRQ8 in the I/O APIC. */
+         irq = (tn == 0) ? 0 : 8;
++        h->pt[tn].source = PTSRC_isa;
++    }
+     else
++    {
+         irq = timer_int_route(h, tn);
++        h->pt[tn].source = PTSRC_ioapic;
++    }
+ 
+     /*
+      * diff is the time from now when the timer should fire, for a periodic
+--- a/xen/arch/x86/hvm/irq.c
++++ b/xen/arch/x86/hvm/irq.c
+@@ -41,6 +41,29 @@ static void assert_gsi(struct domain *d,
+     vioapic_irq_positive_edge(d, ioapic_gsi);
+ }
+ 
++int hvm_ioapic_assert(struct domain *d, unsigned int gsi, bool level)
++{
++    struct hvm_irq *hvm_irq = hvm_domain_irq(d);
++    const struct hvm_vioapic *vioapic;
++    unsigned int pin;
++    int vector;
++
++    if ( gsi >= hvm_irq->nr_gsis )
++    {
++        ASSERT_UNREACHABLE();
++        return -1;
++    }
++
++    spin_lock(&d->arch.hvm_domain.irq_lock);
++    if ( !level || hvm_irq->gsi_assert_count[gsi]++ == 0 )
++        assert_gsi(d, gsi);
++    vioapic = gsi_vioapic(d, gsi, &pin);
++    vector = vioapic ? vioapic->redirtbl[pin].fields.vector : -1;
++    spin_unlock(&d->arch.hvm_domain.irq_lock);
++
++    return vector;
++}
++
+ static void assert_irq(struct domain *d, unsigned ioapic_gsi, unsigned pic_irq)
+ {
+     assert_gsi(d, ioapic_gsi);
+--- a/xen/arch/x86/hvm/vpt.c
++++ b/xen/arch/x86/hvm/vpt.c
+@@ -107,31 +107,50 @@ static int pt_irq_vector(struct periodic
+ static int pt_irq_masked(struct periodic_time *pt)
+ {
+     struct vcpu *v = pt->vcpu;
+-    unsigned int gsi, isa_irq, pin;
+-    struct hvm_vioapic *vioapic;
+-    uint8_t pic_imr;
++    unsigned int gsi = pt->irq;
+ 
+-    if ( pt->source == PTSRC_lapic )
++    switch ( pt->source )
++    {
++    case PTSRC_lapic:
+     {
+         struct vlapic *vlapic = vcpu_vlapic(v);
++
+         return (!vlapic_enabled(vlapic) ||
+                 (vlapic_get_reg(vlapic, APIC_LVTT) & APIC_LVT_MASKED));
+     }
+ 
+-    isa_irq = pt->irq;
+-    gsi = hvm_isa_irq_to_gsi(isa_irq);
+-    pic_imr = v->domain->arch.hvm_domain.vpic[isa_irq >> 3].imr;
+-    vioapic = gsi_vioapic(v->domain, gsi, &pin);
+-    if ( !vioapic )
+-    {
+-        dprintk(XENLOG_WARNING, "d%u: invalid GSI (%u) for platform timer\n",
+-                v->domain->domain_id, gsi);
+-        domain_crash(v->domain);
+-        return -1;
++    case PTSRC_isa:
++    {
++        uint8_t pic_imr = v->domain->arch.hvm_domain.vpic[pt->irq >> 3].imr;
++
++        /* Check if the interrupt is unmasked in the PIC. */
++        if ( !(pic_imr & (1 << (pt->irq & 7))) && vlapic_accept_pic_intr(v) )
++            return 0;
++
++        gsi = hvm_isa_irq_to_gsi(pt->irq);
++    }
++
++    /* Fallthrough to check if the interrupt is masked on the IO APIC. */
++    case PTSRC_ioapic:
++    {
++        unsigned int pin;
++        const struct hvm_vioapic *vioapic = gsi_vioapic(v->domain, gsi, &pin);
++
++        if ( !vioapic )
++        {
++            dprintk(XENLOG_WARNING,
++                    "d%d: invalid GSI (%u) for platform timer\n",
++                    v->domain->domain_id, gsi);
++            domain_crash(v->domain);
++            return -1;
++        }
++
++        return vioapic->redirtbl[pin].fields.mask;
++    }
+     }
+ 
+-    return (((pic_imr & (1 << (isa_irq & 7))) || !vlapic_accept_pic_intr(v)) &&
+-            vioapic->redirtbl[pin].fields.mask);
++    ASSERT_UNREACHABLE();
++    return 1;
+ }
+ 
+ static void pt_lock(struct periodic_time *pt)
+@@ -252,7 +271,7 @@ int pt_update_irq(struct vcpu *v)
+     struct list_head *head = &v->arch.hvm_vcpu.tm_list;
+     struct periodic_time *pt, *temp, *earliest_pt;
+     uint64_t max_lag;
+-    int irq, is_lapic;
++    int irq, pt_vector = -1;
+ 
+     spin_lock(&v->arch.hvm_vcpu.tm_lock);
+ 
+@@ -288,29 +307,42 @@ int pt_update_irq(struct vcpu *v)
+ 
+     earliest_pt->irq_issued = 1;
+     irq = earliest_pt->irq;
+-    is_lapic = (earliest_pt->source == PTSRC_lapic);
+ 
+     spin_unlock(&v->arch.hvm_vcpu.tm_lock);
+ 
+-    if ( is_lapic )
+-        vlapic_set_irq(vcpu_vlapic(v), irq, 0);
+-    else
++    switch ( earliest_pt->source )
+     {
++    case PTSRC_lapic:
++        /*
++         * If periodic timer interrupt is handled by lapic, its vector in
++         * IRR is returned and used to set eoi_exit_bitmap for virtual
++         * interrupt delivery case. Otherwise return -1 to do nothing.
++         */
++        vlapic_set_irq(vcpu_vlapic(v), irq, 0);
++        pt_vector = irq;
++        break;
++
++    case PTSRC_isa:
+         hvm_isa_irq_deassert(v->domain, irq);
+         hvm_isa_irq_assert(v->domain, irq);
++
++        if ( platform_legacy_irq(irq) && vlapic_accept_pic_intr(v) &&
++             v->domain->arch.hvm_domain.vpic[irq >> 3].int_output )
++            return -1;
++
++        pt_vector = pt_irq_vector(earliest_pt, hvm_intsrc_lapic);
++        break;
++
++    case PTSRC_ioapic:
++        /*
++         * NB: At the moment IO-APIC routed interrupts generated by vpt devices
++         * (HPET) are edge-triggered.
++         */
++        pt_vector = hvm_ioapic_assert(v->domain, irq, false);
++        break;
+     }
+ 
+-    /*
+-     * If periodic timer interrut is handled by lapic, its vector in
+-     * IRR is returned and used to set eoi_exit_bitmap for virtual
+-     * interrupt delivery case. Otherwise return -1 to do nothing.  
+-     */ 
+-    if ( !is_lapic &&
+-         platform_legacy_irq(irq) && vlapic_accept_pic_intr(v) &&
+-         (&v->domain->arch.hvm_domain)->vpic[irq >> 3].int_output )
+-        return -1;
+-    else 
+-        return pt_irq_vector(earliest_pt, hvm_intsrc_lapic);
++    return pt_vector;
+ }
+ 
+ static struct periodic_time *is_pt_irq(
+@@ -405,7 +437,14 @@ void create_periodic_time(
+     struct vcpu *v, struct periodic_time *pt, uint64_t delta,
+     uint64_t period, uint8_t irq, time_cb *cb, void *data)
+ {
+-    ASSERT(pt->source != 0);
++    if ( !pt->source ||
++         (pt->irq >= NR_ISAIRQS && pt->source == PTSRC_isa) ||
++         (pt->irq >= hvm_domain_irq(v->domain)->nr_gsis &&
++          pt->source == PTSRC_ioapic) )
++    {
++        ASSERT_UNREACHABLE();
++        return;
++    }
+ 
+     destroy_periodic_time(pt);
+ 
+@@ -485,7 +524,7 @@ static void pt_adjust_vcpu(struct period
+ {
+     int on_list;
+ 
+-    ASSERT(pt->source == PTSRC_isa);
++    ASSERT(pt->source == PTSRC_isa || pt->source == PTSRC_ioapic);
+ 
+     if ( pt->vcpu == NULL )
+         return;
+--- a/xen/include/asm-x86/hvm/irq.h
++++ b/xen/include/asm-x86/hvm/irq.h
+@@ -106,4 +106,7 @@ struct hvm_intack hvm_vcpu_has_pending_i
+ struct hvm_intack hvm_vcpu_ack_pending_irq(struct vcpu *v,
+                                            struct hvm_intack intack);
+ 
++/* Assert an IO APIC pin. */
++int hvm_ioapic_assert(struct domain *d, unsigned int gsi, bool level);
++
+ #endif /* __ASM_X86_HVM_IRQ_H__ */
+--- a/xen/include/asm-x86/hvm/vpt.h
++++ b/xen/include/asm-x86/hvm/vpt.h
+@@ -44,6 +44,7 @@ struct periodic_time {
+     bool_t warned_timeout_too_short;
+ #define PTSRC_isa    1 /* ISA time source */
+ #define PTSRC_lapic  2 /* LAPIC time source */
++#define PTSRC_ioapic 3 /* IOAPIC time source */
+     u8 source;                  /* PTSRC_ */
+     u8 irq;
+     struct vcpu *vcpu;          /* vcpu timer interrupt delivers to */

--- a/main/xen/xsa262-4.9.patch
+++ b/main/xen/xsa262-4.9.patch
@@ -1,0 +1,76 @@
+From: Jan Beulich <jbeulich@suse.com>
+Subject: x86/HVM: guard against emulator driving ioreq state in weird ways
+
+In the case where hvm_wait_for_io() calls wait_on_xen_event_channel(),
+p->state ends up being read twice in succession: once to determine that
+state != p->state, and then again at the top of the loop.  This gives a
+compromised emulator a chance to change the state back between the two
+reads, potentially keeping Xen in a loop indefinitely.
+
+Instead:
+* Read p->state once in each of the wait_on_xen_event_channel() tests,
+* re-use that value the next time around,
+* and insist that the states continue to transition "forward" (with the
+  exception of the transition to STATE_IOREQ_NONE).
+
+This is XSA-262.
+
+Signed-off-by: Jan Beulich <jbeulich@suse.com>
+Reviewed-by: George Dunlap <george.dunlap@citrix.com>
+
+--- a/xen/arch/x86/hvm/ioreq.c
++++ b/xen/arch/x86/hvm/ioreq.c
+@@ -87,14 +87,17 @@ static void hvm_io_assist(struct hvm_ior
+ 
+ static bool_t hvm_wait_for_io(struct hvm_ioreq_vcpu *sv, ioreq_t *p)
+ {
++    unsigned int prev_state = STATE_IOREQ_NONE;
++
+     while ( sv->pending )
+     {
+         unsigned int state = p->state;
+ 
+-        rmb();
+-        switch ( state )
++        smp_rmb();
++
++    recheck:
++        if ( unlikely(state == STATE_IOREQ_NONE) )
+         {
+-        case STATE_IOREQ_NONE:
+             /*
+              * The only reason we should see this case is when an
+              * emulator is dying and it races with an I/O being
+@@ -102,14 +105,30 @@ static bool_t hvm_wait_for_io(struct hvm
+              */
+             hvm_io_assist(sv, ~0ul);
+             break;
++        }
++
++        if ( unlikely(state < prev_state) )
++        {
++            gdprintk(XENLOG_ERR, "Weird HVM ioreq state transition %u -> %u\n",
++                     prev_state, state);
++            sv->pending = 0;
++            domain_crash(sv->vcpu->domain);
++            return 0; /* bail */
++        }
++
++        switch ( prev_state = state )
++        {
+         case STATE_IORESP_READY: /* IORESP_READY -> NONE */
+             p->state = STATE_IOREQ_NONE;
+             hvm_io_assist(sv, p->data);
+             break;
+         case STATE_IOREQ_READY:  /* IOREQ_{READY,INPROCESS} -> IORESP_READY */
+         case STATE_IOREQ_INPROCESS:
+-            wait_on_xen_event_channel(sv->ioreq_evtchn, p->state != state);
+-            break;
++            wait_on_xen_event_channel(sv->ioreq_evtchn,
++                                      ({ state = p->state;
++                                         smp_rmb();
++                                         state != prev_state; }));
++            goto recheck;
+         default:
+             gdprintk(XENLOG_ERR, "Weird HVM iorequest state %u\n", state);
+             sv->pending = 0;


### PR DESCRIPTION
 * CVE-2018-8897  XSA-260 (depends x86-XPTI-reduce-.text.entry.patch)
 * CVE-2018-10982 XSA-261
 * CVE-2018-10981 XSA-262