### PR TITLE
main/perl-file-sharedir: upgrade to 1.116

### DIFF
--- a/main/perl-file-sharedir/APKBUILD
+++ b/main/perl-file-sharedir/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=perl-file-sharedir
 _pkgname=File-ShareDir
-pkgver=1.106
+pkgver=1.116
 pkgrel=0
 pkgdesc="File::ShareDir perl module"
 url="http://search.cpan.org/dist/File-ShareDir/"
@@ -10,6 +10,7 @@ arch="noarch"
 license="GPL-2.0 or Artistic"
 depends="perl perl-class-inspector"
 makedepends="perl-dev"
+checkdepends="perl-file-sharedir-install"
 subpackages="$pkgname-doc"
 source="http://search.cpan.org/CPAN/authors/id/R/RE/REHSACK/$_pkgname-$pkgver.tar.gz"
 
@@ -32,4 +33,4 @@ package() {
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-sha512sums="68935bf150b3c613af46bf783c12524cbe7eabc0363c06ea83959e7353beda822e403d42ab6ddfb679ab1c5ff95d1999c597ef7bfc5e8a3fae70273160ba4964  File-ShareDir-1.106.tar.gz"
+sha512sums="5fcd75254c446f02ee377e6b5848baad95c73779b8525b0ee1699fe675ddd2bd67d0dc057f47b0991ec136de16e06a4891a4b14a78bd96c3e2468640053bbe0e  File-ShareDir-1.116.tar.gz"


### PR DESCRIPTION
New version requires perl-file-sharedir-install to run tests