### PR TITLE
main/curl: security fix for CVE-2018-0500

### DIFF
--- a/main/curl/APKBUILD
+++ b/main/curl/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=curl
 pkgver=7.60.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An URL retrival utility and library"
 url="http://curl.haxx.se"
 arch="all"
@@ -15,10 +15,13 @@ source="http://curl.haxx.se/download/$pkgname-$pkgver.tar.xz"
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev libcurl"
 source="https://curl.haxx.se/download/$pkgname-$pkgver.tar.xz
 	use-OPENSSL_config.patch
+	CVE-2018-0500.patch
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   7.60.0-r2:
+#     - CVE-2018-0500
 #   7.60.0-r0:
 #     - CVE-2018-1000300
 #     - CVE-2018-1000301
@@ -106,4 +109,5 @@ libcurl() {
 }
 
 sha512sums="96a0c32ca846a76bba75e9e560ad4c15df79540992ed1a83713095be94ddba039f289bda9678762fd79fb9691fe810735178fb9dc970c37012dff96b8ce08abf  curl-7.60.0.tar.xz
-708527e73f9512c50e2250ca26786ba8994dc05fd2e362c1feb274e251219fb4bfc97e7e7722aa12424ccaf4c511d90d8820561c82a24f103b9ee2b743f4be28  use-OPENSSL_config.patch"
+708527e73f9512c50e2250ca26786ba8994dc05fd2e362c1feb274e251219fb4bfc97e7e7722aa12424ccaf4c511d90d8820561c82a24f103b9ee2b743f4be28  use-OPENSSL_config.patch
+a8cb646f5c19626843f0b44a4f65b4ed301817f9fff755a4056f873649d49a76677583cd44de6a99b32a639291a06947d7d594e38f85553d475f5e787bc3134c  CVE-2018-0500.patch"

--- a/main/curl/CVE-2018-0500.patch
+++ b/main/curl/CVE-2018-0500.patch
@@ -1,0 +1,34 @@
+From ba1dbd78e5f1ed67c1b8d37ac89d90e5e330b628 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Wed, 13 Jun 2018 12:24:40 +0200
+Subject: [PATCH] smtp: use the upload buffer size for scratch buffer malloc
+
+... not the read buffer size, as that can be set smaller and thus cause
+a buffer overflow! CVE-2018-0500
+
+Reported-by: Peter Wu
+Bug: https://curl.haxx.se/docs/adv_2018-70a2.html
+---
+ lib/smtp.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/lib/smtp.c b/lib/smtp.c
+index e6872badb8..ecf10a41ac 100644
+--- a/lib/smtp.c
++++ b/lib/smtp.c
+@@ -1563,13 +1563,14 @@ CURLcode Curl_smtp_escape_eob(struct connectdata *conn, const ssize_t nread)
+   if(!scratch || data->set.crlf) {
+     oldscratch = scratch;
+ 
+-    scratch = newscratch = malloc(2 * data->set.buffer_size);
++    scratch = newscratch = malloc(2 * UPLOAD_BUFSIZE);
+     if(!newscratch) {
+       failf(data, "Failed to alloc scratch buffer!");
+ 
+       return CURLE_OUT_OF_MEMORY;
+     }
+   }
++  DEBUGASSERT(UPLOAD_BUFSIZE >= nread);
+ 
+   /* Have we already sent part of the EOB? */
+   eob_sent = smtp->eob;


### PR DESCRIPTION
Backport CVE-2018-0500 [patch](https://github.com/curl/curl/commit/ba1dbd78e5f1ed67c1b8d37ac89d90e5e330b628) to 3.5-stable