### PR TITLE
testing/zerotier-one: Update to 1.2.10

### DIFF
--- a/testing/zerotier-one/APKBUILD
+++ b/testing/zerotier-one/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Kyle Parisi <kyleparisi@gmail.com>
 # Maintainer: Kyle Parisi <kyleparisi@gmail.com>
 pkgname=zerotier-one
-pkgver=1.2.4
-pkgrel=5
+pkgver=1.2.10
+pkgrel=0
 pkgdesc="ZeroTier One allows systems to join and participate in ZeroTier virtual networks."
 url="https://www.zerotier.com/"
 arch="x86_64 ppc64le"
@@ -31,6 +31,6 @@ package() {
 			"$pkgdir"/etc/init.d/$pkgname || return 1
 }
 
-sha512sums="82adb110208d24ae2745e3839810afcac87955de050ebfe0517a7dc2a875881dafd40c1b16a041742d8c4d0f6513abcc71d6ea3e06c2fb89b47be2630a500363  zerotier-one-1.2.4.tar.gz
+sha512sums="75d967524b67176295c647d7ea04edd5892bd94e19bbe924b5acf439da35f3bc67145c1265294538fb9dfb90ddd9affe258d46fa6aa69704cbd515bc42237058  zerotier-one-1.2.10.tar.gz
 a63f8e649d63a3de58a556b3adca440cd0c0d4b36239ea547d555b97852d89d0a1446f348d35e98f77faabe1fe4ffb76868b8290ad9f2b4cd8b6c599945a176c  zerotier-one.initd
 fe4468a2fdcda99ab4b6055a567f12c04973ad151ad7c1f710bf4e53a5d7e1190ba864cd45274106e5b341267f24f27b2a4855bd27668fec84545d17627d79e7  ppc64le-make-linux.patch"


### PR DESCRIPTION
Free to close: https://github.com/alpinelinux/aports/pull/1892, https://github.com/alpinelinux/aports/pull/1379 for being dated.