### PR TITLE
mkinitfs: point the /boot/boot symlink at ., not /.

### DIFF
--- a/main/mkinitfs/APKBUILD
+++ b/main/mkinitfs/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=mkinitfs
 pkgver=3.2.0
 _ver=${pkgver%_git*}
-pkgrel=12
+pkgrel=13
 pkgdesc="Tool to generate initramfs images for Alpine"
 url="https://git.alpinelinux.org/cgit/mkinitfs"
 arch="all"

--- a/main/mkinitfs/mkinitfs.trigger
+++ b/main/mkinitfs/mkinitfs.trigger
@@ -18,7 +18,7 @@ done
 # extlinux will use path relative partition, so if /boot is on a
 # separate partition we want /boot/<kernel> resolve to /<kernel>
 if ! [ -e /boot/boot ]; then
-	ln -sf / /boot/boot
+	ln -sf . /boot/boot
 fi
 
 # cleanup unused initramfs


### PR DESCRIPTION
If /boot is on the root partition, I.E., no separate /boot partition,
then the /boot/boot symlink incorrectly pointed to /.  Pointing
/boot/boot to "." is correct in all situations.