### PR TITLE
Enable login console for ppc64le

### DIFF
--- a/main/alpine-baselayout/inittab
+++ b/main/alpine-baselayout/inittab
@@ -12,8 +12,10 @@ tty4::respawn:/sbin/getty 38400 tty4
 tty5::respawn:/sbin/getty 38400 tty5
 tty6::respawn:/sbin/getty 38400 tty6
 
-# Put a getty on the serial port
-#ttyS0::respawn:/sbin/getty -L ttyS0 115200 vt100
+# if ppc64le, put a getty on the serial port
+if [ $(uname -m) = "ppc64le" ]; then
+    ttyS0::respawn:/sbin/getty -L ttyS0 115200 vt100
+fi
 
 # Stuff to do for the 3-finger salute
 ::ctrlaltdel:/sbin/reboot


### PR DESCRIPTION
Since ppc64le is using Petitboot, remove comment in order to use the
getty login console via serial cable.
