### PR TITLE
main/xfsprogs: upgrade to 4.16.1

### DIFF
--- a/main/xfsprogs/APKBUILD
+++ b/main/xfsprogs/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xfsprogs
-pkgver=4.14.0
+pkgver=4.16.1
 pkgrel=0
 pkgdesc="XFS filesystem utilities"
 url="http://xfs.org/index.php/Main_Page"
@@ -41,11 +41,11 @@ package() {
 }
 
 extra() {
-	depends="$pkgname"
+	depends="$pkgname python3" # python3 for xfs_scrub_all
 	pkgdesc="XFS filesystem extra utilities"
 	mkdir -p "$subpkgdir"
-	rmdir "$pkgdir"/lib "$pkgdir"/usr/lib
+	rm -rf "$pkgdir"/lib "$pkgdir"/usr/lib
 	mv "$pkgdir"/usr "$subpkgdir"/
 }
 
-sha512sums="6b8e5e12aa5c4d197feb7c464495a1da163cf7a61416a5b9960dbae9456d776d815d5bb2f60850027274bd8d2cd4409f0fa8d572117043ba38ecc5c785f24967  xfsprogs-4.14.0.tar.gz"
+sha512sums="c83d94950a727c3008c56ca6952e821e5c119e0a40d4c1b3251768e116d1eb62592556006e1cdc491fb8f6dd245c419c985da41ed1656b8d4962188a06d800f5  xfsprogs-4.16.1.tar.gz"


### PR DESCRIPTION
To fix build, remove assumption that "$pkgdir"{/lib,/usr/lib} are empty.
Add python3 dependency to xfsprogs-extra, as xfs_scrub_all needs it.