### PR TITLE
main/grub: remove syslinux dependency

### DIFF
--- a/main/grub/2.02_beta3-mkconfig-alpine.patch
+++ b/main/grub/2.02_beta3-mkconfig-alpine.patch
@@ -1,17 +1,5 @@
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
-@@ -21,8 +21,11 @@
- exec_prefix="@exec_prefix@"
- datarootdir="@datarootdir@"
- 
-+. /etc/update-extlinux.conf
- . "$pkgdatadir/grub-mkconfig_lib"
- 
-+GRUB_CMDLINE_LINUX_DEFAULT="modules=${modules} ${default_kernel_opts} ${GRUB_CMDLINE_LINUX_DEFAULT}"
-+
- export TEXTDOMAIN=@PACKAGE@
- export TEXTDOMAINDIR="@localedir@"
- 
 @@ -75,6 +78,7 @@
    version="$2"
    type="$3"

--- a/main/grub/APKBUILD
+++ b/main/grub/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=grub
 pkgver=2.02
-pkgrel=5
+pkgrel=6
 pkgdesc="Bootloader with support for Linux, Multiboot and more"
 url="https://www.gnu.org/software/grub/"
 arch="all !s390x"
@@ -35,6 +35,7 @@ source="https://ftp.gnu.org/gnu/grub/grub-$pkgver.tar.xz
 	grub2-accept-empty-module.patch
 	grub-xen-host_grub.cfg
 	2.02_beta3-mkconfig-alpine.patch
+	grub.default
 	"
 builddir="$srcdir/grub-$pkgver"
 
@@ -118,7 +119,8 @@ package() {
 
 	rm -f "$pkgdir"/usr/lib/charset.alias
 	# remove grub-install warning of missing directory
-	mkdir -p "$pkgdir"/usr/share/locale
+	mkdir -p "$pkgdir"/usr/share/locale "$pkgdir"/etc/default
+	install -Dm644 "$srcdir"/grub.default "$pkgdir"/etc/default/grub
 }
 
 bios() {
@@ -159,4 +161,5 @@ sha512sums="cc6eb0a42b5c8df2f671cc128ff725afb3ff1f8832a196022e433cf0d3b75decfca2
 f2a7d9ab6c445f4e402e790db56378cecd6631b5c367451aa6ce5c01cd95b95c83c3dd24d6d4b857f8f42601eba82c855607513eb6ce5b2af6bd6c71f046e288  fix-gcc-no-pie-specs.patch
 098a1742aef131c85d63b934a9815879b991f2e73030cb90ac4b5dcd07d249fa0dd0a281e52ada0e10f05d59223493bd416eb47543242bf0ba336a0ebc9b2a1a  grub2-accept-empty-module.patch
 4e7394e0fff6772c89683039ccf81099ebbfe4f498e6df408977a1488fd59389b6e19afdbf0860ec271e2b2aea0df7216243dcc8235d1ca3af0e7f4d0a9d60a4  grub-xen-host_grub.cfg
-5de7c1cc11640a3892447f0daa1e3fd1f67b0c474c8aec555e4e6315b5e6c00491ba02c88b420cec221da0640c6961d639f148746df14a0b2c15bda7989cd25c  2.02_beta3-mkconfig-alpine.patch"
+bb98914f39a35d1f55752318030b2685d0287ac86cb2eee3027a8748a1b9020044a7fb599577fd2e22671473235507f86907ffb2d9c34690af393e12f49580d5  2.02_beta3-mkconfig-alpine.patch
+076621c13cdff8843160750f9f549d566c83fef7036dbe79c8f0e5648fe8acbaf4cbea3be52cd31c1c08cff01711b6c81418b4aaa2abdfb69a0e1f54560b316f  grub.default"

--- a/main/grub/grub.default
+++ b/main/grub/grub.default
@@ -1,0 +1,2 @@
+GRUB_DISTRIBUTOR="Alpine"
+GRUB_CMDLINE_LINUX_DEFAULT="modules=sd-mod,usb-storage,ext3 quiet"


### PR DESCRIPTION
Avoid sourcing another booloader's configuration files (syslinux's /etc/update-extlinux.conf) when using grub which has it's own (/etc/default/grub).