### PR TITLE
main/libgit2: upgrade to 0.27.3

### DIFF
--- a/main/libgit2/APKBUILD
+++ b/main/libgit2/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Pierre-Gilas MILLON <pgmillon@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libgit2
-pkgver=0.27.2
+pkgver=0.27.3
 pkgrel=0
 pkgdesc="A linkable library for Git"
 url="https://libgit2.github.com/"
@@ -21,6 +21,9 @@ options="!check" # FIXME some tests fails
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   0.27.3-r0:
+#   - CVE-2018-10887
+#   - CVE-2018-10888
 #   0.25.1-r0:
 #   - CVE-2016-10128
 #   - CVE-2016-10129
@@ -57,5 +60,5 @@ tests() {
 	cp -a "$builddir"/tests "$subpkgdir"/usr/src/$pkgname/
 }
 
-sha512sums="4fa2b6c1bb340d5dbc3106ababb630a4634cee2415d478be986d315ef9c659d772574a56f0b8fa77d26bd793aea92893fddf64b5f21d7c965069f928b9ce5cff  libgit2-0.27.2.tar.gz
+sha512sums="e470050b89289908ec64dafaa954ad9bfc8f557ba7dafcab440d9efde474f736c025d8202bfd81a508070d9cf678f3fb1f3687d72a849ce86edd1ee90ad13c3b  libgit2-0.27.3.tar.gz
 268e24554282666900a2179a368dc2569cb3bce60ffea187fd53de1bc119a85abc02cddd8be2ab607d44db793c4807acdbb49fc5d1badfc08bf382fa511d7b3e  build-both-static-dynamic.patch"


### PR DESCRIPTION
[Release notes](https://github.com/libgit2/libgit2/releases/tag/v0.27.3).