### PR TITLE
community/cassandra-cpp-driver: Fix libressl compilation issue.

### DIFF
--- a/community/cassandra-cpp-driver/APKBUILD
+++ b/community/cassandra-cpp-driver/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=cassandra-cpp-driver
 _pkgname=cpp-driver
 pkgver=2.9.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Cassandra CPP Driver"
 url="https://datastax.github.io/cpp-driver/"
 arch="x86_64 x86 ppc64le"
@@ -14,6 +14,7 @@ makedepends="cmake make libressl-dev libuv-dev"
 subpackages="$pkgname-dev"
 source="$_pkgname-$pkgver.tar.gz::https://github.com/datastax/cpp-driver/archive/$pkgver.tar.gz
 	libuv-1.21-compat.patch
+	libressl_fix.patch
 	"
 builddir="$srcdir/$_pkgname-$pkgver"
 
@@ -34,4 +35,5 @@ package() {
 }
 
 sha512sums="45c6d58b1d287d142c9d7d6b1e28114683648a3634f44b185208fa44da64d4c8a9d485b3956a0cf7429e96f74faa588de832de30265dfa17782ca90e8163a0c1  cpp-driver-2.9.0.tar.gz
-5932f13a666b95a40d938f2cc6f3b6eb2107d5d569ff67be470913275816109f7a32426cf1e39ef950b9ba1c7f78063c388805b4106368f9f1527ff15c422241  libuv-1.21-compat.patch"
+5932f13a666b95a40d938f2cc6f3b6eb2107d5d569ff67be470913275816109f7a32426cf1e39ef950b9ba1c7f78063c388805b4106368f9f1527ff15c422241  libuv-1.21-compat.patch
+98814f9cb6b19830ffd35cbba00c22699a068c383358c798a777b1fbaa8d8d07eebe2c0d152635719168549cbc3d3fec3d2a64d0da1da333f3e7342708df1131  libressl_fix.patch"

--- a/community/cassandra-cpp-driver/libressl_fix.patch
+++ b/community/cassandra-cpp-driver/libressl_fix.patch
@@ -1,0 +1,20 @@
+--- cpp-driver-2.9.0/src/ssl/ssl_openssl_impl.cpp.orig
++++ cpp-driver-2.9.0/src/ssl/ssl_openssl_impl.cpp
+@@ -113,7 +113,7 @@
+   return len;
+ }
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ static uv_rwlock_t* crypto_locks;
+ 
+ static void crypto_locking_callback(int mode, int n, const char* file, int line) {
+@@ -597,7 +597,7 @@
+   SSL_load_error_strings();
+   OpenSSL_add_all_algorithms();
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+   // We have to set the lock/id callbacks for use of OpenSSL thread safety.
+   // It's not clear what's thread-safe in OpenSSL. Writing/Reading to
+   // a single "SSL" object is NOT and we don't do that, but we do create multiple


### PR DESCRIPTION
* Fixes https://bugs.alpinelinux.org/issues/9204
* Thank you Jie Meng for the bug report and patch/fix.