### PR TITLE
main/openrc: Allow http:// for ssh_key

### DIFF
--- a/main/openrc/firstboot.initd
+++ b/main/openrc/firstboot.initd
@@ -21,7 +21,7 @@ start() {
 		einfo "Fetching ssh keys"
 		mkdir -pm 700 /root/.ssh
 		case "$KOPT_ssh_key" in
-			https://*|ftps://*)
+			https://*|ftps://*|http://*)
 				wget -q "$KOPT_ssh_key" -O /root/.ssh/authorized_keys
 				rc=$?;;
 			*) echo "$KOPT_ssh_key" > /root/.ssh/authorized_keys;;


### PR DESCRIPTION
A slight revert of commit 4ef156921798938 which removed http://*
Since the kernel argument is downloading the public key, we
are not required to use an encrypted protocol. This will also
be easier for a local development environment.