### PR TITLE
testing/boringssl: new aport

### DIFF
--- a/testing/boringssl/APKBUILD
+++ b/testing/boringssl/APKBUILD
@@ -1,0 +1,57 @@
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
+#
+_gitver=d2f87a777955dd53d7768b236ec3804fe50462a7
+pkgname=boringssl
+pkgver=2018.07.04
+_namever=${pkgname}${pkgver%.*}
+pkgrel=0
+pkgdesc="BoringSSL is a fork of OpenSSL that is designed to meet Google's needs."
+url="https://boringssl.googlesource.com/boringssl/"
+arch="all"
+license="custom"
+depends=""
+makedepends="cmake perl go ninja"
+replaces=
+subpackages="$pkgname-dev"
+source="$pkgname-$_gitver.tar.gz::https://github.com/google/boringssl/archive/$_gitver.tar.gz"
+builddir="$srcdir/$pkgname-$_gitver"
+ldpath="/usr/lib/boringssl"
+
+prepare() {
+	default_prepare
+	cd "$builddir"
+}
+
+build() {
+	cd "$builddir"
+	mkdir build
+	cd build
+	cmake .. \
+		-GNinja \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_USE_RELATIVE_PATHS=yes
+	ninja
+}
+
+check() {
+	cd "$builddir"
+	go run util/all_tests.go
+	cd "$builddir/ssl/test/runner"
+	go test
+}
+
+package() {
+	cd "$builddir"
+	install -Dm755 build/crypto/libcrypto.a     "$pkgdir"/usr/lib/boringssl/libcrypto.a
+	install -Dm755 build/ssl/libssl.a           "$pkgdir"/usr/lib/boringssl/libssl.a
+	install -Dm755 build/decrepit/libdecrepit.a "$pkgdir"/usr/lib/boringssl/libdecrepit.a
+	install -Dm755 build/tool/bssl   "$pkgdir"/usr/bin/bssl
+	install -Dm644 LICENSE           "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+
+	cd "include/openssl"
+	for i in *.h; do
+		install -Dm644 "$i" "$pkgdir"/usr/include/boringssl/openssl/"$i"
+	done
+}
+
+sha512sums="25aa2114e6c2b315ccefc3aa767c522121d60f8f753969460a6e6c994b179eabcdcc4213be91baf760f1f331838067e21fd448af28f26f546303bc8778301abd  boringssl-$_gitver.tar.gz"


### PR DESCRIPTION
This aport adds boringssl, the SSL implementation by google, to the repository. This adds the possibility to build and statically link other packages against their implementation.

This aport includes two packages:
- boringssl: Contains only the "bssl" executable, similar to the "openssl" command
- boringssl-dev: This contains the headers and the static libs

The headers are installed unter "/usr/include/boringssl" so it doesn't collide with openssl / libressl. The libs will be installed under "/usr/libs/boringssl" for the same reason.
This means that any depending package has to add these two paths to their CFLAGS in order to compile.