### PR TITLE
testing/wireguard: upgrade to 0.0.20180718

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180708
+pkgver=0.0.20180718
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="91e4eb5c863f7070dc139739bbb5f6ce5b7ff9e8bd293a6217e6b9ac8dcacc710c01bac9386df50bd1226f0534c5332f8e1e2c50e9483e167eac6345a616f6f6  WireGuard-0.0.20180708.tar.xz"
+sha512sums="38d7fa90ab7528c0f29e93c4b37c357e51f33061353c180044c50fe05a37874652b3cb179c80f17b8fe9dddbcb224253723ad730e2ad5649cb17ec9d32e8f9ca  WireGuard-0.0.20180718.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180708
-_rel=2
+_ver=0.0.20180718
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="91e4eb5c863f7070dc139739bbb5f6ce5b7ff9e8bd293a6217e6b9ac8dcacc710c01bac9386df50bd1226f0534c5332f8e1e2c50e9483e167eac6345a616f6f6  WireGuard-0.0.20180708.tar.xz"
+sha512sums="38d7fa90ab7528c0f29e93c4b37c357e51f33061353c180044c50fe05a37874652b3cb179c80f17b8fe9dddbcb224253723ad730e2ad5649cb17ec9d32e8f9ca  WireGuard-0.0.20180718.tar.xz"


### PR DESCRIPTION
```
  * tools: only error on wg show if all interfaces fail
  
  wg(8) now has a more reasonable error code semantic.
  
  * receive: account for zero or negative budget
  
  A correctness fix that no other drivers implement but that we really should
  be doing anyway.
  
  * recieve: disable NAPI busy polling
  
  This avoids adding one reference per peer to the napi_hash hashtable, as
  normally done by netif_napi_add(). Since we potentially could have up to
  2^20 peers this would make busy polling very slow globally. This approach is
  preferable to having only a single napi struct because we get one gro_list
  per peer, which means packets can be combined nicely even if we have a large
  number of peers. This is also done by gro_cells_init() in net/core/gro_cells.c.
  
  * receive: use gro call instead of plain call
  
  This enables incredible performance improvements in some cases. Benchmark and
  see for yourself. It should affect large TCP flows.
  
  * wg-quick: allow link local default gateway
  
  IPv6 endpoints will now work better on BSD and Darwin.
  
  * device: destroy workqueue before freeing queue
  
  Another small correctness fix.
```