### PR TITLE
testing/lsmash: new aport

### DIFF
--- a/testing/lsmash/APKBUILD
+++ b/testing/lsmash/APKBUILD
@@ -17,7 +17,6 @@ build() {
 	./configure \
 		--prefix=/usr \
 		--extra-cflags=-fPIC \
-		--disable-static \
 		--enable-shared
 	make
 }

--- a/testing/lsmash/APKBUILD
+++ b/testing/lsmash/APKBUILD
@@ -1,0 +1,36 @@
+# Contributor: Alexander Edland <alpine@ocv.me>
+# Maintainer: Alexander Edland <alpine@ocv.me>
+pkgname=lsmash
+pkgver=2.14.5
+pkgrel=0
+pkgdesc="MP4 and MOV muxer/demuxer"
+url="https://github.com/l-smash/l-smash"
+arch="all"
+license="ISC"
+options="!check"
+subpackages="$pkgname-dev"
+source="lsmash-$pkgver.tar.gz::https://github.com/l-smash/l-smash/archive/v$pkgver.tar.gz"
+builddir="$srcdir/l-smash-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--prefix=/usr \
+		--extra-cflags=-fPIC \
+		--disable-static \
+		--enable-shared
+	make
+}
+
+package() {
+	cd "$builddir"
+	make -j1 DESTDIR="$pkgdir" install
+	
+	# prefix binaries with lsmash- because
+	# /usr/bin/muxer is likely to cause collisions
+	for i in "$pkgdir"/usr/bin/*; do
+		mv "$i" "${i%/*}/lsmash-${i##*/}"
+	done
+}
+
+sha512sums="1dc38cd89d7b317b608d5f5f411ffeac3c1e7fdeea2fc2d7c09d209dce90756c51c27198c20199082fc2168f966a604cef3f9cfd2fd17086ae0f9c0bf50f1ec7  lsmash-2.14.5.tar.gz"


### PR DESCRIPTION
MP4 and MOV muxer/demuxer  
Suggesting we use non-standard names for the installed binaries, as they are likely to cause collisions with other packages (/usr/bin/muxer for instance)