### PR TITLE
main/grub: add trigger to modify grub.cfg when linux-vanilla kernel is…

### DIFF
--- a/main/grub/APKBUILD
+++ b/main/grub/APKBUILD
@@ -2,12 +2,13 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=grub
 pkgver=2.02
-pkgrel=4
+pkgrel=5
 pkgdesc="Bootloader with support for Linux, Multiboot and more"
 url="https://www.gnu.org/software/grub/"
 arch="all !s390x"
 license="GPL-3.0-or-later"
 depends=""
+triggers="grub.trigger=/boot"
 depends_dev=""
 makedepends="$depends_dev bison flex linux-headers xz-dev lvm2-dev
 	automake autoconf libtool python3 freetype-dev unifont"

--- a/main/grub/grub.trigger
+++ b/main/grub/grub.trigger
@@ -1,0 +1,10 @@
+#!/bin/sh
+if [ -e /boot/grub/grub.cfg ]; then
+	if [ -e /boot/vmlinuz-vanilla ]; then
+		sed -i -e "s/vmlinuz /vmlinuz-vanilla /g" /boot/grub/grub.cfg
+	else
+		if [ -e /boot/vmlinuz ]; then
+			sed -i -e "s/vmlinuz-vanilla/vmlinuz/g" /boot/grub/grub.cfg
+		fi	   
+	fi
+fi


### PR DESCRIPTION
… installed

The upgrade from 3.7 to 3.8 is broken on ppc64le.

In 3.7 the target kernel is named /boot/vmlinuz and /boot/grub/grub.cfg contains the stanza: 
menuentry "Alpine Linux" {
    linux   /boot/vmlinuz modules=sd-mod,usb-storage,ext4 root=UUID=b1d586f4-a7f4-45c0-87bc-36f9bd54110e nomodeset quiet rootfstype=ext4
    initrd  /boot/initramfs-vanilla
}

In 3.8 the target kernel from the linux-vanilla apk is named /boot/vmlinuz-vanilla. During the upgrade the /boot/grub/grub.cfg is not updated so the boot fails. grub.cfg should be modified during the install of the new kernel to:
menuentry "Alpine Linux" {
    linux   /boot/vmlinuz-vanilla modules=sd-mod,usb-storage,ext4 root=UUID=b1d586f4-a7f4-45c0-87bc-36f9bd54110e nomodeset quiet rootfstype=ext4
    initrd  /boot/initramfs-vanilla
}

This patch adds a primitive trigger to the grub package to modify grub.cfg when changes are made to the /boot directory.