### PR TITLE
Redmine #9113 Create /run/redis for docker users

### DIFF
--- a/main/redis/APKBUILD
+++ b/main/redis/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: TBK <alpine@jjtc.eu>
 pkgname=redis
 pkgver=4.0.10
-pkgrel=0
+pkgrel=1
 pkgdesc="Advanced key-value store"
 url="https://redis.io/"
 arch="all"

--- a/main/redis/redis.pre-install
+++ b/main/redis/redis.pre-install
@@ -2,5 +2,6 @@
 
 addgroup -S redis 2>/dev/null
 adduser -S -D -H -h /var/lib/redis -s /bin/false -G redis -g redis redis 2>/dev/null
+install -o redis -g redis -m 0770 -d /run/redis
 
 exit 0


### PR DESCRIPTION
Without this path redis fails to start under docker.