### PR TITLE
testing/php7-timezonedb: upgrade to 2018.5 and use https

### DIFF
--- a/testing/php7-timezonedb/APKBUILD
+++ b/testing/php7-timezonedb/APKBUILD
@@ -2,15 +2,15 @@
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
 pkgname=php7-timezonedb
 _pkgreal=timezonedb
-pkgver=2018.3
-pkgrel=2
+pkgver=2018.5
+pkgrel=0
 pkgdesc="Timezone Database to be used with PHP's date and time functions."
-url="http://pecl.php.net/package/$_pkgreal"
+url="https://pecl.php.net/package/timezonedb"
 arch="all"
 license="PHP"
 depends=""
 makedepends="php7-dev autoconf"
-source="http://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
+source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
 options="!check"  # upstream does not provide tests yet
 
@@ -28,4 +28,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/40_$_pkgreal.ini
 }
 
-sha512sums="0dc2d7e64e3f66248ba11098bdc2e4ace75f596a9271e075f65b39a507c681b66a3d49d9e31ba116c47808e29b289cc01e5d671d6bc676b9783c3532db817f96  timezonedb-2018.3.tgz"
+sha512sums="6e06c1735e7cd0bddf360ed270ca05ab49c2115569d24a9ef235c25496726ab90c3df0320bd329237867336164f35a949fa048cd404077420bc83c2d8d36b899  timezonedb-2018.5.tgz"


### PR DESCRIPTION
https://pecl.php.net/package-changelog.php?package=timezonedb&release=2018.5