### PR TITLE
community/xfce4-mixer: fix build, modernize aport

### DIFF
--- a/community/xfce4-mixer/APKBUILD
+++ b/community/xfce4-mixer/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xfce4-mixer
 pkgver=4.11.0
-pkgrel=3
+pkgrel=4
 pkgdesc="The volume control plugin for the Xfce panel"
 url="https://xfce.org/"
 arch="all"
@@ -31,14 +31,12 @@ build() {
 		--localstatedir=/var \
 		--disable-static \
 		--with-sound=alsa \
-		|| return 1
-	make || return 1
+		CFLAGS="$CFLAGS -I/usr/include/dbus-1.0"
+	make
 }
 
 package() {
 	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
-md5sums="1b3753b91224867a3a2dfddda239c28d  xfce4-mixer-4.11.0.tar.bz2"
-sha256sums="fb0c1df201ed1130f54f15b914cbe5a59286e994a137acda5609570c57112de2  xfce4-mixer-4.11.0.tar.bz2"
 sha512sums="0ef27ece0d5f46bd83db86d8e607d2dc34f4b0221679dbdeae4e4eb9993b30398a2e882b3a870af9928906330898935f2fe29e83442ba6f01b9e19d02ea6f66f  xfce4-mixer-4.11.0.tar.bz2"


### PR DESCRIPTION
This fixes the following build error:
```
In file included from xfce-plugin-dialog.c:35:0:
../libxfce4mixer/libxfce4mixer.h:27:28: fatal error: dbus/dbus-glib.h: No such file or directory
 #include <dbus/dbus-glib.h>
```

@clandmeter, @jirutka, @kaniini, @ncopa:
Right now this blocks edge builders for x86_64, armhf, aarch64, x86. So please merge ASAP once CI shows that it's working (it did on my machine).

