### PR TITLE
testing/vamp-sdk: new aport

### DIFF
--- a/testing/vamp-sdk/APKBUILD
+++ b/testing/vamp-sdk/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Alexander Edland <alpine@ocv.me>
+# Maintainer: Alexander Edland <alpine@ocv.me>
+pkgname=vamp-sdk
+pkgver=2.7.1
+pkgrel=0
+pkgdesc="Framework for audio analysis and feature extraction"
+url="https://code.soundsoftware.ac.uk/projects/vamp-plugin-sdk"
+arch="all"
+license="BSD-3-Clause"
+options="!check"  # testing is done by make
+makedepends="libsndfile-dev"
+subpackages="$pkgname-dev"
+source="https://code.soundsoftware.ac.uk/attachments/download/2206/vamp-plugin-sdk-$pkgver.tar.gz"
+builddir="$srcdir/vamp-plugin-sdk-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var
+	make
+}
+
+package() {
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
+}
+
+sha512sums="91dd7cae72334718dcbdac06b1ffa3f3ba76e977b82b928ab634d9982aa15ca4e30978a7778215753c61e56831077d7634d24e65e468ab6a8a87a5957fb09bf3  vamp-plugin-sdk-2.7.1.tar.gz"


### PR DESCRIPTION
SDK used by audio-related software plugins