### PR TITLE
main/mutt: upgrade to 1.10.0

### DIFF
--- a/main/mutt/APKBUILD
+++ b/main/mutt/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Andrew Manison <amanison@anselsystems.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mutt
-pkgver=1.9.5
+pkgver=1.10.0
 pkgrel=0
 pkgdesc="Small and very powerful text-mode email client"
 url="http://www.mutt.org"
@@ -12,7 +12,7 @@ makedepends="cyrus-sasl-dev gdbm-dev gettext-dev gpgme-dev
 	libidn-dev ncurses-dev libressl-dev perl"
 options="suid !check"
 subpackages="$pkgname-doc $pkgname-lang"
-source="https://bitbucket.org/$pkgname/$pkgname/downloads/$pkgname-$pkgver.tar.gz"
+source="ftp://ftp.mutt.org/pub/$pkgname/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
@@ -55,4 +55,4 @@ package() {
 		"$pkgdir"/etc/Muttrc.gpg.dist
 }
 
-sha512sums="08ceeb7b212f74e4e2b18fedfe15c5ac46a22449f4e75038485748a742727ad6a2d00c1cfee99e1e195e720d83a6320ae38a3f4f94cd92667f22270f3cf6637b  mutt-1.9.5.tar.gz"
+sha512sums="4cade7f17e157c8c2184c96d596d9dbfab704d300074eca66c567f2dab055caa9b828080cce92e2616176000219288630c33542ab83a98db0160cd085b937530  mutt-1.10.0.tar.gz"


### PR DESCRIPTION
Also change URL to ftp://ftp.mutt.org/, as the previous bitbucket seems
no longer maintained.