### PR TITLE
add non-free/b43-firmware-classic

### DIFF
--- a/non-free/b43-firmware-classic/APKBUILD
+++ b/non-free/b43-firmware-classic/APKBUILD
@@ -1,0 +1,23 @@
+# Contributor: Natanael Copa <ncopa@alpinelinux.org>
+# Maintainer: Natanael Copa <ncopa@alpinelinux.org>
+pkgname=b43-firmware-classic
+pkgver=5.100.138
+pkgrel=0
+provides='b43-firmware'
+pkgdesc='Firmware for b43 driver; trusted release'
+url='https://linuxwireless.org/en/users/Drivers/b43#firmware_installation'
+license='propietary'
+depends=''
+makedepends='b43-fwcutter'
+install=
+subpackages=
+arch='noarch'
+source="http://lwfinger.com/b43-firmware/broadcom-wl-$pkgver.tar.bz2"
+
+build() {
+	install -d "$pkgdir"/lib/firmware
+	b43-fwcutter -w "$pkgdir"/lib/firmware \
+		"$srcdir"/broadcom-wl-"$pkgver"/linux/wl_apsta.o
+}
+
+sha512sums="02487e76e3eca7fe97ce2ad7dc9c5d39fac82b8d5f7786cce047f9c85e2426f5b7ea085d84c7d4aae43e0fe348d603e3229211bab601726794ef633441d37a8b  broadcom-wl-5.100.138.tar.bz2"


### PR DESCRIPTION
I am not sure if this is actually helpful – neither this nor the regular b43-firmware (in the updated form that I also submitted) ultimately worked for me.  I also have left the "Maintainer" field blank.

As for b43-firmware I have copied the version and the download-url from Arch Linux. HTTPS unfortunately does not seem to work for the download, but I have verified the checksum against the one from the Arch Linux package. Of course, please double check before merging.