### PR TITLE
main/musl: add additional features definitions for ppc64le

### DIFF
--- a/main/musl/0006-powerpc-update-hwcap.h-for-linux-v4.15.patch
+++ b/main/musl/0006-powerpc-update-hwcap.h-for-linux-v4.15.patch
@@ -1,0 +1,39 @@
+From 0fc2f098a496bc5c7379e2330421fcc86988c2ba Mon Sep 17 00:00:00 2001
+From: Szabolcs Nagy <nsz@port70.net>
+Date: Fri, 2 Feb 2018 20:38:15 +0000
+Subject: [PATCH] powerpc: update hwcap.h for linux v4.15
+
+PPC_FEATURE2_HTM_NO_SUSPEND is new in linux commit
+cba6ac4869e45cc93ac5497024d1d49576e82666
+PPC_FEATURE2_DARN and PPC_FEATURE2_SCV were new in v4.12 in commit
+a4700a26107241cc7b9ac8528b2c6714ff99983d
+---
+ arch/powerpc/bits/hwcap.h   | 3 +++
+ arch/powerpc64/bits/hwcap.h | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/arch/powerpc/bits/hwcap.h b/arch/powerpc/bits/hwcap.h
+index 82c92a93..803de9b5 100644
+--- a/arch/powerpc/bits/hwcap.h
++++ b/arch/powerpc/bits/hwcap.h
+@@ -38,3 +38,6 @@
+ #define PPC_FEATURE2_HTM_NOSC		0x01000000
+ #define PPC_FEATURE2_ARCH_3_00		0x00800000
+ #define PPC_FEATURE2_HAS_IEEE128	0x00400000
++#define PPC_FEATURE2_DARN		0x00200000
++#define PPC_FEATURE2_SCV		0x00100000
++#define PPC_FEATURE2_HTM_NO_SUSPEND	0x00080000
+diff --git a/arch/powerpc64/bits/hwcap.h b/arch/powerpc64/bits/hwcap.h
+index 82c92a93..803de9b5 100644
+--- a/arch/powerpc64/bits/hwcap.h
++++ b/arch/powerpc64/bits/hwcap.h
+@@ -38,3 +38,6 @@
+ #define PPC_FEATURE2_HTM_NOSC		0x01000000
+ #define PPC_FEATURE2_ARCH_3_00		0x00800000
+ #define PPC_FEATURE2_HAS_IEEE128	0x00400000
++#define PPC_FEATURE2_DARN		0x00200000
++#define PPC_FEATURE2_SCV		0x00100000
++#define PPC_FEATURE2_HTM_NO_SUSPEND	0x00080000
+-- 
+2.15.0
+

--- a/main/musl/APKBUILD
+++ b/main/musl/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=musl
 pkgver=1.1.19
-pkgrel=7
+pkgrel=8
 pkgdesc="the musl c library (libc) implementation"
 url="http://www.musl-libc.org/"
 arch="all"
@@ -22,6 +22,7 @@ source="http://www.musl-libc.org/releases/musl-$pkgver.tar.gz
 	0003-fix-fmaf-wrong-result.patch
 	0004-implement-wcsftime-padding-specifier-extensions.patch
 	0005-fix-wrong-result-in-casin-and-many-related-complex-f.patch
+	0006-powerpc-update-hwcap.h-for-linux-v4.15.patch
 
 	2000-pthread-internals-increase-DEFAULT_GUARD_SIZE-to-2-p.patch
 	handle-aux-at_base.patch
@@ -154,6 +155,7 @@ sha512sums="abee52d53af4b3c14c9088866c911a24d2b6ef67dc494f38a7a09dfe77250026f775
 b0bcfc837f888f2b1c2d65c06dcc0a2fa12da78986ba9c7c86a64123ce44c21a63c13c1cc2e93fdf564a3ca4472c29f0acabaff367914c52bf101d6d8a56ee2e  0003-fix-fmaf-wrong-result.patch
 1fedaf691ac394dec3158cff7839e36383d4107b59f003b75c8fb85a5fceb2143e2bb4aae58c08d68ccdf02d5ebf8c9e5031fa6063aa5c3112b4f8c66adab3dd  0004-implement-wcsftime-padding-specifier-extensions.patch
 6d7bbb493ccb7006270ace71266c0daf2c87842480f01cafb25609c9a3c77ae35934ee2a2bf00d78be8cce391204dcb9aba33e4d96dbf2a258595cf7a3939130  0005-fix-wrong-result-in-casin-and-many-related-complex-f.patch
+023fc05d653f4a3be4d16a2e223bddc26be7bc31c4decf3f5b9bed78cbe7bc8687ff8c164b94541f6fda66d6c3864dd42cb10920d066f97d2891e31a366c3e8d  0006-powerpc-update-hwcap.h-for-linux-v4.15.patch
 2c8e1dde1834238097b2ee8a7bfb53471a0d9cff4a5e38b55f048b567deff1cdd47c170d0578a67b1a039f95a6c5fbb8cff369c75b6a3e4d7ed171e8e86ebb8c  2000-pthread-internals-increase-DEFAULT_GUARD_SIZE-to-2-p.patch
 6a7ff16d95b5d1be77e0a0fbb245491817db192176496a57b22ab037637d97a185ea0b0d19da687da66c2a2f5578e4343d230f399d49fe377d8f008410974238  handle-aux-at_base.patch
 8d3a2d5315fc56fee7da9abb8b89bb38c6046c33d154c10d168fb35bfde6b0cf9f13042a3bceee34daf091bc409d699223735dcf19f382eeee1f6be34154f26f  ldconfig


### PR DESCRIPTION
This additional features would avoid FTFBS later as the one found on

rngd_darn.c:208:31: error: 'PPC_FEATURE2_DARN' undeclared (first use in this function)
  if (!(getauxval(AT_HWCAP2) & PPC_FEATURE2_DARN)) {