### PR TITLE
main/mesa: use larger stack size for new threads

### DIFF
--- a/main/mesa/APKBUILD
+++ b/main/mesa/APKBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mesa
 pkgver=18.1.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Mesa DRI OpenGL library"
-url="http://www.mesa3d.org"
+url="https://www.mesa3d.org"
 arch="all"
 license="MIT SGI-B-2.0 BSL-1.0"
 subpackages="$pkgname-dev
@@ -27,6 +27,7 @@ source="https://mesa.freedesktop.org/archive/mesa-$pkgver.tar.xz
 	glx_ro_text_segm.patch
 	musl-fix-includes.patch
 	drmdeps.patch
+	musl-stacksize.patch
 	"
 replaces="mesa-dricore"
 
@@ -267,4 +268,5 @@ _vulkan() {
 sha512sums="04b8e5bbfa640f2303c388ab701fc2aca7f6d5d127ca5a9f9409975556813ba8e94305d27c9cea236a0e6d44a38b97e2877509268a96d9ed2a6762ab385aa3dc  mesa-18.1.4.tar.xz
 8a434ffefdc6ce924d613727a8649b9a77ad9f0ed0674c9cfb8f6ff0fec483f9318e681254535b62c957db1d0432f96427f917e2f139f4c65ef761bffb528255  glx_ro_text_segm.patch
 2c9cb0fa890d29e4140d956ee52a74b4522e29e44fadfc2dd144e581c2701a1d8842ab5c8ff0b68e14b2242e2812a9d4ac0aed1c3314a2143333bc37f2323b58  musl-fix-includes.patch
-3409483217dbec732286e628e268e1e8cd392b7e8efb13c7651b38e6563aa5a4988279efb029096dcd092ebe7a92eece103014ed420d2b242eab8d0237f056fd  drmdeps.patch"
+3409483217dbec732286e628e268e1e8cd392b7e8efb13c7651b38e6563aa5a4988279efb029096dcd092ebe7a92eece103014ed420d2b242eab8d0237f056fd  drmdeps.patch
+2add5225ce599f36afb8b7e9289d4b8cf382e4a320f737ae2010b1fa6e18a7806f991f7625705bdabad4c0cb4f60290fe49dd673b4449f574bef4e56132c22b1  musl-stacksize.patch"

--- a/main/mesa/musl-stacksize.patch
+++ b/main/mesa/musl-stacksize.patch
@@ -1,0 +1,33 @@
+--- a/include/c11/threads_posix.h
++++ b/include/c11/threads_posix.h
+@@ -281,15 +281,29 @@ static inline int
+ thrd_create(thrd_t *thr, thrd_start_t func, void *arg)
+ {
+     struct impl_thrd_param *pack;
++#ifdef __GLIBC__
++    pthread_attr_t *attrp = NULL;
++#else
++    pthread_attr_t attr = { 0 };
++    pthread_attr_init(&attr);
++    pthread_attr_setstacksize(&attr, 8388608);
++    pthread_attr_t *attrp = &attr;
++#endif
+     assert(thr != NULL);
+     pack = (struct impl_thrd_param *)malloc(sizeof(struct impl_thrd_param));
+     if (!pack) return thrd_nomem;
+     pack->func = func;
+     pack->arg = arg;
+-    if (pthread_create(thr, NULL, impl_thrd_routine, pack) != 0) {
++    if (pthread_create(thr, attrp, impl_thrd_routine, pack) != 0) {
++#ifndef __GLIBC__
++        pthread_attr_destroy(&attr);
++#endif
+         free(pack);
+         return thrd_error;
+     }
++#ifndef __GLIBC__
++    pthread_attr_destroy(&attr);
++#endif
+     return thrd_success;
+ }
+ 


### PR DESCRIPTION
Since the introduction of the mesa 18.1.* series, applications that use OpenGL have been consistently segfaulting. I can locally reproduce using`community/mpv` for video playback. This has also been discovered [here](https://github.com/gentoo/musl/issues/136) and the [patch](https://github.com/void-linux/void-packages/blob/18838a6cd6b00b1d309d6cc712b7d54660597221/srcpkgs/libGL/patches/musl-stacksize.patch) was imported after following a discussion [here](https://github.com/void-linux/void-packages/issues/933).

Increasing the stacksise consistently fixes the issue.