### PR TITLE
testing/libpki: new aport

### DIFF
--- a/testing/libpki/APKBUILD
+++ b/testing/libpki/APKBUILD
@@ -1,0 +1,40 @@
+# Contributor: ena r&d <r&d@ena.com>
+# Maintainer: ena r&d <r&d@ena.com>
+pkgname=libpki
+pkgver=0.8.9
+pkgrel=0
+pkgdesc="Easy-to-use high-level library for PKI-enabled applications"
+url="https://www.openca.org/projects/libpki/"
+arch="all"
+license="OpenCA License (Apache-like)"
+depends=""
+makedepends="openldap-dev libxml2-dev"
+install=""
+subpackages="$pkgname-dev $pkgname-doc"
+source="
+	libpki-${pkgver}.tar.gz::https://github.com/openca/libpki/archive/v${pkgver}.tar.gz
+	fix_fcntl_include.patch
+	fix_sysconfdir.patch
+"
+builddir="$srcdir/${pkgname}-${pkgver}"
+
+build() {
+	cd "$builddir"
+	./configure --prefix=/usr --sysconfdir=/etc --with-libdir=/usr/lib
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+	install -d ${pkgdir}/usr/share/licenses/${pkgname}
+	install -p -m644 -D "$builddir"/COPYING ${pkgdir}/usr/share/licenses/${pkgname}/
+	install -d ${pkgdir}/usr/share/doc/${pkgname}
+	for f in README INSTALL NEWS AUTHORS ChangeLog COPYING; do
+		install -p -m644 -D "$builddir"/${f} ${pkgdir}/usr/share/doc/${pkgname}/${f}
+	done
+}
+
+sha512sums="26777dfbfb7c6fd66885ec74df56d2d74943a235abf97526980ee5e9f1d00ddc99ef68564320f0868789223513b6d3b8e9a605e578c2ffaae4cf3fe1772159f0  libpki-0.8.9.tar.gz
+4dec353f5b528cb6440e2f96149c54e17b0e60e17096276ad11927f6dbf6b761fb5d2f7d0e865e89dcc55fe1edd6b3fc5bc5b3875b3b3b2fdbaef7996669583f  fix_fcntl_include.patch
+da924185ea7b201c2c05d9b691f482133df55166830bfb3b4b28761c50715da478cc8b77592e1796af427ec7a225ac8919dfb6f3810a55f763955610402b0a7c  fix_sysconfdir.patch"

--- a/testing/libpki/fix_fcntl_include.patch
+++ b/testing/libpki/fix_fcntl_include.patch
@@ -1,0 +1,12 @@
+--- a/src/libpki/pki.h
++++ b/src/libpki/pki.h
+@@ -66,9 +66,7 @@
+ #include <sys/sem.h>
+ #include <sys/ipc.h>
+ 
+-#ifdef LIBPKI_TARGET_SOLARIS
+ #include <fcntl.h>
+-#endif
+ 
+ #if defined (__GNU_LIBRARY__) && !defined(_SEM_SEMUN_UNDEFINED)
+ 	/* Ok, Semafores are correctly supported */

--- a/testing/libpki/fix_sysconfdir.patch
+++ b/testing/libpki/fix_sysconfdir.patch
@@ -1,0 +1,62 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -579,7 +579,7 @@
+ docdir = @docdir@
+ dvidir = @dvidir@
+ etc_dir = @etc_dir@
+-exec_prefix = @exec_prefix@
++exec_prefix = @sysconfdir@
+ extra_checks = @extra_checks@
+ host = @host@
+ host_alias = @host_alias@
+--- a/etc/Makefile.in
++++ b/etc/Makefile.in
+@@ -548,37 +548,37 @@
+ 
+ install-data-local:
+ 	@$(NORMAL_INSTALL) ; \
+-        $(mkinstalldirs) $(DESTDIR)$(exec_prefix)/etc/libpki; \
+-        $(mkinstalldirs) $(DESTDIR)$(exec_prefix)/etc/libpki/hsm.d; \
+-        $(mkinstalldirs) $(DESTDIR)$(exec_prefix)/etc/libpki/token.d; \
+-        $(mkinstalldirs) $(DESTDIR)$(exec_prefix)/etc/libpki/store.d; \
+-        $(mkinstalldirs) $(DESTDIR)$(exec_prefix)/etc/libpki/profile.d; \
++        $(mkinstalldirs) $(DESTDIR)$(sysconfdir)/libpki; \
++        $(mkinstalldirs) $(DESTDIR)$(sysconfdir)/libpki/hsm.d; \
++        $(mkinstalldirs) $(DESTDIR)$(sysconfdir)/libpki/token.d; \
++        $(mkinstalldirs) $(DESTDIR)$(sysconfdir)/libpki/store.d; \
++        $(mkinstalldirs) $(DESTDIR)$(sysconfdir)/libpki/profile.d; \
+         for file in $(PROFILES) ; do \
+             if test -f $$file; then \
+-              $(INSTALL_DATA) $$file $(DESTDIR)$(exec_prefix)/etc/libpki/profile.d; \
++              $(INSTALL_DATA) $$file $(DESTDIR)$(sysconfdir)/libpki/profile.d; \
+             fi \
+           done
+ 	@for file in $(TOKENS) ; do \
+             if test -f $$file; then \
+-              $(INSTALL_DATA) $$file $(DESTDIR)$(exec_prefix)/etc/libpki/token.d; \
++              $(INSTALL_DATA) $$file $(DESTDIR)$(sysconfdir)/libpki/token.d; \
+             fi \
+           done
+ 	@for file in $(HSMS) ; do \
+             if test -f $$file; then \
+-              $(INSTALL_DATA) $$file $(DESTDIR)$(exec_prefix)/etc/libpki/hsm.d; \
++              $(INSTALL_DATA) $$file $(DESTDIR)$(sysconfdir)/libpki/hsm.d; \
+             fi \
+           done
+ 	@for file in $(STORES) ; do \
+             if test -f $$file; then \
+-              $(INSTALL_DATA) $$file $(DESTDIR)$(exec_prefix)/etc/libpki/store.d; \
++              $(INSTALL_DATA) $$file $(DESTDIR)$(sysconfdir)/libpki/store.d; \
+             fi \
+           done
+ 	@for file in $(CONFIGS) ; do \
+             if test -f $$file; then \
+-              $(INSTALL_DATA) $$file $(DESTDIR)$(exec_prefix)/etc/libpki; \
++              $(INSTALL_DATA) $$file $(DESTDIR)$(sysconfdir)/libpki; \
+             fi \
+           done
+-	@$(INSTALL_DATA) $(PKI_CONFIG) $(DESTDIR)$(exec_prefix)/etc
++	@$(INSTALL_DATA) $(PKI_CONFIG) $(DESTDIR)$(sysconfdir)
+ 
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.


### PR DESCRIPTION
https://www.openca.org/projects/libpki/
Easy-to-use high-level library for PKI-enabled applications

This is a dependency of another aport I'd like to add, namely openca-ocspd.