### PR TITLE
testing/wireguard: upgrade to 0.0.20180613

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180531
+pkgver=0.0.20180613
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="1dfcdcf41adffdc42dcdbb0a84478b28574613b7834c7d1ccd17f176bac1d664afe824c850baf7d34213380ddffdfd66ddc5cbf7861904dc8359d2005ff07dff  WireGuard-0.0.20180531.tar.xz"
+sha512sums="dc61cb61e507bee3d07aa059a0c2f61812641797d041bade49797e31738858951d7ab209e6b5fdcf052a585754c8aa7d5a203474889b193513abfa7e87942181  WireGuard-0.0.20180613.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180531
-_rel=1
+_ver=0.0.20180613
+_rel=2
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="1dfcdcf41adffdc42dcdbb0a84478b28574613b7834c7d1ccd17f176bac1d664afe824c850baf7d34213380ddffdfd66ddc5cbf7861904dc8359d2005ff07dff  WireGuard-0.0.20180531.tar.xz"
+sha512sums="dc61cb61e507bee3d07aa059a0c2f61812641797d041bade49797e31738858951d7ab209e6b5fdcf052a585754c8aa7d5a203474889b193513abfa7e87942181  WireGuard-0.0.20180613.tar.xz"


### PR DESCRIPTION
```
  * wg-quick: android: change name of intent
  * wg-quick: android: delay setting users until end
  
  `ndc users add` eventually invokes SOCK_DESTROY on user sockets, causing
  them to reconnect. By delaying this until after routes are set, we
  ensure that the sockets reconnect using the tunnel, rather than the old
  route. This fixes push notifications on Android.
  
  * chacha20: add missing include to header
  
  Fixes a compile error on some kernels.
  
  * tools: encoding: add missing static array constraints
  
  Makes static analyzers happier.
  
  * tools: support getentropy(3)
  
  This lets us take advantage of both recent glibc calls as well as the long
  standing getentropy functions on the BSDs.
  
  * chacha20poly1305: use slow crypto on -rt kernels
  
  In rt kernels, spinlocks call schedule(), which means preemption can't
  be disabled. The FPU disables preemption. Hence, we can either
  restructure things to move the calls to kernel_fpu_begin/end to be
  really close to the actual crypto routines, or we can do the slower
  lazier solution of just not using the FPU at all on -rt kernels. This
  patch goes with the latter lazy solution. The reason why we don't
  place the calls to kernel_fpu_begin/end close to the crypto routines
  in the first place is that they're very expensive, as it usually
  involves a call to XSAVE. So on sane kernels, we benefit from only
  having to call it once.
```