### PR TITLE
main/alpine-baselayout: revert 'sysctl security changes'

### DIFF
--- a/main/alpine-baselayout/APKBUILD
+++ b/main/alpine-baselayout/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=alpine-baselayout
-pkgver=3.1.0
+pkgver=3.1.1
 pkgrel=0
 pkgdesc="Alpine base dir structure and init scripts"
 url="https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout"
@@ -159,31 +159,8 @@ package() {
 		# Only groups within this id range can use ping.
 		net.ipv4.ping_group_range=999 59999
 
-		# Redirects can potentially be used to maliciously alter hosts
-		# routing tables.
-		net.ipv4.conf.all.accept_redirects = 0
-		net.ipv4.conf.all.secure_redirects = 1
-		net.ipv6.conf.all.accept_redirects = 0
-
-		# The source routing feature includes some known vulnerabilities.
-		net.ipv4.conf.all.accept_source_route = 0
-		net.ipv6.conf.all.accept_source_route = 0
-
-		# See RFC 1337
-		net.ipv4.tcp_rfc1337 = 1
-
-		## Enable IPv6 Privacy Extensions (see RFC4941 and RFC3041)
-		net.ipv6.conf.default.use_tempaddr = 2
-		net.ipv6.conf.all.use_tempaddr = 2
-
 		# Restarts computer after 120 seconds after kernel panic
 		kernel.panic = 120
-
-		# Users should not be able to create soft or hard links to files
-		# which they do not own. This mitigates several privilege
-		# escalation vulnerabilities.
-		fs.protected_hardlinks = 1
-		fs.protected_symlinks = 1
 	EOF
 	cat > "$pkgdir"/etc/fstab <<-EOF
 		/dev/cdrom	/media/cdrom	iso9660	noauto,ro 0 0


### PR DESCRIPTION
Lack of agreement on proper values for these settings indicates
that we should be following the Linux kernel's defaults
rather than enforcing our own.

Multiple mistakes in the original implementation reinforce the
justification for this principle.

We can selectively add back any sysctl settings that have a clear
and compelling need to be overriden.