### PR TITLE
testing/mgba: new aport

### DIFF
--- a/testing/mgba/APKBUILD
+++ b/testing/mgba/APKBUILD
@@ -1,0 +1,85 @@
+# Contributor: Alexander Edland <alpine@ocv.me>
+# Maintainer: Alexander Edland <alpine@ocv.me>
+pkgname=mgba
+pkgver=0.6.3
+pkgrel=0
+pkgdesc="Game Boy Advance Emulator"
+url="https://github.com/mgba-emu/mgba"
+arch="all"
+license="MPL-2.0"
+depends=""
+depends_dev=""
+makedepends="cmake qt5-qtmultimedia-dev qt5-qtbase-dev qt5-qttools-dev
+	sdl-dev libzip-dev zlib-dev libpng-dev ffmpeg-dev imagemagick-dev
+	libepoxy-dev cmocka-dev libedit-dev py3-virtualenv python3-dev"
+checkdepends="py3-cffi py3-cached-property"
+install=""
+subpackages="$pkgname-doc $pkgname-py:_py"
+source="mgba-$pkgver.tar.gz::https://github.com/mgba-emu/mgba/archive/$pkgver.tar.gz
+	http://gbdev.gg8.se/files/roms/blargg-gb-tests/cpu_instrs.zip
+	no-rpath.patch
+	python3.patch
+	mgba-qt.desktop"
+builddir="$srcdir/mgba-$pkgver"
+
+build() {
+	cd "$builddir"
+	
+	# declaration mismatch in include/mgba/core/thread.h
+	export CPPFLAGS="$CPPFLAGS -fno-strict-aliasing"
+	
+	mkdir build
+	cd build
+	cmake \
+		-DCMAKE_INSTALL_PREFIX:PATH=/usr \
+		-DCMAKE_INSTALL_LIBDIR:PATH=/usr/lib \
+		-DBUILD_TEST:BOOL=ON \
+		-DBUILD_SUITE:BOOL=ON \
+		-DBUILD_PYTHON:BOOL=ON \
+		..
+	make
+}
+
+check() {
+	cd "$builddir/build"
+	./mgba-suite
+	
+	# test python bindings by executing an open source ROM
+	# for DMG-01 (OG gameboy) and exporting a png screenshot
+	PYTHONPATH="$PWD/$(echo python/lib.linux-x86_64-3.*)" \
+	LD_LIBRARY_PATH="$builddir/build" \
+	ZIPFILE="$srcdir/cpu_instrs.zip" \
+	/bin/sh "$startdir/test-py.sh"
+}
+
+package() {
+	cd "$builddir/build"
+	make install DESTDIR="$pkgdir"
+	
+	# delete test files
+	rm "$pkgdir/usr/bin/mgba-fuzz"
+	rm "$pkgdir/usr/bin/tbl-fuzz"
+	
+	# add desktop file
+	local _apps="$pkgdir/usr/share/applications"
+	mkdir -p "$_apps"
+	cp "$startdir/mgba-qt.desktop" "$_apps"/
+}
+
+_py() {
+	depends="py3-cffi py3-cached-property"
+	
+	cd "$builddir/build/python"
+	local _bdir=$(echo lib.linux-x86_64-3.*)
+	local _pyver=${_bdir##*-}
+	local _dest="$subpkgdir/usr/lib/python$_pyver/site-packages"
+	
+	mkdir -p "$_dest"
+	mv $_bdir/mgba/ "$_dest/"
+}
+
+sha512sums="d646af7869dbcf8df671a75ecfd8c270950c013b826b23b94bacae43a77243786f198725e1b9bf17827d1ffcf6a8eef70091d53ea878bfb2450472485f42f233  mgba-0.6.3.tar.gz
+ea4a1de976e2188c3720d7b8e6f75f67feaede37473826343f9b0a03fe76405e84305384ceee1bc56a4e8131cab432b63320d4c0b120a6c81425af8f0bfbd234  cpu_instrs.zip
+8fefd97e66b63bc660abab2a5d0f29b96b41022e12e53af9841c97dd8d74dddde9c1ac7b56a7f5d7346aa42671767ce3794ecccf66142262116e740a21f6ef03  no-rpath.patch
+7e2ac69620f0118d429afbb6ae905be1e81c80c5eb83118b74ab65f3db81f25823098475d32add624e4424fdac0f882f18c4b42673719eb278160805330148c8  python3.patch
+f77d1e3a35521f29e9caaebb6b010e497602a467963b95b155f67d39c129d8a1bd6acdbce1a10bf25e68ac38de0e4079deb92c710afccc8a2c4841820d3f9119  mgba-qt.desktop"

--- a/testing/mgba/mgba-qt.desktop
+++ b/testing/mgba/mgba-qt.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=mGBA
+GenericName=Game Boy Advance Emulator
+Exec=mgba-qt %f
+Icon=mgba
+Terminal=false
+Type=Application
+Categories=Game;Emulator;Qt;
+MimeType=application/x-mgba-qt;

--- a/testing/mgba/no-rpath.patch
+++ b/testing/mgba/no-rpath.patch
@@ -1,0 +1,16 @@
+--- mgba-0.6.3/CMakeLists.txt
++++ mgba-0.6.3-mod/CMakeLists.txt
+@@ -108,13 +108,10 @@
+ if (BUILD_OPENEMU)
+ 	set(OE_LIBDIR "${LIBDIR}" CACHE PATH "Installed library directory (OpenEmu)")
+ 	mark_as_advanced(OE_LIBDIR)
+ endif()
+ 
+-
+-set(CMAKE_INSTALL_RPATH "${LIBDIR}")
+-
+ if (NOT DEFINED MANDIR)
+ 	set(MANDIR ${CMAKE_INSTALL_MANDIR})
+ endif()
+ 
+ # Function definitions

--- a/testing/mgba/python3.patch
+++ b/testing/mgba/python3.patch
@@ -1,0 +1,10 @@
+--- mgba-0.6.3/src/platform/python/CMakeLists.txt
++++ mgba-0.6.3-mod/src/platform/python/CMakeLists.txt
+@@ -1,6 +1,6 @@
+-find_program(PYTHON python)
++find_program(PYTHON python3)
+ 
+ get_property(INCLUDE_DIRECTORIES DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
+ set(INCLUDE_FLAGS)
+ foreach(DIR IN LISTS INCLUDE_DIRECTORIES)
+ 	list(APPEND INCLUDE_FLAGS "-I${DIR}")

--- a/testing/mgba/test-py.sh
+++ b/testing/mgba/test-py.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+mkdir test-py
+cd test-py
+
+cat > test.py <<'EOF'
+import sys
+import mgba.core
+import mgba.image
+
+core = mgba.core.loadPath(sys.argv[1])
+screen = mgba.image.Image(*core.desiredVideoDimensions())
+core.setVideoBuffer(screen)
+core.reset()
+
+for i in range(2000):
+	core.runFrame()
+
+with open("dump.png".format(i), "wb") as f:
+	screen.savePNG(f)
+EOF
+
+echo "using LD_LIBRARY_PATH [$LD_LIBRARY_PATH]"
+echo "using PYTHONPATH [$PYTHONPATH]"
+echo "using ZIPFILE [$ZIPFILE]"
+
+unzip "$ZIPFILE"
+echo "running Z80 cpu test suite"
+python3 test.py "cpu_instrs/cpu_instrs.gb"
+ls -al dump.png
+[ $(wc -c < dump.png) -gt 768 ]


### PR DESCRIPTION
https://github.com/mgba-emu/mgba  
Emulator for the Game Boy Advance and older Game Boy consoles

Enabled features: Qt frontend, Python bindings, OpenGL rendering (libepoxy), SDL rendering, Video recording, Savestates, Zip/7z, SQLite3 game-db, Test suite, Debuggers, Shared libraries

Disabled features: Profiling, Examples, Libretro core, Static libraries