### PR TITLE
main/postgresql: security upgrade to 10.5

### DIFF
--- a/main/postgresql/APKBUILD
+++ b/main/postgresql/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: G.J.R. Timmer <gjr.timmer@gmail.com>
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=postgresql
-pkgver=10.4
+pkgver=10.5
 pkgrel=0
 pkgdesc="A sophisticated object-relational DBMS"
 url="https://www.postgresql.org/"
@@ -36,6 +36,9 @@ builddir="$srcdir/$pkgname-$pkgver"
 options="!checkroot"
 
 # secfixes:
+#   10.5-r0:
+#   - CVE-2018-10915
+#   - CVE-2018-10925
 #   10.4-r0:
 #   - CVE-2018-1115
 #   10.3-r0:
@@ -295,7 +298,7 @@ _submv() {
 	done
 }
 
-sha512sums="b7c0d2fdc724e2eb1cda9fc1eb01b47352bbe6ba6357b3e898b7f5990fd78499c8c68dcb3aa9bde7821d71b5882d8856131384e899f8055d89d51cdfdbc9e663  postgresql-10.4.tar.bz2
+sha512sums="1bad30ae88beca66f7e8b99b82e7f02aac1e9230b328e6e5a762a704cdd9dc767d924f5a66c68c93586badfef91b7ff336120a567ce970eaa58bb44c662ad48c  postgresql-10.5.tar.bz2
 1f8e7dc58f5b0a12427cf2fd904ffa898a34f23f3332c8382b94e0d991c007289e7913a69e04498f3d93fc5701855796c207b4b1cc4a0b366f586050124d7fcc  initdb.patch
 5f9d8bb4957194069d01af8ab3abc6d4d83a7e7f8bd7ebe1caae5361d621a3e58f91b14b952958138a794e0a80bc154fbb7e3e78d211e2a95b9b7901335de854  perl-rpath.patch
 8439a6fdfdea0a4867daeb8bc23d6c825f30c00d91d4c39f48653f5ee77341f23282ce03a77aad94b5369700f11d2cb28d5aee360e59138352a9ab331a9f9d0f  conf-unix_socket_directories.patch


### PR DESCRIPTION
CVE-2018-10915 CVE-2018-10925

Ref https://www.postgresql.org/about/news/1878/