### PR TITLE
testing/gnome-shell: update to 3.28 and add new required dependencies aports

### DIFF
--- a/testing/cldr-emoji-annotation/APKBUILD
+++ b/testing/cldr-emoji-annotation/APKBUILD
@@ -1,0 +1,26 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+pkgname=cldr-emoji-annotation
+pkgver=33.1.0_p0
+_tag=${pkgver/_p/_}
+pkgrel=0
+pkgdesc="Emoji annotation files in CLDR"
+arch="noarch"
+url="https://github.com/fujiwarat/cldr-emoji-annotation"
+license="Unicode-DFS-2016"
+makedepends="automake autoconf"
+source="$pkgname-$pkgver.tar.gz::https://github.com/fujiwarat/$pkgname/archive/$_tag.tar.gz"
+builddir="$srcdir/$pkgname-$_tag"
+
+build() {
+	cd "$builddir"
+	./autogen.sh --prefix=/usr
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+
+	install -Dm644 unicode-license.txt "$pkgdir"/usr/share/licenses/$pkgname/license
+}
+sha512sums="57dc2b7c8ce4b287eb83113b4d66f5359ce0e03a86477926705864d997bf87a5638dd66414b8ec4549a887cd328c9f996249269be4ca05f0d86d00393e55c513  cldr-emoji-annotation-33.1.0_p0.tar.gz"

--- a/testing/gnome-shell/APKBUILD
+++ b/testing/gnome-shell/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=gnome-shell
-pkgver=3.26.0
+pkgver=3.28.0
 pkgrel=0
 pkgdesc="GNOME shell"
 url="https://wiki.gnome.org/Projects/GnomeShell"
@@ -19,38 +19,33 @@ makedepends="gnome-desktop-dev
 	mutter-dev
 	libcroco-dev
 	pulseaudio-dev
-
 	evolution-data-server-dev evolution-dev
-
 	python3
 	meson
-	itstool
-	libxml2-utils"
+	libxml2-utils
+	ibus-dev ibus
+	sassc"
 subpackages="$pkgname-lang $pkgname-dbg"
 source="https://download.gnome.org/sources/$pkgname/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$pkgname-$pkgver"
+options="!check" # Requires running X11 server
 
 build() {
 	cd "$builddir"
-	./configure \
-		--build=$CBUILD \
-		--host=$CHOST \
-		--prefix=/usr \
-		--sysconfdir=/etc \
-		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		--disable-man
-	make
+	# Building with NetworkManager fails
+	# Man pages are built using an external file which is not allowed
+	meson . _build --prefix=/usr -Dsystemd=false -Dnetworkmanager=false -Dman=false
+	ninja -C _build
 }
 
 check() {
 	cd "$builddir"
-	make check
+	ninja -C _build test
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install
+	DESTDIR="$pkgdir" ninja -C _build install
 }
 
-sha512sums="3da595226f6c95dbdb934eedf99c83515de516a2a86fa4cb2964520e3b411a0ac450a93743443db94e553681628ece0633dd5196c17e950292bcbd3050c736a7  gnome-shell-3.26.0.tar.xz"
+sha512sums="0c5e78393c8bca8ddb548c2cecd7799258ca00735cb7600feb9f7fa43f460719ad22636255496a40ea81dfcb779faf141b972b54555626f9e27ea5ca2377cc68  gnome-shell-3.28.0.tar.xz"

--- a/testing/mutter/APKBUILD
+++ b/testing/mutter/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=mutter
 pkgver=3.28.0
-pkgrel=0
+pkgrel=1
 pkgdesc="clutter-based window manager and compositor"
 url="https://github.com/GNOME/mutter"
 arch="all"

