### PR TITLE
community/babl: -Ofast fails float-to-8bit test on s390x

### DIFF
--- a/community/babl/APKBUILD
+++ b/community/babl/APKBUILD
@@ -11,6 +11,7 @@ source="https://ftp.gimp.org/pub/babl/${pkgver%.*}/$pkgname-$pkgver.tar.bz2"
 
 build() {
 	cd "$builddir"
+	[ "$CARCH" = "s390x" ] && sed -i -e 's/-Ofast//g' configure
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \


### PR DESCRIPTION
float-to-8bit test is unstable on s390x, it won't fail if previous build
is cached as being successful.

babl commit 90e25d7ff381fc67588d77bb033992079bab5d3a introduces -Ofast
which (probably) causes this.

upstream bug : https://bugzilla.gnome.org/show_bug.cgi?id=790745