### PR TITLE
main/xorg-server: upgrade to 1.20.0

### DIFF
--- a/main/consolekit2/APKBUILD
+++ b/main/consolekit2/APKBUILD
@@ -3,7 +3,7 @@
 pkgbase=ConsoleKit2
 pkgname=consolekit2
 pkgver=1.2.1
-pkgrel=0
+pkgrel=1
 pkgdesc="A framework for defining and tracking users, login sessions, and seats"
 provides="consolekit=$pkgver"
 replaces=consolekit
@@ -12,8 +12,7 @@ url="https://consolekit2.github.io/ConsoleKit2"
 license=GPL2
 depends="polkit eudev"
 makedepends="git automake autoconf gettext-dev glib-dev zlib-dev libxslt-dev
-			 polkit-dev eudev-dev libdrm-dev libnih-dev libtool
-			 xorg-server-dev"
+	polkit-dev eudev-dev libdrm-dev libnih-dev libtool xorg-server-dev"
 source="$pkgname-$pkgver.tar.gz::https://github.com/${pkgname}/${pkgname}/archive/${pkgver}.tar.gz
 		0001-busybox-reboot-and-poweroff-support.patch
 		pam-foreground-compat.ck"

--- a/main/glamor-egl/APKBUILD
+++ b/main/glamor-egl/APKBUILD
@@ -2,9 +2,9 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=glamor-egl
 pkgver=0.6.0
-pkgrel=3
+pkgrel=4
 pkgdesc="X.org glamor library"
-url="http://www.freedesktop.org/wiki/Software/Glamor"
+url="https://www.freedesktop.org/wiki/Software/Glamor"
 arch="all"
 license="MIT"
 depends=""
@@ -12,7 +12,7 @@ depends_dev="mesa-dev"
 makedepends="$depends_dev xorg-server-dev"
 install=""
 subpackages="$pkgname-dev"
