### PR TITLE
community/exim: fix hardcoded bounce_message charset

### DIFF
--- a/community/exim/APKBUILD
+++ b/community/exim/APKBUILD
@@ -6,7 +6,7 @@
 # Maintainer: Jesse Young <jlyo@jlyo.org>
 pkgname=exim
 pkgver=4.91
-pkgrel=0
+pkgrel=1
 pkgdesc="Message Transfer Agent"
 url="http://www.exim.org"
 arch="all"
@@ -21,6 +21,7 @@ install="exim.pre-install"
 subpackages="$pkgname-cdb $pkgname-dbmdb $pkgname-dnsdb $pkgname-sqlite $pkgname-mysql $pkgname-postgresql
 	$pkgname-utils $pkgname-scripts::noarch $pkgname-doc"
 source="https://ftp.exim.org/pub/exim/exim4/$pkgname-$pkgver.tar.xz
+	bounce-charset.patch
 	exim.Makefile
 	exim.confd
 	exim.initd
@@ -115,6 +116,7 @@ dbmdb() { _mv_ext dbmdb; }
 dnsdb() { _mv_ext dnsdb; }
 
 sha512sums="35b34dda8dd0f27c0429e6eb8409756ecd3cf9e535bac421d696b1560db0ff3bf4cd0e4a00bc0b7e32137d31bb5de20776c7c1830ec125aa36b5c4376b0c71a2  exim-4.91.tar.xz
+517447ac989a8de27cca74d544bdbeed6667442d1a229efaaef0a2b2878afb754602ece7c5e9983778224cc052f6d38209a65ef95712a16309d7b72c0e277fa8  bounce-charset.patch
 e9524d3a2cc230b4ecb3b098f53247121b9582fc7807b1549c5a3fd54bb416b837c4e09476f2e01dca03d590a968c40bf90d4b6a9f8a4abad082fdec91916a0f  exim.Makefile
 bb6f5ead067af19ace661cc92bcd428da97570aedd1f9dc5b61a34e7e3fb3e028be6c96d51df73353bdfcaf69a3ee053fb03d245f868d63ebf518aa96ec82d66  exim.confd
 3769e74a54566362bcdf57c45fbf7d130d7a7529fbc40befce431eef0387df117c71a5b57779c507e30d5b125913b5f26c9d16b17995521a1d94997be6dc3e02  exim.initd

--- a/community/exim/bounce-charset.patch
+++ b/community/exim/bounce-charset.patch
@@ -1,0 +1,29 @@
+--- a/src/deliver.c	2018-04-15 02:18:10.000000000 +0300
++++ b/src/deliver.c	2018-06-15 14:01:58.196926447 +0300
+@@ -7291,7 +7291,7 @@
+ 	"MIME-Version: 1.0\n\n"
+ 
+ 	"--%s\n"
+-	"Content-type: text/plain; charset=us-ascii\n\n"
++	"Content-type: text/plain; charset=utf-8\n\n"
+ 
+ 	"This message was created automatically by mail delivery software.\n"
+ 	" ----- The following addresses had successful delivery notifications -----\n",
+@@ -7560,7 +7560,7 @@
+ 
+       /* output human readable part as text/plain section */
+       fprintf(f, "--%s\n"
+-	  "Content-type: text/plain; charset=us-ascii\n\n",
++	  "Content-type: text/plain; charset=utf-8\n\n",
+ 	bound);
+ 
+       if ((emf_text = next_emf(emf, US"intro")))
+@@ -8163,7 +8163,7 @@
+ 
+         /* output human readable part as text/plain section */
+         fprintf(f, "--%s\n"
+-	    "Content-type: text/plain; charset=us-ascii\n\n",
++	    "Content-type: text/plain; charset=utf-8\n\n",
+ 	  bound);
+ 
+         if ((wmf_text = next_emf(wmf, US"intro")))


### PR DESCRIPTION
I changed hardcoded charset from 'us-ascii' to 'utf-8'
to be able to create multilingual bounce messages