### PR TITLE
main/py-dbus: Add python3 support

### DIFF
--- a/main/py-dbus/APKBUILD
+++ b/main/py-dbus/APKBUILD
@@ -2,37 +2,78 @@
 pkgname=py-dbus
 _pkgname=dbus-python
 pkgver=1.2.8
-pkgrel=1
+pkgrel=2
 pkgdesc="Python bindings for DBUS"
 url="http://www.freedesktop.org/wiki/Software/DBusBindings"
 arch="all"
 license="MIT X11"
-depends="python2"
+depends=""
 depends_dev="py-dbus"
-makedepends="dbus-glib-dev python2-dev py2-sphinx"
-subpackages="$pkgname-dev $pkgname-doc"
+makedepends="dbus-glib-dev python2-dev python3-dev py2-sphinx"
+checkdepends="bash dbus py-gobject3 py-tappy"
+subpackages="$pkgname-dev $pkgname-doc py2-dbus:_py2 py3-dbus:_py3"
 source="https://dbus.freedesktop.org/releases/dbus-python/$_pkgname-$pkgver.tar.gz"
+options="!check" # Test suite fails due to permission errors in fakeroot environment
 
 builddir="$srcdir/$_pkgname-$pkgver"
 
+prepare() {
+	cd "$builddir"
+	mkdir ../build-python2
+	mkdir ../build-python3
+	default_prepare
+}
+
 build() {
 	cd "$builddir"
-	./configure \
+	cd ../build-python2
+	"$builddir/configure" \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
 		--enable-documentation
 	make
+	cd ../build-python3
+	"$builddir/configure" \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		PYTHON_VERSION=3
+	make
 }
 
 check() {
 	cd "$builddir"
-	make test
+	cd "../build-python2"
+	make check
+	cd "../build-python3"
+	make check
 }
 
 package() {
 	cd "$builddir"
+	cd "../build-python2"
 	make DESTDIR="$pkgdir" install
+	cd "../build-python3"
+	make DESTDIR="$pkgdir" install
+}
+
+_py2() {
+	replaces="py-dbus"
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/$python* "$subpkgdir"/usr/lib/
 }
 
 sha512sums="6e486fd560944fc1461a27e6798e2c348c7fdf351602c082a0614c0a6822ff147875212bdcb1f818c0ab12470cffc613c0ffbd292cd9d445d3429bee65765905  dbus-python-1.2.8.tar.gz"


### PR DESCRIPTION
Note that similar to py-cairo there is only one -doc and one -dev package for both python versions as these are identical for both python versions.

@ncopa Do you know why there is `make test` in `build()`? It doesn't seem to do anything, it just says `make: Nothing to be done for 'test'.`, before and after these changes.