### PR TITLE
main/curl: upgrade to 7.61.0, add secfixes comment

### DIFF
--- a/main/curl/APKBUILD
+++ b/main/curl/APKBUILD
@@ -3,8 +3,8 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=curl
-pkgver=7.60.0
-pkgrel=1
+pkgver=7.61.0
+pkgrel=0
 pkgdesc="URL retrival utility and library"
 url="https://curl.haxx.se"
 arch="all"
@@ -21,6 +21,8 @@ source="https://curl.haxx.se/download/$pkgname-$pkgver.tar.xz
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   7.61.0-r0:
+#     - CVE-2018-0500
 #   7.60.0-r0:
 #     - CVE-2018-1000300
 #     - CVE-2018-1000301
@@ -105,6 +107,6 @@ libcurl() {
 	mv "$pkgdir"/usr/lib "$subpkgdir"/usr
 }
 
-sha512sums="96a0c32ca846a76bba75e9e560ad4c15df79540992ed1a83713095be94ddba039f289bda9678762fd79fb9691fe810735178fb9dc970c37012dff96b8ce08abf  curl-7.60.0.tar.xz
+sha512sums="1b450bbd794460fea12374a49739a49a43c3651038dc092c277769bab09a62627f8eedfa94b5c1610503bf20eeaf60643a1e32fdcf1bcf8d4085090c4a598b13  curl-7.61.0.tar.xz
 16c9b54cfa996a61278c0a899840be9e42477661ff6d69d6a772671aeb50a597e9de9328ba3c0a5cb71fa073e4a58db5f3962aab7636a9f1327cad343ff05ae9  0001-openssl-fix-build-with-libressl-2.7.patch
 708527e73f9512c50e2250ca26786ba8994dc05fd2e362c1feb274e251219fb4bfc97e7e7722aa12424ccaf4c511d90d8820561c82a24f103b9ee2b743f4be28  use-OPENSSL_config.patch"


### PR DESCRIPTION
[Release notes](https://curl.haxx.se/changes.html).