### PR TITLE
community/sox: enable spectrograms

### DIFF
--- a/community/sox/APKBUILD
+++ b/community/sox/APKBUILD
@@ -10,7 +10,7 @@ options="!check"  # No test suite.
 license="GPL LGPL"
 makedepends="ffmpeg-dev libao-dev libvorbis-dev libogg-dev lame-dev
 	libmad-dev bash alsa-lib-dev libsndfile-dev libsamplerate-dev
-	libtool file-dev libid3tag-dev flac-dev gsm-dev opusfile-dev
+	file-dev libid3tag-dev flac-dev gsm-dev opusfile-dev libpng-dev
 	autoconf automake libtool
 	"
 depends=

--- a/community/sox/APKBUILD
+++ b/community/sox/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=sox
 pkgver=14.4.2
-pkgrel=1
+pkgrel=2
 pkgdesc="The Swiss Army knife of sound processing tools"
 url="http://sox.sourceforge.net/"
 arch="all"


### PR DESCRIPTION
adding libpng as dependency to enable spectrogram creation