### PR TITLE
testing/wireguard: upgrade to 0.0.20180708

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180625
+pkgver=0.0.20180708
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="3bbbc4eeeb8512fe6ec5ce09a95dcf86a93d0dd49edeb70b03dddeafc1d87ca22060d35abe77f5ae52afca6e5cfd7c252fc248f5a1ebfa7e7f9cf55a7eb1cabb  WireGuard-0.0.20180625.tar.xz"
+sha512sums="91e4eb5c863f7070dc139739bbb5f6ce5b7ff9e8bd293a6217e6b9ac8dcacc710c01bac9386df50bd1226f0534c5332f8e1e2c50e9483e167eac6345a616f6f6  WireGuard-0.0.20180708.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180625
-_rel=1
+_ver=0.0.20180708
+_rel=2
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="3bbbc4eeeb8512fe6ec5ce09a95dcf86a93d0dd49edeb70b03dddeafc1d87ca22060d35abe77f5ae52afca6e5cfd7c252fc248f5a1ebfa7e7f9cf55a7eb1cabb  WireGuard-0.0.20180625.tar.xz"
+sha512sums="91e4eb5c863f7070dc139739bbb5f6ce5b7ff9e8bd293a6217e6b9ac8dcacc710c01bac9386df50bd1226f0534c5332f8e1e2c50e9483e167eac6345a616f6f6  WireGuard-0.0.20180708.tar.xz"


### PR DESCRIPTION
```
  * device: print daddr not saddr in missing peer error
  * receive: style
  
  Debug messages now make sense again.
  
  * selftest: ratelimiter: improve chance of success via retry
  * qemu: bump default kernel version
  * qemu: decide debug kernel based on KERNEL_VERSION
  
  Some improvements to our testing infrastructure.
  
  * receive: use NAPI on the receive path
  
  This is a big change that should both improve preemption latency (by not
  disabling it unconditionally) and vastly improve rx performance on most
  systems by using NAPI. The main purpose of this snapshot is to test out this
  technique.
```