### PR TITLE
testing/log4cplus: upgrade to 2.0.1

### DIFF
--- a/testing/log4cplus1/APKBUILD
+++ b/testing/log4cplus1/APKBUILD
@@ -1,7 +1,8 @@
 # Contributor:
 # Maintainer:
-pkgname=log4cplus
-pkgver=2.0.1
+pkgname=log4cplus1
+_pkgname=${pkgname%1}
+pkgver=1.2.1
 pkgrel=0
 _ver=${pkgver%%_rc*}
 _rc=${pkgver##*_rc}
@@ -15,8 +16,8 @@ depends_dev=""
 makedepends="$depends_dev"
 install=""
 subpackages="$pkgname-dev"
-source="https://downloads.sourceforge.net/$pkgname/$pkgname-$_ver.tar.xz"
-builddir="$srcdir/$pkgname-$_ver"
+source="https://downloads.sourceforge.net/$_pkgname/$_pkgname-$_ver.tar.gz"
+builddir="$srcdir/$_pkgname-$_ver"
 
 build() {
 	cd "$builddir"
@@ -41,4 +42,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="68e54dfe4d48ae0eda6deac54713e6e2cee8c4d56d5a5955f8639ad47dec502b4cf13d70e950e5158d7828f27dd6b0b3f3c9b6fe1a190a05eea63e73e3a2f3c0  log4cplus-2.0.1.tar.xz"
+sha512sums="6996378061e591e8e71f9aaa9851ab7c0be6fbac56ffb30d60279538ad204f96ded9c8eb1c3f09317b208326b13c3cf89d9dac659e1b8edfbd4cd3d18d5bc6ef  log4cplus-1.2.1.tar.gz"


### PR DESCRIPTION
Kept log4cplus1 as 1.2.1 for supporting < C++11