### PR TITLE
testing/crosstool-ng: fix build by updating repo URLs and dependencies

### DIFF
--- a/testing/crosstool-ng/APKBUILD
+++ b/testing/crosstool-ng/APKBUILD
@@ -2,14 +2,14 @@
 pkgname=crosstool-ng
 pkgver=1.23.0
 pkgrel=1
-pkgdesc="tool for building toolchains"
-url="http://crosstool-ng.org/"
+pkgdesc="Versatile (cross) toolchain generator with menuconfig-style interface"
+url="https://crosstool-ng.github.io/"
 license="GPL"
 arch="x86 x86_64 ppc64le"
-depends="bash gawk bison flex automake autoconf libtool cvs sed texinfo gperf"
-makedepends="ncurses-dev help2man xz"
+depends="bash gawk bison flex automake autoconf libtool cvs sed texinfo gperf xz wget make"
+makedepends="ncurses-dev help2man"
 subpackages="$pkgname-doc"
-source="http://ymorin.is-a-geek.org/download/crosstool-ng/crosstool-ng-$pkgver.tar.bz2"
+source="http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-$pkgver.tar.bz2"
 
 builddir="$srcdir/$pkgname-$pkgver"
 


### PR DESCRIPTION
- both the project website and package source were updated, build was broken as a result.
- updated project description, dependencies and package source url
  - 'xz' is now a runtime dependency as it is commonly used by ct-ng
  - busybox 'wget' is broken when used by ct-ng for downloading packages,
    added full wget as a run- & build time dependency
  - 'make' is required both during build and runtime