### PR TITLE
testing/mongo-php7-library: upgrade to 1.3.2 and modernize

### DIFF
--- a/testing/mongo-php7-library/APKBUILD
+++ b/testing/mongo-php7-library/APKBUILD
@@ -3,15 +3,15 @@
 _php=php7
 pkgname=mongo-${_php}-library
 _realname=mongo-php-library
-pkgver=1.0.3
+pkgver=1.3.2
 pkgrel=0
 pkgdesc="High-level abstraction around the lower-level drivers for PHP"
 url="https://github.com/mongodb/mongo-php-library"
 arch="noarch"
 license="Apache-2.0"
-makedepends="$depends_dev mongo-${_php}-driver"
+makedepends="$depends_dev ${_php}-mongodb"
 subpackages="$pkgname-doc"
-options="!check"
+options="!check" # require mongodb server
 source="$_realname-$pkgver.tar.gz::https://github.com/mongodb/$_realname/archive/$pkgver.tar.gz"
 builddir="$srcdir"/$_realname-$pkgver
 
@@ -27,9 +27,7 @@ package() {
 	mv src/* "$pkgdir"/usr/lib/${_php}/vendor/mongodb/mongodb
 	mv tests "$pkgdir"/usr/lib/${_php}/vendor/mongodb/mongodb/
 	mv docs/* "$pkgdir"/usr/share/doc/mongo-${_php}-library/docs
-	mv LICENSE README.md RELEASE-* "$pkgdir"/usr/share/doc/mongo-${_php}-library
+	mv LICENSE README.md "$pkgdir"/usr/share/doc/mongo-${_php}-library
 }
 
-md5sums="07efdeeb10ef196705e055b93129afcb  mongo-php-library-1.0.3.tar.gz"
-sha256sums="74873f2bc6b24087fe3a91b48323eec9e0f09e7f913fe2107e141914ee408bd0  mongo-php-library-1.0.3.tar.gz"
-sha512sums="c4cf0c4e13572302ce1cd6b224762b009a06077ed3113cb68ed2a18298a8994c7c90a07b8a158dc9f53d52375aac0e9f1697f63faa1fbc2c1ecc71834a992492  mongo-php-library-1.0.3.tar.gz"
+sha512sums="8015da0abc8fb9954947cbb446eb83a8f58852f36570fa1b0e9c1522a8802ac8f12a2e785378c01ae29dff1396211914f619fb1e4984733bcbd0263d429fb12f  mongo-php-library-1.3.2.tar.gz"


### PR DESCRIPTION
- upgrade to current stable release https://github.com/mongodb/mongo-php-library/releases
- fix dependency on removed https://github.com/alpinelinux/aports/pull/3977 in favour of `php7-mongodb
- removed coping of release files which is not shipped anymore

PS upgrade of dependency https://github.com/alpinelinux/aports/pull/4217