### PR TITLE
main/icu: build static lib

### DIFF
--- a/main/icu/APKBUILD
+++ b/main/icu/APKBUILD
@@ -6,12 +6,12 @@ pkgver=60.2
 # convert x.y.z to x_y_z
 _ver=${pkgver//./_}
 
-pkgrel=1
+pkgrel=2
 pkgdesc="International Components for Unicode library"
 url="http://www.icu-project.org/"
 arch="all"
 license="custom:icu"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
+subpackages="$pkgname-static $pkgname-dev $pkgname-doc $pkgname-libs"
 depends=
 checkdepends="diffutils"
 makedepends=
@@ -56,6 +56,7 @@ build() {
 		--sysconfdir=/etc \
 		--with-data-packaging=library \
 		--disable-samples \
+		--enable-static \
 		--mandir=/usr/share/man
 	make
 }
@@ -73,6 +74,12 @@ package() {
 	chmod +x "$pkgdir"/usr/bin/icu-config
 	install -Dm644 "$srcdir"/icu/license.html \
 		"$pkgdir"/usr/share/licenses/icu/license.html
+}
+
+static() {
+	pkgdesc="$pkgname static libraries"
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib/
 }
 
 libs() {


### PR DESCRIPTION
I've created a separated package because the static libs are huge.

This makes easy to use alpine to build a static version of https://github.com/tectonic-typesetting/tectonic (a latex engine).