### PR TITLE
main/vim: Update to 8.1.0026

### DIFF
--- a/main/vim/APKBUILD
+++ b/main/vim/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=vim
-pkgver=8.1.0022
+pkgver=8.1.0026
 pkgrel=0
 pkgdesc="Improved vi-style text editor"
 url="http://www.vim.org"
@@ -66,5 +66,5 @@ vimdiff() {
 	mv "$pkgdir"/usr/bin/vimdiff "$subpkgdir"/usr/bin
 }
 
-sha512sums="44d44b136e25368a7c5cda156ff1166164e2ec3d0c4f43040cbbd62ca5ec49d1b9d6bdc695daf92a67f6a2f214ab0a9922542b71dde75c99e69291f5164fffa7  vim-8.1.0022.tar.gz
+sha512sums="ccab835923065409910ec2df985d03de1e323bf5c3819365c4215c2f6c0d0eeacd6f47a8bb4d99c7b3deca11e49268f7c6f99b731a1e3f6c88d35141f684995c  vim-8.1.0026.tar.gz
 d9586b777881973cb5e48e18750336a522ed72c3127b2d6b6991e2b943468ca5b694476e7fa39ab469178c1375fc8f52627484e0fe377aea5811a513e35a7b02  vimrc"


### PR DESCRIPTION
This includes a fix for very tall terminals.

Signed-off-by: Leo Unglaub <leo@unglaub.at>