### PR TITLE
community/borgbackup: backport patch to make borg work again

### DIFF
--- a/community/borgbackup/APKBUILD
+++ b/community/borgbackup/APKBUILD
@@ -2,14 +2,15 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=borgbackup
 pkgver=1.1.5
-pkgrel=0
+pkgrel=1
 pkgdesc="Deduplicating backup program"
 url="https://borgbackup.readthedocs.io/"
 arch="all"
 license="BSD-3-Clause"
 depends="python3 py3-msgpack py3-zmq"
 makedepends="python3-dev lz4-dev acl-dev attr-dev libressl-dev linux-headers"
-source="https://github.com/$pkgname/borg/releases/download/$pkgver/$pkgname-$pkgver.tar.gz"
+source="https://github.com/$pkgname/borg/releases/download/$pkgver/$pkgname-$pkgver.tar.gz
+	msgpack-fix.patch"
 
 build() {
 	cd "$builddir"
@@ -25,4 +26,5 @@ package() {
 	find . -name '*.h' -delete -o -name '*.c' -delete -o -name '*.pyx' -delete
 }
 
-sha512sums="22071e4b37059d816592baff852772720769b3d86eb1d071abba67f9d13de809066aa29cdf18f1aaef127d1f24288913a7b0b63d157fb98840b1a71606dc0554  borgbackup-1.1.5.tar.gz"
+sha512sums="22071e4b37059d816592baff852772720769b3d86eb1d071abba67f9d13de809066aa29cdf18f1aaef127d1f24288913a7b0b63d157fb98840b1a71606dc0554  borgbackup-1.1.5.tar.gz
+75cb9c8f3d75ab7ca716d4e0c92ad8097225f1bd5f0a5e8e8213099f56fd4d1ca57587427c20a0695ed154f962fe2a8a0950c7449e29ddf79f5f27aa8ff029dd  msgpack-fix.patch"

--- a/community/borgbackup/msgpack-fix.patch
+++ b/community/borgbackup/msgpack-fix.patch
@@ -1,0 +1,22 @@
+--- borgbackup-1.1.5/setup.py.orig
++++ borgbackup-1.1.5/setup.py
+@@ -36,10 +36,15 @@
+ on_rtd = os.environ.get('READTHEDOCS')
+ 
+ install_requires = [
+-    # msgpack pure python data corruption was fixed in 0.4.6.
+-    # msgpack 0.5.0 was a bit of a troublemaker.
+-    # also, msgpack dropped py34 support at 0.5.0.
+-    'msgpack-python>=0.4.6,<0.5.0',
++    # we are rather picky about msgpack versions, because a good working msgpack is
++    # very important for borg, see https://github.com/borgbackup/borg/issues/3753
++    # best versions seem to be 0.4.6, 0.4.7, 0.4.8 and 0.5.6:
++    'msgpack-python >=0.4.6, <=0.5.6, !=0.5.0, !=0.5.1, !=0.5.2, !=0.5.3, !=0.5.4, !=0.5.5',
++    # if you can't satisfy the above requirement, these are versions that might
++    # also work ok, IF you make sure to use the COMPILED version of msgpack-python,
++    # NOT the PURE PYTHON fallback implementation: ==0.5.1, ==0.5.4
++    # using any other version is not supported by borg development, feel free to
++    # do it on your own risk (and after own testing).
+ ]
+ 
+ # note for package maintainers: if you package borgbackup for distribution,


### PR DESCRIPTION
This fixes https://bugs.alpinelinux.org/issues/8893, caused by upstream error
https://github.com/borgbackup/borg/issues/3753.