### PR TITLE
testing/wireguard: upgrade to 0.0.20180529

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180519
+pkgver=0.0.20180531
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="587a1371edd4a7fdf167154398f8a51da8c70f55e86a4be4b0b830a2f00a1421710017d954ad1aeda4df3a36ca8c9a911ba5fb407a851235257176291af3ee15  WireGuard-0.0.20180519.tar.xz"
+sha512sums="1dfcdcf41adffdc42dcdbb0a84478b28574613b7834c7d1ccd17f176bac1d664afe824c850baf7d34213380ddffdfd66ddc5cbf7861904dc8359d2005ff07dff  WireGuard-0.0.20180531.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180519
-_rel=2
+_ver=0.0.20180531
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="587a1371edd4a7fdf167154398f8a51da8c70f55e86a4be4b0b830a2f00a1421710017d954ad1aeda4df3a36ca8c9a911ba5fb407a851235257176291af3ee15  WireGuard-0.0.20180519.tar.xz"
+sha512sums="1dfcdcf41adffdc42dcdbb0a84478b28574613b7834c7d1ccd17f176bac1d664afe824c850baf7d34213380ddffdfd66ddc5cbf7861904dc8359d2005ff07dff  WireGuard-0.0.20180531.tar.xz"


### PR DESCRIPTION
```
  * allowedips: set pointer to null before freeing
  * ncat-client-server: do not always call sudo and use env bash
  * qemu: bump default kernel for gcc 8.1
  * compat: work around qcom 4.9 backports
  
  The usual fixes.
  
  * tools: fix OpenBSD build
  * tools: always pass -v as first argument to install
  
  Portability changes.
  
  * wg-quick: darwin: rename namefile environment variable
  * wg-quick: darwin: do not remove routes when no real interface
  * wg-quick: freebsd: add new implementation
  * wg-quick: openbsd: add new implementation
  * wg-quick: support FreeBSD/Darwin search path
  * wg-quick: better bash completion for non-renaming OSes
  * wg-quick: allow enumeration of socket files
  
  We now support OpenBSD and FreeBSD, in addition to macOS.

  * compat: don't clash with get_random_u32 backports
  
  This should allow running on recent Qualcomm msm8998 kernels.
  
  * wg-quick: determine IPs when saving interface
  * wg-quick: darwin: add multiple IP addresses
  * wg-quick: freebsd: configure as p2p link
  * wg-quick: darwin: set DNS servers after delay on route change
  
  Usual set of wg-quick changes, since the recent cross platform additions.
  
  * curve25519: x86_64: satisfy sparse
  * curve25519: x86_64: make symbol static
  * crypto: consistent constification
  
  Small cleanups in the crypto primitives.
  
  * chacha20poly1305: split up into separate files
  * chacha20poly1305: combine stack variables into union
  * chacha20poly1305: test scattergather functions too
  * chacha20poly1305: test for authtag failure
  
  We've reorganized our chapoly implementation and added lots of new tests as
  well. The generic C chacha should be slightly faster in the process.
  
  * poly1305: mips: compute S on fly
  
  Small speedup on MIPS.
  
  * device: do not assume dst is always valid
  
  Fixes a crash when forwarding packets from devices that use flow offloading.
  
  * tools: constanter time encoding
  
  Not essential, but nice to have.
```