### PR TITLE
testing/openmpi: fix build hang by disabling ppc64le

### DIFF
--- a/testing/openmpi/APKBUILD
+++ b/testing/openmpi/APKBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Daniel Sabogal <dsabogalcc@gmail.com>
 pkgname=openmpi
 pkgver=3.1.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Message passing library for high-performance computing"
 url="https://www.open-mpi.org/"
-arch="all"
+# disable ppc64le until opal_fifo test can be fixed
+arch="all !ppc64le"
 license="BSD"
 makedepends="perl gfortran hwloc-dev libevent-dev libgomp"
 subpackages="$pkgname-dev:_dev $pkgname-doc"


### PR DESCRIPTION
On ppc64le during make check the opal_fifo test is hanging. This effectively blocks the ppc64le build server. This PR disables ppc64le until I can debug and fix the test