### PR TITLE
testing/gnu-libiconv: remove "return 1"

### DIFF
--- a/testing/gnu-libiconv/APKBUILD
+++ b/testing/gnu-libiconv/APKBUILD
@@ -19,12 +19,12 @@ build() {
 		--prefix=/usr \
 		--mandir=/usr/share/man \
 		--disable-nls \
-		--disable-static \
-		|| return 1
+		--disable-static
+
 	# work around rpath issue
 	sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
 	sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
-	make || return 1
+	make
 }
 
 package() {


### PR DESCRIPTION
Later abuild scripts don't require `|| return 1` anymore