### PR TITLE
community/z3: fix ppc64le test failures by setting proper element width in small allocator 

### DIFF
--- a/community/z3/APKBUILD
+++ b/community/z3/APKBUILD
@@ -2,16 +2,17 @@
 # Maintainer: Sören Tempel <soeren+alpine@soeren-tempel.net>
 pkgname=z3
 pkgver=4.7.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Theorem prover from Microsoft Research"
 url="https://github.com/Z3Prover/z3"
-arch="all !s390x !ppc64le !aarch64"
+arch="all !s390x !aarch64"
 license="MIT"
 depends=""
 makedepends="cmake python3"
 install=""
 subpackages="$pkgname-dev py3-$pkgname:py3:noarch"
-source="https://github.com/Z3Prover/$pkgname/archive/$pkgname-$pkgver.tar.gz"
+source="https://github.com/Z3Prover/$pkgname/archive/$pkgname-$pkgver.tar.gz
+	fix-ppc64le-ptr-size.patch"
 builddir="$srcdir/$pkgname-$pkgname-$pkgver"
 
 build() {
@@ -53,4 +54,5 @@ py3() {
 		"$subpkgdir"/usr/lib/
 }
 
-sha512sums="4c8c856691134298c4b5e465d6fadfe446532dfcd8c92aed7c9a6bbfc8557074a45cd7316dbfa5045824e2504db159afeb8ff676d4bfc942496623cf31d11aa0  z3-4.7.1.tar.gz"
+sha512sums="4c8c856691134298c4b5e465d6fadfe446532dfcd8c92aed7c9a6bbfc8557074a45cd7316dbfa5045824e2504db159afeb8ff676d4bfc942496623cf31d11aa0  z3-4.7.1.tar.gz
+3d019959a104b5fd5f72eeb3738cacbdb145764ad4844eeb2539b36fa3a8228ffa062a0899465d4881b6c226301aa09b129ef06a798744b2eec9f943e0d9d366  fix-ppc64le-ptr-size.patch"

--- a/community/z3/fix-ppc64le-ptr-size.patch
+++ b/community/z3/fix-ppc64le-ptr-size.patch
@@ -1,0 +1,11 @@
+--- a/src/util/machine.h
++++ b/src/util/machine.h
+@@ -20,7 +20,7 @@
+ #ifndef MACHINE_H_
+ #define MACHINE_H_
+
+-#ifdef _AMD64_
++#if defined(_AMD64_) || defined(__powerpc64__)
+ #define PTR_ALIGNMENT 3
+ #else
+ #define PTR_ALIGNMENT 2


### PR DESCRIPTION
test-z3 doc test fails because pointer alignment is incorrectly set to 4 bytes for ppc64le. This causes the small_object_allocator::allocate() to incorrectly set the size of the global m_free_list elements to to be too small. The net result is the 8 byte pointer used to link chunks on the free list to overflow into the next element effectively corrupting the free chain. This fix sets the PTR_ALIGNMENT value correctly for ppc64le to use 8 byte elements.