### PR TITLE
testing/openmpi: fix build hang on ppc64le by disabling builtin atomics

### DIFF
--- a/testing/openmpi/APKBUILD
+++ b/testing/openmpi/APKBUILD
@@ -1,11 +1,11 @@
 # Maintainer: Daniel Sabogal <dsabogalcc@gmail.com>
 pkgname=openmpi
 pkgver=3.1.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Message passing library for high-performance computing"
 url="https://www.open-mpi.org/"
 # disable ppc64le until opal_fifo test can be fixed
-arch="all !ppc64le"
+arch="all"
 license="BSD"
 makedepends="perl gfortran hwloc-dev libevent-dev libgomp"
 subpackages="$pkgname-dev:_dev $pkgname-doc"
@@ -14,13 +14,20 @@ builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
+
+	disable_atomics=""
+        if [ "$CARCH" = ppc64le ]; then
+		disable_atomics="--disable-builtin-atomics"
+        fi
+
 	./configure \
 		--prefix=/usr \
 		--mandir=/usr/share/man \
 		--sysconfdir=/etc/$pkgname \
 		--enable-ipv6 \
 		--with-threads=posix \
-		--with-hwloc=/usr
+		--with-hwloc=/usr \
+		$disable_atomics
 	make
 }
 


### PR DESCRIPTION
ppc64le hangs intermittently on make check when running the opal-fifo test. An issue was opened at the openmpi project, https://github.com/open-mpi/ompi/issues/5470 

The recommended workaround is to build with atomic builtins disable for powerpc64le