### PR TITLE
community/mutagen: add python2

### DIFF
--- a/community/mutagen/APKBUILD
+++ b/community/mutagen/APKBUILD
@@ -1,30 +1,33 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mutagen
 pkgver=1.40.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Audio tagger implemented in Python"
 url="https://github.com/quodlibet/mutagen"
 arch="noarch"
 license="GPL-2.0-or-later"
-depends="python3 py-mutagen"
-makedepends="python3-dev"
-checkdepends="py3-pytest py3-setuptools py3-hypothesis"
-subpackages="$pkgname-doc py-$pkgname:py"
+depends="py3-mutagen"
+makedepends="python2-dev python3-dev"
+checkdepends="py-pytest py-setuptools py-hypothesis"
+subpackages="$pkgname-doc py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="$pkgname-$pkgver.tar.gz::https://github.com/quodlibet/$pkgname/archive/release-$pkgver.tar.gz"
 
 # we dont have all the needed deps for running the test suite yet
 options="!check"
 
 builddir="$srcdir/$pkgname-release-$pkgver"
-
 build() {
 	cd "$builddir"
+	python2 setup.py build
 	python3 setup.py build
 }
 
 package() {
 	cd "$builddir"
-	python3 setup.py install --root="$pkgdir"
+
+	# install only python3 binary and man pages
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+	rm -rf "$pkgdir"/usr/lib
 }
 
 check() {
@@ -32,11 +35,27 @@ check() {
 	python3 setup.py test
 }
 
-py() {
-	pkgdesc="Python library for mutagen"
-	depends="python3"
-	mkdir -p "$subpkgdir"/usr/lib
-	mv "$pkgdir"/usr/lib/python* "$subpkgdir"/usr/lib/
+_py2() {
+	_py python2
+}
+
+_py3() {
+	provides="py-$pkgname"
+	replaces="py-$pkgname"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$python library for $pkgname"
+	depends="$python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+
+	# cleanup binaries and man pages from individual subpackages
+	rm -rf "$subpkgdir"/usr/share "$subpkgdir"/usr/bin
 }
 
 sha512sums="f167eabf8885d822f8e11c34720e24ad49b696d7c479ab957a4c6e84a6feb025c69175352cea610da6b119d11b66fe0fd225b95ce522d7c73f000d6bfffef77c  mutagen-1.40.0.tar.gz"

--- a/testing/nicotine-plus/APKBUILD
+++ b/testing/nicotine-plus/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: dai9ah <dai9ah@protonmail.com>
 pkgname=nicotine-plus
 pkgver=1.4.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Graphical client for the SoulSeek peer-to-peer system"
 url="http://nicotine-plus.org"
 arch="noarch"
 license="GPL-3.0-or-later"
-depends="librsvg py-gtk py-mutagen"
+depends="librsvg py-gtk py2-mutagen"
 subpackages="$pkgname-doc $pkgname-lang"
 source="$pkgname-$pkgver.tar.gz::https://github.com/Nicotine-Plus/$pkgname/archive/$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Add python2 **library** required by the (python2-only) `testing/nicotine-plus` package. The mutagen binary and its library dependency remain python3.