### PR TITLE
testing/wireguard-virt: rebuild against kernel 4.14.67-r0

### DIFF
--- a/testing/wireguard-virt/APKBUILD
+++ b/testing/wireguard-virt/APKBUILD
@@ -10,7 +10,7 @@ _toolsrel=0
 
 _flavor=${FLAVOR:-virt}
 _kpkg=linux-$_flavor
-_kver=4.14.66
+_kver=4.14.67
 _krel=0
 
 _kpkgver="$_kver-r$_krel"


### PR DESCRIPTION
testing/wireguard-virt: rebuild against kernel `4.14.67-r0`