### PR TITLE
testing/rakudo: upgrade to 2018.05

### DIFF
--- a/testing/moarvm/APKBUILD
+++ b/testing/moarvm/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=moarvm
-pkgver=2018.04
+pkgver=2018.05
 pkgrel=0
 pkgdesc="A VM for NQP And Rakudo Perl 6"
 url="http://moarvm.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="cbcceabc2f3d3d3ac73655bf16246f714923abbe909f2bfa6b1f2456801a4bebfe246f552e2704da254609e1edb66b564ef5b845c88af3761a6d552b2364fc51  MoarVM-2018.04.tar.gz"
+sha512sums="0f71eafcaa1c917257bf47955b82d5c8218c171acc9c09080325f7f2b36a1418e718408ef13f69a71ed142620fd4c47d3681dda0543feb705b62d7643e00cd5f  MoarVM-2018.05.tar.gz"

--- a/testing/nqp/APKBUILD
+++ b/testing/nqp/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=nqp
-pkgver=2018.04
+pkgver=2018.05
 pkgrel=0
 pkgdesc="Not Quite Perl"
 url="https://github.com/perl6/nqp"
@@ -14,11 +14,6 @@ install=""
 subpackages="$pkgname-doc"
 source="${pkgname}-${pkgver}.tar.gz::https://github.com/perl6/nqp/archive/${pkgver}.tar.gz"
 builddir="$srcdir"/"$pkgname"-"$pkgver"
-
-# FIXME: some tests fail on armhf and x86, need to investigate more
-case "$CARCH" in
-	armhf | x86) options="$options !check";;
-esac
 
 build() {
 	cd "$builddir"
@@ -44,4 +39,4 @@ doc() {
 	done
 }
 
-sha512sums="30ee26176f1834c528c0b4bdddc8df08c50f6504cb1626b912a050ab5199f3c1000eb9c884c4031771d6f88429c8fbd23457b73aaa8ee7d937c9f29ad1a46429  nqp-2018.04.tar.gz"
+sha512sums="e653469d90c7abadc867d26a5c78d375c0d716c6b49072c76fbb56c17aa67a6c74611aaea0ca21dcb1068d7d966b429044e155f6edccfa794aecfb568694811f  nqp-2018.05.tar.gz"

--- a/testing/rakudo/APKBUILD
+++ b/testing/rakudo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=rakudo
-pkgver=2018.04
+pkgver=2018.05
 pkgrel=0
 pkgdesc="A compiler for the Perl 6 programming language"
 url="http://rakudo.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="d3e50fd1378bffbe6a56e948c44128e68fe070c6eba13a0fc4ca70d40d09cd47fd2902586a5f1af70b3c81caa90bdeb86a4e277a5d8fbf9e48e91c05906a801b  rakudo-2018.04.tar.gz"
+sha512sums="df747015c0f29efee9aa37a18d75749cfa180d65ef78a46113718fc5dfae19623c8b3266915d1d014253fa6d5a1a8fcba7dadef4bbda194198e1dae521c702ba  rakudo-2018.05.tar.gz"


### PR DESCRIPTION
Upgrade moarvm, nqp, and rakudo to version 2018.05, must upgrade all three together.