### PR TITLE
main/varnish: upgrade to 6.0.1

### DIFF
--- a/main/varnish/APKBUILD
+++ b/main/varnish/APKBUILD
@@ -1,9 +1,10 @@
+# Contributor: Pedro Filipe <xpecex@outlook.com>
 # Contributor: Leonardo Arena <rnalrd@alpinelinux.org>
 # Contributor: V.Krishn <vkrishn4@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=varnish
-pkgver=6.0.0
-pkgrel=1
+pkgver=6.0.1
+pkgrel=0
 pkgdesc="High-performance HTTP accelerator"
 url="http://www.varnish-cache.org/"
 arch="all"
@@ -20,7 +21,6 @@ pkggroups="varnish"
 source="http://varnish-cache.org/_downloads/$pkgname-$pkgver.tgz
 	musl-include-vpf.patch
 	musl-include-vsb.patch
-	musl-fix-stack-overflow.patch
 
 	varnishd.initd
 	varnishd.confd
@@ -100,10 +100,9 @@ geoip() {
 		"$subpkgdir"/usr/lib/varnish/plugins/maxminddb.vcl
 }
 
-sha512sums="39bae462fe40bda9b7c93114ab8256c838a7d67f1a9f7397c37ad090163a33232676120eb7609d0512684a563d8e02c1c2ff5e1b9da0ddedef2250db51c3cc79  varnish-6.0.0.tgz
+sha512sums="057cb69ae6a4d980401effb7561d3a9b537216d8626fdf4e7bcc75971958517f51b6bd7f7af86c11bc92a2e77876831c577736dfcd11447ad0128f222c5ad138  varnish-6.0.1.tgz
 2123668169b055f2d88f9b5b8e0877ca8b3cbfcd61e03d91fd7d0513b3267e4ef01a4d858cc6a3298cca0a49aaea2f92ff4fd9c0baf52a6c67b452a53f7e54d0  musl-include-vpf.patch
 c51c8964880990c2b01807b2a38d886b146736a918bda9ea2e032c50085bf6745cab3cccb4ee4c561ab936a8b7cfb278cfcb758543ea6c605c15b8973c9f10ce  musl-include-vsb.patch
-659d2593ecb98d1abf5cf08a0de7791dab484fc33dac518e154431c0cdbb11c5ff3385465f98fc0a14c3599524d3c7d5211b2ad5bfdeb1d7b83b8e7c625664f2  musl-fix-stack-overflow.patch
 5ac7867e85cbd721f903c524ed4b524423d9dada4acfeefb0e543214a208828df5cc4efe2f012991bea6b38c2b223c24b17d3890ec4ed2c57d2b441b8e5a6900  varnishd.initd
 98c8901e53f3c6adb908b9eb01fd441ea53f3c54d4a79aecb1fb1eddfa2fc93de3d0de403a4464a9baff15873b3a20623837e3a37cb225e924a329e32b9e37d6  varnishd.confd
 c67a7898f40849989edcbe74e1a418e196f48e178ca30126bc13db226e4f4c2c2ba74d9d0650ef68ed88732917fc06b80ef1f62c2d9d2c14a89f26fd25aed0f7  varnishlog.initd


### PR DESCRIPTION
https://github.com/varnishcache/varnish-cache/blob/6.0/doc/changes.rst#varnish-cache-601-2018-08-29