### PR TITLE
testing/flatbuffers: add flatc to installation so it can be used in cmake

### DIFF
--- a/testing/flatbuffers/APKBUILD
+++ b/testing/flatbuffers/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=flatbuffers
 pkgver=1.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Memory Efficient Serialization Library"
 url="http://google.github.io/flatbuffers/"
 arch="all !s390x"
@@ -32,6 +32,8 @@ check() {
 package() {
 	cd "$builddir"/build
 	make install DESTDIR="$pkgdir"
+	install -Dm755 "$builddir"/build/flatc \
+		"$pkgdir"/usr/bin/flatc
 }
 
 sha512sums="0ba07dbe5b2fde1d0a6e14ee26ee2816062541d934eda204b846a30c019362f2626761b628c900293928b9b546dba8ca477c13182e022c3e0e0a142fd67f0696  flatbuffers-1.9.0.tar.gz"


### PR DESCRIPTION
Without the `flatc` binary, other CMake projects will not be able to find this dependency.