### PR TITLE
testing/fuse3: upgrade to 3.2.4

### DIFF
--- a/testing/fuse3/APKBUILD
+++ b/testing/fuse3/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=fuse3
 _pkgname=fuse
-pkgver=3.2.3
+pkgver=3.2.4
 pkgrel=0
 pkgdesc="The reference implementation of the Linux FUSE (Filesystem in Userspace) interface"
 url="https://github.com/libfuse/libfuse"
@@ -58,6 +58,6 @@ _EOF_
 
 }
 
-sha512sums="f91ee4b24df64e62d0c50db0bc3807229cfde06da118c87826bc3ee01b41689ec93a96b026226e948e6d7904bb506dc1d8ffa83d29aa12ea7f17009f6060263e  fuse-3.2.3.tar.xz
+sha512sums="ee0f86c7f5f87dea421f1ddfa7843a56c63a08f114c3f77606082764134faabdebd647fd7daaf9d335babf73fe0702f97feaa275dac3605d97a8937fd89ae253  fuse-3.2.4.tar.xz
 1a9e1d1e8a7b0778ffde328e4322c73b5d57ec98d52767c846d755cce861ab27989823a75b6c5f994432ddb77fa351dfa4a8f948c9467c5f7d5f471e4608358b  fix-realpath.patch
 7f6a503ef23cfa8b809c544375c2d83ad56525269b48ad1a7dff0ce36f4bf2f2a3fafed9dc70a71ff6281b261db5f01829e16c06f041921a5d8c8d715a04a8c1  fuse.initd"


### PR DESCRIPTION
[Release notes](https://github.com/libfuse/libfuse/releases/tag/fuse-3.2.4).