### PR TITLE
testing/wireguard-virt: new aport

### DIFF
--- a/testing/wireguard-virt/APKBUILD
+++ b/testing/wireguard-virt/APKBUILD
@@ -1,0 +1,67 @@
+# Contributor: Stuart Cardall <developer@it-offshore.co.uk>
+# Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
+
+# when changing _ver we *must* bump _rel
+# we must also match up _toolsrel with wireguard-tools
+_name=wireguard
+_ver=0.0.20180809
+_rel=0
+_toolsrel=0
+
+_flavor=${FLAVOR:-virt}
+_kpkg=linux-$_flavor
+_kver=4.14.67
+_krel=0
+
+_kpkgver="$_kver-r$_krel"
+_kabi="$_kver-$_krel-$_flavor"
+
+pkgname=$_name-$_flavor
+pkgver=$_kver
+pkgrel=$(( $_krel + $_rel ))
+
+pkgdesc="Next generation secure network tunnel: kernel modules for $_flavor"
+arch='x86_64 x86'
+url='https://www.wireguard.com'
+license="GPL-2.0"
+depends="$_kpkg=$_kpkgver"
+makedepends="$_kpkg-dev=$_kpkgver libmnl-dev"
+install_if="wireguard-tools=$_ver-r$_toolsrel $_kpkg=$_kpkgver"
+options="!check"
+source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$_ver.tar.xz"
+builddir="$srcdir"/WireGuard-$_ver
+
+prepare() {
+	default_prepare
+	# verify the kernel version
+	local _kapkbuild=../../main/linux-$_pkgver/APKBUILD
+	if [ -f $_kapkbuild ]; then
+		(	. $_kapkbuild
+			pkgname=$_name-$_flavor
+			[ "$_kver" != "$pkgver" ] && die "please update _kver to $pkgver"
+			[ "$_krel" != "$pkgrel" ] && die "please update _krel to $pkgrel"
+			return 0
+		)
+	fi
+}
+
+build() {
+	cd "$builddir"
+	# only building module: see wireguard-tools for userspace
+	unset LDFLAGS
+	make -C src/ \
+		KERNELDIR=/lib/modules/$_kabi/build \
+		module
+}
+
+package() {
+	cd "$builddir/src"
+
+	local module=
+	for module in *.ko; do
+		install -v -D -m644 ${module} \
+			"$pkgdir/lib/modules/$_kabi/extra/${module}"
+	done
+}
+
+sha512sums="2278cae078cf3ff9e0c43979ff559820d9d99b64c1ccdbc8a7fea3fc1a5fa0818d782a8962aefc07678599cc15f5a4237fd5dd7ffad108d639c39930979e3cc5  WireGuard-0.0.20180809.tar.xz"


### PR DESCRIPTION
* add `wireguard` kernel module for `linux-virt`

* to have the module loaded correctly on `boot`:

`echo wireguard > /etc/modules-load.d/wireguard.conf`