### PR TITLE
main/libnotify: enable gobject-introspection

### DIFF
--- a/main/libnotify/APKBUILD
+++ b/main/libnotify/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libnotify
 pkgver=0.7.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Desktop notification library"
 url="http://library.gnome.org/devel/notification-spec/"
 arch="all"
@@ -10,7 +10,7 @@ license="LGPL"
 subpackages="$pkgname-dev $pkgname-doc"
 depends=
 depends_dev="gdk-pixbuf-dev glib-dev dbus-dev"
-makedepends="$depends_dev gtk+3.0-dev autoconf automake"
+makedepends="$depends_dev gtk+3.0-dev autoconf automake gobject-introspection-dev"
 source="https://download.gnome.org/sources/${pkgname}/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz
 	skip-tests.patch"
 
@@ -23,7 +23,8 @@ build() {
 		--host=$CHOST \
 		--prefix=/usr \
 		--disable-static \
-		--disable-tests
+		--disable-tests \
+		--enable-introspection
 	make
 }
 


### PR DESCRIPTION
Python depends on this in order to use libnotify.