### PR TITLE
main/php5: security upgrade to 5.6.37

### DIFF
--- a/main/php5/APKBUILD
+++ b/main/php5/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
-pkgver=5.6.36
+pkgver=5.6.37
 pkgrel=0
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
@@ -518,7 +518,7 @@ pdo_dblib()	{ _mv_ext pdo_dblib "$pkgname-pdo freetds"; }
 wddx()		{ _mv_ext wddx; }
 opcache()	{ _mv_ext opcache; }
 
-sha512sums="39988e3be529cdbb12aab848de7bc132475e2c81d322403bc7015b6f8c178334f2bc98cad70ea9426596da8ce160d78ce077578d37c668b7bd481da10bbd8bce  php-5.6.36.tar.bz2
+sha512sums="9cdd7710893ceb464a4818b853a2a70a02f55ece1d23cafe9a5529fdfa9ac1b23cf0eb944bd812825ec946901967a76254b10a38db835759be048cbc01795776  php-5.6.37.tar.bz2
 1f5cb18f85a2e279e24344d993f5c51c7bfbcbecc0e9bfcf075bebd1b0b893e2ffb793d95a632c9333033597d4b4f74840bfd00520a6dc700444d1a054225da1  php-fpm.initd
 895e94c791bd82060ad820fef049d366a09c932097faa6b7b9a2c2e9e00a18cb7c0f9b128679c7659b404379266fd0f95dba5c0333f626194cf60f7bf6044102  php5-module.conf
 f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c939768584f3e4edbe52e8bd6103fb6777462326a9d94e8ab1f505  php-install-pear-xml.patch


### PR DESCRIPTION
CVE not published yet, ref http://php.net/archive/2018.php#id2018-07-20-1

Other branches could cherry-pick from https://github.com/alpinelinux/aports/pull/4815