### PR TITLE
main/freetype: build static lib

### DIFF
--- a/main/freetype/APKBUILD
+++ b/main/freetype/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=freetype
 pkgver=2.9.1
-pkgrel=0
+pkgrel=1
 pkgdesc="TrueType font rendering library"
 url="https://www.freetype.org/"
 arch="all"
@@ -11,7 +11,7 @@ options="!check"
 depends=""
 depends_dev=""
 makedepends="$depends_dev zlib-dev libpng-dev bzip2-dev"
-subpackages="$pkgname-dev $pkgname-doc"
+subpackages="$pkgname-static $pkgname-dev $pkgname-doc"
 source="http://download.savannah.gnu.org/releases/freetype/freetype-$pkgver.tar.bz2
 	40-memcpy-fix.patch
 	0001-Enable-table-validation-modules.patch
@@ -39,11 +39,17 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
-		--disable-static \
+		--enable-static \
 		--with-bzip2 \
 		--with-png \
 		--enable-freetype-config
 	make
+}
+
+static() {
+	pkgdesc="$pkgname static libraries"
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib/
 }
 
 package() {


### PR DESCRIPTION
This makes easy to use alpine to build a static version of https://github.com/tectonic-typesetting/tectonic (a latex engine).