### PR TITLE
community/php5: fix dependency (part 2)

### DIFF
--- a/community/php5/APKBUILD
+++ b/community/php5/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
 pkgver=5.6.37
-pkgrel=1
+pkgrel=2
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
 arch="all"
@@ -428,6 +428,7 @@ pear() {
 
 phpdbg() {
 	pkgdesc="Interactive PHP debugger"
+	depends="$pkgname-common"
 	provides="php-phpdbg"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/phpdbg* "$subpkgdir"/usr/bin/
@@ -438,12 +439,12 @@ _mv_ext() {
 	local ini=$ext.ini
 	pkgdesc="${ext} extension for PHP"
 	provides="php-$extname"
+	depends="${pkgname}-common"
 
 	# extension dependencies
 	if [ -n "${2-}" ]; then
-		depends="${2-}"
+		depends="${depends} ${2-}"
 	fi
-	depends="${pkgname}-common ${depends}"
 
 	# work around dependency issue
 	# https://bugs.alpinelinux.org/issues/1848


### PR DESCRIPTION
some fixes after #5018

removed php5-cli dependency on all extensions
added php5-common (config) dependency to phpdbg