### PR TITLE
main/strace: upgrade to 4.23

### DIFF
--- a/main/strace/APKBUILD
+++ b/main/strace/APKBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=strace
-pkgver=4.22
+pkgver=4.23
 pkgrel=0
-pkgdesc="A useful diagnositic, instructional, and debugging tool"
-url="https://strace.io/"
+pkgdesc="Diagnostic, debugging and instructional userspace tracer"
+url="https://strace.io"
 arch="all"
 # disable checks for now, due to testsuite failure
 options="!check"
@@ -59,7 +59,7 @@ package() {
 	make -j1 DESTDIR="$pkgdir" install
 }
 
-sha512sums="9d382531ff5f99f972b1f6ae7f1a07094bf7bbf9806335eb6a6c1df5ab9704b09ef415ff9e7b66c82071e87c7de09b05e0885c1dab8433f48db77b3b879fe75e  strace-4.22.tar.gz
+sha512sums="f7694c18a32fcdcfee8f54f866ff8102b6b1797c89d97daf91e62d8c8f642b937ffcbb5ee4c027b1eb3163125e2b65ab063e856657aff056c70b0dbfc46f0aea  strace-4.23.tar.gz
 273b92ebf0069f19bef7ec26c7860e2af7ef01e782255c70ded1ae5e967f8f6bf031ecba96612c6083bf58f46278ba4ab3ec0fb35b08c8c8d668191f97adee52  disable-fortify.patch
 b70cee89dd49a2b5a69dc2a56c3a11169d3306e1a73981155188b574486965c034aa52b4ac1c6edff5ef55c9d52f27750acb242fac095a8a9f69689b51b3fad1  fix-ppc-pt-regs-collision.patch
 44b1872cf996caa4970fa6c2875a3a2cffe4a38455e328d968bd7855ef9a05cf41190794dc137bc8667576635f5271057cf0e6cde9a6c7aee66afd1dba9bdba0  nlattr-fix.patch"


### PR DESCRIPTION
[Release notes](https://github.com/strace/strace/releases/tag/v4.23).