### PR TITLE
testing/bfs: fix broken tests on ppc64le because of 64k pagesize

### DIFF
--- a/testing/bfs/APKBUILD
+++ b/testing/bfs/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: dai9ah <dai9ah@protonmail.com>
 pkgname=bfs
 pkgver=1.2.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Breadth-first variant of the UNIX find command"
 url="https://github.com/tavianator/bfs"
 arch="all"
@@ -11,7 +11,8 @@ makedepends="linux-headers"
 checkdepends="bash"
 subpackages="$pkgname-doc"
 options="!checkroot"
-source="$pkgname-$pkgver.tar.gz::https://github.com/tavianator/$pkgname/archive/$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/tavianator/$pkgname/archive/$pkgver.tar.gz
+	adj_large_pagesz.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -29,4 +30,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="ec78687b1c3d62e1f625b18d2f668f91663425db634cbb540c0e06b279702d1b9ffb88eddb35db229839ba85eac788416f059a65887a313409d6c3be281bb331  bfs-1.2.2.tar.gz"
+sha512sums="ec78687b1c3d62e1f625b18d2f668f91663425db634cbb540c0e06b279702d1b9ffb88eddb35db229839ba85eac788416f059a65887a313409d6c3be281bb331  bfs-1.2.2.tar.gz
+241d153ec97e2d1803ddafdf8cf66a5f83038e2b91b018a2be5bc10267a7f59436e5b6cd3abb7752dc3c15b779336cf51a8e617d9d3d1d13579bf2422a38f368  adj_large_pagesz.patch"

--- a/testing/bfs/adj_large_pagesz.patch
+++ b/testing/bfs/adj_large_pagesz.patch
@@ -1,0 +1,13 @@
+--- a/exec.c
++++ b/exec.c
+@@ -95,6 +95,10 @@
+ 	long page_size = sysconf(_SC_PAGESIZE);
+ 	if (page_size < 4096) {
+ 		page_size = 4096;
++	} else {
++		if (page_size > (BFS_EXEC_ARG_MAX/1024)) {
++			page_size = BFS_EXEC_ARG_MAX/1024;
++		}
+ 	}
+ 	arg_max -= 2*page_size;
+ 	bfs_exec_debug(execbuf, "ARG_MAX: %ld remaining after headroom\n", arg_max);


### PR DESCRIPTION
test_exec_plus test fails because sysconf(_SC_ARG_MAX) is not large enough to contain two 64K pages (ppc64le default page size). Since maximum argument size allowed by BFS is only 16K anyway (BFS_EXEC_ARG_MAX) then update arg size check to make sure it is at least 32k. 