### PR TITLE
main/gnupg: upgrade to 2.2.8

### DIFF
--- a/main/gnupg/APKBUILD
+++ b/main/gnupg/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gnupg
-pkgver=2.2.7
+pkgver=2.2.8
 _ver=${pkgver/_beta/-beta}
 pkgrel=0
 pkgdesc="GNU Privacy Guard 2 - a PGP replacement tool"
@@ -66,7 +66,7 @@ scdaemon() {
 	mv "${pkgdir}/usr/libexec/scdaemon" "${subpkgdir}/usr/libexec/"
 }
 
-sha512sums="f858b275876d38b9d3a60e5428574f1008a73a948f67a2fa43bcf1970a5dbb60ec3f0e2b2271243229465eb9b22124e216894f0b3d72004acf3ed0c3481da33d  gnupg-2.2.7.tar.bz2
+sha512sums="24271ec2663b941ed5e72e2179b48ac73d5cd838292aa9d4954952b11713f4b466f30e6af632b22c9e7c284350e300a07046d41d0ab73dcbd1639b303cd09007  gnupg-2.2.8.tar.bz2
 c6cc4595081c5b025913fa3ebecf0dff87a84f3c669e3fef106e4fa040f1d4314ee52dd4c0e0002b213034fb0810221cfdd0033eae5349b6e3978f05d08bcac7  0001-Include-sys-select.h-for-FD_SETSIZE.patch
 b19a44dacf061dd02b439ab8bd820e3c721aab77168f705f5ce65661f26527b03ea88eec16d78486a633c474120589ec8736692ebff57ab9b95f52f57190ba6b  fix-i18n.patch
 4bfb9742279c2d1c872d63cd4bcb01f6a2a13d94618eff954d3a37451fa870a9bb29687330854ee47e8876d6e60dc81cb2569c3931beaefacda33db23c464402  60-scdaemon.rules"

--- a/main/gnupg/APKBUILD
+++ b/main/gnupg/APKBUILD
@@ -22,6 +22,10 @@ source="https://gnupg.org/ftp/gcrypt/$pkgname/$pkgname-$_ver.tar.bz2
 install="$pkgname-scdaemon.pre-install"
 builddir="$srcdir"/$pkgname-$_ver
 
+# secfixes:
+#   2.2.8-r0:
+#     - CVE-2018-12020
+
 build() {
 	cd "$builddir"
 	./configure \


### PR DESCRIPTION
https://lists.gnupg.org/pipermail/gnupg-announce/2018q2/000425.html

fixes:
- [CVE-2018-12020](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12020)