### PR TITLE
main/jemalloc: upgrade to 5.1.0, modernize, clarify license

### DIFF
--- a/main/jemalloc/APKBUILD
+++ b/main/jemalloc/APKBUILD
@@ -1,19 +1,16 @@
 # Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=jemalloc
-pkgver=5.0.1
+pkgver=5.1.0
 pkgrel=0
 pkgdesc="A general purpose malloc(3) implementation"
-url="http://www.canonware.com/jemalloc/"
+url="http://jemalloc.net/"
 arch="all"
-license="BSD"
-depends=""
-makedepends=""
+license="BSD-2-Clause"
 subpackages="$pkgname-dev $pkgname-doc"
 source="$pkgname-$pkgver.tar.bz2::https://github.com/$pkgname/$pkgname/releases/download/$pkgver/$pkgname-$pkgver.tar.bz2
 	jemalloc-no-pprof.patch
 	"
-builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
@@ -25,15 +22,19 @@ build() {
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--localstatedir=/var \
-		--disable-syscall \
-		|| return 1
-	make || return 1
+		--disable-syscall
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="8cb5957a5724eb2bbad120cf0028ea8b2b14b4a416c1751b7c967351a7fd51135058ea0d3c4dc1d127c86f3aa7e9fd5ef101857110aabfdb7789427791c432c3  jemalloc-5.0.1.tar.bz2
-a97c4eb504f8eb725fdd65683b512ea69773f1a183020a785cd02c5ac7e174a7206bf921a30ce63e5b183ef7bef34cec28ccdb57e16dfebd33f5a8161af2989d  jemalloc-no-pprof.patch"
+sha512sums="d9abebe54d303ca931b8c31c1033f23ff5fb060f2377ec8386f4d79c352e65c78ed34f680c352dac14f7d7115d10245782d553d988bc13df2eb34a2f0942ef6f  jemalloc-5.1.0.tar.bz2
+1e59e6e3bd98be3be12a2619acf213445906c1f70d5e06fbfb98c1409c93486934ab53d58709a05e0c109e5ba9eab16d2110163e173de22ef2dc969d1cde9274  jemalloc-no-pprof.patch"

--- a/main/jemalloc/jemalloc-no-pprof.patch
+++ b/main/jemalloc/jemalloc-no-pprof.patch
@@ -1,6 +1,6 @@
---- a/Makefile.in.orig
+--- a/Makefile.in
 +++ b/Makefile.in
-@@ -319,7 +319,7 @@ done
+@@ -467,7 +467,7 @@
  
  install_doc: install_doc_html install_doc_man
  
@@ -8,4 +8,4 @@
 +install: install_include install_lib install_doc
  
  tests_unit: $(TESTS_UNIT:$(srcroot)%.c=$(objroot)%$(EXE))
- tests_integration: $(TESTS_INTEGRATION:$(srcroot)%.c=$(objroot)%$(EXE))
+ tests_integration: $(TESTS_INTEGRATION:$(srcroot)%.c=$(objroot)%$(EXE)) $(TESTS_INTEGRATION_CPP:$(srcroot)%.cpp=$(objroot)%$(EXE))


### PR DESCRIPTION
100% backwards compatible https://abi-laboratory.pro/tracker/timeline/jemalloc/