### PR TITLE
testing/sane and testing/hplip: Support all architectures, package python part

### DIFF
--- a/testing/hplip/APKBUILD
+++ b/testing/hplip/APKBUILD
@@ -4,13 +4,13 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 pkgname=hplip
 pkgver=3.18.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Drivers for HP printers and scanners"
-arch="x86 x86_64" # missing sane on several arches
+arch="all"
 url="http://hplipopensource.com"
 license="GPL"
 depends=""
-makedepends="libjpeg-turbo-dev net-snmp-dev cups-dev libusb-dev sane-dev"
+makedepends="libjpeg-turbo-dev net-snmp-dev cups-dev libusb-dev sane-dev python-dev"
 subpackages="$pkgname-doc $pkgname-libs sane-backend-hpaio:sane"
 source="http://downloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.gz
 	fix-includes.patch"
@@ -25,7 +25,6 @@ build() {
 	cd "$builddir"
 	./configure --prefix=/usr \
 		--with-docdir=/usr/share/doc/$pkgname \
-		--enable-lite-build \
 		--disable-doc-build \
 		--disable-gui-build \
 		--disable-fax-build \
@@ -49,7 +48,6 @@ package() {
 		"$pkgdir"/usr/share/hal \
 		"$pkgdir"/usr/lib/systemd \
 		"$pkgdir"/usr/lib/cups/filter/pstotiff
-	install -m755 -D prnt/filters/hpps "$pkgdir"/usr/lib/cups/filter/hpps
 }
 
 sane() {

--- a/testing/sane/APKBUILD
+++ b/testing/sane/APKBUILD
@@ -7,23 +7,26 @@ pkgver=1.0.27
 pkgrel=1
 pkgdesc="Scanner Access Now Easy - an universal scanner interface"
 url="http://www.sane-project.org/"
-arch="x86 x86_64"
+arch="all"
 license="GPL-2.0-or-later GPL-2.0-or-later-with-sane-exception Public-Domain"
 depends=""
 depends_dev=""
 makedepends="diffutils file libtool libusb-dev v4l-utils-dev net-snmp-dev avahi-dev libpng-dev
-	libjpeg-turbo-dev tiff-dev libgphoto2-dev libieee1284-dev linux-headers"
+	libjpeg-turbo-dev tiff-dev libgphoto2-dev linux-headers"
+case "$CARCH" in
+x86*) makedepends="$makedepends libieee1284-dev";;
+esac
 install="$pkgname-saned.pre-install $pkgname.pre-install"
 pkgusers="saned"
 pkggroups="scanner"
-_backends="abaton agfafocus apple artec artec_eplus48u as6e avision bh canon canon630u canon_dr canon_pp cardscan
+_backends="abaton agfafocus apple artec artec_eplus48u as6e avision bh canon canon630u canon_dr cardscan
 	coolscan coolscan2 coolscan3 dc25 dc210 dc240 dell1600n_net dmc epjitsu epson epson2 epsonds fujitsu genesys
-	gphoto2 gt68xx hp hp3500 hp3900 hp4200 hp5400 hp5590 hpsj5s hpljm1005 hs2p ibm kodak kodakaio kvs1025 kvs20xx
-	kvs40xx leo lexmark ma1509 magicolor matsushita microtek microtek2 mustek mustek_pp mustek_usb mustek_usb2
+	gphoto2 gt68xx hp hp3500 hp3900 hp4200 hp5400 hp5590 hpljm1005 hs2p ibm kodak kodakaio kvs1025 kvs20xx
+	kvs40xx leo lexmark ma1509 magicolor matsushita microtek microtek2 mustek mustek_usb mustek_usb2
 	nec net niash pie pieusb pixma plustek plustek_pp ricoh rts8891 s9036 sceptre sharp sm3600 sm3840 snapscan
 	sp15c st400 stv680 tamarack teco1 teco2 teco3 test u12 umax umax_pp umax1220u v4l xerox_mfp p5"
 case "$CARCH" in
-x86*) _backends="$_backends qcam";;
+x86*) _backends="$_backends canon_pp hpsj5s mustek_pp qcam";;
 esac
 
 _pkgdesc_dell1600n_net="SANE backend for Dell 1600n that supports colour and monochrome scans over ethernet, usb not supported"
@@ -32,7 +35,7 @@ for _backend in $_backends; do
 done
 subpackages="$pkgname-doc $pkgname-dev $subpackages $pkgname-utils $pkgname-saned
 	$pkgname-udev::noarch $_pkgname::noarch"
-source="https://alioth.debian.org/frs/download.php/file/4224/$_pkgname-$pkgver.tar.gz
+source="https://fossies.org/linux/misc/$_pkgname-$pkgver.tar.gz
 	$pkgname-saned.initd
 	include.patch
 	network.patch


### PR DESCRIPTION
This adds support for all architectures to sane by removing parallel port support for all non-x86 architectures. As the original source location has been shut down (but sane still links to it) I have changed the source url to point to fossies.org.

Further, these changes enable support for all architectures in hplip (my original motivation, thus both in one PR). This also removes the "lite" build option from hplip and adds `python-dev` as build dependency to build the python library that is required by the hpps filter. The hpps filter has already been packaged and installed before, however it was completely broken as it is basically only a wrapper around the Python library that was missing. Without the "lite" build option, it is installed automatically now. With these changes, I can print on my HP OfficeJet Pro 8210 (network) printer from an armhf tablet running Alpine Linux/postmarketOS. Note that curerently, python is not a dependency of hplip (as none of the libraries is linked against python), however, without python being installed, the hpps filter (and possibly also other parts of hplip) won't work. 

[Edit] In the meantime I've been able to test sane on my armhf tablet. After adding the necessary firmware, scanning works with an Epson Perfection 3490 Photo USB scanner using the already packaged simple-scan GUI and sane's snapscan backend.