### PR TITLE
testing/openmpi: upgrade to 3.1.0, fix s390x

### DIFF
--- a/testing/openmpi/APKBUILD
+++ b/testing/openmpi/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Daniel Sabogal <dsabogalcc@gmail.com>
 pkgname=openmpi
-pkgver=3.0.0
+pkgver=3.1.0
 pkgrel=0
 pkgdesc="Message passing library for high-performance computing"
 url="https://www.open-mpi.org/"
@@ -44,4 +44,4 @@ _dev() {
 	done
 }
 
-sha512sums="7e37eacf959a803d6d89dff4291b64a1f3d83bc7941b778a2fb13d12be0f205cb904e4a807d79676ad1e31fd99ffb15f255c8a227e830673455abb144f14616a  openmpi-3.0.0.tar.bz2"
+sha512sums="23a43a16683c4b56f96c711fe009d992f3bd4e10cf9ef55091865a5b1aed195cc1de6a87720564f70d3b60a2441966bab39cda8969293aeb118cda10aead3dee  openmpi-3.1.0.tar.bz2"


### PR DESCRIPTION
openmpi commit bc54c99e12cf33c5a6c70bf1c3952075b66a76ca allows check for
using s390x's builtin asm, previous versions need
--enable-builtin-atomics