### PR TITLE
community/wait4ports: upgrade to v0.2.2

### DIFF
--- a/community/wait4ports/APKBUILD
+++ b/community/wait4ports/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Erik Ogan <erik@stealthymonkeys.com>
 # Maintainer: Erik Ogan <erik@stealthymonkeys.com>
 pkgname=wait4ports
-pkgver=0.0.4
+pkgver=0.2.2
 pkgrel=0
 pkgdesc="A small utility to wait for network peer availability."
 url="https://github.com/erikogan/wait4ports"
@@ -15,14 +15,16 @@ builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
-	make || return 1
+	make
 }
 
 package() {
 	cd "$builddir"
-	make PREFIX="$pkgdir" install || return 1
+	make PREFIX="$pkgdir" install
 }
 
-md5sums="540262422fc204037bb2315bcfb438e5  wait4ports-0.0.4.tar.gz"
-sha256sums="c94789f1c353c87d0a14fea88ef565cef8807bde2903e5020565f86c656e2597  wait4ports-0.0.4.tar.gz"
-sha512sums="a3f0df9fcfde0c49626327f19a5ba71d8c59311f04a874f3470d92503d577a4eedcc46f4432ddf9386b966ce5bee522f3c9a2c4d88b037ffd0caf7022358a461  wait4ports-0.0.4.tar.gz"
+check() {
+  $builddir/wait4ports -v
+}
+
+sha512sums="a375bd8b7a4d1523221e227d726c1672413627ca485a3279bce21186e958c989de6b99584ffa173ff804484e23f29c18fae5e5d2c088efbd5bbeffb1eeb5a824  wait4ports-0.2.2.tar.gz"


### PR DESCRIPTION
(These changes are necessary to make the package useful in docker-compose files versions after v1.)

Adds:
* IPv6 support
* Hostname resolution
* Verbosity and sleep interval configuration via environment and command-line