### PR TITLE
main/git: add less as dependency

### DIFF
--- a/main/git/APKBUILD
+++ b/main/git/APKBUILD
@@ -14,7 +14,7 @@ pkgdesc="Distributed version control system"
 url="https://www.git-scm.com"
 arch="all"
 license="GPL-2.0-or-later"
-depends=""
+depends="less"
 # we need tcl and tk to be built before git due to git-gui and gitk
 makedepends="zlib-dev libressl-dev curl-dev expat-dev perl-dev python2-dev
 	pcre2-dev asciidoc xmlto perl-error tcl tk"


### PR DESCRIPTION
When we install `git` in a new environment, `git diff` command does not
function well on some shells without `less`.
Granted this is an implicit dependency, but it affects user experience
as there is no error message that indicates what is missing.