### PR TITLE
testing/bfs: fix ppc64le failing test and reenable architecture for building

### DIFF
--- a/testing/bfs/APKBUILD
+++ b/testing/bfs/APKBUILD
@@ -2,16 +2,17 @@
 # Maintainer: dai9ah <dai9ah@protonmail.com>
 pkgname=bfs
 pkgver=1.2.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Breadth-first variant of the UNIX find command"
 url="https://github.com/tavianator/bfs"
-arch="all !ppc64le"
+arch="all"
 license="0BSD"
 makedepends="linux-headers"
 checkdepends="bash"
 subpackages="$pkgname-doc"
 options="!checkroot"
-source="$pkgname-$pkgver.tar.gz::https://github.com/tavianator/$pkgname/archive/$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/tavianator/$pkgname/archive/$pkgver.tar.gz
+	fix_headroom.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -29,4 +30,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="ec78687b1c3d62e1f625b18d2f668f91663425db634cbb540c0e06b279702d1b9ffb88eddb35db229839ba85eac788416f059a65887a313409d6c3be281bb331  bfs-1.2.2.tar.gz"
+sha512sums="ec78687b1c3d62e1f625b18d2f668f91663425db634cbb540c0e06b279702d1b9ffb88eddb35db229839ba85eac788416f059a65887a313409d6c3be281bb331  bfs-1.2.2.tar.gz
+dde2977ef90f4e53bbb2de41b93de4fc921d366eaedff0f1d6b3dc17ad3336b0c7957feccaa1a8c33545ac33208c4be32f0ad96f255e23a83396e2592b4f911f  fix_headroom.patch"

--- a/testing/bfs/fix_headroom.patch
+++ b/testing/bfs/fix_headroom.patch
@@ -1,0 +1,20 @@
+--- a/exec.c	2018-07-10 13:36:22.698784874 +0000
++++ b/exec.c	2018-07-10 13:37:32.296154568 +0000
+@@ -92,11 +92,16 @@
+ 	// Assume arguments are counted with the granularity of a single page,
+ 	// and allow two pages of headroom to account for rounding as well as
+ 	// any other data we may not be counting
++	// so allow a one page cushion to account for rounding up
+ 	long page_size = sysconf(_SC_PAGESIZE);
+ 	if (page_size < 4096) {
+ 		page_size = 4096;
+ 	}
+-	arg_max -= 2*page_size;
++	arg_max -= page_size;
++	bfs_exec_debug(execbuf, "ARG_MAX: %ld remaining after page cushion\n", arg_max);
++
++	// POSIX recommends an additional 2048 bytes of headroom
++	arg_max -= 2048;
+ 	bfs_exec_debug(execbuf, "ARG_MAX: %ld remaining after headroom\n", arg_max);
+ 
+ 	if (arg_max < 0) {


### PR DESCRIPTION
cherry picked fix from bfs project at https://github.com/tavianator/bfs/commit/30b48746565be758f7014dce9448d8e91febab60

For Linux-style accounting, we really only need to handle a single page
of wasted space due to rounding.  Subtracting two pages for extra
headroom was reasonable on systems with 4K pages, but overkill on
systems like ppc64le with 64K pages.  Worse yet was the fact that Alpine
Linux only gives us 128K for arguments.

Instead, only subtract a single page, plus the POSIX-recommended 2048
bytes.