### PR TITLE
testing/java-service-wrapper: new aport

### DIFF
--- a/testing/java-service-wrapper/APKBUILD
+++ b/testing/java-service-wrapper/APKBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Stefan Umbreit <stefan.umbreit@tutamail.com>
+# Contributor: Stefan Umbreit <stefan.umbreit@tutamail.com>
+
+pkgname=java-service-wrapper
+pkgver=3.5.35
+pkgrel=0
+pkgdesc="Enables a Java Application to be run as a Windows Service or Unix Daemon"
+url="https://wrapper.tanukisoftware.com/doc/english/introduction.html"
+arch="x86 x86_64 aarch64 armhf"
+license="GPL2"
+depends=""
+makedepends="apache-ant"
+install=""
+source="https://wrapper.tanukisoftware.com/download/${pkgver}/wrapper_${pkgver}_src.tar.gz
+	testsuite.patch
+	no-java-command-resolve.patch
+	target-jre-1.7.patch
+	remove-glibc-version-detection.patch"
+builddir="${srcdir}/wrapper_${pkgver}_src/"
+options="!check" # unit test only exists for x86_64
+
+build() {
+	cd "$builddir"
+	source /etc/profile.d/apache-ant.sh
+	test "$CARCH" = "x86_64" || test "$CARCH" = "aarch64" && _bits=64 || _bits=32
+	test "$CARCH" != "${CARCH#arm}" && _arch=armhf || _arch=x86
+
+	ant -Dbits="$_bits" -Ddist.arch="$_arch" jar compile-c
+}
+
+package() {
+	cd "$builddir"
+	install -Dm755 bin/wrapper       "${pkgdir}/usr/bin/java-service-wrapper"
+	install -Dm644 lib/libwrapper.so "${pkgdir}/usr/lib/java-service-wrapper/libwrapper.so"
+	install -Dm644 lib/wrapper.jar   "${pkgdir}/usr/share/java/wrapper-${pkgver}.jar"
+	install -Dm644 doc/wrapper-community-license*.txt "${pkgdir}/usr/share/licenses/java-service-wrapper/LICENSE"
+	ln -s /usr/share/java/wrapper-${pkgver}.jar "${pkgdir}/usr/share/java/wrapper.jar"
+}
+sha512sums="bbddd5a30b461abe8b414eeea7a958866dc57b1b816c87dd967a602137a5cf5e097cce8bda91ce5f3ae6358bef9d10d2013e7166e94ccf0f81b35b1520fa9207  wrapper_3.5.35_src.tar.gz
+c058363d17e0594ccce355183358d016acf8ec06dd88ff3dc3b360d143cd56fd1a70b5d7d9f5bf774451ea0eed5a78752c8b3fcc32422a1a97d52eb43e057e91  testsuite.patch
+1581a01ec1e4a352d86939e43e659c86fe8f99420e67ded44ed8ec42462b35a540b7763a8d1c055d8710dae422b8163d8ff650df016779f68ec6672cd8fc1150  no-java-command-resolve.patch
+bcba0752cf9113003df05e0b974e1385e56a171105614febbe865a034e2b905624cb0cba085e7a6b3fc22d0fd285822d3a1401ace0f1463a2dd8f9b591d3124b  target-jre-1.7.patch
+fdcebcd5f120be29030a33932c4ae51005452acddb043e6397bc71d90eb173263dd76b7434642a93e40a2ef7d6acb47dcfed05f0a002d0c435a32f2c8939f378  remove-glibc-version-detection.patch"

--- a/testing/java-service-wrapper/APKBUILD
+++ b/testing/java-service-wrapper/APKBUILD
@@ -9,7 +9,7 @@ url="https://wrapper.tanukisoftware.com/doc/english/introduction.html"
 arch="x86 x86_64 aarch64 armhf"
 license="GPL2"
 depends=""
-makedepends="apache-ant openjdk8 libc-dev"
+makedepends="apache-ant openjdk8 linux-headers"
 install=""
 source="https://wrapper.tanukisoftware.com/download/${pkgver}/wrapper_${pkgver}_src.tar.gz
 	testsuite.patch

--- a/testing/java-service-wrapper/APKBUILD
+++ b/testing/java-service-wrapper/APKBUILD
@@ -9,7 +9,7 @@ url="https://wrapper.tanukisoftware.com/doc/english/introduction.html"
 arch="x86 x86_64 aarch64 armhf"
 license="GPL2"
 depends=""
-makedepends="apache-ant openjdk8"
+makedepends="apache-ant openjdk8 libc-dev"
 install=""
 source="https://wrapper.tanukisoftware.com/download/${pkgver}/wrapper_${pkgver}_src.tar.gz
 	testsuite.patch

--- a/testing/java-service-wrapper/APKBUILD
+++ b/testing/java-service-wrapper/APKBUILD
@@ -9,7 +9,7 @@ url="https://wrapper.tanukisoftware.com/doc/english/introduction.html"
 arch="x86 x86_64 aarch64 armhf"
 license="GPL2"
 depends=""
-makedepends="apache-ant"
+makedepends="apache-ant openjdk8"
 install=""
 source="https://wrapper.tanukisoftware.com/download/${pkgver}/wrapper_${pkgver}_src.tar.gz
 	testsuite.patch

