### PR TITLE
testing/py-atomicwrites: new aport

### DIFF
--- a/testing/py-atomicwrites/APKBUILD
+++ b/testing/py-atomicwrites/APKBUILD
@@ -1,0 +1,39 @@
+##
+# Copyright (c) 2018 Riverbed Technology, Inc.
+#
+# This software is licensed under the terms and conditions of the MIT License
+# accompanying the software ('License').  This software is distributed
+# AS IS as set forth in the License.
+##
+# Contributor: Arthur Jones <arthur.jones@riverbed.com>
+_pkgname=atomicwrites
+pkgname=py3-${_pkgname}
+pkgver=1.1.5
+pkgrel=0
+pkgdesc="Powerful Python library for atomic file writes"
+url="https://python-atomicwrites.readthedocs.io/en/latest/"
+arch="noarch"
+license="MIT"
+depends="python3"
+makedepends="python3-dev py3-setuptools"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/untitaker/python-${_pkgname}/archive/${pkgver}.tar.gz"
+builddir="$srcdir/python-$_pkgname-$pkgver"
+
+
+build() {
+	cd "$builddir"
+	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python3 setup.py check
+}
+
+package() {
+	cd "$builddir"
+	mkdir -p "$pkgdir"
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+sha512sums="8fba7bf6270c2a5d2925c14c4620e3b391fe333617ee3ddee5d3559d39ad9cbdd61fafc715bb9c1802b35079c18ae1a8330c29c24a9c980886b4a73660d3941a  py-atomicwrites-1.1.5.tar.gz"


### PR DESCRIPTION
pytest seems to depend on it.

Issue: https://bugs.alpinelinux.org/issues/8975