### PR TITLE
main/squid: security patches

### DIFF
--- a/main/squid/APKBUILD
+++ b/main/squid/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=squid
 pkgver=3.5.27
-pkgrel=1
+pkgrel=2
 pkgdesc="A full-featured Web proxy cache server."
 url="http://www.squid-cache.org"
 install="squid.pre-install squid.pre-upgrade"
@@ -18,6 +18,9 @@ linguas="af ar az bg ca cs da de el es et fa fi fr he hu hy id it ja ka ko lt
 	lv ms nl oc pl pt ro ru sk sl sr sv th tr uk uz vi zh"
 langdir="/usr/share/squid/errors"
 source="http://www.squid-cache.org/Versions/v3/${pkgver%.*}/squid-${pkgver}.tar.xz
+	SQUID-2018_1.patch
+	SQUID-2018_2.patch
+	SQUID-2018_3.patch
 	bug-3679.patch
 
 	squid.initd
@@ -29,9 +32,10 @@ pkggroups="squid"
 builddir="$srcdir"/$pkgname-$pkgver
 
 # secfixes:
-#   3.5.27-r0:
+#   3.5.27-r2:
 #     - CVE-2018-1000024
 #     - CVE-2018-1000027
+#     - CVE-2018-1172
 
 prepare() {
 	cd "$builddir"
@@ -112,6 +116,9 @@ squid_kerb_auth() {
 	mv "$pkgdir"/usr/lib/squid/squid_kerb_auth "$subpkgdir"/usr/lib/squid/
 }
 sha512sums="4172a053c3b7ffe7a12dfb3febac96942d0fbbe7e98e3f797f22cd75b0a3a89cbbfe7260b5daad099e79d5e9303bb5dfbfee7499cb30a90590aa1bd242ff4817  squid-3.5.27.tar.xz
+d08d87d4cf97e794735e29ed2a273e27757a9ef95059cf6a2e2855a0c56e92d9e665b85115c9f3b699974447a7b9cccadb0a8ce606beedb41d27df8361241f8b  SQUID-2018_1.patch
+392442527ead5cbb045f6eded522c9aff6ce395034ca028e7298394eccb6ed5b06c814f966ddc6cb264b9a37bf7ae2751e3ed87853566b1d7b757d99280fe60c  SQUID-2018_2.patch
+20a036b34f7a595d83e707180d831c4adc9b7432f09be5341cfe7b3b00cbe3e5c0de07376a67834b94e08c849703822371eb71938a024307cb52cf8ef52138e8  SQUID-2018_3.patch
 d44d0688a416ce993e186afe77051f764c7b01f452cfe27474a7876bc7f58e36c15c06978eedb189b98e276f512aa3bd58992a08668e89a5ef9cd843c22af72a  bug-3679.patch
 15d95f7d787be8c2e6619ef1661fd8aae8d2c1ede706748764644c7dc3d7c34515ef6e8b7543295fddc4e767bbd74a7cf8c42e77cf60b3d574ff11b3f6e336c9  squid.initd
 7292661de344e8a87d855c83afce49511685d2680effab3afab110e45144c0117935f3bf73ab893c9e6d43f7fb5ba013635e24f6da6daf0eeb895ef2e9b5baa9  squid.confd

--- a/main/squid/SQUID-2018_1.patch
+++ b/main/squid/SQUID-2018_1.patch
@@ -1,0 +1,28 @@
+commit eb2db98a676321b814fc4a51c4fb7928a8bb45d9 (refs/remotes/origin/v3.5)
+Author: Amos Jeffries <yadij@users.noreply.github.com>
+Date:   2018-01-19 13:54:14 +1300
+
+    ESI: make sure endofName never exceeds tagEnd (#130)
+
+diff --git a/src/esi/CustomParser.cc b/src/esi/CustomParser.cc
+index d86d2d3..db634d9 100644
+--- a/src/esi/CustomParser.cc
++++ b/src/esi/CustomParser.cc
+@@ -121,7 +121,7 @@ ESICustomParser::parse(char const *dataToParse, size_t const lengthOfData, bool
+ 
+             char * endofName = strpbrk(const_cast<char *>(tag), w_space);
+ 
+-            if (endofName > tagEnd)
++            if (!endofName || endofName > tagEnd)
+                 endofName = const_cast<char *>(tagEnd);
+ 
+             *endofName = '\0';
+@@ -214,7 +214,7 @@ ESICustomParser::parse(char const *dataToParse, size_t const lengthOfData, bool
+ 
+             char * endofName = strpbrk(const_cast<char *>(tag), w_space);
+ 
+-            if (endofName > tagEnd)
++            if (!endofName || endofName > tagEnd)
+                 endofName = const_cast<char *>(tagEnd);
+ 
+             *endofName = '\0';

--- a/main/squid/SQUID-2018_2.patch
+++ b/main/squid/SQUID-2018_2.patch
@@ -1,0 +1,23 @@
+commit 8232b83d3fa47a1399f155cb829db829369fbae9 (refs/remotes/origin/v3.5)
+Author: squidadm <squidadm@users.noreply.github.com>
+Date:   2018-01-21 08:07:08 +1300
+
+    Fix indirect IP logging for transactions without a client connection (#129) (#136)
+
+diff --git a/src/client_side_request.cc b/src/client_side_request.cc
+index be124f3..203f89d 100644
+--- a/src/client_side_request.cc
++++ b/src/client_side_request.cc
+@@ -488,9 +488,9 @@ clientFollowXForwardedForCheck(allow_t answer, void *data)
+         * Ensure that the access log shows the indirect client
+         * instead of the direct client.
+         */
+-        ConnStateData *conn = http->getConn();
+-        conn->log_addr = request->indirect_client_addr;
+-        http->al->cache.caddr = conn->log_addr;
++        http->al->cache.caddr = request->indirect_client_addr;
++        if (ConnStateData *conn = http->getConn())
++            conn->log_addr = request->indirect_client_addr;
+     }
+     request->x_forwarded_for_iterator.clean();
+     request->flags.done_follow_x_forwarded_for = true;

--- a/main/squid/SQUID-2018_3.patch
+++ b/main/squid/SQUID-2018_3.patch
@@ -1,0 +1,22 @@
+commit afcff5ec02ea196704a0f40014b21a53911b4e17 (refs/remotes/origin/v3.5)
+Author: Amos Jeffries <amosjeffries@squid-cache.org>
+Date:   2018-04-17 10:02:25 +1200
+
+    Skip ssl_bump ACL checks for internal requests
+
+diff --git a/src/client_side_request.cc b/src/client_side_request.cc
+index 203f89d..7fb58c2 100644
+--- a/src/client_side_request.cc
++++ b/src/client_side_request.cc
+@@ -1419,6 +1419,11 @@ ClientRequestContext::checkNoCacheDone(const allow_t &answer)
+ bool
+ ClientRequestContext::sslBumpAccessCheck()
+ {
++    if (!http->getConn()) {
++        http->al->ssl.bumpMode = Ssl::bumpEnd; // SslBump does not apply; log -
++        return false;
++    }
++
+     // If SSL connection tunneling or bumping decision has been made, obey it.
+     const Ssl::BumpMode bumpMode = http->getConn()->sslBumpMode;
+     if (bumpMode != Ssl::bumpEnd) {


### PR DESCRIPTION
Included missing patches for:
 - CVE-2018-1000024
 - CVE-2018-1000027

Included new patch for:
 - CVE-2018-1172