### PR TITLE
main/tiny-ec2-bootstrap: upgrade to 1.2.0

### DIFF
--- a/main/tiny-ec2-bootstrap/APKBUILD
+++ b/main/tiny-ec2-bootstrap/APKBUILD
@@ -1,14 +1,14 @@
 # Contributor: Mike Crute <mike@crute.us>
 # Maintainer: Mike Crute <mike@crute.us>
 pkgname=tiny-ec2-bootstrap
-pkgver=1.0.0
+pkgver=1.2.0
 pkgrel=0
 pkgdesc="A tiny EC2 instance bootstrapper that uses instance metadata"
 url="https://github.com/mcrute/tiny-ec2-bootstrap"
 arch="noarch"
 license="MIT"
 options="!check"  # no tests provided
-depends="openrc"
+depends="openrc e2fsprogs-extra"
 source="$pkgname-$pkgver.tar.gz::https://github.com/mcrute/$pkgname/archive/release-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-release-$pkgver"
 
@@ -17,4 +17,4 @@ package() {
 	make install PREFIX=$pkgdir
 }
 
-sha512sums="3075327ad7cf9a2eb26b3c9e98785f542f46ab8ca01125efb6a5bf34fe16a14e346bec0abfe3f09ac99a616eae361f4cbde09f41c65ba5d8fe6fea8c035e2970  tiny-ec2-bootstrap-1.0.0.tar.gz"
+sha512sums="a653dd56ac7cc887077d83d1e01c6e2b58550548293e848a456b74a45b2d0061ed3a4188e9a4eb3aaf23ee96d22b00f4e0610d044d640e036591dc43b4681a63  tiny-ec2-bootstrap-1.2.0.tar.gz"


### PR DESCRIPTION
Upgraded to latest upstream release