### PR TITLE
testing/rakudo: upgrade to 2018.06

### DIFF
--- a/testing/moarvm/APKBUILD
+++ b/testing/moarvm/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=moarvm
-pkgver=2018.04
+pkgver=2018.06
 pkgrel=0
 pkgdesc="A VM for NQP And Rakudo Perl 6"
 url="http://moarvm.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="cbcceabc2f3d3d3ac73655bf16246f714923abbe909f2bfa6b1f2456801a4bebfe246f552e2704da254609e1edb66b564ef5b845c88af3761a6d552b2364fc51  MoarVM-2018.04.tar.gz"
+sha512sums="5d256cd7a49472e106326281059f8e9f8eb7591d116bfcdd33daeada42764774362ab8802edf889c5d875d438518ee9f243f5e44f451c9cf3495f7c7641be700  MoarVM-2018.06.tar.gz"

--- a/testing/nqp/APKBUILD
+++ b/testing/nqp/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=nqp
-pkgver=2018.04
+pkgver=2018.06
 pkgrel=0
 pkgdesc="Not Quite Perl"
 url="https://github.com/perl6/nqp"
@@ -14,11 +14,6 @@ install=""
 subpackages="$pkgname-doc"
 source="${pkgname}-${pkgver}.tar.gz::https://github.com/perl6/nqp/archive/${pkgver}.tar.gz"
 builddir="$srcdir"/"$pkgname"-"$pkgver"
-
-# FIXME: some tests fail on armhf and x86, need to investigate more
-case "$CARCH" in
-	armhf | x86) options="$options !check";;
-esac
 
 build() {
 	cd "$builddir"
@@ -44,4 +39,4 @@ doc() {
 	done
 }
 
-sha512sums="30ee26176f1834c528c0b4bdddc8df08c50f6504cb1626b912a050ab5199f3c1000eb9c884c4031771d6f88429c8fbd23457b73aaa8ee7d937c9f29ad1a46429  nqp-2018.04.tar.gz"
+sha512sums="b98744403e77ff4086f5ab8dc26f3d7181793c1af404e51d620d245c895976c05c2ef791d2a91e200a5a39b3406c61f4b1a9ec5baf6daca72c2374ba356c5f60  nqp-2018.06.tar.gz"

--- a/testing/rakudo/APKBUILD
+++ b/testing/rakudo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=rakudo
-pkgver=2018.04
+pkgver=2018.06
 pkgrel=0
 pkgdesc="A compiler for the Perl 6 programming language"
 url="http://rakudo.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="d3e50fd1378bffbe6a56e948c44128e68fe070c6eba13a0fc4ca70d40d09cd47fd2902586a5f1af70b3c81caa90bdeb86a4e277a5d8fbf9e48e91c05906a801b  rakudo-2018.04.tar.gz"
+sha512sums="b14b19d4952f8725868612e9295e3e1c04523cfe948b55db02a1bab463d5a586bfaf6e32e9218a14d7d063d322b337358de561dceec44e5d59617a7e0e4b60a8  rakudo-2018.06.tar.gz"


### PR DESCRIPTION
Upgrade moarvm, nqp, and rakudo to version 2018.06, must upgrade all three together.