-source="http://www.x.org/releases/individual/driver/glamor-egl-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/glamor-egl-$pkgver.tar.bz2"
 
 _builddir="$srcdir"/glamor-egl-$pkgver
 prepare() {

--- a/main/xautolock/APKBUILD
+++ b/main/xautolock/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Johannes Matheis <jomat+alpinebuild@jmt.gr>
 pkgname=xautolock
 pkgver=2.2
-pkgrel=3
+pkgrel=4
 pkgdesc="An automatic X screen-locker/screen-saver"
 url="ftp://ibiblio.org/pub/Linux/X11/screensavers/"
 arch="all !aarch64"
@@ -12,7 +12,7 @@ depends_dev="imake xorg-server-dev libxscrnsaver-dev xorg-cf-files"
 makedepends="$depends_dev"
 install=""
 subpackages="$pkgname-doc"
-source="http://www.ibiblio.org/pub/linux/X11/screensavers/xautolock-$pkgver.tgz
+source="https://www.ibiblio.org/pub/linux/X11/screensavers/xautolock-$pkgver.tgz
 	processwait.patch"
 
 _builddir="$srcdir/$pkgname-$pkgver"

--- a/main/xf86-input-evdev/APKBUILD
+++ b/main/xf86-input-evdev/APKBUILD
@@ -1,16 +1,16 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-input-evdev
-pkgver=2.10.5
+pkgver=2.10.6
 pkgrel=0
 pkgdesc="X.org evdev input driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc $pkgname-dev"
 depends=""
 makedepends="libxkbfile-dev xorg-server-dev libxi-dev libxrandr-dev
 	eudev-dev mtdev-dev libevdev-dev"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir"/$pkgname-$pkgver
 build() {
@@ -33,4 +33,4 @@ package() {
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 
-sha512sums="4362c1d12e91f25789722b1cc1b624530fd67f0d061d4c4e204af9f5024df0c9e20b73c87be15051f581a2a178f07f380215b172aba4c67db8805b4eeb82819a  xf86-input-evdev-2.10.5.tar.bz2"
+sha512sums="560b0a6491d50a46913a5890a35c0367e59f550670993493bd9712d712a9747ddaa6fe5086daabf2fcafa24b0159383787eb273da4a2a60c089bfc0a77ad2ad1  xf86-input-evdev-2.10.6.tar.bz2"

--- a/main/xf86-input-keyboard/APKBUILD
+++ b/main/xf86-input-keyboard/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-input-keyboard
 pkgver=1.9.0
-pkgrel=0
+pkgrel=1
 pkgdesc="X.org keyboard input driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="libxkbfile-dev xorg-server-dev libxi-dev libxrandr-dev"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -19,14 +19,14 @@ build() {
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
+
 sha512sums="d1a52d10039096d0d5e09750b6a8c2388345748331615af93e5be499646c3bc5fbbfc897fcebdeada5efaafff94f26a2ab84d6e35f01a875b8b9956a42015df9  xf86-input-keyboard-1.9.0.tar.bz2"

--- a/main/xf86-input-libinput/APKBUILD
+++ b/main/xf86-input-libinput/APKBUILD
@@ -2,9 +2,9 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-input-libinput
 pkgver=0.28.0
-pkgrel=1
+pkgrel=2
 pkgdesc="X.Org input driver based on libinput"
-url="http://xorg.freedesktop.org"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 depends=""

--- a/main/xf86-input-mouse/APKBUILD
+++ b/main/xf86-input-mouse/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-input-mouse
 pkgver=1.9.3
-pkgrel=0
+pkgrel=1
 pkgdesc="X.org mouse input driver"
 url="https://www.x.org"
 arch="all"
@@ -12,11 +12,6 @@ makedepends="libxkbfile-dev xorg-server-dev libxi-dev libxrandr-dev"
 source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir/$pkgname-$pkgver"
-
-prepare() {
-	cd "$builddir"
-	default_prepare
-}
 
 build() {
 	cd "$builddir"

--- a/main/xf86-input-synaptics/APKBUILD
+++ b/main/xf86-input-synaptics/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-input-synaptics
 pkgver=1.9.1
-pkgrel=0
+pkgrel=1
 pkgdesc="X.org synaptics input driver"
 url="https://www.x.org"
 arch="all"

--- a/main/xf86-input-vmmouse/APKBUILD
+++ b/main/xf86-input-vmmouse/APKBUILD
@@ -1,21 +1,21 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-input-vmmouse
 pkgver=13.1.0
-pkgrel=3
+pkgrel=4
 pkgdesc="X.org VMware mouse input driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org/"
 arch="x86 x86_64"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="libxkbfile-dev xorg-server-dev libxi-dev libxrandr-dev eudev-dev"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
 	cd "$builddir"
-	update_config_sub || return 1
+	update_config_sub
 	default_prepare
 }
 
@@ -25,16 +25,16 @@ build() {
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
-		--prefix=/usr \
-		|| return 1
-	make || return 1
+		--prefix=/usr
+	make
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
+
 md5sums="85e2e464b7219c495ad3a16465c226ed  xf86-input-vmmouse-13.1.0.tar.bz2"
 sha256sums="0af558957ac1be1b2863712c2475de8f4d7f14921fd01ded2e2fde4921b19319  xf86-input-vmmouse-13.1.0.tar.bz2"
 sha512sums="38e09c5d7da971eb25ed79fc2daac3b8e1f5e6ec1096424696652c975ea653ed4a49d7779e7735d81a512c12c0a30829d5443ca78a275f3181ebd1740dd2dfd4  xf86-input-vmmouse-13.1.0.tar.bz2"

--- a/main/xf86-video-amdgpu/APKBUILD
+++ b/main/xf86-video-amdgpu/APKBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Linus Swälas <linus.swalas@borderless.se>
 pkgname=xf86-video-amdgpu
 pkgver=18.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="AMD Rx/HDxxxx video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
@@ -11,7 +11,7 @@ options="!check"
 depends="mesa-dri-ati"
 makedepends="xorg-server-dev libxi-dev libdrm-dev mesa-dev eudev-dev pixman-dev
 	util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {

--- a/main/xf86-video-apm/APKBUILD
+++ b/main/xf86-video-apm/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-apm
 pkgver=1.2.5
-pkgrel=10
+pkgrel=11
 pkgdesc="Alliance ProMotion video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org/"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
 	mibstore.patch
 	"
 

--- a/main/xf86-video-ark/APKBUILD
+++ b/main/xf86-video-ark/APKBUILD
@@ -1,16 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-ark
 pkgver=0.7.5
-pkgrel=9
+pkgrel=10
 pkgdesc="X.Org driver for ark cards"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
 	mibstore.patch"
 
 builddir="$srcdir"/$pkgname-$pkgver

--- a/main/xf86-video-ast/APKBUILD
+++ b/main/xf86-video-ast/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-ast
 pkgver=1.1.5
-pkgrel=3
+pkgrel=4
 pkgdesc="X.Org driver for ASpeedTech cards"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver

--- a/main/xf86-video-ati/APKBUILD
+++ b/main/xf86-video-ati/APKBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-ati
 pkgver=18.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="ATI video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
@@ -11,7 +11,7 @@ depends="mesa-dri-ati"
 makedepends="xorg-server-dev libxi-dev libdrm-dev mesa-dev eudev-dev pixman-dev
 	xorgproto"
 options="!check"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 builddir="$srcdir"/$pkgname-$pkgver
 
 build() {

--- a/main/xf86-video-chips/APKBUILD
+++ b/main/xf86-video-chips/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-chips
 pkgver=1.2.7
-pkgrel=2
+pkgrel=3
 pkgdesc="Chips and Technologies video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir"/$pkgname-$pkgver
 build() {

--- a/main/xf86-video-dummy/APKBUILD
+++ b/main/xf86-video-dummy/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-dummy
 pkgver=0.3.8
-pkgrel=2
+pkgrel=3
 pkgdesc="X.Org driver for dummy cards"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir"/$pkgname-$pkgver
 build() {

--- a/main/xf86-video-fbdev/APKBUILD
+++ b/main/xf86-video-fbdev/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-fbdev
 pkgver=0.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Video driver for framebuffer device"
 url="https://www.x.org"
 arch="all"

--- a/main/xf86-video-glint/APKBUILD
+++ b/main/xf86-video-glint/APKBUILD
@@ -1,16 +1,16 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-glint
 pkgver=1.2.9
-pkgrel=2
+pkgrel=3
 pkgdesc="GLINT/Permedia video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros libdrm-dev mesa-dev
 	xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir"/$pkgname-$pkgver
 

--- a/main/xf86-video-i128/APKBUILD
+++ b/main/xf86-video-i128/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-i128
 pkgver=1.3.6
-pkgrel=10
+pkgrel=11
 pkgdesc="Number 9 I128 video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
 	mibstore.patch"
 
 builddir="$srcdir"/$pkgname-$pkgver

--- a/main/xf86-video-i740/APKBUILD
+++ b/main/xf86-video-i740/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-i740
 pkgver=1.3.6
-pkgrel=2
+pkgrel=3
 pkgdesc="Intel i740 video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver

--- a/main/xf86-video-intel/APKBUILD
+++ b/main/xf86-video-intel/APKBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-intel
 pkgver=2.99.917_git20170325
-pkgrel=2
+pkgrel=3
 pkgdesc="X.Org driver for Intel cards"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="x86 x86_64"
 license="MIT"
 subpackages="$pkgname-doc"
@@ -12,7 +12,7 @@ makedepends="xorg-server-dev libxi-dev libdrm-dev mesa-dev libxvmc-dev
 	xcb-util-dev eudev-dev util-macros autoconf automake libtool xorgproto
 	"
 _ver=${pkgver%_git*}
-source="http://www.x.org/releases/individual/driver/$pkgname-$_ver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$_ver.tar.bz2
 	git.patch
 	"
 

--- a/main/xf86-video-nouveau/APKBUILD
+++ b/main/xf86-video-nouveau/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-nouveau
 pkgver=1.0.15
-pkgrel=2
+pkgrel=3
 pkgdesc="Open-source X.org drivers for nVidia video cards"
 url="https://nouveau.freedesktop.org/"
 arch="all"
@@ -12,7 +12,7 @@ depends_dev=
 makedepends="libdrm-dev xorg-server-dev util-macros eudev-dev xorgproto"
 install=""
 subpackages="$pkgname-doc"
-source="http://www.x.org/archive/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/archive/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir"/$pkgname-$pkgver
 build() {

--- a/main/xf86-video-nv/APKBUILD
+++ b/main/xf86-video-nv/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-nv
 pkgver=2.1.21
-pkgrel=2
+pkgrel=3
 pkgdesc="Nvidia video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir"/$pkgname-$pkgver
 build() {

--- a/main/xf86-video-openchrome/APKBUILD
+++ b/main/xf86-video-openchrome/APKBUILD
@@ -1,16 +1,16 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-openchrome
 pkgver=0.6.0
-pkgrel=3
+pkgrel=4
 pkgdesc="X.Org driver for VIA/S3G cards"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev libxvmc-dev mesa-dev util-macros
 	xorgproto"
-source="http://www.x.org/releases/individual/driver/xf86-video-openchrome-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/xf86-video-openchrome-$pkgver.tar.bz2
 	openchrome.xinf
 	"
 

--- a/main/xf86-video-qxl/APKBUILD
+++ b/main/xf86-video-qxl/APKBUILD
@@ -2,15 +2,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-qxl
 pkgver=0.1.5
-pkgrel=4
+pkgrel=5
 pkgdesc="Xorg X11 qxl video driver"
-url="http://www.x.org"
+url="https://www.x.org"
 arch="x86 x86_64"
 license="MIT"
 depends=
 makedepends="xorg-server-dev spice-dev xorg-server python2 xorgproto"
 install=""
-source="http://www.x.org/releases/individual/driver/xf86-video-qxl-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/xf86-video-qxl-$pkgver.tar.bz2"
 
 builddir="$srcdir"/xf86-video-qxl-$pkgver
 subpackages="$pkgname-doc xspice"

--- a/main/xf86-video-r128/APKBUILD
+++ b/main/xf86-video-r128/APKBUILD
@@ -1,16 +1,16 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-r128
-pkgver=6.10.2
-pkgrel=2
+pkgver=6.11.0
+pkgrel=0
 pkgdesc="ATI Rage128 video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev libdrm-dev mesa-dev expat-dev util-macros
 	autoconf automake libtool xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir/$pkgname-$pkgver"
 build() {
@@ -34,4 +34,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
-sha512sums="564b65454ee538c1b9dc5d22a52a57bdff0c1f94e1832719a8310699cee7167c1ca8fcd26243dfc4089832b1fcbab9efafb69c9061b328532f689d02a0acac23  xf86-video-r128-6.10.2.tar.bz2"
+
+sha512sums="1211cac52f65010aa4e168a173660186ad2b8595688a910ac545b0321d0d6879e02284b3bb26779faf3cf5b3b3031f33adb63ff596fb55a8f7a1f465ca0db1ba  xf86-video-r128-6.11.0.tar.bz2"

--- a/main/xf86-video-rendition/APKBUILD
+++ b/main/xf86-video-rendition/APKBUILD
@@ -1,16 +1,16 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-rendition
-pkgver=4.2.6
-pkgrel=3
+pkgver=4.2.7
+pkgrel=0
 pkgdesc="Rendition video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org/"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 options="!strip"
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir=$srcdir/$pkgname-$pkgver
 
@@ -37,4 +37,5 @@ package() {
 	strip $pkgdir/usr/lib/xorg/modules/drivers/rendition_drv.so
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
-sha512sums="ef4910b11ede69af89a7ee60039113a35c03f2bab5f9433eefbb4ed685b0260f630e9047fa8ab60a7f0e8a0958a24f8821b719e061c26bc51ff7736b500ddbc7  xf86-video-rendition-4.2.6.tar.bz2"
+
+sha512sums="5a23a599488946499e9bb3dfaf553cd68b6a1555a9c46b4038f355038a28747715bb940c52170f909917386911c8ae2607c669ba28f24a6c10ad375dab4535aa  xf86-video-rendition-4.2.7.tar.bz2"

--- a/main/xf86-video-s3/APKBUILD
+++ b/main/xf86-video-s3/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-s3
 pkgver=0.6.5
-pkgrel=10
+pkgrel=11
 pkgdesc="X.Org driver for s3 cards"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
 	mibstore.patch"
 
 builddir="$srcdir"/$pkgname-$pkgver

--- a/main/xf86-video-s3virge/APKBUILD
+++ b/main/xf86-video-s3virge/APKBUILD
@@ -1,17 +1,17 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-s3virge
 pkgver=1.10.7
-pkgrel=3
+pkgrel=4
 pkgdesc="S3 ViRGE video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org/"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+	check-max-value.patch
 	"
-
 builddir="$srcdir"/$pkgname-$pkgver
 build() {
 	cd "$builddir"
@@ -33,4 +33,6 @@ package() {
 	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
-sha512sums="bbeb3af1558eeb25768ec86e14687d442d54046913af6f4f4eb49c0b9641377b0d6f0e85629b16e46db07adb2358053cbfbe7b366d0cb9a817a011a1c7703e57  xf86-video-s3virge-1.10.7.tar.bz2"
+
+sha512sums="bbeb3af1558eeb25768ec86e14687d442d54046913af6f4f4eb49c0b9641377b0d6f0e85629b16e46db07adb2358053cbfbe7b366d0cb9a817a011a1c7703e57  xf86-video-s3virge-1.10.7.tar.bz2
+af7fdc0f850103fb9e8631c1b26b1eb6117eac83b76a9d575b33affeb55985ffe9f61c1c7dcb4c7b00656edfc5df4c2d4c75e56f2dd4c2112dedf654564ff259  check-max-value.patch"

--- a/main/xf86-video-s3virge/check-max-value.patch
+++ b/main/xf86-video-s3virge/check-max-value.patch
@@ -1,0 +1,24 @@
+--- a/src/s3v_driver.c
++++ b/src/s3v_driver.c
+@@ -1212,8 +1212,6 @@
+     /* todo -  The virge limit is 2048 vertical & horizontal */
+     /* pixels, not clock register settings. */
+ 			 	/* true for all ViRGE? */
+-  pScrn->maxHValue = 2048;
+-  pScrn->maxVValue = 2048;
+ 
+     				/* Lower depths default to config file */
+   pScrn->virtualX = pScrn->display->virtualX;
+@@ -2566,6 +2564,12 @@
+     if ((pScrn->bitsPerPixel + 7)/8 * mode->HDisplay > 4095)
+ 	return MODE_VIRTUAL_X;
+ 
++    if (mode->HTotal > 2048)
++        return MODE_BAD_HVALUE;
++
++    if (mode->VTotal > 2048)
++        return MODE_BAD_VVALUE;
++        
+     return MODE_OK;
+ }
+ 

--- a/main/xf86-video-savage/0001-Add-check-for-max-HV-Value-to-ValidMode-hook.patch
+++ b/main/xf86-video-savage/0001-Add-check-for-max-HV-Value-to-ValidMode-hook.patch
@@ -1,0 +1,45 @@
+From 0ece556daa8a88771b669d8104396abd9166d2d0 Mon Sep 17 00:00:00 2001
+From: Stefan Dirsch <sndirsch@suse.de>
+Date: Mon, 25 Jun 2018 15:55:06 +0200
+Subject: [PATCH] Add check for max[HV]Value to ValidMode hook
+
+xorg-server 1.20 removed this check, so implement this in the driver
+itself.
+
+Signed-off-by: Stefan Dirsch <sndirsch@suse.de>
+Reviewed-by: Emil Velikov <emil.velikov@collabora.com>
+---
+ src/savage_driver.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/savage_driver.c b/src/savage_driver.c
+index 58a294d..3cda923 100644
+--- a/src/savage_driver.c
++++ b/src/savage_driver.c
+@@ -2034,8 +2034,6 @@ static Bool SavagePreInit(ScrnInfoPtr pScrn, int flags)
+     xf86DrvMsg(pScrn->scrnIndex, X_PROBED, "Detected current MCLK value of %1.3f MHz\n",
+ 	       mclk / 1000.0);
+ 
+-    pScrn->maxHValue = 2048 << 3;	/* 11 bits of h_total 8-pixel units */
+-    pScrn->maxVValue = 2048;		/* 11 bits of v_total */
+     pScrn->virtualX = pScrn->display->virtualX;
+     pScrn->virtualY = pScrn->display->virtualY;
+ 
+@@ -3637,6 +3635,14 @@ static ModeStatus SavageValidMode(SCRN_ARG_TYPE arg, DisplayModePtr pMode,
+        (pMode->VDisplay > psav->PanelY)))
+ 	    return MODE_PANEL;
+ 
++    /* 11 bits of h_total 8-pixel units */
++    if (pMode->HTotal > (2048 << 3))
++	return MODE_BAD_HVALUE;
++
++    /* 11 bits of v_total */
++    if (pMode->VTotal > 2048)
++	return MODE_BAD_VVALUE;
++
+     if (psav->UseBIOS) {
+ 	refresh = SavageGetRefresh(pMode);
+         return (SavageMatchBiosMode(pScrn,pMode->HDisplay,
+-- 
+2.18.0
+

--- a/main/xf86-video-savage/APKBUILD
+++ b/main/xf86-video-savage/APKBUILD
@@ -1,18 +1,18 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-savage
 pkgver=2.3.9
-pkgrel=2
+pkgrel=3
 pkgdesc="S3 Savage video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros libdrm-dev mesa-dev
 	xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+	0001-Add-check-for-max-HV-Value-to-ValidMode-hook.patch
 	"
-
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -35,4 +35,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
-sha512sums="35fe52651fe5799bbbc6e7b3608a655102547e8f8f2189288d3f5b477f819bfc56a9a8eef39813ca455e56076e4f7c36304480c3ccddbac6c794672828cf705a  xf86-video-savage-2.3.9.tar.bz2"
+sha512sums="35fe52651fe5799bbbc6e7b3608a655102547e8f8f2189288d3f5b477f819bfc56a9a8eef39813ca455e56076e4f7c36304480c3ccddbac6c794672828cf705a  xf86-video-savage-2.3.9.tar.bz2
+485112d65bf36be55eca607daf3f05f637b29826d3fb915f92158c3564f3033f40a6078be8626bd9ea7cef1cb6900fed054496d0f803a048fada905fb179235a  0001-Add-check-for-max-HV-Value-to-ValidMode-hook.patch"

--- a/main/xf86-video-siliconmotion/APKBUILD
+++ b/main/xf86-video-siliconmotion/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-siliconmotion
 pkgver=1.7.9
-pkgrel=2
+pkgrel=3
 pkgdesc="Silicon Motion video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="x86_64 x86"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver

--- a/main/xf86-video-sis/0001-Remove-reference-to-virtualFrom.patch
+++ b/main/xf86-video-sis/0001-Remove-reference-to-virtualFrom.patch
@@ -1,0 +1,28 @@
+From 4b1356a2b7fd06e9a05d134caa4033681c939737 Mon Sep 17 00:00:00 2001
+From: Adam Jackson <ajax@redhat.com>
+Date: Thu, 16 Feb 2017 11:21:27 -0500
+Subject: [PATCH] Remove reference to ->virtualFrom
+
+The core will print this information as well anyway.
+
+Signed-off-by: Adam Jackson <ajax@redhat.com>
+---
+ src/sis_driver.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/sis_driver.c b/src/sis_driver.c
+index 8f06164..513f68b 100644
+--- a/src/sis_driver.c
++++ b/src/sis_driver.c
+@@ -2738,7 +2738,7 @@ SiSPrintModes(ScrnInfoPtr pScrn)
+     float hsync, refresh = 0.0;
+     char *desc, *desc2, *prefix, *uprefix, *output;
+ 
+-    xf86DrvMsg(pScrn->scrnIndex, pScrn->virtualFrom, "Virtual size is %dx%d "
++    xf86DrvMsg(pScrn->scrnIndex, X_INFO, "Virtual size is %dx%d "
+ 	       "(pitch %d)\n", pScrn->virtualX, pScrn->virtualY,
+ 	       pScrn->displayWidth);
+ 
+-- 
+2.18.0
+

--- a/main/xf86-video-sis/APKBUILD
+++ b/main/xf86-video-sis/APKBUILD
@@ -1,17 +1,17 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-sis
 pkgver=0.10.9
-pkgrel=2
+pkgrel=3
 pkgdesc="X.org SiS video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev util-macros mesa-dev libxi-dev xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+	0001-Remove-reference-to-virtualFrom.patch
 	"
-
 builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
@@ -35,4 +35,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
-sha512sums="7cb11d2f1f8be8d92159af7e322a9e4fe4e3436c38932d6d665b8854c2009495e99ff075c7a14d9db9c781114afc8397f0e8c1225d9a2f4bbf1b6a4b6cd6745d  xf86-video-sis-0.10.9.tar.bz2"
+sha512sums="7cb11d2f1f8be8d92159af7e322a9e4fe4e3436c38932d6d665b8854c2009495e99ff075c7a14d9db9c781114afc8397f0e8c1225d9a2f4bbf1b6a4b6cd6745d  xf86-video-sis-0.10.9.tar.bz2
+0439a8ad058b348fb285d3f460cebf25f0df29f82c6f1268c8d9bc90646934b89f08bf5e92e7cc7680c141c9d772f82237f0964cb0ced05ea9ef02094c886a21  0001-Remove-reference-to-virtualFrom.patch"

--- a/main/xf86-video-sunleo/APKBUILD
+++ b/main/xf86-video-sunleo/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-sunleo
 pkgver=1.2.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Leo video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver

--- a/main/xf86-video-tdfx/APKBUILD
+++ b/main/xf86-video-tdfx/APKBUILD
@@ -1,16 +1,16 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-tdfx
 pkgver=1.4.7
-pkgrel=2
+pkgrel=3
 pkgdesc="3Dfx video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros libdrm-dev mesa-dev
 	xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver

--- a/main/xf86-video-vesa/APKBUILD
+++ b/main/xf86-video-vesa/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-vesa
 pkgver=2.3.4
-pkgrel=4
+pkgrel=5
 pkgdesc="X.org generic VESA video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libxi-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2"
 
 builddir="$srcdir"/$pkgname-$pkgver
 build() {

--- a/main/xf86-video-vmware/APKBUILD
+++ b/main/xf86-video-vmware/APKBUILD
@@ -1,24 +1,17 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-vmware
-pkgver=13.2.1
-pkgrel=2
+pkgver=13.3.0
+pkgrel=0
 pkgdesc="X.org VMWare video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="x86 x86_64"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libdrm-dev	libxi-dev eudev-dev util-macros
 	xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
 	"
-
-prepare() {
-	cd "$builddir"
-	chmod a+w config.sub
-	update_config_sub
-	default_prepare
-}
 
 build() {
 	cd "$builddir"
@@ -40,4 +33,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
-sha512sums="9c48eaf5be6ece5685e07a53842083d091edba482ac0ea8318ac5b0adb9fc468f932685e4bdaf7e565f7a1cf723dcea2731616613798ebde2bbc18418a369a9d  xf86-video-vmware-13.2.1.tar.bz2"
+
+sha512sums="c318de893cae7b2b11e11c1b389ee47478b7c8d1f52c27099dbe453efec28f3e9da449217307a8c2251999eada66312f766996be1a6ead413b8b6dedc42c68ca  xf86-video-vmware-13.3.0.tar.bz2"

--- a/main/xf86-video-xgixp/APKBUILD
+++ b/main/xf86-video-xgixp/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-video-xgixp
 pkgver=1.8.1
-pkgrel=10
+pkgrel=11
 pkgdesc="X.org XGIXP video driver"
-url="http://xorg.freedesktop.org/"
+url="https://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
 depends=
 makedepends="xorg-server-dev libdrm-dev mesa-dev util-macros xorgproto"
-source="http://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
+source="https://www.x.org/releases/individual/driver/$pkgname-$pkgver.tar.bz2
 	git-fixes.patch"
 
 builddir="$srcdir"/$pkgname-$pkgver

--- a/main/xorg-server/APKBUILD
+++ b/main/xorg-server/APKBUILD
@@ -1,14 +1,14 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xorg-server
-pkgver=1.19.6
-pkgrel=3
+pkgver=1.20.0
+pkgrel=0
 pkgdesc="X.Org X servers"
 url="http://xorg.freedesktop.org"
 arch="all"
 license="MIT"
 options="suid"
-subpackages="$pkgname-dbg $pkgname-dev $pkgname-doc xfbdev xvfb $pkgname-xephyr
+subpackages="$pkgname-dbg $pkgname-dev $pkgname-doc xvfb $pkgname-xephyr
 	$pkgname-xnest $pkgname-xwayland"
 # the modesetting driver is now shipped with xorg server
 replaces="xf86-video-modesetting"
@@ -115,13 +115,13 @@ build() {
 		--enable-config-udev \
 		--enable-dri \
 		--enable-dri2 \
+		--enable-dri3 \
 		--enable-glamor \
 		--enable-ipv6 \
 		--enable-kdrive \
 		--enable-xace \
 		--enable-xcsecurity \
 		--enable-xephyr \
-		--enable-xfbdev \
 		--enable-xnest \
 		--enable-xorg \
 		--enable-xres \
@@ -129,10 +129,8 @@ build() {
 		--enable-xwayland \
 		--disable-config-hal \
 		--disable-dmx \
-		--disable-tslib \
 		--disable-systemd-logind \
 		--with-os-vendor="${DISTRO_NAME:-Alpine Linux}"
-
 	make
 }
 
@@ -153,13 +151,6 @@ package() {
 	install -m644 "$srcdir"/20-modules.conf "$pkgdir"/etc/X11/xorg.conf.d/
 	install -m755 -d "$pkgdir"/var/lib/xkb
 	install -m644 -D COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
-}
-
-xfbdev() {
-	pkgdesc="X.org server for framebuffer"
-	depends=
-	mkdir -p "$subpkgdir"/usr/bin
-	mv "$pkgdir"/usr/bin/Xfbdev "$subpkgdir"/usr/bin/
 }
 
 xvfb() {
@@ -188,7 +179,7 @@ xwayland() {
 	mv "$pkgdir"/usr/bin/Xwayland "$subpkgdir"/usr/bin/
 }
 
-sha512sums="38519a8d0af9dd034045fc346959496dd718fa59b6188307974797a1cd9c349deb54987f6232ea8396baf810dcc710c0ff191f76ed2186cae4d44921b3680412  xorg-server-1.19.6.tar.bz2
+sha512sums="1489e8511c9da682ef0460182dfeeddd241c72d4ef4d206d9706f1e39572c09953df851fab18cefb65a1ee4c6710c6ba13c63c9c9fc0bc1b5f12c50780412cde  xorg-server-1.20.0.tar.bz2
 4dcaa60fbfc61636e7220a24a72bba19984a6dc752061cb40b1bd566c0e614d08927b6c223ffaaaa05636765fddacdc3113fde55d25fd09cd0c786ff44f51447  autoconfig-nvidia.patch
 30a78f4278edd535c45ee3f80933427cb029a13abaa4b041f816515fdd8f64f00b9c6aef50d4eba2aaf0d4f333e730399864fd97fa18891273601c77a6637200  autoconfig-sis.patch
 b799e757a22a61ac283adbd7a8df1ad4eccce0bb6cac38a0c962ba8438bba3cf6637a65bb64859e7b32399fca672283a49960207e186c271ba574580de360d09  fix-musl-arm.patch

--- a/testing/xf86-input-wacom/APKBUILD
+++ b/testing/xf86-input-wacom/APKBUILD
@@ -2,16 +2,16 @@
 # Maintainer: Ivan Tham <pickfire@riseup.net>
 pkgname=xf86-input-wacom
 pkgver=0.36.1
-pkgrel=0
+pkgrel=1
 pkgdesc="X.org Wacom tablet input driver"
 url="https://github.com/linuxwacom/xf86-input-wacom"
 arch="all"
 license="GPL-2.0-or-later"
-makedepends="xorg-server-dev libxext-dev libxi-dev libxrandr-dev
-	libxinerama-dev eudev-dev"
+makedepends="xorg-server-dev libxext-dev libxi-dev libxrandr-dev libxinerama-dev
+	eudev-dev"
 checkdepends="bash findutils"
 subpackages="$pkgname-dev $pkgname-doc"
-source="$url/releases/download/$pkgname-$pkgver/$pkgname-$pkgver.tar.bz2"
+source="https://github.com/linuxwacom/xf86-input-wacom/releases/download/$pkgname-$pkgver/$pkgname-$pkgver.tar.bz2"
 builddir="$srcdir"/$pkgname-$pkgver
 
 build() {

--- a/testing/xorgxrdp/APKBUILD
+++ b/testing/xorgxrdp/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer:
 pkgname=xorgxrdp
-pkgver=0.2.6
+pkgver=0.2.7
 pkgrel=0
 pkgdesc="Xorg drivers for xrdp"
 url="https://github.com/neutrinolabs/xorgxrdp"
@@ -9,7 +9,7 @@ arch="all !x86"
 license="X11"
 makedepends="xorg-server-dev xrdp-dev nasm"
 subpackages="$pkgname-dev"
-source="https://github.com/neutrinolabs/$pkgname/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz"
+source="https://github.com/neutrinolabs/xorgxrdp/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -29,4 +29,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="b798b1bb610fa8e1c5280177593763f15aa031920f5ca03455eed1b873678fdb72c5745198ee39901c173b5cf6aa36caf05f5d04593ae602d59f18d523c0c030  xorgxrdp-0.2.6.tar.gz"
+sha512sums="b209f89017b9bcc8386e8690cfb0c59cb6817c37a051f1d6256365afa2d80290f5b162c01b34faab828c811c26d2a26bc9e55eb3925522833bd3a598e67127f3  xorgxrdp-0.2.7.tar.gz"


### PR DESCRIPTION
The following ~~(3)~~ (1) package fails to rebuild against the new video ABI:

- `main/xf86-video-s3virge-1.10.7`
~~- `main/xf86-video-savage-2.3.9`~~
~~- `main/xf86-video-sis-0.10.9`~~

Those packages are at their latest version as seen [here](https://www.x.org/releases/individual/driver) and I'm not sure if they will continue to be supported going forward (xorg-video-abi-24 included).