### PR TITLE
testing/py-ansible-lint: upgrade, add check, remove broken subpackage

### DIFF
--- a/testing/ansible-lint/APKBUILD
+++ b/testing/ansible-lint/APKBUILD
@@ -1,7 +1,6 @@
 # Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
-pkgname=py-ansible-lint
-_pkgname=ansible-lint
+pkgname=ansible-lint
 pkgver=3.4.23
 pkgrel=0
 pkgdesc="A tool to check ansible playbooks"
@@ -10,8 +9,9 @@ arch="noarch"
 license="MIT"
 depends="ansible py3-six"
 makedepends="python3-dev py3-setuptools"
-source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
-builddir="$srcdir"/$_pkgname-$pkgver
+source="https://files.pythonhosted.org/packages/source/${pkgname:0:1}/$pkgname/$pkgname-$pkgver.tar.gz"
+provides="py3-ansible-lint=$pkgver-r$pkgrel" # for backward compatibility
+replaces="py3-ansible-lint" # for backward compatibility
 
 build() {
 	cd "$builddir"

--- a/testing/py-ansible-lint/APKBUILD
+++ b/testing/py-ansible-lint/APKBUILD
@@ -2,47 +2,30 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=py-ansible-lint
 _pkgname=ansible-lint
-pkgver=3.4.20
+pkgver=3.4.23
 pkgrel=0
 pkgdesc="A tool to check ansible playbooks"
-url="https://github.com/willthames/ansible-lint"
+url="https://github.com/ansible/ansible-lint"
 arch="noarch"
 license="MIT"
-depends="ansible py-setuptools"
-makedepends="python2-dev python3-dev"
-subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+depends="ansible py3-six"
+makedepends="python3-dev py3-setuptools"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 builddir="$srcdir"/$_pkgname-$pkgver
 
 build() {
 	cd "$builddir"
-	python2 setup.py build
 	python3 setup.py build
 }
 
 package() {
-	mkdir -p "$pkgdir"
-}
-
-_py2() {
-	replaces="$pkgname"
-	depends="${depends//py-/py2-}"
-	_py python2
-}
-
-_py3() {
-	depends="${depends//py-/py3-}"
-	_py python3
-}
-
-_py() {
-	local python="$1"
-	pkgdesc="$pkgdesc (for $python)"
-	depends="$depends $python"
-	install_if="$pkgname=$pkgver-r$pkgrel $python"
-
 	cd "$builddir"
-	$python setup.py install --prefix=/usr --root="$subpkgdir"
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
 }
 
-sha512sums="a1644cbad1b629cf2d428bded305793ca8e97dc73c1fa9454f65bcce8e51fee23ea0dcd0bca7fbe998bed0dc008a5cf8363980ed180fd3b8cb2a7f214b34cff2  ansible-lint-3.4.20.tar.gz"
+check() {
+	cd "$builddir/build/lib"
+	python3 -c "import ansiblelint"
+}
+
+sha512sums="b7754283943af88b8e11950b142bc36542c10d6f761a78f87d27954c62b70c77ae1d8925611d33f4daefc3c02d5fb217c419e3271eee33573a1cd48473bbf22d  ansible-lint-3.4.23.tar.gz"


### PR DESCRIPTION
This pull request addresses issues reported at: https://bugs.alpinelinux.org/issues/9145
It proposes four distinct changes:

- upgrade to the most recent release 3.4.23
- explicitly list python package dependencies not shared with Ansible - six
- add a basic `check()`
- remove the non-functional `py2-` sub package