### PR TITLE
main/alpine-baselayout: also create /opt

### DIFF
--- a/main/alpine-baselayout/APKBUILD
+++ b/main/alpine-baselayout/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=alpine-baselayout
 pkgver=3.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Alpine base dir structure and init scripts"
 url="https://git.alpinelinux.org/cgit/aports/tree/main/alpine-baselayout"
 arch="all"
@@ -80,6 +80,7 @@ package() {
 		media/usb \
 		mnt \
 		proc \
+		opt \
 		run \
 		sbin \
 		srv \


### PR DESCRIPTION
From `hier(7)`:

	/opt   This directory should contain add-on packages that contain
	       static files.

Briefly skipping over `hier(7)` this seems to be the only non-optional directory which alpine-baselayout doesn't create.

---

@ncopa you are the maintainer of this aport, is there any specific reason why you didn't create that directory in the first place?