### PR TITLE
main/bubblewrap: fix for path normalization without procfs

### DIFF
--- a/main/bubblewrap/APKBUILD
+++ b/main/bubblewrap/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=bubblewrap
 pkgver=0.2.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Unprivileged sandboxing tool"
 url="https://github.com/projectatomic/bubblewrap"
 arch="all"
@@ -48,5 +48,5 @@ bashcomp() {
 }
 
 sha512sums="746f10cd9f9852ca4679d589357402ec10c352e02f77384844a4657fd9b2952189a3299319fbefedd35358d39fd16ded63cc3db95041ed2091548183786b8b63  bubblewrap-0.2.0.tar.gz
-400a0446670ebf80f16739f1a7a2878aadc3099424f957ba09ec3df780506c23a11368f0578c9e352d7ca6473fa713df826fad7a20c50338aa5f9fa9ac6b84a4  realpath-workaround.patch
+e1b350baf969ef2b22b519d95f77f65f18f0fe76b38c6010c0eb414728c948c7753617fc5f0398f1a7b8d0ca1675869d788e3196c7dec254352dff63e9c4ac24  realpath-workaround.patch
 f59cda3b09dd99db9ca6d97099a15bb2523e054063d677502317ae3165ba2e32105a0ae8f877afc3827bd28d093c9d9d413270f4c87d9fe5f26f3eee670d916e  musl-fixes.patch"

--- a/main/bubblewrap/realpath-workaround.patch
+++ b/main/bubblewrap/realpath-workaround.patch
@@ -1,19 +1,53 @@
 Musl realpath() implementation currently depends on /proc which is
 not available when setting up pivot root. For the time being just
-fallback to given path if realpath() fails. If there was symlinks
-that would have required normalizing the following parse_mountinfo()
+fallback to a naive normalization algorithm originated from
+VoidLinux' xbps. If there was path that would have required advanced
+normalizing as provided by realpath() the following parse_mountinfo()
 will fail.
 
-diff --git a/bind-mount.c b/bind-mount.c
-index 7d3543f..c33b701 100644
---- a/bind-mount.c
-+++ b/bind-mount.c
-@@ -397,7 +397,7 @@ bind_mount (int           proc_fd,
+
+diff --git bind-mount.c.orig bind-mount.c
+index 045fa0e..d05b540 100644
+--- bind-mount.c.orig
++++ bind-mount.c
+@@ -23,6 +23,28 @@
+ #include "utils.h"
+ #include "bind-mount.h"
+ 
++#ifndef __GLIBC__
++static char *
++normpath(char *path)
++{
++  char *seg = NULL, *p = NULL;
++
++  for (p = path, seg = NULL; *p; p++) {
++    if (strncmp(p, "/../", 4) == 0 || strncmp(p, "/..", 4) == 0) {
++      memmove(seg ? seg : p, p+3, strlen(p+3) + 1);
++      return normpath(path);
++    } else if (strncmp(p, "/./", 3) == 0 || strncmp(p, "/.", 3) == 0) {
++      memmove(p, p+2, strlen(p+2) + 1);
++    } else if (strncmp(p, "//", 2) == 0 || strncmp(p, "/", 2) == 0) {
++      memmove(p, p+1, strlen(p+1) + 1);
++    }
++    if (*p == '/')
++      seg = p;
++  }
++  return path;
++}
++#endif
++
+ static char *
+ skip_token (char *line, bool eat_whitespace)
+ {
+@@ -397,7 +419,11 @@ bind_mount (int           proc_fd,
       path, so to find it in the mount table we need to do that too. */
    resolved_dest = realpath (dest, NULL);
    if (resolved_dest == NULL)
--    return 2;
-+    resolved_dest = strdup (dest);
++#ifdef __GLIBC__
+     return 2;
++#else
++    resolved_dest = normpath(strdup(dest));
++#endif
  
    mount_tab = parse_mountinfo (proc_fd, resolved_dest);
    if (mount_tab[0].mountpoint == NULL)


### PR DESCRIPTION
Instead of using the unnormalized path if realpath() fails this patch
introduces a naive approach to normalize the path instead. This fix
allows to run various flatpak packages including steam.