### PR TITLE
main/busybox: don’t silently ignore certificate validation

### DIFF
--- a/main/busybox/0001-wget-dont-silently-ignore-certificate-validation.patch
+++ b/main/busybox/0001-wget-dont-silently-ignore-certificate-validation.patch
@@ -1,0 +1,86 @@
+From 98b5605d1c766ede183f7e72fce88b4832ecc0c2 Mon Sep 17 00:00:00 2001
+From: Jakub Jirutka <jakub@jirutka.cz>
+Date: Thu, 24 May 2018 02:19:23 +0200
+Subject: [PATCH] wget: don't silently ignore certificate validation
+
+Internal TLS code (FEATURE_WGET_HTTPS) does not implement validation
+of the server's certificate.  It is documented in the code, but not
+even mentioned in the --help message, so users typically don't know
+about this behaviour.  That's a crime against security!
+
+This patch changes this behaviour for the case when both
+FEATURE_WGET_LONG_OPTIONS and FEATURE_WGET_HTTPS are enabled - any
+attempt to open a TLS connection using internal TLS code (i.e. without
+certificate validation) ends with error, unless the user specified
+option "--no-check-certificate".
+---
+ networking/wget.c | 30 +++++++++++++++++++-----------
+ 1 file changed, 19 insertions(+), 11 deletions(-)
+
+diff --git a/networking/wget.c b/networking/wget.c
+index 30c3392..074de91 100644
+--- a/networking/wget.c
++++ b/networking/wget.c
+@@ -136,18 +136,21 @@
+ //usage:#define wget_full_usage "\n\n"
+ //usage:       "Retrieve files via HTTP or FTP\n"
+ //usage:	IF_FEATURE_WGET_LONG_OPTIONS(
+-//usage:     "\n	--spider	Only check URL existence: $? is 0 if exists"
++//usage:     "\n	--spider		Only check URL existence: $? is 0 if exists"
++//usage:		IF_FEATURE_WGET_HTTPS(
++//usage:     "\n	--no-check-certificate	Don't validate the server's certificate"
++//usage:		)
+ //usage:	)
+-//usage:     "\n	-c		Continue retrieval of aborted transfer"
+-//usage:     "\n	-q		Quiet"
+-//usage:     "\n	-P DIR		Save to DIR (default .)"
+-//usage:     "\n	-S    		Show server response"
++//usage:     "\n	-c			Continue retrieval of aborted transfer"
++//usage:     "\n	-q			Quiet"
++//usage:     "\n	-P DIR			Save to DIR (default .)"
++//usage:     "\n	-S    			Show server response"
+ //usage:	IF_FEATURE_WGET_TIMEOUT(
+-//usage:     "\n	-T SEC		Network read timeout is SEC seconds"
++//usage:     "\n	-T SEC			Network read timeout is SEC seconds"
+ //usage:	)
+-//usage:     "\n	-O FILE		Save to FILE ('-' for stdout)"
+-//usage:     "\n	-U STR		Use STR for User-Agent header"
+-//usage:     "\n	-Y on/off	Use proxy"
++//usage:     "\n	-O FILE			Save to FILE ('-' for stdout)"
++//usage:     "\n	-U STR			Use STR for User-Agent header"
++//usage:     "\n	-Y on/off		Use proxy"
+ 
+ #include "libbb.h"
+ 
+@@ -271,6 +274,7 @@ enum {
+ 	WGET_OPT_HEADER     = (1 << 10) * ENABLE_FEATURE_WGET_LONG_OPTIONS,
+ 	WGET_OPT_POST_DATA  = (1 << 11) * ENABLE_FEATURE_WGET_LONG_OPTIONS,
+ 	WGET_OPT_SPIDER     = (1 << 12) * ENABLE_FEATURE_WGET_LONG_OPTIONS,
++	WGET_OPT_NO_CHECK_CERT = (1 << 13) * ENABLE_FEATURE_WGET_LONG_OPTIONS,
+ };
+ 
+ enum {
+@@ -714,6 +718,11 @@ static void spawn_ssl_client(const char *host, int network_fd, int flags)
+ 	int pid;
+ 	char *servername, *p;
+ 
++#if ENABLE_FEATURE_WGET_LONG_OPTIONS
++	if (!(option_mask32 & WGET_OPT_NO_CHECK_CERT))
++		bb_error_msg_and_die("unable to validate the server's certificate");
++#endif
++
+ 	servername = xstrdup(host);
+ 	p = strrchr(servername, ':');
+ 	if (p) *p = '\0';
+@@ -1402,10 +1411,9 @@ IF_DESKTOP(	"tries\0"            Required_argument "t")
+ 		"header\0"           Required_argument "\xff"
+ 		"post-data\0"        Required_argument "\xfe"
+ 		"spider\0"           No_argument       "\xfd"
++		"no-check-certificate\0" No_argument   "\xfc"
+ 		/* Ignored (we always use PASV): */
+ IF_DESKTOP(	"passive-ftp\0"      No_argument       "\xf0")
+-		/* Ignored (we don't do ssl) */
+-IF_DESKTOP(	"no-check-certificate\0" No_argument   "\xf0")
+ 		/* Ignored (we don't support caching) */
+ IF_DESKTOP(	"no-cache\0"         No_argument       "\xf0")
+ IF_DESKTOP(	"no-verbose\0"       No_argument       "\xf0")

--- a/main/busybox/APKBUILD
+++ b/main/busybox/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=busybox
 pkgver=1.28.3
-pkgrel=0
+pkgrel=1
 pkgdesc="Size optimized toolbox of many common UNIX utilities"
 url=http://busybox.net
 arch="all"
@@ -41,6 +41,8 @@ source="http://busybox.net/downloads/$pkgname-$pkgver.tar.bz2
 
 	0001-nsenter-Rename-network-option-to-net.patch
 	0002-nsenter-fix-parsing-of-t-S-and-G-options.patch
+
+	0001-wget-dont-silently-ignore-certificate-validation.patch
 
 	acpid.logrotate
 	busyboxconfig
@@ -205,6 +207,7 @@ d90d6b3406760fe3df6dbed46a0f4d1c02a69d5184ebc86d8c1692bc4576532127283ba3ff9a81e6
 0dbe3ee424c0a6e4aba4f551f6b6b9ee087655a03747a40906961b141d40b1cbb2345438f17887a1b78d880cb3a7ad0116936dd7c05e95160febfd299423e83b  0001-cat-fix-cat-e-and-cat-v-erroneously-numbering-1st-li.patch
 d2364e20b12c5215c4baecc3c6faf903e6e1e2bee95d697af047d680e9d57e7aeea54c8584d062d92daa0ea64898b502fbae010b22ab236ec4018966b74deeec  0001-nsenter-Rename-network-option-to-net.patch
 0dbffae82b62317fc4144a01940ebc601e58b0e14eb8338bc42db79407d0b74dbe9f0f44758b9a5baa399eb90f8e8ee8f9c344bebd1b03bdd2ce520cb2b28d5e  0002-nsenter-fix-parsing-of-t-S-and-G-options.patch
+6b7e73b27fe7ff24d02c64a7f42826be6e96ddad7659c2e2b245f215ce2f9d1c777b908e9fb8d7be77d52e7753484b7d55d35d7a661f88d9db50b20df8c21d49  0001-wget-dont-silently-ignore-certificate-validation.patch
 a9b1403c844c51934637215307dd9e2adb9458921047acff0d86dcf229b6e0027f4b2c6cdaa25a58407aad9d098fb5685d58eb5ff8d2aa3de4912cdea21fe54c  acpid.logrotate
 035f2a28719971d9ff805d208d70bc1144fd3701235dc46ef581a559e696ef92265f28f7debf0248a2cee004a773dcd07828bcc088716f5aff944ccdce15d30f  busyboxconfig
 0efbe22e2fd56993d92b6542d4ccffb2b42d50495be085c98f417a71f503b4071e2f092afcec77f78064d33ffb0922c28daa3cb9958e6d7fb26d5a660abd90f4  busyboxconfig-extras


### PR DESCRIPTION
Ref https://bugs.alpinelinux.org/issues/8917

As I’m thinking about it, it may be better to just print bold warning message about insecure connection for now and switch to error in v3.9. WDYT?