### PR TITLE
main/python3: Update to 3.6.6

### DIFF
--- a/main/python3/APKBUILD
+++ b/main/python3/APKBUILD
@@ -3,9 +3,9 @@
 
 pkgname=python3
 # the python2-tkinter's pkgver needs to be synchronized with this.
-pkgver=3.6.4
+pkgver=3.6.6
 _basever="${pkgver%.*}"
-pkgrel=1
+pkgrel=0
 pkgdesc="A high-level scripting language"
 url="http://www.python.org"
 arch="all"
@@ -17,10 +17,6 @@ makedepends="expat-dev libressl-dev zlib-dev ncurses-dev bzip2-dev xz-dev
 	sqlite-dev libffi-dev tcl-dev linux-headers gdbm-dev readline-dev"
 source="http://www.python.org/ftp/python/$pkgver/Python-$pkgver.tar.xz
 	musl-find_library.patch
-	fix-xattrs-glibc.patch
-	bpo-30353.patch
-	libressl.patch
-	libressl-2.7.patch
 	"
 builddir="$srcdir/Python-$pkgver"
 
@@ -144,9 +140,5 @@ wininst() {
 		"$subpkgdir"/usr/lib/python$_basever/distutils/command
 }
 
-sha512sums="09ba2103ac517ac4d262f00380c9aac836a53401ce252540c17fd821a3b92e1ddf32528d00772221eb3126b12cb95b62c3ac3e852f4951e6f2eb406c88c848a2  Python-3.6.4.tar.xz
-ab8eaa2858d5109049b1f9f553198d40e0ef8d78211ad6455f7b491af525bffb16738fed60fc84e960c4889568d25753b9e4a1494834fea48291b33f07000ec2  musl-find_library.patch
-37b6ee5d0d5de43799316aa111423ba5a666c17dc7f81b04c330f59c1d1565540eac4c585abe2199bbed52ebe7426001edb1c53bd0a17486a2a8e052d0f494ad  fix-xattrs-glibc.patch
-df54032e66171483aad24f9f370e185072dcb2d6981210a8dd79b5fa51c2c7aa64da2501aa96bb5009bfb658387851068bc82f23c515f739672722495c2c98dd  bpo-30353.patch
-8402ab554bb121c5737b5dc49c18719a5655545e914eed2210374b8aeaad3db7f0cff45c1c23a8e06a0f298677995a8d35ba6336667c69125eb1428254beba20  libressl.patch
-bd93678693fcb6aaba784023b5b5fc90b0ba18078f2b1fa4f2cfd153307418cd8c0317b8f2bcdaf6da8ed6ecece0a96eaf9ac62cf987f9a7e042d0b4d2e81d0c  libressl-2.7.patch"
+sha512sums="c71f87c5906e770322a14cacad228655659f782207db826320449d12bf86091c3662f317e1773158dec52f8b052eaedfb4c03b561cc2a6cfcd381597fd2d2b04  Python-3.6.6.tar.xz
+ab8eaa2858d5109049b1f9f553198d40e0ef8d78211ad6455f7b491af525bffb16738fed60fc84e960c4889568d25753b9e4a1494834fea48291b33f07000ec2  musl-find_library.patch"


### PR DESCRIPTION
This PR updates python to the latest 3.6.x and conflicts with PR #4840 (which will update python to the 3.7 branch)