### PR TITLE
testing/nghttp2-boringssl: new aport

### DIFF
--- a/testing/nghttp2-boringssl/APKBUILD
+++ b/testing/nghttp2-boringssl/APKBUILD
@@ -13,6 +13,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
 source="https://github.com/tatsuhiro-t/$_pkgname/releases/download/v$pkgver/nghttp2-$pkgver.tar.xz
 boringssl.patch"
 builddir="$srcdir"/$_pkgname-$pkgver
+replaces="nghttp2"
 
 check() {
 	cd "$builddir"

--- a/testing/nghttp2-boringssl/APKBUILD
+++ b/testing/nghttp2-boringssl/APKBUILD
@@ -1,0 +1,49 @@
+# Contributor: Natanael Copa <ncopa@alpinelinux.org>
+# Maintainer: Francesco Colista <fcolista@alpinelinux.org>
+pkgname=nghttp2-boringssl
+_pkgname=${pkgname/-boringssl/}
+pkgver=1.32.0
+pkgrel=0
+pkgdesc="Experimental HTTP/2 client, server and proxy using boringssl"
+url="https://nghttp2.org"
+arch="all"
+license="MIT"
+makedepends="libev-dev boringssl-dev zlib-dev c-ares-dev autoconf automake libtool"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
+source="https://github.com/tatsuhiro-t/$_pkgname/releases/download/v$pkgver/nghttp2-$pkgver.tar.xz
+boringssl.patch"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+build() {
+	cd "$builddir"
+	autoreconf -vif
+	OPENSSL_LIBS="-L/usr/lib/boringssl -lssl -lcrypto" \
+	OPENSSL_CFLAGS="-I/usr/include/boringssl" \
+	./configure \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--localstatedir=/var \
+		--disable-static \
+		--without-libxml2 \
+		--without-spdylay \
+		--without-neverbleed \
+		--without-jemalloc \
+		--disable-python-bindings \
+		--enable-app 
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="ec7e417fbc5497861d2b6dde5145da1640b36441882824e85940e5ca6ac52ec444aa7123846960f7211dd96462eab421d39f9cc49454f3f52e0dcdb36402044e  nghttp2-1.32.0.tar.xz
+ce60a4f2e1cfa53226a5498568dc7817d58afd45ecfb87b8afc20d6c667914b0a4b3f985bb125825ce5166e45214635ece51f55227b9b764da21e270528bd674  boringssl.patch"

--- a/testing/nghttp2-boringssl/boringssl.patch
+++ b/testing/nghttp2-boringssl/boringssl.patch
@@ -1,0 +1,21 @@
+--- a/src/shrpx_tls.cc
++++ b/src/shrpx_tls.cc
+@@ -1978,7 +1978,7 @@
+ #endif /* !WORDS_BIGENDIAN */
+
+ StringRef get_x509_serial(BlockAllocator &balloc, X509 *x) {
+-#if OPENSSL_1_1_API
++#if false
+   auto sn = X509_get0_serialNumber(x);
+   uint64_t r;
+   if (ASN1_INTEGER_get_uint64(&r, sn) != 1) {
+@@ -2031,7 +2031,7 @@
+     return -1;
+   }
+
+-  unsigned char *s;
++  char *s;
+   auto slen = BIO_get_mem_data(b, &s);
+   auto tt = util::parse_openssl_asn1_time_print(
+       StringRef{s, static_cast<size_t>(slen)});
+


### PR DESCRIPTION
This aport adds the nghttp2 packages compiled and linked against boringssl.
In order for this to work, the testing/boringssl PR  #4676 has to be merged.