### PR TITLE
community/php7: fix license, use https, fix include_path setting

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -26,15 +26,15 @@
 pkgname=php7
 _pkgreal=php
 pkgver=7.2.8
-pkgrel=0
+pkgrel=1
 _apiver=20170718
 _suffix=${pkgname#php}
 # Is this package the default (latest) PHP version?
 _default_php="yes"
 pkgdesc="The PHP$_suffix language runtime engine"
-url="http://www.php.net/"
+url="https://secure.php.net/"
 arch="all"
-license="PHP-3.0 BSD LGPL-2.0 MIT Zend"
+license="PHP-3.01"
 depends="$pkgname-common"
 depends_dev="$pkgname=$pkgver-r$pkgrel autoconf pcre-dev"
 # Most dependencies between extensions is auto-discovered (see _extension()).
@@ -89,13 +89,14 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-apache2 $pkgname-phpdbg
 	$pkgname-embed $pkgname-litespeed $pkgname-cgi $pkgname-fpm
 	$pkgname-pear::noarch
 	"
-source="http://php.net/distributions/$_pkgreal-$pkgver.tar.bz2
+source="https://php.net/distributions/$_pkgreal-$pkgver.tar.bz2
 	$pkgname-fpm.initd
 	$pkgname-fpm.logrotate
 	$pkgname-module.conf
 	disabled-tests.list
 	install-pear.patch
 	includedir.patch
+	sharedir.patch
 	php7-fpm-version-suffix.patch
 	allow-build-recode-and-imap-together.patch
 	fix-tests-devserver.patch
@@ -645,6 +646,7 @@ cacce7bf789467ff40647b7319e3760c6c587218720538516e8d400baa75651f72165c4e28056cd0
 6593accfe1ef0d9d28d257b2825823afdbfaa72bbf2e09e4ed689b644571a0d085cd4d6c92ffdff6ca9d0bb6d31cf84e5db5c4a4d88f192bba3f95a0c9b1dfd7  disabled-tests.list
 f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c939768584f3e4edbe52e8bd6103fb6777462326a9d94e8ab1f505  install-pear.patch
 199aecdbd3b4035aabf5379c215f82412d3c98b79a1ee186944e7fe1f0ed6f40789ea30e2355149491de6be34fc66c5e486e2a79a7e41ab2ae18706ef3ffe79b  includedir.patch
+db4c47cb254d208e4055db9287f4f4bacc0339f1f5912d2bf9c66e8a0fd0db9d53fb02aaa6d30a823a4b8504a04a9ce906706f3792684654131bb5b26aeb77b2  sharedir.patch
 6d4aa75b94ce7c88f97574a06964fafd7cb6657c1cb19c0b93776dedef05857331cce9c40f69a442ef84c66aa9137ad9f6197cc25f2384a27b8fd7350838292e  php7-fpm-version-suffix.patch
 f8ecae241a90cbc3e98aa4deb3d5d35ef555f51380e29f4e182a8060dffeb84be74f030a14c6b452668471030d78964f52795ca74275db05543ccad20ef1f2cc  allow-build-recode-and-imap-together.patch
 5bb1f90de8c543d4efffa8bc604fb3239e478d9d9625d30cd03449643906a0fe5407123403206ec57f4bf9f18893a7ff4524ccf417b2bd8bce4ee7d18815b576  fix-tests-devserver.patch"

--- a/community/php7/sharedir.patch
+++ b/community/php7/sharedir.patch
@@ -1,0 +1,11 @@
+--- a/php.ini-production	2018-07-28 18:05:51.737130931 +0300
++++ b/php.ini-production	2018-07-28 18:06:45.177774666 +0300
+@@ -711,7 +711,7 @@
+ ;;;;;;;;;;;;;;;;;;;;;;;;;
+ 
+ ; UNIX: "/path1:/path2"
+-;include_path = ".:/php/includes"
++include_path = ".:/usr/share/php7"
+ ;
+ ; Windows: "\path1;\path2"
+ ;include_path = ".;c:\php\includes"


### PR DESCRIPTION
- https://secure.php.net/license/index.php
- setting is broken, thanks to @jirutka 