### PR TITLE
testing/mutter: upgrade Mutter to 3.28

### DIFF
--- a/testing/mutter/APKBUILD
+++ b/testing/mutter/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=mutter
 pkgver=3.28.0
-pkgrel=0
+pkgrel=1
 pkgdesc="clutter-based window manager and compositor"
 url="https://github.com/GNOME/mutter"
 arch="all"


### PR DESCRIPTION
GNOME can't be installed right now due to a partly done upgrade to 3.28. More packages will have to be upgraded after this one, but I'll do it in separate PR's due to requiring new dependencies.