### PR TITLE
testing/wireguard: upgrade to 0.0.20180519

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180513
+pkgver=0.0.20180519
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="82f46fc50f47ac94948a7984a209ec55506c2bf1c41edf3a89f8043a0c770d6e88fdd7888b01ea41b227d316f53606a354f4d5d184ab2f1ecef80e0b376270b1  WireGuard-0.0.20180513.tar.xz"
+sha512sums="587a1371edd4a7fdf167154398f8a51da8c70f55e86a4be4b0b830a2f00a1421710017d954ad1aeda4df3a36ca8c9a911ba5fb407a851235257176291af3ee15  WireGuard-0.0.20180519.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180513
-_rel=1
+_ver=0.0.20180519
+_rel=2
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="82f46fc50f47ac94948a7984a209ec55506c2bf1c41edf3a89f8043a0c770d6e88fdd7888b01ea41b227d316f53606a354f4d5d184ab2f1ecef80e0b376270b1  WireGuard-0.0.20180513.tar.xz"
+sha512sums="587a1371edd4a7fdf167154398f8a51da8c70f55e86a4be4b0b830a2f00a1421710017d954ad1aeda4df3a36ca8c9a911ba5fb407a851235257176291af3ee15  WireGuard-0.0.20180519.tar.xz"


### PR DESCRIPTION
```
  * chacha20poly1305: add mips32 implementation
  
  "The OpenWRT Commit" - this significantly speeds up performance on cheap
  plastic MIPS routers, and presumably the remaining MIPS32r2 super computers
  out there.
  
  * timers: reinitialize state on init
  * timers: round up instead of down in slack_time
  * timers: remove slack_time
  * timers: clear send_keepalive timer on sending handshake response
  * timers: no need to clear keepalive in persistent keepalive
  
  Andrew He and I have helped simplify the timers and remove some old warts,
  making the whole system a bit easier to analyze.
  
  * tools: fix errno propagation and messages
  
  Error messages are now more coherent.
  
  * wg-quick: use invoking shell in auto rooting
  
  Rather than letting sudo use bash from PATH, we now have it use whatever bash
  is currently executing the script.
  
  * device: remove allowedips before individual peers
  
  This avoids an O(n^2) traversal in favor of an O(n) one. Before systems with
  many peers would grind when deleting the interface.
  
  * dns-hatchet: update paths
  
  Our reorganizing of the wg-quick bash paths was not sync'd with this patch,
  resulting in some trivial problems for Fedora and OpenSUSE.
  
  * compat: backport for OpenSUSE 15
  
  Usual compat fixes.
  
  * wg-quick: add darwin implementation
  
  We released a Darwin implementation of wg-quick(8), to be used with the new
  wireguard-go snapshot.
  
  * wg-quick: darwin: ensure socket directory exists
  * wg-quick: darwin: remove v6 routes after shutdown
  * wg-quick: darwin: bash correctness
  * wg-quick: darwin: restore DNS on down
  * wg-quick: darwin: use bash from environment and require bash 4+
  * wg-quick: darwin: sometimes there are no network services
  * wg-quick: darwin: avoid routing loop if no default
  * wg-quick: darwin: networksetup does not like missing stdio
  * wg-quick: darwin: reorder functions
  * wg-quick: darwin: simpler inclusion check
  
  After a pretty intense first few days of the new macOS port, we've fixed a few
  bugs and improved functionality of wg-quick(8).
  
  * ncat-client-server: add wg-quick variant
  
  We now have client-quick.sh that does the same as client.sh except it builds a
  file for wg-quick(8), which can then be used in `wg-quick up demo`.
```