### PR TITLE
testing/ocaml-dtoa: avoid testing/flow link error by eliminating bign…

### DIFF
--- a/testing/ocaml-dtoa/APKBUILD
+++ b/testing/ocaml-dtoa/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=ocaml-dtoa
 _pkgname=dtoa
 pkgver=0.3.1
-pkgrel=0
+pkgrel=1
 pkgdesc="double-to-ascii ocaml implementation"
 url="https://github.com/flowtype/ocaml-dtoa"
 arch="all !x86 !armhf !s390x"  # limited by ocaml aport
@@ -12,7 +12,8 @@ depends="ocaml-runtime"
 checkdepends="ocaml-ounit-dev"
 makedepends="dune ocaml ocaml-findlib opam"
 subpackages="$pkgname-dev"
-source="https://github.com/flowtype/$pkgname/archive/v$pkgver/$pkgname-$pkgver.tar.gz"
+source="https://github.com/flowtype/$pkgname/archive/v$pkgver/$pkgname-$pkgver.tar.gz
+	bignum_align_noinline.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -53,4 +54,5 @@ dev() {
 	mv *.cmx *.cmxa *.mli "$subpkgdir"/$sitelib/
 }
 
-sha512sums="25eb4f867759a37b42352ca43d5afeecf9baf9b2d9aa8c763dbae3e89581e960bd93ac02e497ac2053d56c1f851d5a8566a65652f9fd9fc6d2c66c525bd60fd2  ocaml-dtoa-0.3.1.tar.gz"
+sha512sums="25eb4f867759a37b42352ca43d5afeecf9baf9b2d9aa8c763dbae3e89581e960bd93ac02e497ac2053d56c1f851d5a8566a65652f9fd9fc6d2c66c525bd60fd2  ocaml-dtoa-0.3.1.tar.gz
+a27524248cf0c68c46f4f22ac63c729047837dcb56eedc1c1f88fbf8d9fb65d3b668bf38b0f3052e63da7e6824dcc22c5e3290be95a69078a5b70e61356af33e  bignum_align_noinline.patch"

--- a/testing/ocaml-dtoa/bignum_align_noinline.patch
+++ b/testing/ocaml-dtoa/bignum_align_noinline.patch
@@ -1,0 +1,11 @@
+--- a/src/bignum.c	2018-07-09 14:12:25.025413017 +0000
++++ b/src/bignum.c	2018-07-09 14:13:23.210604404 +0000
+@@ -86,7 +86,7 @@
+ }
+ 
+ 
+-void bignum_align(bignum* num, bignum other) {
++__attribute__((noinline)) void bignum_align(bignum* num, bignum other) {
+   if (num->exponent > other.exponent) {
+     // If "X" represents a "hidden" digit (by the exponent) then we are in the
+     // following case (a == this, b == other):


### PR DESCRIPTION
…um_align inlining

The libtoa_stubs.a library created when building testing/ocaml-dtoa on ppc64le contains the bignum_align.part.4 section created by the compiler optimizing the bignum_align(). This causes the linking against the library on ppc64le to report errors like we see when building the testing/flow package. For example:

```
/usr/lib/gcc/powerpc64le-alpine-linux-musl/6.4.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: /usr/lib/ocaml/lwt/liblwt_unix_stubs.a(unix_lseek_job.o): In function `result_lseek':
    /home/buildozer/aports/testing/ocaml-lwt/src/lwt-3.2.1/_build/default/src/unix/unix_lseek_job.c:113:(.text+0xb8): call to `result_lseek.part.0' lacks nop, can't restore toc; (-mcmodel=small toc adjust stub)
    /usr/lib/gcc/powerpc64le-alpine-linux-musl/6.4.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: /usr/lib/ocaml/lwt/liblwt_unix_stubs.a(unix_lseek_job.o): In function `result_lseek_64':
    /home/buildozer/aports/testing/ocaml-lwt/src/lwt-3.2.1/_build/default/src/unix/unix_lseek_job.c:134:(.text+0x134): call to `result_lseek_64.part.1' lacks nop, can't restore toc; (-mcmodel=small toc adjust stub)
```

Note: reference commit https://github.com/alpinelinux/aports/commit/f420f9b85b5f5612f58a45ab49e8aba54f6f5527

To prevent this add the __attribute__((noinline)) to bignum_align() and rebuild the libtoa_stubs.a library. Once the testing/ocaml-dtoa libtoa_stubs.a library is rebuilt packages that link against in on ppc64 linke testing/flow will work.