### PR TITLE
new aport: libyang, a YANG parser and toolkit

### DIFF
--- a/testing/libyang/APKBUILD
+++ b/testing/libyang/APKBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Arthur Jones <arthur.jones@riverbed.com>
+pkgname=libyang
+_srcver=0.15-r1
+pkgver=${_srcver/-r/.}
+pkgrel=0
+pkgdesc="yang parser and validator"
+url="https://github.com/CESNET/libyang"
+arch="x86_64"
+license="BSD-3-Clause"
+makedepends="cmake pcre-dev cmocka-dev bison flex doxygen"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-dbg $pkgname-utils"
+source="https://github.com/CESNET/libyang/archive/v${_srcver}.tar.gz"
+builddir="$srcdir"/$pkgname-$_srcver
+
+build() {
+	cd "$builddir"
+	mkdir build
+	cd build
+	cmake \
+		-DENABLE_BUILD_TESTS=ON \
+		-DCMAKE_INSTALL_PREFIX:PATH=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DCMAKE_BUILD_TYPE:String="Release" ..
+	make
+}
+
+check() {
+	cd "$builddir"/build
+
+	make test
+}
+
+package() {
+	cd "$builddir"/build
+
+	make DESTDIR="$pkgdir" install
+}
+
+utils() {
+	pkgdesc="$pkgdesc (utilities)"
+	mkdir -p "$subpkgdir"/usr/bin
+	for p in yangre yanglint; do
+		mv "$pkgdir"/usr/bin/$p "$subpkgdir"/usr/bin
+	done
+}
+
+sha512sums="ce0cb7aa8076c43aea2421b402f936e47092fd99a359cf383204c5d4bfede170159f2e04d59b0c1606b23ef4ef40593d39420c93a92d7223e603a925ee1add41  v0.15-r1.tar.gz"


### PR DESCRIPTION
libyang provides a C interface into YANG data models, which are
becoming increasingly important for network configuration and
operational state.  There are patches under review in frr to
use libyang, and the yanglint utility (in the utils package)
is very helpful for debugging and creating yang models.

Fixes: #9133