### PR TITLE
testing/log4cpp: new aport

### DIFF
--- a/testing/log4cpp/APKBUILD
+++ b/testing/log4cpp/APKBUILD
@@ -1,0 +1,41 @@
+# Contributor: Hidde van der Heide <hvanderheide@nexuz.net>
+# Maintainer:
+pkgname=log4cpp
+pkgver=1.1.3
+pkgrel=0
+pkgdesc="Log for C++, modeled after Log4j."
+url="http://log4cpp.sourceforge.net/"
+arch="all"
+license="LGPL-2.1-or-later"
+depends=""
+makedepends=""
+install=""
+subpackages="$pkgname-dev"
+source="http://downloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/"
+
+build() {
+	cd "$builddir/$pkgname"
+	./configure \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var \
+		--disable-dot \
+		--disable-static \
+		--disable-doxygen \
+		--without-idsa
+	make
+}
+
+check() {
+	cd "$builddir/$pkgname"
+	make check
+}
+
+package() {
+	cd "$builddir/$pkgname"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="88e5e10bce8d7d6421c3dcf14aa25385159c4ae52becdc1f3666ab86e1ad3f633786d82afe398c517d4faaa57b3e7b7c0b524361d81c6b9040dbded5cecc19de  log4cpp-1.1.3.tar.gz"


### PR DESCRIPTION
http://log4cpp.sourceforge.net
Log for C++ is a library of C++ classes for flexible logging to files, syslog and other destinations. It is modeled after the Log for Java library (http://jakarta.apache.org/log4j/), staying as close to their API as is reasonable.

I have no affiliation with this project, nor am I a C++ developer, just need it as a dependency for another package I am preparing. I am happy to maintain it but might not be the best fit.