### PR TITLE
scripts/mkimg.standard.sh. For ppc64le add ibmvscsi module to command line to avoid ra…

### DIFF
--- a/scripts/mkimg.standard.sh
+++ b/scripts/mkimg.standard.sh
@@ -15,6 +15,9 @@ profile_standard() {
 		initfs_features="$initfs_features dasd_mod qeth"
 		initfs_cmdline="modules=loop,squashfs,dasd_mod,qeth quiet"
 	fi
+	if [ "$ARCH" = "ppc64le" ]; then
+		initfs_cmdline="modules=loop,squashfs,sd-mod,usb-storage,ibmvscsi quiet"
+	fi
 }
 
 profile_extended() {


### PR DESCRIPTION
…ce issue during install from iso for qemu guest

During install of qemu guest using iso image the boot intermittently fails and drops into the emergency shell with the message "Mounting boot media failed". It looks like the nlplug-findfs -p /sbin/mdev -d -b /tmp/repositories -a /tmp/apkovls is sometimes not discovering the cdrom (dev/sr0). Adding the ibmvscsi module to the default command line should avoid this race.