### PR TITLE
community/py-lz4: upgrade to 2.1.0

### DIFF
--- a/community/py-lz4/APKBUILD
+++ b/community/py-lz4/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=py-lz4
-pkgver=2.0.1
+pkgver=2.1.0
 _pkgname=${pkgname#py-}
 pkgrel=0
 pkgdesc="LZ4 Bindings for Python"
@@ -65,5 +65,5 @@ _tests() {
 	mv "$builddir"/tests "$subpkgdir"/usr/share/$pkgname
 }
 
-sha512sums="e1fa406227aa522d47a20bc2720fd402df216a4fc008688f4e0d8802e660c81e3b6449131b78254c615c9a5b452e5b0576f4fe82ce914998fb8ee989ebf38389  lz4-2.0.1.tar.gz
+sha512sums="d1edeccfcc7c0ee45b59424729b74f67931c0662ac8c4302793a6e298adc23506f0b674248366d55484b7a86cdb0b9af50879b9fd3675cae10e543e1d4804468  lz4-2.1.0.tar.gz
 bfd746ae77169f4b963a386816f8480f817587535415144f3a716a00ad22f18db3dfde5b2bbe69892d2298e19453a88531eec90b72fca13961f404555de41b8b  system-lz4.patch"


### PR DESCRIPTION
This release changes the handling of errors for block decompression when
`uncompressed_size > 0`. In this case, we no longer check that the uncompressed
data has exactly the size specified by `uncompressed_size`: this argument is
now used as an upper bound.

In addition, we introduce a new exception:` LZ4BlockError` which is raised
whenever the `LZ4`library fails.

These two changes together allow "guessing" of the uncompressed data size:
simply set uncompressed_size to a number and try decompress, and catch
`LZ4BlockError`. If `LZ4BlockError` is raised, increase `uncompressed_size`
and try again.

See the documentation for more details and examples:

http://python-lz4.readthedocs.io/en/stable/lz4.block.html