### PR TITLE
testing/apparmor: move apparmor_parser to /sbin

### DIFF
--- a/testing/apparmor/APKBUILD
+++ b/testing/apparmor/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Allan Garret <allan.garret@gmail.com>
 pkgname=apparmor
 pkgver=2.13
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux application security framework - mandatory access control for programs"
 url="https://gitlab.com/apparmor/apparmor/wikis/home"
 arch="all"
@@ -82,7 +82,6 @@ package() {
 
 	make -C parser install DESTDIR="$pkgdir"
 	mv "$pkgdir"/lib "$pkgdir"/usr/lib
-	mv "$pkgdir"/sbin "$pkgdir"/usr/sbin
 	mkdir -p "$pkgdir"/usr/libexec/apparmor
 	mv "$pkgdir"/usr/lib/apparmor/rc.apparmor.functions \
 		"$pkgdir"/usr/libexec/apparmor/


### PR DESCRIPTION
There are several applications that have /sbin/apparmor_parser
hardcoded, so it's better to move it and not break things