### PR TITLE
community/libreswan: fix build break because of missing ldns-dev depe…

### DIFF
--- a/community/libreswan/APKBUILD
+++ b/community/libreswan/APKBUILD
@@ -2,7 +2,7 @@
 
 pkgname=libreswan
 pkgver=3.21
-pkgrel=1
+pkgrel=2
 pkgdesc="IPsec implementation for Linux"
 url="https://libreswan.org"
 arch="all"
@@ -11,7 +11,7 @@ depends="nss-tools iproute2"
 provides="openswan"
 makedepends="bison flex coreutils bash xmlto
 	gmp-dev linux-pam-dev nss-dev unbound-dev libcap-ng-dev
-	curl-dev nspr-dev bsd-compat-headers
+	curl-dev nspr-dev bsd-compat-headers ldns-dev
 	"
 subpackages="$pkgname-doc"
 source="https://download.libreswan.org/libreswan-$pkgver.tar.gz


### PR DESCRIPTION
…ndancy. 
Build fails with fatal error: ldns/ldns.h: No such file or directory
Added ldns-dev to makedepends to fix