### PR TITLE
community/phpmyadmin: fix apache2 config and improve

### DIFF
--- a/community/phpmyadmin/APKBUILD
+++ b/community/phpmyadmin/APKBUILD
@@ -1,17 +1,15 @@
 # Contributor: Sergei Lukin <sergej.lukin@gmail.com>
 # Contributor: Matt Smith <mcs@darkregion.net>
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
-_php=php7
 pkgname=phpmyadmin
 pkgver=4.8.2
-pkgrel=0
+pkgrel=1
 pkgdesc="A Web-based PHP tool for administering MySQL"
 url="https://www.phpmyadmin.net/"
 arch="noarch"
 license="GPL-2.0 MIT BSD"
-depends="${_php} ${_php}-mysqli ${_php}-zip ${_php}-bz2
-	${_php}-ctype ${_php}-gd ${_php}-mcrypt ${_php}-json"
-depends_dev=
+depends="php7 php7-mysqli php7-bz2 php7-ctype php7-curl php7-gd php7-json
+	php7-mbstring php7-openssl php7-session php7-zip"
 makedepends="$depends_dev"
 install="$pkgname.post-install"
 subpackages="$pkgname-doc"
@@ -50,15 +48,6 @@ options="!check"  # tests require running MySQL
 #     - CVE-2016-9866
 
 _builddir="$srcdir"/$_fullpkgname
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
 
 build() {
 	return 0
@@ -67,43 +56,38 @@ build() {
 package() {
 	cd "$_builddir"
 	mkdir -p "$pkgdir"/usr/share/webapps/$pkgname \
-		"$pkgdir"/etc/$pkgname \
-		|| return 1
+		"$pkgdir"/etc/$pkgname
 
 	# copy phpmyadmin
-	cp -r "$_builddir"/* "$pkgdir"/usr/share/webapps/$pkgname/ \
-		|| return 1
+	cp -r "$_builddir"/* "$pkgdir"/usr/share/webapps/$pkgname/
 
 	# install the sample config
 	install -m660  \
 		"$pkgdir"/usr/share/webapps/$pkgname/config.sample.inc.php \
-		"$pkgdir"/etc/$pkgname/config.inc.php \
-		|| return 1
+		"$pkgdir"/etc/$pkgname/config.inc.php
 	ln -sf /etc/$pkgname/config.inc.php \
-		"$pkgdir"/usr/share/webapps/$pkgname/config.inc.php \
-		|| return 1
+		"$pkgdir"/usr/share/webapps/$pkgname/config.inc.php
 
 	# install the apache2 config
 	install -Dm644 "$srcdir"/$pkgname.apache2.conf \
-		"$pkgdir"/etc/apache2/conf.d/$pkgname.conf || return 1
+		"$pkgdir"/etc/apache2/conf.d/$pkgname.conf
 
 	# copy sample config
-	mkdir -p "$pkgdir"/usr/share/$pkgname/ || return 1
+	mkdir -p "$pkgdir"/usr/share/$pkgname/
 	mv "$pkgdir"/usr/share/webapps/$pkgname/config.sample.inc.php \
-		"$pkgdir"/usr/share/$pkgname/ || return 1
+		"$pkgdir"/usr/share/$pkgname/
 }
 
 doc() {
 	cd "$_builddir"
-	mkdir -p "$subpkgdir"/usr/share/doc/$pkgname || return 1
+	mkdir -p "$subpkgdir"/usr/share/doc/$pkgname
 
 	_docs="ChangeLog LICENSE README RELEASE-DATE-$pkgver"
 	for _doc in $_docs; do
 		mv "$pkgdir"/usr/share/webapps/$pkgname/$_doc \
-			"$subpkgdir"/usr/share/doc/$pkgname/ \
-			|| return 1
+			"$subpkgdir"/usr/share/doc/$pkgname/
 	done
 }
 
 sha512sums="32c5f048b31089ea6a6bc0212b32f01eb842eddc323a9729b98a693d96d38b0ef091b4521381dae432d2482bf0214ad65ffaa13c925b0dca5dcb645e2987eb33  phpMyAdmin-4.8.2-all-languages.tar.xz
-c6af2960b95924c31cc05d90e7282ba9be6cb6eabb134b8bb627230a4253c017eca75132420a356acd6aecdce146e29666ed90fc90749820060a64478d3e2105  phpmyadmin.apache2.conf"
+ba5776800f5c7b6cbb4ae594ec77c4d3e0d0bd319d109c676bd6c969054967baef99cab1a30c2efa26487b2ec03ef9b81d035a4323003565cffb19b08fdce9f5  phpmyadmin.apache2.conf"

--- a/community/phpmyadmin/phpmyadmin.apache2.conf
+++ b/community/phpmyadmin/phpmyadmin.apache2.conf
@@ -1,7 +1,19 @@
 Alias /phpmyadmin "/usr/share/webapps/phpmyadmin"
 <Directory "/usr/share/webapps/phpmyadmin">
+	AddDefaultCharset UTF-8
 	AllowOverride All
 	Options FollowSymlinks
-	Order allow,deny
-	Allow from all
+	<IfModule mod_authz_core.c>
+		Require all granted
+	</IfModule>
+</Directory>
+<Directory "/usr/share/webapps/phpmyadmin/libraries">
+	<IfModule mod_authz_core.c>
+		Require all denied
+	</IfModule>
+</Directory>
+<Directory "/usr/share/webapps/phpmyadmin/templates">
+	<IfModule mod_authz_core.c>
+		Require all denied
+	</IfModule>
 </Directory>


### PR DESCRIPTION
- package was broken because of missing session & mbstring extensions
- apache config was broken - needs to use current syntax
- as package depends on php7 now no reason in substitution (php5 support will gone in 4 month)
- fixed the list of php extensions required to run app https://docs.phpmyadmin.net/en/latest/require.html#php

Closes #8088