### PR TITLE
testing/frr: set /etc/frr to be owned by frr:frr

### DIFF
--- a/testing/frr/APKBUILD
+++ b/testing/frr/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Arthur Jones <arthur.jones@riverbed.com>
 pkgname=frr
 pkgver=5.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="FRRouting is a fork of quagga"
 pkgusers="frr"
 pkggroups="frr"
@@ -65,6 +65,7 @@ package() {
 
 	install -Dm644 "$builddir"/tools/etc/frr/daemons "$pkgdir"$_sysconfdir
 	install -Dm644 "$builddir"/tools/etc/frr/daemons.conf "$pkgdir"$_sysconfdir
+	chown -R ${pkgusers%% *}:${pkggroups%% *} "$pkgdir"$_sysconfdir
 	install -Dm755 "$srcdir"/frr.initd "$pkgdir"/etc/init.d/frr.initd
 }
 


### PR DESCRIPTION
Currently, /etc/frr is owned by root, but when re-writing config
with command like:

router# copy running-config startup-config

we fail as we drop down to frr:frr when writing config.

Here, we chown -R frr:frr /etc/frr to make sure we can re-write config
safely

Fixes: #9328