### PR TITLE
community/libcouchbase: upgrade to 2.9.3

### DIFF
--- a/community/libcouchbase/APKBUILD
+++ b/community/libcouchbase/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Nathan Johnson <nathan@nathanjohnson.info>
 # Maintainer: Nathan Johnson <nathan@nathanjohnson.info>
 pkgname=libcouchbase
-pkgver=2.9.2
+pkgver=2.9.3
 pkgrel=1
 pkgdesc="C client library for Couchbase"
 url="https://developer.couchbase.com/community"
@@ -74,6 +74,6 @@ bin() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="a3eb8501a2e7c7e4d13fbd52b1ad77ec03d8fd3f88d149f1250b7afe1039ad698ea5f31813d842f00bbe025ea3d9f628922858b25ac7346b2ed542b404b2a81b  libcouchbase-2.9.2.tar.gz
+sha512sums="79b842967beaec0f26244b8ea18fa588d00356e04c47c052234cb15a2b3b1b2134e9d8cad5f5c1958321ec0c762b59785d37b2ac275e80eab5693b7dd252bceb  libcouchbase-2.9.3.tar.gz
 987b76b9c8a38a1f144bcada3c24192b30b352c993c433f4a2a1e381b765ae6bb845ebc6393c794da1b4efbb68fd1d34b027104fecf5c9bcc29b0f58c7f6a474  disable_git_version_check.patch
 72319b86fdd91728723ccb091e72199788a84e2ec9ea12c0fcd1ed686eb155ec11e0addbff96735f83e7f31764a85650f0483b6e76d3a8bee16f71b2751fe4a9  fix_socktest.patch"


### PR DESCRIPTION
https://github.com/couchbase/libcouchbase/releases/tag/2.9.3