### PR TITLE
main/duplicity: fix dependencies and add check (including missing deps)

### DIFF
--- a/main/duplicity/APKBUILD
+++ b/main/duplicity/APKBUILD
@@ -8,7 +8,7 @@ pkgdesc="Encrypted bandwidth-efficient backup using the rsync algorithm"
 url="http://duplicity.nongnu.org/"
 arch="all"
 license="GPL"
-depends="python2 py-boto gnupg ncftp py-lockfile"
+depends="python2 py-boto gnupg ncftp py2-fasteners"
 makedepends="python2-dev py-setuptools librsync-dev"
 subpackages="$pkgname-doc $pkgname-lang"
 source="https://code.launchpad.net/$pkgname/${pkgver:0:3}-series/$pkgver/+download/$pkgname-$pkgver.tar.gz"
@@ -17,6 +17,14 @@ builddir="$srcdir/$pkgname-$pkgver"
 build() {
 	cd "$builddir"
 	python2 setup.py build
+}
+
+check() {
+	cd "$builddir/duplicity"
+	python2 compilec.py
+	cd ..
+	# Run a simple smoke-test
+	PYTHONPATH="$PWD" python2 bin/duplicity -V | grep -q duplicity
 }
 
 package() {

--- a/main/py2-fasteners/APKBUILD
+++ b/main/py2-fasteners/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Jean-Louis Fuchs <ganwell@fangorn.ch>
+# Maintainer: Jean-Louis Fuchs <ganwell@fangorn.ch>
+pkgname=py2-fasteners
+pkgver=0.14.1
+pkgrel=0
+pkgdesc="A python package that provides useful locks"
+url="https://github.com/harlowja/fasteners/"
+arch="noarch"
+license="Apache-2.0"
+depends="python2 py2-monotonic py2-six"
+makedepends="python2-dev py-setuptools"
+source="fasteners-$pkgver.tar.gz::https://github.com/harlowja/fasteners/archive/$pkgver.tar.gz"
+sha512sums="954d692b7f43563ba1413854c8dec2f5ff98757346c55aaa5f39e9aa777fb746bf4f9506beab6cfa149d5646db4b3de58d35bcef95e3128096c3346c9fd8015c  fasteners-0.14.1.tar.gz"
+builddir="$srcdir/fasteners-$pkgver"
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+}
+
+package() {
+	cd "$builddir"
+	python2 setup.py install --prefix=/usr --root="$pkgdir"
+}
+

--- a/main/py2-monotonic/APKBUILD
+++ b/main/py2-monotonic/APKBUILD
@@ -1,0 +1,29 @@
+# Contributor: Jean-Louis Fuchs <ganwell@fangorn.ch>
+# Maintainer: Jean-Louis Fuchs <ganwell@fangorn.ch>
+pkgname=py2-monotonic
+pkgver=1.5
+pkgrel=0
+pkgdesc="Provides a clock which never goes backwards."
+url="https://github.com/atdt/monotonic/"
+arch="noarch"
+license="Apache-2.0"
+depends="python2"
+makedepends="python2-dev"
+source="monotonic-$pkgver.tar.gz::https://github.com/atdt/monotonic/archive/$pkgver.tar.gz"
+sha512sums="acee69916a82059a027e7bcc03c58deb5ce773a1aff45938699cf09c3ab49b7827c2c01b431593ed76ae49009728c3d52923267eccfc7e15390f8730351a39e2  monotonic-1.5.tar.gz"
+builddir="$srcdir/monotonic-$pkgver"
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+}
+
+package() {
+	cd "$builddir"
+	python2 setup.py install --prefix=/usr --root="$pkgdir"
+}


### PR DESCRIPTION
I added the dependencies directly to main, because duplicity is currently broken. It would also be nice to backport this to 3.8-stable. (Do I have to do an extra PR?)