### PR TITLE
main/fuse: upgrade to 2.9.8, clarify license

### DIFF
--- a/main/fuse/APKBUILD
+++ b/main/fuse/APKBUILD
@@ -1,11 +1,11 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=fuse
-pkgver=2.9.7
-pkgrel=1
+pkgver=2.9.8
+pkgrel=0
 pkgdesc="A library that makes it possible to implement a filesystem in a userspace program."
 url="https://github.com/libfuse/"
 arch="all"
-license="LGPL-2.0-only GPL-2.0-only"
+license="GPL-2.0-only LGPL-2.1-only"
 depends=
 makedepends="gettext-dev"
 install=
@@ -15,6 +15,10 @@ source="https://github.com/libfuse/libfuse/releases/download/fuse-$pkgver/fuse-$
 	fuse.initd"
 options="suid !check"  # No test suite.
 builddir="$srcdir"/$pkgname-$pkgver
+
+# secfixes:
+#   2.9.8-r0:
+#     - CVE-2018-10906
 
 build() {
 	cd "$builddir"
@@ -53,6 +57,6 @@ _EOF_
 
 }
 
-sha512sums="f47304d9c7a1815f7a2905b7bdb7785d4c10292a80c8dc1ec45d895af96bc6ffd6d84ff2617bd976a1d0867ab8ec1a404a5a05ace85a69ecca830f371d08f8e2  fuse-2.9.7.tar.gz
+sha512sums="0a9b14d96c6f98f5c903baf00114bfff72f9aeb97224702bbed370516b2b582401d5b436fcef979918ffd85d69ba4a82c8f722c0b35ebd50f7aa5f4ddfdcf8ad  fuse-2.9.8.tar.gz
 5672ceb35acabb4bd97b6efc30614f22def62882fe198e2a8598a074d45b6b5337c082a5e09b5e399b6e5212dc1fbde9071c2a5051534c32091444c350b9c657  fix-realpath.patch
 7f6a503ef23cfa8b809c544375c2d83ad56525269b48ad1a7dff0ce36f4bf2f2a3fafed9dc70a71ff6281b261db5f01829e16c06f041921a5d8c8d715a04a8c1  fuse.initd"


### PR DESCRIPTION
[Release notes](https://github.com/libfuse/libfuse/releases/tag/fuse-2.9.8).

Fixes [CVE-2018-10906](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-10906)