### PR TITLE
main/memcached: upgrade to 1.5.9, clarify license

### DIFF
--- a/main/memcached/APKBUILD
+++ b/main/memcached/APKBUILD
@@ -1,12 +1,12 @@
 # Contributor: Jeff Bilyk <jbilyk@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=memcached
-pkgver=1.5.8
+pkgver=1.5.9
 pkgrel=0
 pkgdesc="Distributed memory object caching system"
 url="http://memcached.org/"
 arch="all"
-license="BSD"
+license="BSD-3-Clause"
 depends_dev="${pkgname}=${pkgver}-r${pkgrel}"
 makedepends="$depends_dev cyrus-sasl-dev libevent-dev libseccomp-dev linux-headers"
 install="$pkgname.pre-install"
@@ -50,6 +50,6 @@ package() {
 		"$pkgdir/etc/conf.d/$pkgname"
 }
 
-sha512sums="6f0e3ce9cae3e424c41223597353b9520e7e7f97fb4719a5d520dfd34e1d917d4ee0e42bced0a5799042227b80bc4ed2778715a71b9941239db13cb367bdb088  memcached-1.5.8.tar.gz
+sha512sums="06f7f09a0ec1ec02353296f79776ce9229c648f4ca7c6914f82b3e50455c3b5c8d535c62d8a823f5a50375acddb9cb77470bec430c2acb37f107fb660fe29e54  memcached-1.5.9.tar.gz
 31bd788433b8021ed332f86d291e7f03222ae234520e52ba673b581d5da2adf5656e8f73e8b985df73258dea9b2a1b8ef36195163fe47a92fda59825deedfed4  memcached.confd
 9615769b14175a25b50c9871b48c0635b5397ebe45231b43ee29a603eceb7b16bfc5ac744017b89b19082209c09597b3038a03ed0d5d9b45c60454d5b2717a55  memcached.initd"


### PR DESCRIPTION
https://github.com/memcached/memcached/wiki/ReleaseNotes159