### PR TITLE
non-free/b43-firmware: update to new and more complete version

### DIFF
--- a/non-free/b43-firmware/APKBUILD
+++ b/non-free/b43-firmware/APKBUILD
@@ -1,9 +1,8 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
-pkgname=b43-firmware-classic
+pkgname=b43-firmware
 pkgver=6.30.163.46
 pkgrel=0
-provides='b43-firmware'
 pkgdesc='Firmware for b43 driver'
 url='https://linuxwireless.org/en/users/Drivers/b43#firmware_installation'
 license='propietary'

--- a/non-free/b43-firmware/APKBUILD
+++ b/non-free/b43-firmware/APKBUILD
@@ -1,22 +1,23 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
-pkgname=b43-firmware
-pkgver=4.150.10.5
+pkgname=b43-firmware-classic
+pkgver=6.30.163.46
 pkgrel=0
-pkgdesc="Firmware for b43 driver"
-url="http://linuxwireless.org/en/users/Drivers/b43#firmware_installation"
-license="propietary"
-depends=""
-makedepends="b43-fwcutter"
+provides='b43-firmware'
+pkgdesc='Firmware for b43 driver'
+url='https://linuxwireless.org/en/users/Drivers/b43#firmware_installation'
+license='propietary'
+depends=''
+makedepends='b43-fwcutter'
 install=
 subpackages=
-arch="noarch"
-source="http://mirror2.openwrt.org/sources/broadcom-wl-$pkgver.tar.bz2"
+arch='noarch'
+source="http://lwfinger.com/b43-firmware/broadcom-wl-$pkgver.tar.bz2"
 
 build() {
 	install -d "$pkgdir"/lib/firmware
 	b43-fwcutter -w "$pkgdir"/lib/firmware \
-		"$srcdir"/broadcom-wl-$pkgver/driver/wl_apsta_mimo.o
+		"$srcdir"/broadcom-wl-"$pkgver"/linux/wl_apsta.o
 }
 
-md5sums="0c6ba9687114c6b598e8019e262d9a60  broadcom-wl-4.150.10.5.tar.bz2"
+sha512sums="0144894fbbb5e8ebab6c423d9bd0f3249be94f2f468a50b8bf721a3b17f1f6e57467c79e87abc8d136bfc92e701ed046885fead892e9a73efa5217d710311ae9  broadcom-wl-6.30.163.46.tar.bz2"

--- a/non-free/b43-firmware/APKBUILD
+++ b/non-free/b43-firmware/APKBUILD
@@ -16,7 +16,7 @@ source="http://lwfinger.com/b43-firmware/broadcom-wl-$pkgver.tar.bz2"
 build() {
 	install -d "$pkgdir"/lib/firmware
 	b43-fwcutter -w "$pkgdir"/lib/firmware \
-		"$srcdir"/broadcom-wl-"$pkgver"/linux/wl_apsta.o
+		"$srcdir"/broadcom-wl-"$pkgver".wl_apsta.o
 }
 
 sha512sums="0144894fbbb5e8ebab6c423d9bd0f3249be94f2f468a50b8bf721a3b17f1f6e57467c79e87abc8d136bfc92e701ed046885fead892e9a73efa5217d710311ae9  broadcom-wl-6.30.163.46.tar.bz2"


### PR DESCRIPTION
I have not touched the "Maintainer" field, as I have no interest in maintaining this – I merely wanted to share the maintenance I happened to have done.

I have copied the version and the download-url from Arch Linux. HTTPS unfortunately does not seem to work for the download, but I have verified the checksum against the one from the Arch Linux package. Of course, please double check before merging.