### PR TITLE
community/redshift: upgrade to 1.12

### DIFF
--- a/community/redshift/APKBUILD
+++ b/community/redshift/APKBUILD
@@ -1,17 +1,13 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: 7heo <7heo@mail.com>
 pkgname=redshift
-pkgver=1.11
-pkgrel=1
+pkgver=1.12
+pkgrel=0
 pkgdesc="Adjusts the color temperature of your screen according to your surroundings"
 url="http://jonls.dk/redshift/"
 arch="all"
 license="GPL-3.0"
-depends=""
-depends_dev=""
 makedepends="libxcb-dev libxxf86vm-dev libdrm-dev intltool"
-install=
-replaces=""
 subpackages="$pkgname-doc"
 source="https://github.com/jonls/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.xz"
 
@@ -28,20 +24,17 @@ build() {
 		--enable-vidmode \
 		--disable-silent-rules \
 		--disable-nls \
-		|| return 1
-	make || return 1
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 
 	install -Dm644 redshift.conf.sample \
-		"$pkgdir"/usr/share/doc/$pkgname/examples/redshift.conf || return 1
-	install -m644 ABOUT-NLS DESIGN HACKING NEWS README README-colorramp \
-		"$pkgdir"/usr/share/doc/$pkgname/ || return 1
+		"$pkgdir"/usr/share/doc/$pkgname/examples/redshift.conf
+	install -m644 ABOUT-NLS DESIGN NEWS README README-colorramp \
+		"$pkgdir"/usr/share/doc/$pkgname/
 }
 
-md5sums="a31d768b0348c5202e58612855a9027e  redshift-1.11.tar.xz"
-sha256sums="10e350f93951c0521dd6f103d67a485972c307214f036e009acea2978fe4f359  redshift-1.11.tar.xz"
-sha512sums="88d7a4aabfaf3073f88673bc77df19d7bd79cb19aa8e647670cc52c02443475a4602f109fc4a06bf1639d1829d16a2644854039f90a614fc1a51c9cb4c81de16  redshift-1.11.tar.xz"
+sha512sums="225e222e5f2c55be4571094ccaf02a92e162dfc35fd0fe504084e21e358b888a72f9992f9f9edaf1d496eb673af74a0d825ae5cf6ef7f0f1ab51d32419722c32  redshift-1.12.tar.xz"


### PR DESCRIPTION
`HACKING` file is no longer present in sources, so remove it