### PR TITLE
testing/wireguard: upgrade to 0.0.20180625

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180613
+pkgver=0.0.20180625
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="dc61cb61e507bee3d07aa059a0c2f61812641797d041bade49797e31738858951d7ab209e6b5fdcf052a585754c8aa7d5a203474889b193513abfa7e87942181  WireGuard-0.0.20180613.tar.xz"
+sha512sums="3bbbc4eeeb8512fe6ec5ce09a95dcf86a93d0dd49edeb70b03dddeafc1d87ca22060d35abe77f5ae52afca6e5cfd7c252fc248f5a1ebfa7e7f9cf55a7eb1cabb  WireGuard-0.0.20180625.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180613
-_rel=2
+_ver=0.0.20180625
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="dc61cb61e507bee3d07aa059a0c2f61812641797d041bade49797e31738858951d7ab209e6b5fdcf052a585754c8aa7d5a203474889b193513abfa7e87942181  WireGuard-0.0.20180613.tar.xz"
+sha512sums="3bbbc4eeeb8512fe6ec5ce09a95dcf86a93d0dd49edeb70b03dddeafc1d87ca22060d35abe77f5ae52afca6e5cfd7c252fc248f5a1ebfa7e7f9cf55a7eb1cabb  WireGuard-0.0.20180625.tar.xz"


### PR DESCRIPTION
```

  * receive: don't toggle bh
  
  The last snapshot caused a big performance regression, which we partially
  revert here. This general matter, though, will be revisited in the future,
  perhaps by switching to NAPI.
  
  * main: test poly1305 before chacha20poly1305
  * poly1305: give linker the correct constant data section size
  
  While the default bfd linker did the right thing, gold would sometimes merge
  section incorrectly because of an incorrect section length field, resulting in
  wrong calculations.
  
  * simd: add missing header
  
  Fixes a compile error on a few odd kernels.
  
  * global: fix a few typos
  * manpages: eliminate whitespace at the end of the line
  * tools: fix misspelling of strchrnul in comment
  
  Cosmetic fixups.
  
  * global: use ktime boottime instead of jiffies
  * global: use fast boottime instead of normal boottime
  * compat: more robust ktime backport
  
  We now use the equivalent of clock_gettime(CLOCK_BOOTTIME) for doing age
  checks on time-limited objects, such as ephemeral keys, so that on systems
  where we don't clear before sleep (like Android), we make sure to invalidate
  the objects after the proper amount of time, taking into account time spent
  asleep.
  
  * wg-quick: android: prevent outgoing handshake packets from being dropped
  
  Recent android phones block outgoing packets using iptables while the system
  is asleep. This makes sense for most services, but not for a tunnel device
  itself, so we work around this by inserting our own iptables rule.
```