### PR TITLE
main/shards: upgrade to 0.8.1

### DIFF
--- a/community/shards/APKBUILD
+++ b/community/shards/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=shards
-pkgver=0.8.0
+pkgver=0.8.1
 pkgrel=0
 _minitestver=0.4.0
 pkgdesc="Dependency manager for the Crystal language"
@@ -42,5 +42,5 @@ package() {
 	make install DESTDIR="$pkgdir" PREFIX=/usr
 }
 
-sha512sums="c366dec216676975cadfd8210a89c407ddc6335859b323736da8e950cf70b78456b3802d2b65d1f6d71a196946a06264b97f60bdc057b6f376e191559a78584d  shards-0.8.0.tar.gz
+sha512sums="c0a8a8531a37e033c6d96ac36dd30dcd3d005c6b1bd7c94dbeee7f6ea9b34a08ab2e14b826c3c18f60dca991f60ec6780df090cafc32403a7272e39dc07e99df  shards-0.8.1.tar.gz
 3865d9b78a4ec23c774b3cc345a623edeb5b42f4b4a119a3d8816b78263ef57fd474ffa57a3fbbed8633cf952d8bcb8d016e3c9b528eae6f79aec4636a11660f  minitest.cr-0.4.0.tar.gz"


### PR DESCRIPTION
[Release notes](https://github.com/crystal-lang/shards/releases/tag/v0.8.1).