### PR TITLE
testing/ndppd: new aport

### DIFF
--- a/testing/ndppd/APKBUILD
+++ b/testing/ndppd/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Anthony Ruhier <anthony.ruhier@gmail.com>
+# Maintainer: Anthony Ruhier <anthony.ruhier@gmail.com>
+pkgname=ndppd
+pkgver=20170920
+pkgrel=0
+_commit="88b9bc561ce42f2eb97ea041cd8920797b44dd53"
+pkgdesc="NDP Proxy Daemon"
+url="https://github.com/navossoc/ndppd"
+arch="all"
+license="GPL-3.0-or-later"
+depends=""
+makedepends="linux-headers"
+install=""
+subpackages="$pkgname-doc"
+source="https://github.com/navossoc/ndppd/archive/$_commit.tar.gz
+	ndppd.initd
+	"
+builddir="$srcdir/$pkgname-$_commit"
+
+build() {
+	cd "$builddir"
+	# work around parallel build issue
+	make all
+}
+
+package() {
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" PREFIX=/usr install
+	install -Dm755 "$srcdir"/ndppd.initd "$pkgdir"/etc/init.d/ndppd
+	install -Dm644 "$builddir"/ndppd.conf-dist "$pkgdir"/etc/ndppd.conf
+	install -Dm644 "$builddir"/ndppd.conf-dist \
+		"$pkgdir"/usr/share/doc/ndppd/ndppd.conf.example
+}
+sha512sums="5be824404e100e03525a8bcd795b216456bc4d9c57e49c8f7e18a40af47f99e1bef365e7eb60193dd8bd3e552435125bbbca8192b8122b2808c1aa9d0acba538  88b9bc561ce42f2eb97ea041cd8920797b44dd53.tar.gz
+3b049547ab2c239026abf2af8a3159c4cd66a5604fef0402e19ea2ed2adb25e73fab07d1198d1c3d0630bd12e859dd308efb230bacace7587becd0adade6b913  ndppd.initd"

--- a/testing/ndppd/ndppd.initd
+++ b/testing/ndppd/ndppd.initd
@@ -1,0 +1,33 @@
+#!/sbin/openrc-run
+
+CONFIGFILE=/etc/ndppd.conf
+PIDFILE=/run/ndppd/ndppd.pid
+
+depend() {
+	need net
+	after firewall
+}
+
+checkconfig() {
+	if [ ! -f "${CONFIGFILE}" ]; then
+		eerror "Configuration file ${CONFIGFILE} not found"
+		return 1
+	fi
+
+	checkpath -d ${PIDFILE%/*}
+}
+
+start() {
+	checkconfig || return 1
+
+	ebegin "Starting IPv6 Router Advertisement Daemon"
+	start-stop-daemon -S -x /usr/sbin/ndppd \
+		-- -c "${CONFIGFILE}" -p "${PIDFILE}" -d
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping IPv6 Router Advertisement Daemon"
+	start-stop-daemon -K -x /usr/sbin/ndppd --pidfile "${PIDFILE}"
+	eend $?
+}


### PR DESCRIPTION
Hi,
I created a package for ndppd, a NDP proxy daemon .
As the maintainer does not release anything for 2 years and prefers using the git master branch, I decided to use the last commit of master. And as it did not build on musl, related to [this issue](https://github.com/DanielAdolfsson/ndppd/issues/40), I used a fork that includes some fixes to make it work.

Thanks!