### PR TITLE
main/imagemagick: upgrade to 7.0.8.2

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
-pkgver=7.0.7.32
+pkgver=7.0.8.2
 _abiver=7
 _pkgver=${pkgver%.*}-${pkgver##*.}
 pkgrel=0
@@ -80,4 +80,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="6fa38dcaf6236a8442e5004b9cae267572974614bea182474cc2d667ff611f2c1bdae929bcdd9d73fbd825515f18758253c834b00675c62f0ac814aee74f3bf6  ImageMagick-7.0.7-32.tar.xz"
+sha512sums="1a0694dddbe12117341fc82e8f8c023e438f38c9cfb65bdfc4d7f9d31299df77796b4b87df641abc9a8a6670d45785d487d141e2bfbd625cd37aeab6b3a85615  ImageMagick-7.0.8-2.tar.xz"


### PR DESCRIPTION
100% backwards compatible - https://abi-laboratory.pro/?view=timeline&l=imagemagick