### PR TITLE
main/graphite2: update to 1.3.11 and build static lib

### DIFF
--- a/main/graphite2/APKBUILD
+++ b/main/graphite2/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=graphite2
 _realname=${pkgname/2/}
-pkgver=1.3.10
-pkgrel=1
+pkgver=1.3.11
+pkgrel=0
 pkgdesc="reimplementation of the SIL Graphite text processing engine"
 url="http://graphite.sil.org/"
 arch="all"
@@ -13,9 +13,8 @@ depends=""
 depends_dev="freetype-dev"
 makedepends="$depends_dev cmake"
 install=""
-subpackages="$pkgname-dev"
+subpackages="$pkgname-static $pkgname-dev"
 source="$pkgname-$pkgver.tar.gz::https://github.com/silnrsi/$_realname/archive/$pkgver.tar.gz
-	cmake.patch
 	graphite2-1.2.0-cmakepath.patch
 	"
 
@@ -23,6 +22,11 @@ builddir="$srcdir"/$_realname-$pkgver
 
 build() {
 	cd "$builddir"
+
+	# static and shared version needs to be build in separated dirs
+	# See https://github.com/silnrsi/graphite/pull/12#issuecomment-311756732
+
+	# shared
 	mkdir build && cd build
 	cmake -G "Unix Makefiles" .. \
 		-DCMAKE_C_FLAGS:STRING="${CFLAGS}" \
@@ -35,6 +39,28 @@ build() {
 	# fix unwanted -O3 cflag (taken form Debian)
 	find . -type f ! -name "rules" ! -name "changelog" -exec sed -i -e 's/\-O3//g' {} \;
 	make
+
+	# static
+	cd ..
+	mkdir build-static && cd build-static
+	cmake -G "Unix Makefiles" .. \
+		-DCMAKE_C_FLAGS:STRING="${CFLAGS}" \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_BUILD_TYPE:STRING=Release \
+		-DGRAPHITE2_COMPARE_RENDERER=OFF \
+		-DGRAPHITE2_NFILEFACE=ON \
+		-DGRAPHITE2_NSEGCACHE=ON \
+		-DBUILD_SHARED_LIBS=OFF
+
+	# fix unwanted -O3 cflag (taken form Debian)
+	find . -type f ! -name "rules" ! -name "changelog" -exec sed -i -e 's/\-O3//g' {} \;
+	make
+}
+
+static() {
+	pkgdesc="$pkgname static libraries"
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$builddir"/build-static/src/libgraphite2.a "$subpkgdir"/usr/lib/
 }
 
 package() {
@@ -42,6 +68,5 @@ package() {
 	make DESTDIR="$pkgdir/" install
 }
 
-sha512sums="9a6ff2ad88f04e55a6da862e6eefcf2d87c562bb9feedddc4532b66f7938b9ade4a12c8a4b19ab7b08ec3e34a96b97331621a7465b672407ab4d1af756df04c1  graphite2-1.3.10.tar.gz
-44dcff1e6c8c5e3df92eae8cab501c9605a1cd3e16b6cdce2e376d78fd08b26b7f6e037b7e5878099ba426a93572114169b5f64c4d2ae0bcbe223f1d28b00eb5  cmake.patch
+sha512sums="53c5e9442900bc4d8a1b45be5198c25a82e34b077d62ff11036f5f4bfc69906891a16dbc17d521fafe8738ef9363cbacd201e1848221cdd70c5c40a59c4ab03f  graphite2-1.3.11.tar.gz
 4ef5414e6d554bb8d6ead435e38d061a073f350c313b7141158bb68332f5f57ca5250385875a387b828bb657964588e974143b96b5e11c2cd314871e7baddb88  graphite2-1.2.0-cmakepath.patch"


### PR DESCRIPTION
The update, which includes minor [bug fixes](https://github.com/silnrsi/graphite/releases/tag/1.3.11), is necessary to include the static build support.

The cmake.patch is not necessary anymore. Upstream [made](https://github.com/silnrsi/graphite/commit/ec6ad80db17101601bd6290bf00c9ab6cd669db7#diff-3dea97423f83302e647a3bab62bf1157) the same change.