### PR TITLE
main/gnupg: security fix for CVE-2018-12020

### DIFF
--- a/main/gnupg/0001-gpg-Sanitize-diagnostic-with-the-original-file-name.patch
+++ b/main/gnupg/0001-gpg-Sanitize-diagnostic-with-the-original-file-name.patch
@@ -1,0 +1,43 @@
+From 13f135c7a252cc46cff96e75968d92b6dc8dce1b Mon Sep 17 00:00:00 2001
+From: Werner Koch <wk@gnupg.org>
+Date: Fri, 8 Jun 2018 10:45:21 +0200
+Subject: [PATCH] gpg: Sanitize diagnostic with the original file name.
+
+* g10/mainproc.c (proc_plaintext): Sanitize verbose output.
+--
+
+This fixes a forgotten sanitation of user supplied data in a verbose
+mode diagnostic.  The mention CVE is about using this to inject
+status-fd lines into the stderr output.  Other harm good as well be
+done.  Note that GPGME based applications are not affected because
+GPGME does not fold status output into stderr.
+
+CVE-id: CVE-2018-12020
+GnuPG-bug-id: 4012
+---
+ g10/mainproc.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/g10/mainproc.c b/g10/mainproc.c
+index d2ceec2fd..a9da08f74 100644
+--- a/g10/mainproc.c
++++ b/g10/mainproc.c
+@@ -851,7 +851,14 @@ proc_plaintext( CTX c, PACKET *pkt )
+   if (pt->namelen == 8 && !memcmp( pt->name, "_CONSOLE", 8))
+     log_info (_("Note: sender requested \"for-your-eyes-only\"\n"));
+   else if (opt.verbose)
+-    log_info (_("original file name='%.*s'\n"), pt->namelen, pt->name);
++    {
++      /* We don't use print_utf8_buffer because that would require a
++       * string change which we don't want in 2.2.  It is also not
++       * clear whether the filename is always utf-8 encoded.  */
++      char *tmp = make_printable_string (pt->name, pt->namelen, 0);
++      log_info (_("original file name='%.*s'\n"), (int)strlen (tmp), tmp);
++      xfree (tmp);
++    }
+ 
+   free_md_filter_context (&c->mfx);
+   if (gcry_md_open (&c->mfx.md, 0, 0))
+-- 
+2.17.1
+

--- a/main/gnupg/APKBUILD
+++ b/main/gnupg/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=gnupg
 pkgver=2.1.12
 _ver=${pkgver/_beta/-beta}
-pkgrel=0
+pkgrel=1
 pkgdesc="GNU Privacy Guard 2 - a PGP replacement tool"
 url="http://www.gnupg.org/"
 arch="all"
@@ -15,7 +15,12 @@ makedepends="curl-dev libksba-dev libgcrypt-dev libgpg-error-dev
 subpackages="$pkgname-doc"
 source="ftp://ftp.gnupg.org/gcrypt/gnupg/gnupg-$_ver.tar.bz2
 	0001-Include-sys-select.h-for-FD_SETSIZE.patch
+	0001-gpg-Sanitize-diagnostic-with-the-original-file-name.patch
 	fix-i18n.patch"
+
+# secfixes:
+#   2.1.12-r1:
+#     - CVE-2018-12020
 
 _builddir="$srcdir"/$pkgname-$_ver
 prepare() {
@@ -52,12 +57,7 @@ package() {
 	ln -s gpgv2 "$pkgdir"/usr/bin/gpgv
 }
 
-md5sums="573bc2cd83934eed12f0d0db443f5bde  gnupg-2.1.12.tar.bz2
-1d944009f039912d92e4f119bd6826e4  0001-Include-sys-select.h-for-FD_SETSIZE.patch
-27d7489ecb666f27bce449ce536376c0  fix-i18n.patch"
-sha256sums="ac34929d2400a58a349963865442ee6cdd75e500a8d5df083d29835e88bfc506  gnupg-2.1.12.tar.bz2
-6ce103e1bf68ba8e35b0e6d5805632deddded62b3224b185589f7bd9243ddb9e  0001-Include-sys-select.h-for-FD_SETSIZE.patch
-635669c56ed5c5e004fb8146b2fa1fc578ea9d8671d4ef51370a19dfdafbc8b9  fix-i18n.patch"
 sha512sums="fdf24d4980ba4011840fd2316a856db2bf50e531071c2bfb899af2b4f5580a9f2992f85a451670a7121d04b608bfb147cefdca1c6f6eb55bc23ecfe5052639e6  gnupg-2.1.12.tar.bz2
 c6cc4595081c5b025913fa3ebecf0dff87a84f3c669e3fef106e4fa040f1d4314ee52dd4c0e0002b213034fb0810221cfdd0033eae5349b6e3978f05d08bcac7  0001-Include-sys-select.h-for-FD_SETSIZE.patch
+80c771c52562b1e5bdb82de33c6a1dc741c82b6f3c451b0dba760abf5f6181eb7efd0145f7aaab4062eaedc933d7c8afbd2a65c517d252b4053c9f893ff51883  0001-gpg-Sanitize-diagnostic-with-the-original-file-name.patch
 b19a44dacf061dd02b439ab8bd820e3c721aab77168f705f5ce65661f26527b03ea88eec16d78486a633c474120589ec8736692ebff57ab9b95f52f57190ba6b  fix-i18n.patch"


### PR DESCRIPTION
Backport for gnupg-2.1.12 in 3.4-stable.