### PR TITLE
main/fail2ban: fix tests

### DIFF
--- a/main/fail2ban/APKBUILD
+++ b/main/fail2ban/APKBUILD
@@ -9,7 +9,8 @@ url="http://www.fail2ban.org"
 arch="noarch"
 license="GPL-2.0-or-later"
 depends="python3 iptables ip6tables logrotate"
-makedepends="python3-dev py3-setuptools"
+makedepends="python3-dev py3-setuptools bash"
+subpackages="$pkgname-doc $pkgname-openrc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/$pkgver.tar.gz
 		fail2ban.confd
 		fail2ban.logrotate


### PR DESCRIPTION
- tests depends on bash https://github.com/fail2ban/fail2ban/blob/0.10.3.1/fail2ban/tests/actiontestcase.py#L496
- also packaging system complains about `-doc` & `-openrc` so added

PS follow-up to https://github.com/alpinelinux/aports/pull/3916