### PR TITLE
testing/frr: break out a pythontools subpackage to clean up dependencies

### DIFF
--- a/testing/frr/APKBUILD
+++ b/testing/frr/APKBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Arthur Jones <arthur.jones@riverbed.com>
 pkgname=frr
 pkgver=5.0.1
-pkgrel=0
+pkgrel=1
 pkgdesc="FRRouting is a fork of quagga"
 pkgusers="frr"
 pkggroups="frr"
 url="https://frrouting.org/"
 arch="x86_64"
 license="GPL-2.0-only and LGPL-2.1-only"
-depends="iproute2 python2 py2-ipaddr bash"
+depends="iproute2 bash"
 makedepends="autoconf automake libtool
 	bsd-compat-headers
 	c-ares-dev
@@ -22,7 +22,12 @@ makedepends="autoconf automake libtool
 	"
 checkdepends="pytest py-setuptools"
 install="$pkgname.pre-install"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-dbg $pkgname-openrc"
+subpackages="$pkgname-dev
+	$pkgname-doc
+	$pkgname-dbg
+	$pkgname-openrc
+	$pkgname-pythontools
+	"
 source="https://github.com/FRRouting/frr/archive/$pkgname-$pkgver.tar.gz
     make-check-bypass-isisd-tlv.patch
     frr.initd
@@ -62,6 +67,14 @@ package() {
 	install -Dm644 "$builddir"/tools/etc/frr/daemons.conf "$pkgdir"$_sysconfdir
 	install -Dm755 "$srcdir"/frr.initd "$pkgdir"/etc/init.d/frr.initd
 }
+
+pythontools() {
+	pkgdesc="$pkgdesc (tools)"
+	depends="python2 py2-ipaddr"
+	mkdir -p "$subpkgdir"/usr/lib/frr
+	mv "$pkgdir"/usr/lib/frr/frr-reload.py "$subpkgdir/usr/lib/frr"
+}
+
 sha512sums="e2a3a4e21998f8c85b59fc971190d0b5340bbcd88356a637740ad8e564275b0df14da78b72a24a99a58435725cded1b9089814fc926a7a4080bd3a8762973548  frr-5.0.1.tar.gz
 3c679b857018d82443abd34823e712a8657a597b4210730d260e9796516982a137234354422cb439989985367531d600e205d3fb791cdb7b212425bb704c2016  make-check-bypass-isisd-tlv.patch
 9d2cfa95c3a79fa0da321319dcd6f439a267b69071233d4ad4b56f770eb9852c3c8b3be24c1e396701509a09eabb6ba618af6fa4a0a643bd37eeee7b6496a787  frr.initd"


### PR DESCRIPTION
For convenience, frr-reload.py is now packaged with the main package,
but that brings in python2.  Here, we break out an frr-pythontools package
so that we can keep python2 out of the base package.

Fixes #9172