### PR TITLE
testing/liquibase: upgrade to 3.6.2

### DIFF
--- a/testing/liquibase/APKBUILD
+++ b/testing/liquibase/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=liquibase
-pkgver=3.6.1
+pkgver=3.6.2
 pkgrel=0
 pkgdesc="Source Control for your Database"
 url="http://www.liquibase.org/"
@@ -41,5 +41,4 @@ doc() {
 		cp -r $file "$subpkgdir"/usr/share/doc/"$pkgname"
 	done
 }
-
-sha512sums="7a35b9c1d9d783266ff5c109a1f5c8aaeae4dfef74e8d8de2a636f992933791c33164f2507542b601acb23e311aad61ec77ed84351ce93f262519b0113ca6b94  liquibase-3.6.1-bin.tar.gz"
+sha512sums="66404f18a2790ff8341ad5ccc493b9ee49e4d382c4ec4b2ebc7b74db35a2c332b4b0e7f62fd848ad75b0bfff1f74a82a8143e723048cd4e26632af2f7f2e5eb0  liquibase-3.6.2-bin.tar.gz"


### PR DESCRIPTION
https://github.com/liquibase/liquibase/releases/tag/liquibase-parent-3.6.2