### PR TITLE
testing/sitecopy: new aport

### DIFF
--- a/testing/sitecopy/APKBUILD
+++ b/testing/sitecopy/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Christoph Lorenz <mail@christophlorenz.de>
+# Maintainer: Christoph Lorenz <mail@christophlorenz.de>
+pkgname=sitecopy
+pkgver="0.16.3"
+pkgrel=0
+pkgdesc="sitecopy"
+url="https://github.com/brainsqueezer/sitecopy/"
+arch="all"
+license="GPL-2.0"
+depends="expat expat-dev libintl gettext-dev"
+makedepends=""
+install=""
+options="!check"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/brainsqueezer/sitecopy/archive/master.tar.gz"
+builddir="$srcdir/sitecopy-master"
+pkgdir="$srcdir/sitecopy-master"
+
+prepare() {
+	default_prepare
+	mkdir -p ${builddir%/*}
+	cd "$builddir"
+	./configure --prefix=/usr --with-expat
+	}
+
+build() {
+	cd "$builddir"
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="7bb9fcb86ca809c41b70fb86ac5140e264b942b387f9dc5d282d34c285de5ce0694d27765f9dda17ff07238b874911fe71bd409ff224bfda3426b23c46e449d5  sitecopy-0.16.3.tar.gz"


### PR DESCRIPTION
https://github.com/brainsqueezer/sitecopy
Sitecopy allows you to easily maintain remote Web sites.