### PR TITLE
community/mbedtls: upgrade to 2.12.0

### DIFF
--- a/community/mbedtls/APKBUILD
+++ b/community/mbedtls/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mbedtls
-pkgver=2.11.0
+pkgver=2.12.0
 pkgrel=0
 pkgdesc="Light-weight cryptographic and SSL/TLS library"
 url="https://tls.mbed.org"
@@ -54,10 +54,10 @@ package() {
 }
 
 utils() {
-	pkgdesc="Utilities for mbedtls"
+	pkgdesc="Utilities for mbedtls (including gen_key / cert_write)"
 
-	mkdir -p "$subpkgdir"/usr/libexec
-	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/libexec/mbedtls
+	mkdir -p "$subpkgdir"/usr
+	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
 static() {
@@ -68,4 +68,4 @@ static() {
 	chmod -x "$subpkgdir"/usr/lib/*.a
 }
 
-sha512sums="301ddc6757be32aaa8ddbfd6c665a1d78c4869007a5aff954b54479c26f90d25bbfcb8c866dd6ae73a8222123928355e84ca5b59d24512d2bfdf1cdc41050e29  mbedtls-2.11.0.tar.gz"
+sha512sums="c7c2aeb1717886ad87486af2dccb05b2f051372c69fc914f30e4ace1067f5be39ba04e093ad522f904e23a576c1ff430bd772e77823d0f4720f6fc5c1b8aa98c  mbedtls-2.12.0.tar.gz"


### PR DESCRIPTION
* includes fixes for **CVE-2018-0497** and **CVE-2018-0498**

https://github.com/ARMmbed/mbedtls/blob/development/ChangeLog
