### PR TITLE
main/py-google-api-python-client: improved dependencies

### DIFF
--- a/main/py-google-api-python-client/APKBUILD
+++ b/main/py-google-api-python-client/APKBUILD
@@ -2,12 +2,12 @@
 pkgname=py-google-api-python-client
 _pkgname=google-api-python-client
 pkgver=1.7.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Google API Client Library for Python"
 url="https://github.com/google/google-api-python-client"
 arch="noarch"
 license="Apache"
-depends="python2 py-httplib2 py-oauth2client py-uritemplate py-six"
+depends="py-httplib2 py-oauth2client py-uritemplate py-six"
 makedepends="python2-dev python3-dev py-setuptools"
 subpackages="py3-${pkgname#py-}:_py3 py2-${pkgname#py-}:_py2"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"


### PR DESCRIPTION
py3-google-api-python-client should not depend upon python2, python3 is
sufficient.

Lines 30 and 40 add the python2 dependency to
py2-google-api-python-client so specifying python2 on line 10 is not
required.

Fixes issue #9156