### PR TITLE
main/dropbear: disable wtmp and lastlog support

### DIFF
--- a/main/dropbear/APKBUILD
+++ b/main/dropbear/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dropbear
 pkgver=2018.76
-pkgrel=0
+pkgrel=1
 pkgdesc="small SSH 2 client/server designed for small memory environments"
 url="http://matt.ucc.asn.au/dropbear/dropbear.html"
 arch="all"

--- a/main/dropbear/APKBUILD
+++ b/main/dropbear/APKBUILD
@@ -34,7 +34,9 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
-		--localstatedir=/var
+		--localstatedir=/var \
+		--disable-wtmp \
+		--disable-lastlog
 	make PROGRAMS="$_progs"
 }
 


### PR DESCRIPTION
As spotted on this issue (https://bugs.alpinelinux.org/issues/5075), musl does not support wtmp, nor alpine support lastlog.