### PR TITLE
community/x265: fix build break on ppc64le parseCpuName invocation

### DIFF
--- a/community/x265/APKBUILD
+++ b/community/x265/APKBUILD
@@ -2,14 +2,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=x265
 pkgver=2.8
-pkgrel=0
+pkgrel=1
 pkgdesc="Open Source H265/HEVC video encoder"
 url="http://x265.org"
 arch="all"
 license="GPL-2.0-or-later"
 makedepends="cmake nasm"
 subpackages="$pkgname-dev $pkgname-libs"
-source="$pkgname-$pkgver.tar.gz::https://bitbucket.org/multicoreware/$pkgname/downloads/${pkgname}_${pkgver}.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://bitbucket.org/multicoreware/$pkgname/downloads/${pkgname}_${pkgver}.tar.gz
+	fix_parsecpuname.patch"
 builddir="$srcdir/${pkgname}_$pkgver"
 
 build() {
@@ -43,4 +44,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="c2a8eaec64aa022badcbcd2a96304a9abd9d08489300b6a9c4c9d76066f3d9848e6948238c84ae16ea91bff0b2fac528a67ee29950d94dcd0ea7c0e9e7baa714  x265-2.8.tar.gz"
+sha512sums="c2a8eaec64aa022badcbcd2a96304a9abd9d08489300b6a9c4c9d76066f3d9848e6948238c84ae16ea91bff0b2fac528a67ee29950d94dcd0ea7c0e9e7baa714  x265-2.8.tar.gz
+fe80a030d399662219d98399bb9372006902fcb74b84665fbf54c454ede4e62ef2fb4e5a60ad914f6def39fc665fd1150464a235a276a6cb0b5ecd050dd7d89b  fix_parsecpuname.patch"

--- a/community/x265/fix_parsecpuname.patch
+++ b/community/x265/fix_parsecpuname.patch
@@ -1,0 +1,11 @@
+--- a/source/common/param.cpp
++++ b/source/common/param.cpp
+@@ -633,7 +633,7 @@
+         if (bValueWasNull)
+             p->cpuid = atobool(value);
+         else
+-            p->cpuid = parseCpuName(value, bError);
++            p->cpuid = parseCpuName(value, bError, false);
+ #endif
+     }
+     OPT("fps")


### PR DESCRIPTION
Cherry picked commit from https://bitbucket.org/multicoreware/x265/commits/4504219210793536d921ee4e0b3058698c630bf4 to fix build break.