### PR TITLE
community/php7-pecl-igbinary: renamed from php7-igbinary, modernize

### DIFF
--- a/community/php7-pecl-igbinary/APKBUILD
+++ b/community/php7-pecl-igbinary/APKBUILD
@@ -1,16 +1,18 @@
 # Contributor: Andy Postnikov <apostnikov@gmail.com>
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
 
-pkgname=php7-igbinary
+pkgname=php7-pecl-igbinary
 _pkgreal=igbinary
 pkgver=2.0.7
-pkgrel=0
+pkgrel=1
 pkgdesc="Igbinary is a drop in replacement for the standard php serializer"
 url="https://pecl.php.net/package/igbinary"
 arch="all"
 license="BSD-3-Clause"
-makedepends="autoconf php7-dev"
-source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
+provides="php7-igbinary=$pkgver-r$pkgrel" # for backward compatibility
+replaces="php7-igbinary" # for backward compatibility
+makedepends="autoconf php7-dev re2c"
+source="$pkgname-$pkgver.tgz::https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 build() {
@@ -35,4 +37,4 @@ package() {
 		"$pkgdir"/etc/php7/conf.d/$_pkgreal.ini
 }
 
-sha512sums="216a622f8421f4e2140d5ef8250b66b2b536a7de6c236c6f62938ea49abc264c6c23cf0b41dd954bb89a03ff83fc4d6c7209386a2b05bf523f6312a6c16e1f0a  igbinary-2.0.7.tgz"
+sha512sums="216a622f8421f4e2140d5ef8250b66b2b536a7de6c236c6f62938ea49abc264c6c23cf0b41dd954bb89a03ff83fc4d6c7209386a2b05bf523f6312a6c16e1f0a  php7-pecl-igbinary-2.0.7.tgz"


### PR DESCRIPTION
build with `re2c` and rename according to https://bugs.alpinelinux.org/issues/9277