### PR TITLE
main/alpine-baselayout: Set hvc0 for ppc64le console access

### DIFF
--- a/main/alpine-baselayout/APKBUILD
+++ b/main/alpine-baselayout/APKBUILD
@@ -195,6 +195,8 @@ package() {
 			sed -i "s/tty$i::/\#tty$i::/g" "$srcdir"/inittab
 		done
 		echo "console::respawn:/sbin/getty 38400 /dev/console" >> "$srcdir"/inittab
+	elif [ "$CARCH" = "ppc64le" ]; then
+		echo "hvc0::respawn:/sbin/getty -L hvc0 115200 vt100" >> "$srcdir"/inittab
 	fi
 
 	install -m644 \


### PR DESCRIPTION
On ppc64le when net booting Alpine, we will not get a login prompt from Petitboot. By default ppc64le uses hvc0 and not ttyS0. This patch starts a getty on hvc0 rather than ttyS0 in order to properly get a login prompt from Petitboot. Thanks to @jk-ozlabs and @tmh1999 for help with this patch.