### PR TITLE
community/aqbanking: fix build break by reordering plugin dependancies

### DIFF
--- a/community/aqbanking/APKBUILD
+++ b/community/aqbanking/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=aqbanking
 pkgver=5.7.8
 _pkgrel=217
-pkgrel=0
+pkgrel=1
 pkgdesc="A library for online banking and financial applications"
 url="http://www.aquamaniac.de/aqbanking"
 arch="all"
@@ -15,6 +15,7 @@ makedepends="gwenhywfar-dev gmp-dev gettext-dev bzip2
 install=""
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 source="$pkgname-$pkgver.tar.gz::https://www.aquamaniac.de/sites/download/download.php?package=03&release=${_pkgrel}&file=02&dummy=$pkgname-$pkgver.tar.gz
+	reorder_deps	
 	libintl.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -39,6 +40,7 @@ build() {
 		--localstatedir=/var \
 		--disable-python \
 		--with-backends="aqhbci aqofxconnect"
+	patch -p1 < "$srcdir"/reorder_deps
 	make -j1
 }
 
@@ -48,4 +50,5 @@ package() {
 }
 
 sha512sums="4078c3bc2c0b6f38f853fed064e37b6188c0b8158416ca6482756232ef8fe71e9cc1df0abe8c6bcbe8a7e818c24210f553c367f540d60cb7b7cf0161a9ca7117  aqbanking-5.7.8.tar.gz
+8f804cac018493cb7f106887a19cacf1c00578e6a08af68b0f4379980f962bc5be84404f6c4582de84463e73af048e653327d53d110728225dce50ec94264198  reorder_deps
 142f0037abfc18e4ce297b815bcf6f24c50a4a46581d58651e7e76aedb9977e42b58f7a7fb145d6d463e61e99fffb018e238d3f7c81cb306526b4fcabaacda71  libintl.patch"

--- a/community/aqbanking/reorder_deps
+++ b/community/aqbanking/reorder_deps
@@ -1,0 +1,11 @@
+--- a/src/plugins/backends/aqhbci/plugin/Makefile
++++ b/src/plugins/backends/aqhbci/plugin/Makefile
+@@ -1033,7 +1033,7 @@
+ check-am: all-am
+ check: $(BUILT_SOURCES)
+ 	$(MAKE) $(AM_MAKEFLAGS) check-recursive
+-all-am: Makefile $(PROGRAMS) $(LTLIBRARIES) $(DATA) $(HEADERS)
++all-am: Makefile $(LTLIBRARIES) $(DATA) $(HEADERS) $(PROGRAMS)
+ installdirs: installdirs-recursive
+ installdirs-am:
+ 	for dir in "$(DESTDIR)$(libdir)" "$(DESTDIR)$(plugindir)" "$(DESTDIR)$(plugindir)" "$(DESTDIR)$(xmldatadir)" "$(DESTDIR)$(iheaderdir)"; do \


### PR DESCRIPTION
In 3.8 automake 1.16 invoked on src/plugins/backends/aqhbci/plugin/Makefile generates a Makefile with:
all-am: Makefile $(PROGRAMS) $(LTLIBRARIES) $(DATA) $(HEADERS)
This results in a build error:
error: cannot find the library '/home/buildozer/aports/community/aqbanking/src/aqbanking-5.7.8/src/plugins/backends/aqhbci/plugin/libaqhbci.la'

In prior builds (3.7 and edge) with automake 1.15 the same Makefile.am generates a Makefile with:
all-am: Makefile  $(LTLIBRARIES) $(DATA) $(HEADERS) $(PROGRAMS)
which builds without error.

This PR introduces a patch that changes the order of all-am dependencies to what had been generated in earlier versions of automake. It is not done as an ordinary patch since it must be applied after autogen.sh is run.