### PR TITLE
main/git: update to 2.18.0

### DIFF
--- a/main/git/APKBUILD
+++ b/main/git/APKBUILD
@@ -8,7 +8,7 @@
 #   2.14.1:
 #   - CVE-2017-1000117
 pkgname=git
-pkgver=2.17.1
+pkgver=2.18.0
 pkgrel=0
 pkgdesc="Distributed version control system"
 url="https://www.git-scm.com"
@@ -30,7 +30,7 @@ subpackages="$pkgname-doc
 	$pkgname-cvs::noarch
 	$pkgname-p4::noarch
 	$pkgname-daemon
-	$pkgname-gitweb
+	$pkgname-gitweb::noarch
 	$pkgname-subtree::noarch
 	$pkgname-subtree-doc:subtree_doc:noarch
 	$pkgname-perl:_git_perl:noarch
@@ -264,7 +264,7 @@ _perl_config() {
 	perl -e "use Config; print \$Config{$1};"
 }
 
-sha512sums="77c27569d40fbae1842130baa0cdda674a02e384631bd8fb1f2ddf67ce372dd4903b2ce6b4283a4ae506cdedd5daa55baa2afe6a6689528511e24e4beb864960  git-2.17.1.tar.xz
+sha512sums="db19363c9c2042248322d49874a27c0614acfb912183725e5d4f0331d6b44cef66a9a7da6a49bd4a17e5d86d30c5fed6bef7527f386494184595a433c4060e46  git-2.18.0.tar.xz
 85767b5e03137008d6a96199e769e3979f75d83603ac8cb13a3481a915005637409a4fd94e0720da2ec6cd1124f35eba7cf20109a94816c4b4898a81fbc46bd2  bb-tar.patch
 89528cdd14c51fd568aa61cf6c5eae08ea0844e59f9af9292da5fc6c268261f4166017d002d494400945e248df6b844e2f9f9cd2d9345d516983f5a110e4c42a  git-daemon.initd
 fbf1f425206a76e2a8f82342537ed939ff7e623d644c086ca2ced5f69b36734695f9f80ebda1728f75a94d6cd2fcb71bf845b64239368caab418e4d368c141ec  git-daemon.confd"


### PR DESCRIPTION
Just released. Also marking git-web as noarch as abuild suggested it.