### PR TITLE
main/libressl: upgrade to 2.7.4, add secfixes comment

### DIFF
--- a/main/libressl/APKBUILD
+++ b/main/libressl/APKBUILD
@@ -3,13 +3,16 @@
 # Maintainer: Orion <systmkor@gmail.com>
 #
 # secfixes:
+#   2.7.4-r0:
+#     - CVE-2018-0732
+#     - CVE-2018-0495
 #   2.5.3-r1:
 #     - CVE-2017-8301
 #
 pkgname=libressl
-pkgver=2.7.3
+pkgver=2.7.4
 _namever=${pkgname}${pkgver%.*}
-pkgrel=1
+pkgrel=0
 pkgdesc="Version of the TLS/crypto stack forked from OpenSSL"
 url="http://www.libressl.org/"
 arch="all"
@@ -82,7 +85,7 @@ _libs() {
 	fi
 }
 
-sha512sums="5fafff32bc4effa98c00278206f0aeca92652c6a8101b2c5da3904a5a3deead2d1e3ce979c644b8dc6060ec216eb878a5069324a0396c0b1d7b6f8169d509e9b  libressl-2.7.3.tar.gz
+sha512sums="1cd82a1bff4f655251b5feb0c850f4164e0fd548e4b404407370f74dcc75c205f42efc7787a157eecac84cbbe46af48cb63f46b3fef75f4a0a9ea19a5863a691  libressl-2.7.4.tar.gz
 9f1628fbc2a697b6570353920d784b161ca0a122047066d8bee15225bad1e5271aa2ed72b145506bcd4ffe58b35da2caf38c4a048db7e014dabd16b5eba44581  starttls-ldap.patch
 ef8150843f5aae577a859198439673591764fb3ab1da03436607328962f084356fd7f793484c3ad5f2294bd9e8dad15644c311b0da811acbc83eed4b71c0145a  ssl-libcompat.patch
 4c992872addbe4fd612ba9e3f859b5ba69b448aafa7676751ca7ca09bbcfc47a2a1cad468c235f8d1a65c65e8efb38f27c512a32b444346c39ec0d8dcfbcd346  s_client-add-options-verify_.patch"


### PR DESCRIPTION
[Release notes](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.7.4-relnotes.txt) for v2.7.4
fixes:
- [CVE-2018-0495](https://www.nccgroup.trust/us/our-research/technical-advisory-return-of-the-hidden-number-problem/)

- [CVE-2018-0732](https://nvd.nist.gov/vuln/detail/CVE-2018-0732)