### PR TITLE
testing/bazel: new aport

### DIFF
--- a/testing/bazel/APKBUILD
+++ b/testing/bazel/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor:
+# Maintainer:
+pkgname=bazel
+pkgver=0.13.1
+pkgrel=0
+pkgdesc="a fast, scalable, multi-language and extensible build system"
+url="https://bazel.build"
+arch="all"
+license="Apache-2.0"
+depends="openjdk8-jre"
+makedepends="bash zip unzip openjdk8 linux-headers python"
+install=""
+source="https://github.com/bazelbuild/bazel/releases/download/0.13.1/bazel-$pkgver-dist.zip"
+builddir="$srcdir"
+
+build() {
+	cd "$builddir"
+	JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk bash ./compile.sh
+}
+
+check() {
+	cd "$builddir"
+	JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk ./output/bazel > /dev/null
+}
+
+package() {
+	cd "$builddir"
+	mkdir -p "$pkgdir"/usr/bin
+	cp output/bazel "$pkgdir"/usr/bin
+}
+
+sha512sums="8b54631e9335e4bedbc774b2168d204bb982fca9d53c50a8681109b24e4a96701144f64041d3ae366bd1770bf472715f3b72f2b6da280c274eb0990b2e4e76f4  bazel-0.13.1-dist.zip"


### PR DESCRIPTION
This APKBUILD introduces the Bazel build system.

Bazel creates a self-contained binary, but requires a Java Runtime Environment, and a environment variable JAVA_HOME that points to it.
I'd appreciate some feedback if this is correct to ship it that way.