### PR TITLE
main/bind: upgrade to 9.12.1-P2

### DIFF
--- a/main/bind/APKBUILD
+++ b/main/bind/APKBUILD
@@ -3,12 +3,12 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=bind
-pkgver=9.12.0
+pkgver=9.12.1_p2
 _ver=${pkgver%_p*}
 _p=${pkgver#*_p}
 _major=${pkgver%%.*}
 [ "$_p" != "$pkgver" ] && _ver="${_ver}-P$_p"
-pkgrel=3
+pkgrel=0
 pkgdesc="The ISC DNS server"
 url="http://www.isc.org"
 arch="all"
@@ -36,6 +36,9 @@ source="https://ftp.isc.org/isc/${pkgname}${_major}/$_ver/$pkgname-$_ver.tar.gz
 builddir="$srcdir/$pkgname-$_ver"
 
 # secfixes:
+#   9.12.1_P2-r0:
+#     - CVE-2018-5736
+#     - CVE-2018-5737
 #   9.11.2_p1-r0:
 #     - CVE-2017-3145
 #   9.11.0_p5-r0:
@@ -136,7 +139,7 @@ tools() {
 	done
 }
 
-sha512sums="4b6f1b8830f57cdffcbd3c4cfb965b978d8c6e99fa40aae8276ea2741ef47d336e1edf8fb33a01a8a5d7e0efd910adae7645152e948c5728f08fa103b2b230f3  bind-9.12.0.tar.gz
+sha512sums="de47eef272c437316444c4f585a2f98ae9169fc118fd057464a5cd064bb9079ffc07145dabf388cd240f56a5ad6d3ad78cf8d98fc37609681eba5d87e18a4f9a  bind-9.12.1-P2.tar.gz
 7167dccdb2833643dfdb92994373d2cc087e52ba23b51bd68bd322ff9aca6744f01fa9d8a4b9cd8c4ce471755a85c03ec956ec0d8a1d4fae02124ddbed6841f6  bind.so_bsdcompat.patch
 70cc46b8ecc863b8dfb9b36648131963f40377c5586c6e6ea469f0b7a4a7b3f6e78ad4e7cb21fabc9660b2a02ddc0677d33fc32e8b6948b37b74119cc7de68b0  libressl-2.7.patch
 196c0a3b43cf89e8e3547d7fb63a93ff9a3306505658dfd9aa78e6861be6b226580b424dd3dd44b955b2d9f682b1dc62c457f3ac29ce86200ef070140608c015  named.initd


### PR DESCRIPTION
@ncopa Providing upstream BIND fix for:
https://www.us-cert.gov/ncas/current-activity/2018/05/18/ISC-Releases-Security-Advisories-BIND

Includes fix for 2 medium remote vulnerabilities:
https://kb.isc.org/article/AA-01602/0
and
https://kb.isc.org/article/AA-01606/0

Summary:
Bind 9.12.1-P2 provides fix.

sha512sum: de47eef272c437316444c4f585a2f98ae9169fc118fd057464a5cd064bb9079ffc07145dabf388cd240f56a5ad6d3ad78cf8d98fc37609681eba5d87e18a4f9a