--- a/testing/unicode-character-database/APKBUILD
+++ b/testing/unicode-character-database/APKBUILD
@@ -1,0 +1,24 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+pkgname=unicode-character-database
+pkgver=11.0.0
+pkgrel=0
+pkgdesc="Unicode Character Database"
+arch="noarch"
+license="BSD"
+url="http://www.unicode.org/"
+makedepends="libarchive-tools"
+source="UCD-$pkgver.zip::http://www.unicode.org/Public/zipped/$pkgver/UCD.zip
+	Unihan-$pkgver.zip::http://www.unicode.org/Public/zipped/$pkgver/Unihan.zip"
+noextract={UCD,Unihan}-$pkgver.zip
+options="!check"
+builddir="$srcdir"
+
+package() {
+	cd "$srcdir"
+	for _f in UCD Unihan; do
+		install -Dm644 $_f-$pkgver.zip "$pkgdir/usr/share/unicode/$_f.zip"
+		bsdtar -C "$pkgdir/usr/share/unicode" -x --no-same-owner --no-same-permissions -f $_f-$pkgver.zip
+	done
+}
+sha512sums="954a499ff072727c8778e711fb1753834adf09277c9e9a2592c02b59971860f9a407c7e9985ed1e6bdda7a3cf3b1cd6316599c4bffe8b0625413f874486830c1  UCD-11.0.0.zip
+a045e79545f1ec3529a8556d41c73b20809979e002f98314068c6f91daa79abb2ab3ab383090651b55fb55e343d8fcf67bea822d93d6e3221a206d58ef9e3a7b  Unihan-11.0.0.zip"

--- a/testing/unicode-emoji/APKBUILD
+++ b/testing/unicode-emoji/APKBUILD
@@ -1,0 +1,27 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+pkgname=unicode-emoji
+pkgver=11.0
+pkgrel=0
+pkgdesc="Unicode Emoji Data Files"
+arch="noarch"
+license="BSD"
+url="http://www.unicode.org/emoji/"
+source="emoji-data-$pkgver.txt::http://www.unicode.org/Public/emoji/$pkgver/emoji-data.txt
+        emoji-sequences-$pkgver.txt::http://www.unicode.org/Public/emoji/$pkgver/emoji-sequences.txt
+        emoji-test-$pkgver.txt::http://www.unicode.org/Public/emoji/$pkgver/emoji-test.txt
+        emoji-variation-sequences-$pkgver.txt::http://www.unicode.org/Public/emoji/$pkgver/emoji-variation-sequences.txt
+        emoji-zwj-sequences-$pkgver.txt::http://www.unicode.org/Public/emoji/$pkgver/emoji-zwj-sequences.txt"
+builddir="$srcdir"
+
+package() {
+	cd "$builddir"
+
+	for _f in data sequences test variation-sequences zwj-sequences; do
+		install -Dm644 emoji-$_f-$pkgver.txt "$pkgdir/usr/share/unicode/emoji/emoji-$_f.txt"
+	done
+}
+sha512sums="501847414275564c7753b7d2b8e45cdfbf9fe96a96f0f3eea81f34c480da551b317b432ca426f6441c95eea520992e8888ead749e9c60da38233afd159d9b555  emoji-data-11.0.txt
+c9af23e0738350b6d61691498ac82cccec970bb2cd4a0c5d6fab6c86fef742c09c6a83f50124c1f98c285e706d145786bb29cbf4339ff1a01c75ad7515b159a6  emoji-sequences-11.0.txt
+89c5a0f2eb460234e50dcc0fc904fbb254a1c0afa54b5bb672032f01764e0bed3624d1a4cd5627c83fcf1ea1347c9e3baaca05b2c685890afa505763baf8be79  emoji-test-11.0.txt
+a0a487ef43d9cd49ff2ced654794e7190f357b00dd70ec9b84e640181dc5b2df44b2063aa4b16447d00815094155b24531f115e9121c51c95635b0af4b043643  emoji-variation-sequences-11.0.txt
+a2a50cd5451d3ba1da0f3b46e18a10d621ead0372599b98dad0fd47fdb271407f72bd72854136c93311b13950cedc2b1594f06d460e551ab120ed30ba8abce4d  emoji-zwj-sequences-11.0.txt"


### PR DESCRIPTION
Please have a good look at the new aports, especially ibus, as I did this a bit hasty using the PKGBUILDs from Arch Linux and I'm sure there is something to improve.

Also, Mutter needed a `$pkgrel` bump to being able to be installed.