### PR TITLE
community/zabbix: Fix zabbix loadable modules work

### DIFF
--- a/community/zabbix/APKBUILD
+++ b/community/zabbix/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=zabbix
 pkgver=3.4.8
-pkgrel=0
+pkgrel=1
 pkgdesc="Enterprise-class open source distributed monitoring"
 url="http://www.zabbix.com"
 arch="all"

--- a/community/zabbix/APKBUILD
+++ b/community/zabbix/APKBUILD
@@ -87,6 +87,9 @@ build() {
 			--with-ssh2 \
 			--with-gnutls
 			"
+	# pass --export-dynamic to the linker                                         
+	# to make zabbix loadable modules work                                        
+	LDFLAGS="$LDFLAGS -Wl,--export-dynamic"   
         # we run build for each db type
         # make sure prepare is same for each db
 	for db in postgresql mysql sqlite3; do

--- a/testing/mongo-php7-library/APKBUILD
+++ b/testing/mongo-php7-library/APKBUILD
@@ -3,7 +3,7 @@
 _php=php7
 pkgname=mongo-${_php}-library
 _realname=mongo-php-library
-pkgver=1.4.2
+pkgver=1.3.2
 pkgrel=0
 pkgdesc="High-level abstraction around the lower-level drivers for PHP"
 url="https://github.com/mongodb/mongo-php-library"
@@ -30,4 +30,4 @@ package() {
 	mv LICENSE README.md "$pkgdir"/usr/share/doc/mongo-${_php}-library
 }
 
-sha512sums="c473b85f60fd942f591c712187d68744b95472f11450af5bcd1768d79fb0e3ffe08c486fad72898fe5fd3002e865ea79959767b80830db92bd92d87f52877f33  mongo-php-library-1.4.2.tar.gz"
+sha512sums="8015da0abc8fb9954947cbb446eb83a8f58852f36570fa1b0e9c1522a8802ac8f12a2e785378c01ae29dff1396211914f619fb1e4984733bcbd0263d429fb12f  mongo-php-library-1.3.2.tar.gz"


### PR DESCRIPTION
Zabbix loadable modules functionality requires that all the symbols in a binary (agent, server or proxy) should be added to dynamic symbol table. Zabbix executables use dlopen() to load modules (shared libraries), which in turn refer to symbols defined in the executable. So --export-dynamic is required to be passed in such cases. Without it zabbix binaries can't load any modules (errroring about undefined symbols in modules).