--- a/testing/java-service-wrapper/no-java-command-resolve.patch
+++ b/testing/java-service-wrapper/no-java-command-resolve.patch
@@ -1,0 +1,25 @@
+|Original version of this patch by Ralph Sennhauser <sera@gentoo.org>
+|Updated version for 3.5.25 by tomboy64 <tomboy64@sina.cn>
+|
+|Added in 3.5.4, make false default for Gentoo
+|
+|* Add a new wrapper.java.command.resolve property to control whether or not the
+|  Wrapper tries to resolve any symbolic links in the Java command, specified
+|  with the wrapper.java.command property.  Historically, it has always done so,
+|  but some jvm started applications like run-java-tool on Gentoo will fail if
+|  it is run directly as they have a check to make sure it is launched via a
+|  symbolic link.
+|
+
+--- a/src/c/wrapper.c.old	2014-07-21 09:12:55.000000000 +0200
++++ b/src/c/wrapper.c	2014-07-21 09:13:22.000000000 +0200
+@@ -4908,7 +4908,7 @@
+     if (!path) {
+         log_printf(WRAPPER_SOURCE_WRAPPER, LEVEL_WARN, TEXT("The configured wrapper.java.command could not be found, attempting to launch anyway: %s"), *para);
+     } else {
+-        replacePath = getBooleanProperty(properties, TEXT("wrapper.java.command.resolve"), TRUE);
++        replacePath = getBooleanProperty(properties, TEXT("wrapper.java.command.resolve"), FALSE);
+         if (replacePath == TRUE) {
+             free(*para);
+             *para = malloc((_tcslen(path) + 1) * sizeof(TCHAR));
+

--- a/testing/java-service-wrapper/remove-glibc-version-detection.patch
+++ b/testing/java-service-wrapper/remove-glibc-version-detection.patch
@@ -1,0 +1,45 @@
+Removes the glibc version detection as well as the workaround for
+certain glibc versions where 'ftell' is known to leak memory.
+Obviously not needed for musl ...
+
+Index: a/src/c/logger.c
+===================================================================
+--- a/src/c/logger.c	(revision 1987)
++++ b/src/c/logger.c	(working copy)
+@@ -79,7 +79,10 @@
+   #include <errno.h>
+  #else /* LINUX */
+   #include <asm/errno.h>
+-  #include <gnu/libc-version.h>
++  #include <features.h>
++  #ifdef __GNU_LIBRARY__
++   #include <gnu/libc-version.h>
++  #endif
+  #endif
+ 
+ #endif
+@@ -3840,6 +3843,7 @@
+     return result != -1 ? result : (result = (_tcsicmp(getDistro(), fedoraPattern) == 0));
+ }
+ 
++#ifdef __GNU_LIBRARY__
+ /**
+  * Check if the glibc version of the user is upper to given numbers.
+  */
+@@ -3855,6 +3859,7 @@
+     return ((vmaj == maj && vmin == min &&  vrev >= rev) || (vmaj == maj && vmin > min) || vmaj > maj);
+ }
+ #endif
++#endif
+ 
+ /**
+  * Check if the system is Centos with glibc < 2.21 as there is a memory leak issue under these conditions.
+@@ -3861,7 +3866,7 @@
+  */
+ int doesFtellCauseMemoryLeak() {
+     static int result = -1;
+-#ifdef LINUX
++#if defined LINUX && defined __GNU_LIBRARY__
+     if (result == -1) {
+         if ((isCentos() || isAMI() || isRHEL() || isFedora()) && !wrapperAssertGlibcUserBis(2, 21, 0)){
+             result = 1;

--- a/testing/java-service-wrapper/target-jre-1.7.patch
+++ b/testing/java-service-wrapper/target-jre-1.7.patch
@@ -1,0 +1,13 @@
+Index: build.xml
+===================================================================
+--- a/build.xml	(revision 1987)
++++ b/build.xml	(working copy)
+@@ -177,7 +177,7 @@
+         </condition>
+         
+         <!-- Java version. -->
+-        <property name="javac.target.version" value="1.4"/>
++        <property name="javac.target.version" value="1.7"/>
+         <condition property="javac.target.warn" value="true">
+             <not>
+                 <equals arg1="${java.specification.version}" arg2="1.4"/>

--- a/testing/java-service-wrapper/testsuite.patch
+++ b/testing/java-service-wrapper/testsuite.patch
@@ -1,0 +1,12 @@
+diff -u -r wrapper_3.5.25_src.orig/src/c/Makefile-linux-x86-64.make wrapper_3.5.25_src/src/c/Makefile-linux-x86-64.make
+--- wrapper_3.5.25_src.orig/src/c/Makefile-linux-x86-64.make	2014-09-06 00:06:05.730644375 +0200
++++ wrapper_3.5.25_src/src/c/Makefile-linux-x86-64.make	2014-09-06 00:06:51.130013387 +0200
+@@ -23,7 +23,7 @@
+ LIB = ../../lib
+ TEST = ../../test
+ 
+-all: init wrapper libwrapper.so testsuite
++all: init wrapper libwrapper.so
+ 
+ clean:
+ 	rm -f *.o


### PR DESCRIPTION
https://wrapper.tanukisoftware.com/doc/english/introduction.html
Enables a Java Application to be run as a Windows Service or Unix Daemon.

This is based on the corresponding Arch package
https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=java-service-wrapper
and Gentoo patches:
https://github.com/gentoo/gentoo/tree/master/dev-java/java-service-wrapper

To make it work with Alpine I had to remove a glibc specific version detection
which was only used to work around a glibc memory leak.