### PR TITLE
main/gnupg: security fix for CVE-2018-12020

### DIFF
--- a/main/gnupg/0001-gpg-Sanitize-diagnostic-with-the-original-file-name.patch
+++ b/main/gnupg/0001-gpg-Sanitize-diagnostic-with-the-original-file-name.patch
@@ -1,0 +1,43 @@
+From 13f135c7a252cc46cff96e75968d92b6dc8dce1b Mon Sep 17 00:00:00 2001
+From: Werner Koch <wk@gnupg.org>
+Date: Fri, 8 Jun 2018 10:45:21 +0200
+Subject: [PATCH] gpg: Sanitize diagnostic with the original file name.
+
+* g10/mainproc.c (proc_plaintext): Sanitize verbose output.
+--
+
+This fixes a forgotten sanitation of user supplied data in a verbose
+mode diagnostic.  The mention CVE is about using this to inject
+status-fd lines into the stderr output.  Other harm good as well be
+done.  Note that GPGME based applications are not affected because
+GPGME does not fold status output into stderr.
+
+CVE-id: CVE-2018-12020
+GnuPG-bug-id: 4012
+---
+ g10/mainproc.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/g10/mainproc.c b/g10/mainproc.c
+index d2ceec2fd..a9da08f74 100644
+--- a/g10/mainproc.c
++++ b/g10/mainproc.c
+@@ -851,7 +851,14 @@ proc_plaintext( CTX c, PACKET *pkt )
+   if (pt->namelen == 8 && !memcmp( pt->name, "_CONSOLE", 8))
+     log_info (_("Note: sender requested \"for-your-eyes-only\"\n"));
+   else if (opt.verbose)
+-    log_info (_("original file name='%.*s'\n"), pt->namelen, pt->name);
++    {
++      /* We don't use print_utf8_buffer because that would require a
++       * string change which we don't want in 2.2.  It is also not
++       * clear whether the filename is always utf-8 encoded.  */
++      char *tmp = make_printable_string (pt->name, pt->namelen, 0);
++      log_info (_("original file name='%.*s'\n"), (int)strlen (tmp), tmp);
++      xfree (tmp);
++    }
+ 
+   free_md_filter_context (&c->mfx);
+   if (gcry_md_open (&c->mfx.md, 0, 0))
+-- 
+2.17.1
+

--- a/main/gnupg/APKBUILD
+++ b/main/gnupg/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=gnupg
 pkgver=2.1.10
 _ver=${pkgver/_beta/-beta}
-pkgrel=0
+pkgrel=1
 pkgdesc="GNU Privacy Guard 2 - a PGP replacement tool"
 url="http://www.gnupg.org/"
 arch="all"
@@ -15,7 +15,12 @@ makedepends="curl-dev libksba-dev libgcrypt-dev libgpg-error-dev
 subpackages="$pkgname-doc"
 source="ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-$_ver.tar.bz2
 	0001-Include-sys-select.h-for-FD_SETSIZE.patch
+	0001-gpg-Sanitize-diagnostic-with-the-original-file-name.patch
 	fix-i18n.patch"
+
+# secfixes:
+#   2.1.10-r1:
+#     - CVE-2018-12020
 
 _builddir="$srcdir"/$pkgname-$_ver
 prepare() {


### PR DESCRIPTION
Backport for gnupg-2.1.10 in 3.3-stable.