### PR TITLE
testing/wireguard: upgrade to 0.0.20180802

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180718
+pkgver=0.0.20180802
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="38d7fa90ab7528c0f29e93c4b37c357e51f33061353c180044c50fe05a37874652b3cb179c80f17b8fe9dddbcb224253723ad730e2ad5649cb17ec9d32e8f9ca  WireGuard-0.0.20180718.tar.xz"
+sha512sums="73449764547d531ff5528b49d411c9a8aa9d36bdf659b03ff904272cceb9f09718da81ed204b623c189e194ad11257b05e0d8db27db0a3d3f751fc0abc17d76c  WireGuard-0.0.20180802.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180718
-_rel=1
+_ver=0.0.20180802
+_rel=2
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="38d7fa90ab7528c0f29e93c4b37c357e51f33061353c180044c50fe05a37874652b3cb179c80f17b8fe9dddbcb224253723ad730e2ad5649cb17ec9d32e8f9ca  WireGuard-0.0.20180718.tar.xz"
+sha512sums="73449764547d531ff5528b49d411c9a8aa9d36bdf659b03ff904272cceb9f09718da81ed204b623c189e194ad11257b05e0d8db27db0a3d3f751fc0abc17d76c  WireGuard-0.0.20180802.tar.xz"


### PR DESCRIPTION
```
  * receive: check against proper return value type
  
  Ensure error counters are correct in the receive path.
  
  * embeddable-wg-library: do not left shift negative numbers
  
  Avoids implementation-defined C behavior and also improves performance.
  
  * wg-quick: android: allow package to be overridden
  * wg-quick: android: remove compat code
  
  Small android fixes.
  
  * qemu: show log if process crashes
  * qemu: update musl and kernel
  
  The usual QEMU suite bump.
  
  * curve25519-x86_64: tighten the x25519 assembly
  
  Small performance optimization from Samuel.
  The wide multiplication by 38 in mul_a24_eltfp25519_1w is redundant:
  (2^256-1) * 121666 / 2^256 is at most 121665, and therefore a 64-bit
  multiplication can never overflow.
  
  * curve25519-x86_64: tighten reductions modulo 2^256-38
  
  Small performance optimization from Samuel.
  At this stage the value if C[4] is at most ((2^256-1) + 38*(2^256-1)) / 2^256 = 38,
  so there is no need to use a wide multiplication.
  
  * curve25519-x86_64: simplify the final reduction by adding 19 beforehand
  
  Small performance optimization from Samuel.
  At this stage the value if C[4] is at most ((2^256-1) + 38*(2^256-1)) / 2^256 = 38,
  Correctness can be quickly verified with the following z3py script:
  
  >>> from z3 import *
  >>> x = BitVec("x", 256) # any 256-bit value
  >>> ref = URem(x, 2**255 - 19) # correct value
  >>> t = Extract(255, 255, x); x &= 2**255 - 1; # btrq $63, %3
  >>> u = If(t != 0, BitVecVal(38, 256), BitVecVal(19, 256)) # cmovncl %k5, %k4
  >>> x += u # addq %4, %0; adcq $0, %1; adcq $0, %2; adcq $0, %3;
  >>> t = Extract(255, 255, x); x &= 2**255 - 1; # btrq $63, %3
  >>> u = If(t != 0, BitVecVal(0, 256), BitVecVal(19, 256)) # cmovncl %k5, %k4
  >>> x -= u # subq %4, %0; sbbq $0, %1; sbbq $0, %2; sbbq $0, %3;
  >>> prove(x == ref)
  proved
  
  * ratelimiter: prevent init/uninit race
  
  Fixes a classic ABA problem that isn't actually reachable because of
  rtnl_lock, but it's good to be correct anyway.
  
  * peer: simplify rcu reference counts
  
  Use RCU reference counts only when we must, and otherwise use a more
  reasonably named function.
  
  * main: add missing chacha20poly1305 header
  * send: address of variable is never null
  * noise: remove outdated comment
  * main: properly name label
  * noise: use hex constant for tai64n offset
  * device: adjust comment
  
  A series of last minute nits before submitting upstream.

  * chacha20poly1305: selftest: split up test vector constants
  
  The test vectors are encoded as long strings -- really long strings -- and
  apparently RFC821 doesn't like lines longer than 998.
  https://cr.yp.to/smtp/message.html
  
  * queueing: keep reference to peer after setting atomic state bit
  
  This fixes a regression introduced when preparing the LKML submission.
  
  * allowedips: prevent double read in kref
  * allowedips: avoid window of disappeared peer
  * hashtables: document immediate zeroing semantics
  * peer: ensure resources are freed when creation fails
  * queueing: document double-adding and reference conditions
  * queueing: ensure strictly ordered loads and stores
  * cookie: returned keypair might disappear if rcu lock not held
  * noise: free peer references on failure
  * peer: ensure destruction doesn't race
  
  Various fixes, as well as lots of code comment documentation, for a
  small variety of the less obvious aspects of object lifecycles,
  focused on correctness.
  
  * allowedips: free root inside of RCU callback
  * allowedips: use different macro names so as to avoid confusion
  
  These incorporate two suggestions from LKML.
```