### PR TITLE
testing/wireguard: upgrade to 0.0.20180809

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180802
+pkgver=0.0.20180809
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="73449764547d531ff5528b49d411c9a8aa9d36bdf659b03ff904272cceb9f09718da81ed204b623c189e194ad11257b05e0d8db27db0a3d3f751fc0abc17d76c  WireGuard-0.0.20180802.tar.xz"
+sha512sums="2278cae078cf3ff9e0c43979ff559820d9d99b64c1ccdbc8a7fea3fc1a5fa0818d782a8962aefc07678599cc15f5a4237fd5dd7ffad108d639c39930979e3cc5  WireGuard-0.0.20180809.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180802
-_rel=2
+_ver=0.0.20180809
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="73449764547d531ff5528b49d411c9a8aa9d36bdf659b03ff904272cceb9f09718da81ed204b623c189e194ad11257b05e0d8db27db0a3d3f751fc0abc17d76c  WireGuard-0.0.20180802.tar.xz"
+sha512sums="2278cae078cf3ff9e0c43979ff559820d9d99b64c1ccdbc8a7fea3fc1a5fa0818d782a8962aefc07678599cc15f5a4237fd5dd7ffad108d639c39930979e3cc5  WireGuard-0.0.20180809.tar.xz"


### PR DESCRIPTION
```
  * send: switch handshake stamp to an atomic
  
  Rather than abusing the handshake lock, we're much better off just using
  a boring atomic64 for this. It's simpler and performs better. Also, while
  we're at it, we set the handshake stamp both before and after the
  calculations, in case the calculations block for a really long time waiting
  for the RNG to initialize. 
  
  * compat: better atomic acquire/release backport
  
  This should fix compilation and correctness on several platforms.
  
  * crypto: move simd context to specific type
  
  This was a suggestion from Andy Lutomirski on LKML.
  
  * chacha20poly1305: selftest: use arrays for test vectors
  
  We no longer have lines so long that they're rejected by SMTP servers.
  
  * qemu: add easy git harness
  
  This makes it a bit easier to use our qemu harness for testing our mainline
  integration tree.
  
  * curve25519-x86_64: avoid use of r12
  
  This causes problems with RAP and KERNEXEC for PaX, as r12 is a
  reserved register.
  
  * chacha20: use memmove in case buffers overlap
  
  A small correctness fix that we never actually hit in WireGuard but is
  important especially for moving this into a general purpose library.
  
  * curve25519-hacl64: simplify u64_eq_mask
  * curve25519-hacl64: correct u64_gte_mask
  
  Two bitmath fixes from Samuel, which come complete with a z3 script proving
  their correctness.
  
  * timers: include header in right file
  
  This fixes compilation in some environments.
  
  * netlink: don't start over iteration on multipart non-first allowedips
  
  Matt Layher found a bug where a netlink dump of peers would never terminate in
  some circumstances, causing wg(8) to keep trying forever. We now have a fix as
  well as a unit test to mitigate this, and we'll be looking to create a fuzzer
  out of Matt's nice library.
```