### PR TITLE
community/docker: upgrade to 18.06.0

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 # Contributor: Bernhard J. M. Gruen <bernhard.gruen@googlemail.com>
 pkgname=docker
-pkgver=18.03.1
+pkgver=18.06.0
 _ver=${pkgver/_/-}-ce
 pkgrel=0
 _gitcommit=v$_ver
@@ -15,12 +15,12 @@ options="!check"
 install="$pkgname.pre-install"
 
 # from "$srcdir"/docker-ce-"$_ver"-ce/components/engine/hack/dockerfile/install/*.installer
-_runc_ver=4fc53a81fb7c994640722ac585fa9ca548971871
-_containerd_ver=773c489c9c1b21a6d78b5c538cd395416ec50f88
-_tini_ver=949e6facb77383876aeff8a6944dde66b3089574
-_libnetwork_ver=c15b372ef22125880d378167dde44f4b134e1a77
+_runc_ver=69663f0bd4b60df09991c08812a60108003fa340
+_containerd_ver=d64c661f1d51c48782c9cec8fda7604785f93587 # v1.1.1
+_tini_ver=fec3683b971d9c3ef73f284f176672c44b448662 # v0.18.0
+_libnetwork_ver=3ac297bc7fd0afec9051bbb47024c9bc1d75bf5b # proxy.installer
 
-_cobra_ver="0.0.2"
+_cobra_ver="0.0.3"
 _go_md2man_ver="1.0.8"
 
 subpackages="
@@ -105,9 +105,9 @@ build() {
 	# runc
 	msg "building runc"
 	cd "$_runc_builddir"
+	mv vendor src
 	mkdir -p src/github.com/opencontainers/
 	ln -s "$_runc_builddir" src/github.com/opencontainers/runc
-	cd src/github.com/opencontainers/runc
 	GOPATH="$PWD" make COMMIT="$_runc_ver"
 
 	# tini
@@ -232,13 +232,13 @@ vim() {
 	done
 }
 
-sha512sums="48c4916421cd500ada1bfc2207123a29870939a15a1c7c4a0c082f61c1e3e063381e2345ee9df645dbaca49e002dbfaba70cf6fe233b39a4e1f44fb015807e10  docker-18.03.1.tar.gz
-f7d765c6d0a24adf1030cb41d71ce532f2f5b3dd4c05c48aaa6eb37604c3854cc3a463aff19defc7c259564e237ef30f7e39d4787dad0ee42bb534c3d65946c0  runc-4fc53a81fb7c994640722ac585fa9ca548971871.tar.gz
-a9833beac55f388acf90cd657755f7752e90eb396be6080570e184e23c5e96e9c3d7632f5e256178417c964457cb58b49b6e531d9844feecf2043ae6d200e93a  containerd-773c489c9c1b21a6d78b5c538cd395416ec50f88.tar.gz
-300e197313017536f91768ba675f2ab773eb1914f8e5908f4ff5b6fc8c4f0fa5ba1653cd9f8ca26e7c466f1623716aa45a2746f862e47ca9fe9136010085f600  libnetwork-c15b372ef22125880d378167dde44f4b134e1a77.tar.gz
-b6c1454f734662adf2fdedcb75cb7cdc82f4cf5b4c41fadf6891a670fa26d49b789034f4af8bf920b9e1ff1c3536123637ade9471f4ae2c1ef6c534e839b9f27  tini-949e6facb77383876aeff8a6944dde66b3089574.tar.gz
+sha512sums="d5bd6a83126c4dba14c775533b6c9bda35af2cd97db13922b3766494ce10dd9316d0167c87a6683dede28ea063f9435a0a009b96e413dad8abc7884a3468d589  docker-18.06.0.tar.gz
+9a55bdb8e39830f46cceff48970b7688139927552e3d268b9ef4a6e640ffc3d95164b99c5b05d07d295bedc2ea22daf6062fd520df1548d78b1d481fd928f1e3  runc-69663f0bd4b60df09991c08812a60108003fa340.tar.gz
+cf719e5c3d7e48eef2726b376f05e923241df8814c2b54c9b89fd9526f1124cead0b0641f17eaf11e67ec19c14a86d56f5955855c992190497415102207aa205  containerd-d64c661f1d51c48782c9cec8fda7604785f93587.tar.gz
+21d3d1bd8aafeab51a3e0a14ada4d559b5b113a48d315e91f7d70e4fa839f5c92d4068b38c28bf6929da9c11cfc61703bafc7148f64b784208d61fa14ee4545d  libnetwork-3ac297bc7fd0afec9051bbb47024c9bc1d75bf5b.tar.gz
+ee46d21467f8bacb4e8be72f5dfcbb23c1964286e90b4b3d3bf67dbbf79a337968ac8a0042a8191e329a65398b20ea160aae3ae5ef20ee03ebae11c2083d7621  tini-fec3683b971d9c3ef73f284f176672c44b448662.tar.gz
 4c52e01c9b07582b5d55d1e94935378a676bd284a3e8230a8a191d4678b1b6ae92b704a249117c542832170069a70c649e58a1752fb2973709259b5bc108db91  go-md2man-1.0.8.tar.gz
-2ff7dcc8275d2a2619f1dc8bcb890af42a9695a922fe408782b457e8e940ce32976f030c897170bfa7ee01ca22cb11b6ab74ef7da9da578baa9f494c2e93c573  cobra-0.0.2.tar.gz
+c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 33155a79799cc6c0520a030e1a9bdba60441776d612e5e255574b23bbce1c7a8e5d868284b05a8a92704be6bbb7db905388564e867986a705acbe4884ac58584  docker-openrc-fixes.patch
 29a343848d0aa14864c6bfc87c2a6fd408f546f0114e12f7035fb4678ee769fe728872a5d283803177990a61d7e02c4916017d5e45380ad3b0a2dffa3e746857  tini-cmake-fixes.patch
 9b24dc0c50904c3d12bb04c1a7df169651043ddbc258018647010a5aa01d8a19ad54d10ca79dce6d6283c81f4fa0cc8de417f6180dd824c5a588b22b23546cb5  docker-openrc-busybox-ash.patch"

--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -29,6 +29,7 @@ subpackages="
 	$pkgname-zsh-completion:zshcomp:noarch
 	$pkgname-vim:vim:noarch
 	$pkgname-doc
+	$pkgname-openrc
 	"
 
 source="


### PR DESCRIPTION
This change to APKBUILD for runc also fixes a warning that gets
logged every 30 seconds while running dockerd:
failed to retrieve docker-runc version: unknown output format: runc version spec: 1.0.0\n
Reason: the way it was built before was partially wrong

Please also port this aport back to 3.8.0