### PR TITLE
testing/php7-stats: clarify license, disable on s390x due to failing tests

### DIFF
--- a/testing/php7-stats/APKBUILD
+++ b/testing/php7-stats/APKBUILD
@@ -3,11 +3,11 @@
 pkgname=php7-stats
 _pkgreal=stats
 pkgver=2.0.3
-pkgrel=4
+pkgrel=5
 pkgdesc="Extension that provides few dozens routines for statistical computation."
 url="http://pecl.php.net/package/$_pkgreal"
-arch="all"
-license="PHP"
+arch="all !s390x" # too many tests fails on s390x
+license="PHP-3.01"
 depends=""
 makedepends="php7-dev autoconf"
 source="http://pecl.php.net/get/$_pkgreal-$pkgver.tgz"


### PR DESCRIPTION
- https://pecl.php.net/package/stats points to 3.01 license
- 15 of 87 tests fail on s390x, and extension looks not maintained for a long time