### PR TITLE
Bump RabbitMQ version to 3.7.5

### DIFF
--- a/testing/rabbitmq-server/APKBUILD
+++ b/testing/rabbitmq-server/APKBUILD
@@ -1,13 +1,13 @@
 # Contributor: Nathan Johnson <nathan@nathanjohnson.info>
 # Maintainer: Nathan Johnson <nathan@nathanjohnson.info>
 pkgname=rabbitmq-server
-pkgver=3.6.10
+pkgver=3.7.5
 _realver=${pkgver//\./_}
 pkgrel=0
 pkgdesc="RabbitMQ is an open source multi-protocol messaging broker."
 url="http://www.rabbitmq.com/"
 arch="noarch"
-license="MPL-1.1"
+license="MPL 1.1"
 depends="erlang erlang-tools erlang-runtime-tools erlang-stdlib
 	logrotate erlang-ssl erlang-crypto erlang-parsetools
 	erlang-mnesia erlang-sasl erlang-inets erlang-syntax-tools
@@ -15,7 +15,7 @@ depends="erlang erlang-tools erlang-runtime-tools erlang-stdlib
 depends_dev=""
 makedepends="$depends_dev erlang-dev python2 py2-simplejson xmlto libxslt
 	rsync zip gawk grep erlang-compiler erlang-erl-docgen
-	erlang-edoc socat"
+	erlang-edoc elixir socat"
 install="$pkgname.pre-install $pkgname.post-deinstall"
 pkgusers="rabbitmq"
 pkggroups="rabbitmq"
@@ -23,7 +23,7 @@ subpackages="$pkgname-doc"
 source="
 	rabbitmq-server.initd
 	rabbitmq-server.logrotate
-	https://github.com/rabbitmq/${pkgname}/releases/download/rabbitmq_v${_realver}/${pkgname}-${pkgver}.tar.xz
+	https://github.com/rabbitmq/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.xz
 "
 
 builddir="$srcdir/${pkgname}-${pkgver}"
@@ -77,7 +77,6 @@ package() {
 	chown -R $pkgusers:$pkggroups "$pkgdir"/var/lib/rabbitmq
 	chown -R $pkgusers:$pkggroups "$pkgdir"/var/log/rabbitmq
 }
-
 sha512sums="a8bb02a7cae1f8720e5c7aaabfe6a2c0e731cffbe0d8f99bdcb6597daa654dc49e6d41943974601435700cf469eaa8286dc91a3255a6b9023754c3861fbb5cd9  rabbitmq-server.initd
 b8655cb048ab3b32001d4e6920bb5366696f3a5da75c053605e9b270e771c548e36858dca8338813d34376534515bba00af5e6dd7b4b1754a0e64a8fb756e3f3  rabbitmq-server.logrotate
-64e618e51ab259463029ad75b981dbf64687515e52d19854f225d4c68077e683ef56f0f6bb92cbbf91f140bc829d905473d687d083d12f36dd2cdfab3defaed6  rabbitmq-server-3.6.10.tar.xz"
+0ea83f893cb9c1bf2118bbf4efc25c8edc31d5244cbe3dd9a25bc646d002de3f6b5043a90c40408b0007cffd185f09565a4310b8e6a63e13dfe7f61aab3d0d48  rabbitmq-server-3.7.5.tar.xz"


### PR DESCRIPTION
3.6.x is EOLd by upstream
See: https://www.rabbitmq.com/news.html#2018-03-08T01:00:00+00:00