### PR TITLE
community/gitea: upgrade to 1.4.1, switch upstream URL to https

### DIFF
--- a/community/gitea/APKBUILD
+++ b/community/gitea/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=gitea
-pkgver=1.4.0
+pkgver=1.4.1
 pkgrel=0
 pkgdesc="A self-hosted Git service written in Go"
-url="http://gitea.io/"
+url="https://gitea.io"
 arch="all"
 license="MIT"
 depends="git"
@@ -67,7 +67,7 @@ check() {
 	"$builddir"/$pkgname help > /dev/null
 }
 
-sha512sums="d51a47374ce02a542e491079111a3f770db79017004a22b6ebeefc0c65c04036f992534a61d241846e35b7d0da778db4c3de73a151e70adca78966178448c3d1  gitea-1.4.0.tar.gz
+sha512sums="3b812bd61215230035ec9241e953f239981d04580d931f379aa550e11d2f7facd56bf70ac9e2d866224d341570a238bcc5c2fa71fd1432cfb95b8c8b703784e6  gitea-1.4.1.tar.gz
 a7c70a144dc0582d6230e59ff717023fddcac001a6a9c895b46a0df1fbd9639453b2f5027d47dad21f442869c145dbc801eda61b6c50a2dd8103f562b8569009  gitea.initd
 27a202006d6e8d4146659f6356eaa99437f9f596dd369e9430d64b859bc6a1ad16091eef09232aa385fe1bf8ca94bbdf31b94975068220ad10338cded384f726  gitea.ini
 a49e6d820e2ca4c8d583b31a8eb02d8bf3cb7a96ac4f82196fbeb4de0ed22e8e1f64b0f2a6edabed94a07762df0788a2a29dbd58db5213ea6c83c9d0bd7ba24d  allow-to-set-version.patch"


### PR DESCRIPTION
https://github.com/go-gitea/gitea/releases/tag/v1.4.1