### PR TITLE
testing/ranger: resurrect and update to 1.9.1

### DIFF
--- a/testing/ranger/APKBUILD
+++ b/testing/ranger/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bartłomiej Piotrowski <nospam@bpiotrowski.pl>
+# Maintainer: Jan Tatje <jan@jnt.io>
+
+pkgname=ranger
+pkgver=1.9.2
+pkgrel=0
+pkgdesc="A simple, vim-like file manager"
+url="https://ranger.github.io/"
+arch="noarch"
+license="GPL-3.0"
+options="" # `make test` fails even on unused-variable warnings, which there are 715 of
+depends="python3"
+makedepends="flake8 pylint pytest"
+subpackages="$pkgname-doc"
+source="https://ranger.github.io/${pkgname}-${pkgver}.tar.gz"
+
+build() {
+	return 0
+}
+
+check() {
+	cd "$srcdir"/$pkgname-$pkgver
+	make test
+}
+
+package() { 
+	cd "$srcdir"/$pkgname-$pkgver
+	python3 setup.py -q install --root="${pkgdir}" --optimize=1
+}
+
+sha512sums="07f1fa59221588bf787a2d755205a11614e0c4afe4a5680e41d26a7d3e574eaf1cae2a648fb034de37b8d02bda3ae97882616b2999ada39bb01296a5883a5a0d  ranger-1.9.2.tar.gz"


### PR DESCRIPTION
This APKBUILD was unmaintained, didn't work and got purged.
Issue was either in ranger or ncurses, both of which have been updated in the meantime, which has fixed the segfault problem.