### PR TITLE
community/lxcfs: Modprobe modules instead of failing when absent

### DIFF
--- a/community/lxcfs/APKBUILD
+++ b/community/lxcfs/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=lxcfs
 pkgver=3.0.1
-pkgrel=0
+pkgrel=1
 pkgdesc="FUSE filesystem for LXC"
 url="https://linuxcontainers.org/lxcfs"
 arch="all"
@@ -48,6 +48,6 @@ package() {
 
 sha512sums="b3533fb3b7909973a79ac8eddda0faefdec19dd7209fce8e0ea8fb90981c3c5a0d0154eadb9686abf688cddd6ed294e52f64e71c509d00c4f228cc21b00645e2  lxcfs-3.0.1.tar.gz
 71df316b1aaf1a0fadc230473a66c0be4d201d706481f1042c353b79fc629e9e681ec4fe0dfb113370e00d3f40175b0d7759fdcdcce57cf1d2db585068aa6e8d  lxcfs.confd
-b4e3bb76f4720d74c768c44c377665ad40e92da7332efebbf9100b6164e4e81214921c751d8ecd14dcef85c22cfa79bacf7e444d8159e93c719ff81ce2e9ba1c  lxcfs.initd
+ca0bbb96f5b54bc1d580cac70ad04bcfe3a88c8abb7b791962386ba1aa69ad5f3769baa667b9d5ca36f81f75d08a7909c76c8418c2fe526daef97792f1e2dafa  lxcfs.initd
 16c65a10b2b95a85ea21d2cb44a45c9c7faf1e22c8c438c7325be96025588834a528544598a91facc13fa93cc46f6c4534fa2ca6bb58b152a26f1ced94b18f16  README.alpine
 003702bad354bf0499449022a364a822e52e752cfb5491c9983b8f5d5160d53fbf598bdb7e7c6e7eab9544384ac79586552c3bb26463bd189e485909d884882b  lxcfs-subdir.patch"

--- a/community/lxcfs/lxcfs.initd
+++ b/community/lxcfs/lxcfs.initd
@@ -19,16 +19,8 @@ depend() {
 }
 
 start_pre() {
-	local module=
 	checkpath --directory ${VARDIR}
-	for module in fuse autofs4; do
-		if ! $(lsmod | grep -q ^$module); then
-			eerror "Enable module: $module"
-			eerror "modprobe $module"
-			eerror "echo $module >> /etc/modules"
-			eend 1
-		fi
-	done
+	modprobe fuse autofs4
 }
 
 find_perms() {


### PR DESCRIPTION
Previously, lxcfs failed when the kernel modules were not listed the lsmod
output. Built-in kernel modules never show up in lsmod, thus the service
could not be properly started on such systems.

Fixes [#9214](https://bugs.alpinelinux.org/issues/9214).