### PR TITLE
community/librdkafka: upgrade to 0.11.5

### DIFF
--- a/community/librdkafka/APKBUILD
+++ b/community/librdkafka/APKBUILD
@@ -1,15 +1,17 @@
 # Contributor: Bennett Goble <nivardus@gmail.com>
 # Maintainer: Bennett Goble <nivardus@gmail.com>
 pkgname=librdkafka
-pkgver=0.11.4
-pkgrel=1
+pkgver=0.11.5
+pkgrel=0
 pkgdesc="The Apache Kafka C/C++ library"
 url="https://github.com/edenhill/librdkafka"
 arch="all"
 license="BSD"
-makedepends="bash python2 libressl-dev zlib-dev"
+makedepends="bash python2 libressl-dev cyrus-sasl-dev lz4-dev zlib-dev"
 subpackages="$pkgname-dev"
-source="$pkgname-$pkgver.tar.gz::https://github.com/edenhill/$pkgname/archive/v$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/edenhill/$pkgname/archive/v$pkgver.tar.gz
+        libressl.patch
+        "
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -28,4 +30,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="6b34e7c476d328a2f8e8321f6ddcaeaf43730284bb3aaddac81c3cd9a1fa5d7f7ef7481f1093b36d89edde7b766da6cd27a9eb9a635b12b640e8a46a269bafc8  librdkafka-0.11.4.tar.gz"
+sha512sums="4a8dc46ad66f23cff4d4ef2fc8daa7207bfa3e77fd3580b3f141a73b449e60ea5381e97263235b4d0d762df027a8a2cad08637d88162d9605c82d74a1e64b67c  librdkafka-0.11.5.tar.gz
+9f867ef02d1dd0f6d1dcfa97bf12c1b7efd45a7765594a61e39ab544cf460cbeacf188ffa0a75bc3e01a14370fe6c7b664c59a41ad05f89aaffcc28f6fffb78c  libressl.patch"

--- a/community/librdkafka/libressl.patch
+++ b/community/librdkafka/libressl.patch
@@ -1,0 +1,39 @@
+diff --git a/src/rdkafka_conf.c b/src/rdkafka_conf.c
+index e0683f5..27c4e0b 100644
+--- a/src/rdkafka_conf.c
++++ b/src/rdkafka_conf.c
+@@ -485,7 +485,7 @@ static const struct rd_kafka_property rd_kafka_properties[] = {
+ 	  "protocol. See manual page for `ciphers(1)` and "
+ 	  "`SSL_CTX_set_cipher_list(3)."
+ 	},
+-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(LIBRESSL_VERSION_NUMBER)
+         { _RK_GLOBAL, "ssl.curves.list", _RK_C_STR,
+           _RK(ssl.curves_list),
+           "The supported-curves extension in the TLS ClientHello message specifies "
+diff --git a/src/rdkafka_conf.h b/src/rdkafka_conf.h
+index 27e448d..9aec8be 100644
+--- a/src/rdkafka_conf.h
++++ b/src/rdkafka_conf.h
+@@ -148,7 +148,7 @@ struct rd_kafka_conf_s {
+ 	struct {
+ 		SSL_CTX *ctx;
+ 		char *cipher_suites;
+-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(LIBRESSL_VERSION_NUMBER)
+ 		char *curves_list;
+ 		char *sigalgs_list;
+ #endif
+diff --git a/src/rdkafka_transport.c b/src/rdkafka_transport.c
+index 815fb31..472a9ca 100644
+--- a/src/rdkafka_transport.c
++++ b/src/rdkafka_transport.c
+@@ -872,7 +872,7 @@ int rd_kafka_transport_ssl_ctx_init (rd_kafka_t *rk,
+ 		}
+ 	}
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(LIBRESSL_VERSION_NUMBER)
+ 	/* Curves */
+ 	if (rk->rk_conf.ssl.curves_list) {
+ 		rd_kafka_dbg(rk, SECURITY, "SSL",


### PR DESCRIPTION
* Upgrade to 0.11.5 https://github.com/edenhill/librdkafka/releases/tag/v0.11.5
* LibreSSL Fix (upstream: https://github.com/edenhill/librdkafka/pull/1901)
* Enable SASL support & use system LZ4 instead of bundled
