### PR TITLE
main/alpine-baselayout: Use the proper getty for login on ppc64le

### DIFF
--- a/main/alpine-baselayout/APKBUILD
+++ b/main/alpine-baselayout/APKBUILD
@@ -195,6 +195,8 @@ package() {
 			sed -i "s/tty$i::/\#tty$i::/g" "$srcdir"/inittab
 		done
 		echo "console::respawn:/sbin/getty 38400 /dev/console" >> "$srcdir"/inittab
+	elif [ "$CARCH" = "ppc64le" ]; then
+		echo "console::respawn:/sbin/getty -L /dev/console 0 vt100" >> "$srcdir"/inittab
 	fi
 
 	install -m644 \


### PR DESCRIPTION
On ppc64le when net booting Alpine we will not get a login prompt from Petitboot. Despite hvc0 being the default TTY, we need to make sure getty uses the correct console for a login prompt. This patch will set TTY as `/dev/console `and the TERMTYPE as `vt100` while using a safer BAUD value in order to work on varying ppc64le hardware.