### PR TITLE
main/nettle: disable arm neon

### DIFF
--- a/main/nettle/APKBUILD
+++ b/main/nettle/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=nettle
 pkgver=3.4
-pkgrel=0
+pkgrel=1
 pkgdesc="A low-level cryptographic library"
 url="http://www.lysator.liu.se/~nisse/nettle/"
 arch="all"
@@ -17,6 +17,7 @@ source="http://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
+	[ "$CARCH" = "armhf" ] && local _ARM_NEON="--disable-arm-neon"
 	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
@@ -28,7 +29,8 @@ build() {
 		--infodir=/usr/share/info \
 		--localstatedir=/var \
 		--enable-shared \
-		--disable-openssl
+		--disable-openssl \
+		$_ARM_NEON
 	make
 	# strip comments in fields from .pc as it confuses pkgconf
 	sed -i -e 's/ \#.*//' *.pc


### PR DESCRIPTION
nettle checks the build machine for cpu features which ends up enabling
neon but armv6 only supports up to vfpv2.