### PR TITLE
testing/gdal: upgrade to 2.3.1

### DIFF
--- a/testing/gdal/APKBUILD
+++ b/testing/gdal/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Trevor R.H. Clarke <trevor@notcows.com>
 # Maintainer: Trevor R.H. Clarke <trevor@notcows.com>
 pkgname=gdal
-pkgver=2.3.0
+pkgver=2.3.1
 pkgrel=0
 pkgdesc="A translator library for raster and vector geospatial data formats"
 url="http://gdal.org"
@@ -72,4 +72,4 @@ check() {
 	# confirms PostgreSQL/PostGIS support
 	apps/ogr2ogr --formats | grep "PostgreSQL -vector- (rw+): PostgreSQL/PostGIS"
 }
-sha512sums="7eb5abd9e61fca2ac8c7022029b2492b98f56873ffd277e15ced23d3742e26fd29eb5f8ed7c916b096c3caeed9efc03d0c022390fa0bf762d0c6cb5c04e70ec7  gdal-2.3.0.tar.xz"
+sha512sums="9c016788478d15155d8be69eac2988a31bd59bd8dc6ef440cef71c833a3f9563cdb37e6c9b2219eb416f9e11bed199268469e15f3228c520dc6e74f1ce2fdbf3  gdal-2.3.1.tar.xz"


### PR DESCRIPTION
http://trac.osgeo.org/gdal/wiki/Release/2.3.1-News