### PR TITLE
testing/frr: new aport for free range routing, a fork of quagga

### DIFF
--- a/testing/frr/APKBUILD
+++ b/testing/frr/APKBUILD
@@ -1,0 +1,64 @@
+# Maintainer: Arthur Jones <arthur.jones@riverbed.com>
+pkgname=frr
+pkgver=5.0.1
+pkgrel=0
+pkgdesc="FRRouting is a fork of quagga"
+pkgusers="frr"
+pkggroups="frr"
+url="https://frrouting.org/"
+arch="x86_64"
+license="GPL-2.0-only and LGPL-2.1-only"
+depends="json-c c-ares iproute2 python2 py-ipaddr bash"
+makedepends="ncurses-dev net-snmp-dev gawk texinfo perl
+    acct autoconf automake bash bison bsd-compat-headers
+    c-ares-dev cryptsetup-libs device-mapper-libs flex
+    json-c-dev kmod lddtree libacl libblkid libburn libedit
+    libisoburn libisofs libltdl libtool libuuid linux-headers lzo m4 mkinitfs
+    mtools pcre perl python2-dev readline-dev
+    squashfs-tools texinfo xorriso py-sphinx"
+checkdepends="pytest py-setuptools"
+install="$pkgname.pre-install"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-dbg $pkgname-openrc"
+source="https://github.com/FRRouting/frr/archive/$pkgname-$pkgver.tar.gz
+    make-check-bypass-isisd-tlv.patch
+    frr.initd
+    "
+builddir="$srcdir"/$pkgname-$pkgname-$pkgver
+
+_sysconfdir=/etc/frr
+
+build() {
+	cd "$builddir"
+	./bootstrap.sh
+	./configure \
+		--prefix=/usr \
+		--sbindir=/usr/lib/frr \
+		--sysconfdir=$_sysconfdir \
+		--libdir=/usr/lib \
+		--localstatedir=/run/frr \
+		--enable-systemd=no \
+		--enable-vtysh \
+		--enable-multipath=64 \
+		--enable-vty-group=frrvty \
+		--enable-user=${pkgusers%% *} \
+		--enable-group=${pkggroups%% *}
+	make
+}
+
+check() {
+	cd "$builddir"
+
+	make -j 1 check
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+
+	install -Dm644 "$builddir"/tools/etc/frr/daemons "$pkgdir"$_sysconfdir
+	install -Dm644 "$builddir"/tools/etc/frr/daemons.conf "$pkgdir"$_sysconfdir
+	install -Dm755 "$srcdir"/frr.initd "$pkgdir"/etc/init.d/frr.initd
+}
+sha512sums="e2a3a4e21998f8c85b59fc971190d0b5340bbcd88356a637740ad8e564275b0df14da78b72a24a99a58435725cded1b9089814fc926a7a4080bd3a8762973548  frr-5.0.1.tar.gz
+3c679b857018d82443abd34823e712a8657a597b4210730d260e9796516982a137234354422cb439989985367531d600e205d3fb791cdb7b212425bb704c2016  make-check-bypass-isisd-tlv.patch
+9d2cfa95c3a79fa0da321319dcd6f439a267b69071233d4ad4b56f770eb9852c3c8b3be24c1e396701509a09eabb6ba618af6fa4a0a643bd37eeee7b6496a787  frr.initd"

--- a/testing/frr/frr.initd
+++ b/testing/frr/frr.initd
@@ -1,0 +1,19 @@
+#!/sbin/openrc-run
+
+description="FRRouting"
+
+start() {
+        /usr/lib/frr/frr start
+}
+
+stop() {
+        /usr/lib/frr/frr stop
+}
+
+restart() {
+        /usr/lib/frr/frr restart
+}
+
+status() {
+        /usr/lib/frr/frr status
+}

--- a/testing/frr/frr.pre-install
+++ b/testing/frr/frr.pre-install
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+for g in frr frrvty; do
+	addgroup -S $g 2>/dev/null
+done
+
+adduser -S -D -H -h /var/run/frr -s /sbin/nologin -G frr -g frr frr 2>/dev/null
+adduser frr frrvty 2>/dev/null
+
+exit 0

--- a/testing/frr/make-check-bypass-isisd-tlv.patch
+++ b/testing/frr/make-check-bypass-isisd-tlv.patch
@@ -1,0 +1,49 @@
+commit f404be7c728ca3433bb4aeaeac5e3c450941de35
+Author: Arthur Jones <arthur.jones@riverbed.com>
+Date:   Wed Jun 6 07:47:17 2018 -0700
+
+    tests/isisd: bypass test_fuzz_isis_tlv when inet_ntop is broken
+    
+    On Alpine Linux edge, musl does not seem to be RFC 5952 4.2.2
+    compliant (how to print a single :0: in the IPv6 address).  Let's
+    skip that test, as we get false negatives when running against
+    that version of musl.
+    
+    Credit for the idea for the fix and how to fix it is due to
+    chris@opensourcerouting.org.
+    
+    Testing done:
+    
+    make check on alpine linux passes now
+    
+    Issue: https://github.com/FRRouting/frr/issues/2375
+    Signed-off-by: Arthur Jones <arthur.jones@riverbed.com>
+
+diff --git a/tests/isisd/test_fuzz_isis_tlv.py b/tests/isisd/test_fuzz_isis_tlv.py
+index bf700bfee..d96e3c4fe 100644
+--- a/tests/isisd/test_fuzz_isis_tlv.py
++++ b/tests/isisd/test_fuzz_isis_tlv.py
+@@ -2,10 +2,21 @@ import frrtest
+ 
+ import pytest
+ import platform
++import socket
+ 
+-if platform.uname()[0] == 'SunOS':
++
++##
++# on musl, ntop compresses a single :0: -> :: which is against RFC
++##
++def inet_ntop_broken():
++    addr = '1:2:3:4:0:6:7:8'
++    return socket.inet_ntop(socket.AF_INET6,
++                            socket.inet_pton(socket.AF_INET6, addr)) != addr
++
++
++if platform.uname()[0] == 'SunOS' or inet_ntop_broken():
+     class TestFuzzIsisTLV:
+-        @pytest.mark.skipif(True, reason='Test unsupported on SunOS')
++        @pytest.mark.skipif(True, reason='Test unsupported')
+         def test_exit_cleanly(self):
+             pass
+ else:


### PR DESCRIPTION
FRRouting is free software that implements and manages various
IPv4 and IPv6 routing protocols.

Currently FRRouting supports BGP4, BGP4+, OSPFv2, OSPFv3, RIPv1, RIPv2,
RIPng, IS-IS, PIM-SM/MSDP, LDP and Babel as well as very early support
for EIGRP and NHRP.

Issue: https://bugs.alpinelinux.org/issues/8795