### PR TITLE
testing/googler: upgrade to 3.6

### DIFF
--- a/testing/googler/APKBUILD
+++ b/testing/googler/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Ivan Tham <pickfire@riseup.net>
 # Maintainer: Ivan Tham <pickfire@riseup.net>
 pkgname=googler
-pkgver=3.5
+pkgver=3.6
 pkgrel=0
 pkgdesc="Google Search, Google Site Search, Google News from the terminal"
 url="https://github.com/jarun/googler"
@@ -13,7 +13,7 @@ subpackages="$pkgname-doc
 	$pkgname-fish-completions:fishcomp:noarch
 	$pkgname-zsh-completion:zshcomp:noarch
 	"
-source="$pkgname-$pkgver.tar.gz::https://github.com/jarun/$pkgname/archive/v$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/jarun/googler/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -58,4 +58,4 @@ zshcomp() {
                 "$subpkgdir"/usr/share/zsh/site-functions/
 }
 
-sha512sums="fd3cd58ff6c492b04a8c0b271207452991155c571fc31f237eb13fe8ccc08cc3096a994085daa0001b22307e99516dba24af44fd43ddc88d2eaeda5a975cbe9a  googler-3.5.tar.gz"
+sha512sums="d3c8328ad5b7fdcdde32a1b0bdd2f9d87266d9a06ba344b8034442200bea2f787d1bae9c5ca44a5119ef28a8fc0040f29388285c9030c14bc858d9673d0fa177  googler-3.6.tar.gz"


### PR DESCRIPTION
https://github.com/jarun/googler/releases/tag/v3.6