### PR TITLE
main/mesa: Upgrade to 18.0.5

### DIFF
--- a/main/mesa/APKBUILD
+++ b/main/mesa/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mesa
-pkgver=18.0.2
-pkgrel=1
+pkgver=18.0.5
+pkgrel=0
 pkgdesc="Mesa DRI OpenGL library"
 url="http://www.mesa3d.org"
 arch="all"
@@ -265,7 +265,7 @@ _vulkan() {
 		_mv_vulkan intel ;;
 	esac
 }
-sha512sums="77d24d01c4c22596d28421aeb74932ff232730a4f556ae1a2e8777ece2876e4e352679575385c065505df4a2a83d2c1cf30db92dcf88038417e36a2768332d7e  mesa-18.0.2.tar.xz
+sha512sums="63b47cdca7f8282aab7aaa66233411f02918e5c4804b7a0010de2b1867fe90171e492ff031dfc4aa20968dfc99bd7dceb5d35fd44c709e54a2ece61175a60f3d  mesa-18.0.5.tar.xz
 c3d4804ebc24c7216e4c9d4995fb92e116be7f478024b44808ee134a4c93bb51d1f66fe5fb6eca254f124c4abf6f81272b027824b3e2650a9607818bf793035a  glx_ro_text_segm.patch
 910dd69c29b9b51b3b66e975baefbd8a6458500ef3164837036a4ac923c33254d558d678a100025ba2a69fd1111aa6b3ec83f332a66cae4207431e5e1c8ec567  musl-fix-includes.patch
 3409483217dbec732286e628e268e1e8cd392b7e8efb13c7651b38e6563aa5a4988279efb029096dcd092ebe7a92eece103014ed420d2b242eab8d0237f056fd  drmdeps.patch"


### PR DESCRIPTION
Probably the last of 18.0 series. We can use this one with 3.8 release if #4433 (18.1 upgrade) will not merged early.