### PR TITLE
[v3.7] community/php7: security upgrade to 7.1.30

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -25,7 +25,7 @@
 
 pkgname=php7
 _pkgreal=php
-pkgver=7.1.17
+pkgver=7.1.30
 pkgrel=0
 _apiver=20160303
 _suffix=${pkgname#php}
@@ -88,7 +88,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-apache2 $pkgname-phpdbg
 	$pkgname-embed $pkgname-litespeed $pkgname-cgi $pkgname-fpm
 	$pkgname-pear::noarch
 	"
-source="http://php.net/distributions/$_pkgreal-$pkgver.tar.bz2
+source="https://php.net/distributions/$_pkgreal-$pkgver.tar.bz2
 	$pkgname-fpm.initd
 	$pkgname-fpm.logrotate
 	$pkgname-module.conf
@@ -181,8 +181,35 @@ ppc64le) options="$options !check";;
 esac
 
 # secfixes:
-#   7.1.17-r0:
+#   7.1.29-r0:
+#     - CVE-2019-11034
+#     - CVE-2019-11035
+#     - CVE-2019-11036
+#     - CVE-2019-9637
+#     - CVE-2019-9638
+#     - CVE-2019-9639
+#     - CVE-2019-9640
+#     - CVE-2019-9641
+#     - CVE-2019-6977
+#     - CVE-2018-20783
+#     - CVE-2018-19935
+#     - CVE-2018-19518
+#     - CVE-2018-19396
+#     - CVE-2018-19395
+#     - CVE-2018-17082
+#     - CVE-2018-15132
+#     - CVE-2018-14884
+#     - CVE-2018-14883
+#     - CVE-2018-14851
+#     - CVE-2018-7584
 #     - CVE-2018-5712
+#     - CVE-2016-10166
+#   7.1.17-r0:
+#     - CVE-2018-10549
+#     - CVE-2018-10548
+#     - CVE-2018-10547
+#     - CVE-2018-10546
+#     - CVE-2018-10545
 #   7.1.15-r0:
 #     - CVE-2018-7584
 #   7.1.13-r0:
@@ -643,7 +670,7 @@ _mv() {
 	mv $@
 }
 
-sha512sums="6a3d7e93ee3d167a16b95de88929509fa4a4a053bbf793f3919850065f46169488301a1a11e72a69829793dd51190eb035c56ed9330184d7084a738671538e14  php-7.1.17.tar.bz2
+sha512sums="9b8ae29d149803768408261306ed409e6191f403e1dff9fa8d608608c19f112c4822b34b242da82034954223196958b6d74ddd709cf7fe97fbc70237e196c9d0  php-7.1.30.tar.bz2
 1c708de82d1086f272f484faf6cf6d087af7c31750cc2550b0b94ed723961b363f28a947b015b2dfc0765caea185a75f5d2c2f2b099c948b65c290924f606e4f  php7-fpm.initd
 cacce7bf789467ff40647b7319e3760c6c587218720538516e8d400baa75651f72165c4e28056cd0c1dc89efecb4d00d0d7823bed80b29136262c825ce816691  php7-fpm.logrotate
 274bd7b0b2b7002fa84c779640af37b59258bb37b05cb7dd5c89452977d71807f628d91b523b5039608376d1f760f3425d165242ca75ee5129b2730e71c4e198  php7-module.conf


### PR DESCRIPTION
https://www.php.net/ChangeLog-7.php#7.1.29
http://php.net/archive/2019.php#id2019-03-07-3
http://php.net/archive/2018.php#id2018-12-06-4
http://php.net/archive/2018.php#id2018-09-13-4