### PR TITLE
community/php7-apcu: fix license, use https, add missing file

### DIFF
--- a/community/php7-apcu/APKBUILD
+++ b/community/php7-apcu/APKBUILD
@@ -4,14 +4,14 @@ pkgname=php7-apcu
 _pkgreal=apcu
 # release 5 is php7+
 pkgver=5.1.12
-pkgrel=0
+pkgrel=1
 pkgdesc="PHP extension APC User Cache"
-url="http://pecl.php.net/package/$_pkgreal"
+url="https://pecl.php.net/package/apcu"
 arch="all"
-license="PHP"
+license="PHP-3.01"
 depends=""
 makedepends="pcre-dev php7-dev autoconf"
-source="http://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
+source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 build() {
@@ -33,6 +33,7 @@ package() {
 	make INSTALL_ROOT="$pkgdir"/ install
 	install -d "$pkgdir"/etc/php7/conf.d
 	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/$_pkgreal.ini
+	install -D -m644 apc.php "$pkgdir"/usr/share/php7/apcu/apc.php
 }
 
 sha512sums="f53b7840d5aecfc899e3e878f0bb9a5dc4a83628543963c20c25ce2b2a2adf14dd40d39a6a2014c139962453e0e9e5038fca7b1d0be205c0b9b2aa6e3fefb054  apcu-5.1.12.tgz"


### PR DESCRIPTION
- SPDX identifier fixed according https://pecl.php.net/package/APCu
- added apc.php