### PR TITLE
community/dnscrypt-proxy upgrade to 2.0.15

### DIFF
--- a/community/dnscrypt-proxy/APKBUILD
+++ b/community/dnscrypt-proxy/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Ian Bashford <ianbashford@gmail.com>
 # Maintainer: Ian Bashford <ianbashford@gmail.com>
 pkgname=dnscrypt-proxy
-pkgver=2.0.14
+pkgver=2.0.15
 pkgrel=0
 pkgdesc="A tool for securing communications between a client and a DNS resolver"
 url="https://dnscrypt.info"
@@ -54,8 +54,8 @@ setup() {
 	install -m755 -D "$srcdir"/$pkgname.setup "$subpkgdir"/usr/sbin/setup-dnscrypt
 }
 
-sha512sums="2574f900b6e2f75eeeee2f634e22df41145243c23cd9a890fcfa73f13b7d032bc2b029cbb6498f5c2cd33e212392ca2298a1dce6bb369be5c9afccc21a706613  dnscrypt-proxy-2.0.14.tar.gz
+sha512sums="4517ab7b7eb1474f8c9e133a289caf6c02f472b51b910f1fbe1e5ffd6d389943626c8878e68f7f27a47b00301a427dfe9c563bc82b67cafab32f4ab3bc4c84b9  dnscrypt-proxy-2.0.15.tar.gz
 e0a72d39d47dc24b889d08beedbd9fdf21615f42fbab79980debdfd2c3feaa83dc3f776351f7dd13533cc85905ce4e01812e4ff8a80a9ccc0b21e9db7d6cb232  dnscrypt-proxy.initd
 c001ae39da1b2db71764cab568f9ed18e4de0cea3d1a4e7bd6dd01a5668b81a888ea9eef99de6beac08857ad7f8eb1a32d730e946ac3563e4dcfa27147e35052  dnscrypt-proxy.confd
 66dd43d84117a0151ae41f34d82b716760382a5a491424bf6418228ffd21f0dfbc88e34cc5074e11f97f006335d97b85367bb9ab1d96747a48e893c022ad52d0  dnscrypt-proxy.setup
-5c5bb0b331c8394018ce82519c133b26b067e426325d9250f05f6281d472c1669deb0d237fbc8c9e1aca1c0311a1c9ece0583afed97bba676af96dd50997145d  config-full-paths.patch"
+0de69a4a32e50bc0c23c67fb314f30c5404d823e060d1fb88933d3e6aa8eabe8b93c452cd2994faa7482d9b135535326814eaf40a515f9b5d713fb4a86a0096c  config-full-paths.patch"

--- a/community/dnscrypt-proxy/config-full-paths.patch
+++ b/community/dnscrypt-proxy/config-full-paths.patch
@@ -79,6 +79,11 @@ index 0000000..347ada5
 +
 +force_tcp = false
 +
++## HTTP / SOCKS proxy
++## Uncomment the following line to route all TCP connections to a local Tor node
++## Tor doesn't support UDP, so set `force_tcp` to `true` as well.
++
++# proxy = "socks5://127.0.0.1:9050"
 +
 +## How long a DNS query will wait for a response, in milliseconds
 +


### PR DESCRIPTION
Support for proxies (HTTP/SOCKS)
Querylog files have a new record indicating the outcome