### PR TITLE
testing/brotli: upgrade to 1.0.5

### DIFF
--- a/testing/brotli/APKBUILD
+++ b/testing/brotli/APKBUILD
@@ -9,7 +9,7 @@ arch="all"
 license="MIT"
 makedepends="cmake"
 subpackages="$pkgname-doc $pkgname-dev"
-source="$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/google/brotli/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
@@ -18,12 +18,17 @@ prepare() {
 }
 
 build() {
-	mkdir "$builddir"/build
-	cd "$builddir"/build
-	cmake .. \
-		-DCMAKE_BUILD_TYPE=Release \
+	cd "$builddir"
+	if [ "$CBUILD" != "$CHOST" ]; then
+		CMAKE_CROSSOPTS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
+	fi
+	cmake \
 		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DCMAKE_INSTALL_LIBDIR=/usr/lib
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_SHARED_LIBS=True \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_C_FLAGS="$CFLAGS" \
+		${CMAKE_CROSSOPTS}
 	make
 }
 
@@ -34,10 +39,9 @@ check() {
  
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" -C build install
+	make DESTDIR="$pkgdir" install
 	
-	local man
-	for man in docs/*.?; do
+	local man; for man in docs/*.?; do
 		install -D -m644 $man "$pkgdir"/usr/share/man/man${man##*.}/${man##*/}
 	done
 }

--- a/testing/brotli/APKBUILD
+++ b/testing/brotli/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: prspkt <prspkt@protonmail.com>
 # Maintainer: prspkt <prspkt@protonmail.com>
 pkgname=brotli
-pkgver=1.0.4
+pkgver=1.0.5
 pkgrel=0
 pkgdesc="Generic lossless compressor"
 url="https://github.com/google/brotli"
@@ -42,4 +42,4 @@ package() {
 	done
 }
 
-sha512sums="7d41ad37ca0755ba9e08e7355fb031e24a53a5f6d44ff827adee6d9712765af02142cb463ef558f92449ce3b73e559cffb52315a329ab702f4c46927f993b616  brotli-1.0.4.tar.gz"
+sha512sums="703cad94c7f250133d2cfe222f3183612c7649b184bba218907b805f423568046d42695f33acf7da95daf684be118c9d631cfa5706e5a195b611c716db4c839a  brotli-1.0.5.tar.gz"


### PR DESCRIPTION
[Release notes](https://github.com/google/brotli/releases/tag/v1.0.5).
Sorry for the _noisy_ 2nd commit. I refactored the build section to be more in line with the cmake boilerplate provided by newapkbuild.