### PR TITLE
main/harfbuzz: build static lib

### DIFF
--- a/main/harfbuzz/APKBUILD
+++ b/main/harfbuzz/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=harfbuzz
 pkgver=1.7.6
-pkgrel=0
+pkgrel=1
 pkgdesc="Text shaping library"
 url="http://freedesktop.org/wiki/Software/HarfBuzz"
 arch="all"
@@ -13,7 +13,7 @@ options="!check"
 makedepends="freetype-dev glib-dev gobject-introspection-dev cairo-dev icu-dev
 	graphite2-dev"
 checkdepends="python3"
-subpackages="$pkgname-dev $pkgname-icu"
+subpackages="$pkgname-static $pkgname-dev $pkgname-icu"
 source="http://www.freedesktop.org/software/$pkgname/release/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir/$pkgname-$pkgver"
@@ -27,7 +27,7 @@ build() {
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--localstatedir=/var \
-		--disable-static \
+		--enable-static \
 		--with-glib \
 		--with-gobject \
 		--with-graphite2 \
@@ -44,6 +44,12 @@ check() {
 package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install
+}
+
+static() {
+	pkgdesc="$pkgname static libraries"
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib/
 }
 
 dev() {


### PR DESCRIPTION
This makes easy to use alpine to build a static version of https://github.com/tectonic-typesetting/tectonic (a latex engine).