### PR TITLE
main/apache2: security upgrade to 2.4.34

### DIFF
--- a/main/apache2/APKBUILD
+++ b/main/apache2/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 pkgname=apache2
 _pkgreal=httpd
-pkgver=2.4.33
-pkgrel=1
+pkgver=2.4.34
+pkgrel=0
 pkgdesc="A high performance Unix-based HTTP server"
 url="http://httpd.apache.org/"
 arch="all"
@@ -32,7 +32,7 @@ source="http://archive.apache.org/dist/$_pkgreal/$_pkgreal-$pkgver.tar.bz2
 	apache2.logrotate
 	apache2.initd
 	alpine.layout
-	libressl-2.7.patch
+	apache-2.4.34-libressl-compatibility.patch
 	conf/0001-httpd.conf-ServerRoot.patch
 	conf/0002-httpd.conf-ServerTokens.patch
 	conf/0003-httpd.conf-ServerSignature.patch
@@ -52,6 +52,9 @@ options="suid"
 builddir="$srcdir"/$_pkgreal-$pkgver
 
 # secfixes:
+#   2.4.34-r0:
+#     - CVE-2018-1333
+#     - CVE-2018-8011
 #   2.4.33-r0:
 #     - CVE-2017-15710
 #     - CVE-2017-15715
@@ -320,12 +323,12 @@ _lua() {
 		"$subpkgdir"/usr/lib/apache2/ || return 1
 	_load_mods
 }
-sha512sums="e74b2b3346d67be45a8bc8a7cbb8eabf5c403a5cfe5797a976f94a539529843fbcdf03b9ca0548816b2cf37f4ce0eb301f8d5af25b1270fdf8dd9f5bf0585269  httpd-2.4.33.tar.bz2
+sha512sums="2bc09213f08a4722e305929fbac5f5060c7a8444704494894bb9b61f17e4d20bb6e3d663bb93fc5b2030b04a43fb12373d260cc291422b210b299725aaf3b5c8  httpd-2.4.34.tar.bz2
 8e62b101f90c67babe864bcb74f711656180b011df3fd4b541dc766b980b72aa409e86debf3559a55be359471c1cad81b8779ef3a55add8d368229fc7e9544fc  apache2.confd
 18e8859c7d99c4483792a5fd20127873aad8fa396cafbdb6f2c4253451ffe7a1093a3859ce719375e0769739c93704c88897bd087c63e1ef585e26dcc1f5dd9b  apache2.logrotate
 81a2d2a297d8049ba1b021b879ec863767149e056d9bdb2ac8acf63572b254935ec96c2e1580eba86639ea56433eec5c41341e4f1501f9072745dccdb3602701  apache2.initd
 177c58d049fc4476fd9b9b36b67725145777c84cf81948105c9314cb09312dff6c1931fe21aaa243597abaefded6c6dfd80d83839e45a23950b50de615d73b06  alpine.layout
-166e123e149162b3140b96435927a985697b2507646f3d696578eae726e8c9d259469889527d7d4259791b130fe4b1b87f8be56574f3ea1272c27516beb06ae9  libressl-2.7.patch
+fb0e896666126fd2c79cf12533a09f19ff991a44ede33ab7933381fbe5ebf94008ffb4c824a9958e47d2277fd4b985f14597fa533b2964666e3d4684e8ede9d9  apache-2.4.34-libressl-compatibility.patch
 361e0a74f6f8f5734f074dc2f2001ff64896ecc81f88ea384b6db7db33b7738eb92b4e16163b356259581a8e7dd86adeac971d36d2584abb781e8f9b8fae6356  0001-httpd.conf-ServerRoot.patch
 40f3b7579c403952ba1efcb8dfd6ffd91c2695a06a2e5530ab5a583946558790fbfa16cad259d273ac1aa7a6335dd79636aa82fd844dc3a60a34c34d90db5e17  0002-httpd.conf-ServerTokens.patch
 ad0c1711bc240f99cd0256d0984ad0142e03c384d30378ccca3e47cdd2596307e64bb19fbd810a56c0e4c0716577d3160bad2ae39783b1358412588bc729c113  0003-httpd.conf-ServerSignature.patch

--- a/main/apache2/apache-2.4.34-libressl-compatibility.patch
+++ b/main/apache2/apache-2.4.34-libressl-compatibility.patch
@@ -1,18 +1,9 @@
-diff --git a/modules/md/md_crypt.c b/modules/md/md_crypt.c
-index 66682ea..9cc7862 100644
---- a/modules/md/md_crypt.c
-+++ b/modules/md/md_crypt.c
-@@ -471,7 +471,7 @@ apr_status_t md_pkey_gen(md_pkey_t **ppkey, apr_pool_t *p, md_pkey_spec_t *spec)
-     }
- }
- 
--#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000f)
- 
- #ifndef NID_tlsfeature
- #define NID_tlsfeature          1020
+# based on upstream commit from:
+# https://github.com/apache/httpd/commit/8134addfabf2685e08da6d51167775b628fda0dc
+# this should be included in the next release (2.4.34?)
+
 diff --git a/modules/ssl/mod_ssl.c b/modules/ssl/mod_ssl.c
-index 48d64cb..2392019 100644
+index 48d64cb624..2392019aed 100644
 --- a/modules/ssl/mod_ssl.c
 +++ b/modules/ssl/mod_ssl.c
 @@ -398,7 +398,7 @@ static int ssl_hook_pre_config(apr_pool_t *pconf,
@@ -25,21 +16,31 @@ index 48d64cb..2392019 100644
  #else
      OPENSSL_malloc_init();
 diff --git a/modules/ssl/ssl_engine_init.c b/modules/ssl/ssl_engine_init.c
-index a3a74f4..33ea494 100644
+index a3a74f474c..88c0939cab 100644
 --- a/modules/ssl/ssl_engine_init.c
 +++ b/modules/ssl/ssl_engine_init.c
-@@ -616,7 +616,8 @@ static apr_status_t ssl_init_ctx_protocol(server_rec *s,
+@@ -546,7 +546,8 @@ static apr_status_t ssl_init_ctx_protocol(server_rec *s,
+     char *cp;
+     int protocol = mctx->protocol;
+     SSLSrvConfigRec *sc = mySrvConfig(s);
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L || \
++	(defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20800000L)
+     int prot;
+ #endif
+ 
+@@ -616,7 +617,8 @@ static apr_status_t ssl_init_ctx_protocol(server_rec *s,
  
      SSL_CTX_set_options(ctx, SSL_OP_ALL);
  
 -#if OPENSSL_VERSION_NUMBER < 0x10100000L
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L  || \
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
 +	(defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20800000L)
      /* always disable SSLv2, as per RFC 6176 */
      SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2);
  
 diff --git a/modules/ssl/ssl_private.h b/modules/ssl/ssl_private.h
-index a39569c..e0e1b37 100644
+index a39569cbf7..e0e1b37087 100644
 --- a/modules/ssl/ssl_private.h
 +++ b/modules/ssl/ssl_private.h
 @@ -132,13 +132,14 @@


### PR DESCRIPTION
http://www.apache.org/dist/httpd/CHANGES_2.4.34

Needs backport security
- CVE-2018-1333 https://www.mail-archive.com/announce@httpd.apache.org/msg00129.html
- CVE-2018-8011 https://www.mail-archive.com/announce@httpd.apache.org/msg00130.html