### PR TITLE
main/ncurses: upgrade to 6.1

### DIFF
--- a/main/ncurses/APKBUILD
+++ b/main/ncurses/APKBUILD
@@ -1,19 +1,17 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=ncurses
-pkgver=6.0_p20180121
-_ver=${pkgver%_p*}-${pkgver#*_p}
-pkgrel=1
+pkgver=6.1
+_ver=${pkgver%_p*} #-${pkgver#*_p}
+pkgrel=0
 pkgdesc="Console display library"
 url="https://www.gnu.org/software/ncurses/"
 arch="all"
-options="!check"  # "tests" are actual demo programs, not a test suite.
+options="!check" # "tests" are actual demo programs, not a test suite.
 license="MIT"
-depends=
 makedepends_build="ncurses"
-source="http://invisible-mirror.net/archives/ncurses/current/ncurses-$_ver.tgz"
 subpackages="$pkgname-static $pkgname-dev $pkgname-doc $pkgname-libs
 	$pkgname-terminfo-base:base:noarch $pkgname-terminfo:terminfo:noarch"
-
+source="https://ftp.gnu.org/gnu/ncurses/ncurses-$_ver.tar.gz"
 builddir="$srcdir"/ncurses-$_ver
 
 # secfixes:
@@ -103,4 +101,4 @@ static() {
 	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib/
 }
 
-sha512sums="f233a0630df01d96e01c5fabfb8a3d96860c9d8827c910019af410ee1b3190979a8f357ca292b083914c5ef41532f068d46685d4919b4c1d9258add5fb4dc343  ncurses-6.0-20180121.tgz"
+sha512sums="e308af43f8b7e01e98a55f4f6c4ee4d1c39ce09d95399fa555b3f0cdf5fd0db0f4c4d820b4af78a63f6cf6d8627587114a40af48cfc066134b600520808a77ee  ncurses-6.1.tar.gz"


### PR DESCRIPTION
> Release Notes
> 
> These notes are for ncurses 6.1, released January 27, 2018.
> 
> This release is designed to be source-compatible with ncurses 5.0 through 6.0; providing extensions to the application binary interface (ABI). Although the source can still be configured to support the ncurses 5 ABI, the intent of the release is to provide extensions to the ncurses 6 ABI:
> 
>     improve integration of tput and tset
> 
>     provide support for extended numeric capabilities.
> 
> There are, of course, numerous other improvements, listed in this announcement.
> 
> The release notes also mention some bug-fixes, but are focused on new features and improvements to existing features since ncurses 6.0 release.

https://www.gnu.org/software/ncurses/