### PR TITLE
testing/php7-couchbase: upgrade to 2.5.0 & modernize

### DIFF
--- a/testing/php7-couchbase/APKBUILD
+++ b/testing/php7-couchbase/APKBUILD
@@ -2,17 +2,17 @@
 # Maintainer: Nathan Johnson <nathan@nathanjohnson.info>
 pkgname=php7-couchbase
 _pkgreal=couchbase
-pkgver=2.4.6
+pkgver=2.5.0
 pkgrel=0
 _phpver=${pkgname#php}
 _phpver=${_phpver%%-*}
 pkgdesc="PHP$_phpver extension for Couchbase"
-url="http://pecl.php.net/package/couchbase"
+url="https://pecl.php.net/package/couchbase"
 arch="all"
 license="Apache-2.0"
 depends="php$_phpver-common php$_phpver-json"
 makedepends="php$_phpver-dev autoconf libcouchbase-dev zlib-dev"
-source="$pkgname-$pkgver.tgz::http://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
+source="$pkgname-$pkgver.tgz::https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 options="!check"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
@@ -39,4 +39,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$confdir"/$_pkgreal.ini
 }
 
-sha512sums="15dacbea0fb82101a5dfd20b5ed5d95d133af67c66fff95366af52eeb54f3c0eb928721bfa32b6a6dd1e258e80b5210f970999d9263f7a6172af4f851da812ab  php7-couchbase-2.4.6.tgz"
+sha512sums="28007f5689a34e53ba521f7542ebf6f682f04c2163286e74fb3faa2ab1b90eeb4316b193fa75f8adb4da0c46faa227d028c3e4c98622e365e11475c29fe02d51  php7-couchbase-2.5.0.tgz"


### PR DESCRIPTION
Ref https://pecl.php.net/package-changelog.php?package=couchbase&release=2.5.0

Depends on https://github.com/alpinelinux/aports/pull/4477

```
checking for libcouchbase in default path... found in /usr
checking for libcouchbase version >= 2.9.2... 0x020807
configure: error: libcouchbase greater or equal to 2.9.2 required
>>> ERROR: php7-couchbase: all failed
```

