### PR TITLE
community/namecoin: upgrade to 0.16.2

### DIFF
--- a/community/namecoin/APKBUILD
+++ b/community/namecoin/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=namecoin
-pkgver=0.16.1
+pkgver=0.16.2
 _ver=${pkgver/_/}
 pkgrel=0
 pkgdesc="Namecoin is a peer to peer DNS based on bitcoin"
@@ -12,7 +12,8 @@ makedepends="$depends_dev autoconf automake libtool boost-dev libressl-dev
 	db-dev miniupnpc-dev qt5-qtbase-dev qt5-qttools-dev protobuf-dev
 	libqrencode-dev libevent-dev chrpath"
 install="$pkgname.post-install $pkgname.pre-install"
-subpackages="$pkgname-dev $pkgname-qt $pkgname-cli $pkgname-tx $pkgname-tests $pkgname-bench $pkgname-doc $pkgname-openrc"
+subpackages="$pkgname-dev $pkgname-qt $pkgname-cli $pkgname-tx $pkgname-tests $pkgname-bench
+	$pkgname-doc $pkgname-openrc"
 source="$pkgname-$_ver.tar.gz::https://github.com/$pkgname/$pkgname-core/archive/nc${_ver}.tar.gz
 	ssize_t.patch
 	$pkgname.initd
@@ -88,7 +89,7 @@ dev() {
 	mv "$pkgdir"/usr/include "$subpkgdir"/usr/
 }
 
-sha512sums="42b976c2422e871a8f6f6f40a5421e74731c22c8d1fc2baa481250dd746525bb96e2880620ceea07e914bf4f0104802c846a300e44747c74ca58630a98c743a6  namecoin-0.16.1.tar.gz
+sha512sums="65eefb3a9adef3aca78dfd4992b36a7b19cb6e46d20346139c2b4c69160c77adcd7908eb1d054bf2fd9cb721dd0d9da2b2aa3a14289392f76192aad86dfac80f  namecoin-0.16.2.tar.gz
 98aa5ad81bdb4ae961b791bc978c39117cdf2d83c2181f92bebbb0db107d9b6e86eda265fb3f93ff8a5ca8a7754d7148818b98095d57201dff9363d60b97e7dd  ssize_t.patch
 1753132f349e02cc248a622eb17f2f98a180d561d46f2e8916b84cc26c98d546214ca305bb1ea378ae14090c0abf8d6ac257c98c6776bbe4dabd68c108f595a3  namecoin.initd
 3f92cb9a5f66d0e9e3792691b2e62b929c092030273bb87ebd9564e0c02196a5a9f69c458162f1b35099ac28e9b79b1c4035144b9d2dae4ad3e87d05a40d7ed4  namecoin.conf"


### PR DESCRIPTION
* [release notes](https://github.com/namecoin/namecoin-core/blob/master/doc/release-notes/release-notes-0.16.2.md)