### PR TITLE
testing/python-fido2: new aport

### DIFF
--- a/testing/py-fido2/APKBUILD
+++ b/testing/py-fido2/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Daniel Everett <deverett@gmail.com>
 # Maintainer: Daniel Everett <deverett@gmail.com>
-pkgname=python-fido2
-_pkgname=${pkgname#python-}
+pkgname=py-fido2
+_pkgname=${pkgname#py-}
 pkgver=0.3.0
 pkgrel=0
-pkgdesc="rovides library functionality for FIDO 2.0, including communication with a device over USB"
+pkgdesc="Provides library functionality for FIDO 2.0, including communication with a device over USB"
 url="https://developers.yubico.com/python-fido2/"
 arch="noarch"
 license="BSD-2-Clause Apache-2.0 MPL-2.0"

--- a/testing/python-fido2/APKBUILD
+++ b/testing/python-fido2/APKBUILD
@@ -1,0 +1,52 @@
+# Contributor: Daniel Everett <deverett@gmail.com>
+# Maintainer: Daniel Everett <deverett@gmail.com>
+pkgname=python-fido2
+_pkgname=${pkgname#python-}
+pkgver=0.3.0
+pkgrel=0
+pkgdesc="rovides library functionality for FIDO 2.0, including communication with a device over USB"
+url="https://developers.yubico.com/python-fido2/"
+arch="noarch"
+license="BSD-2-Clause Apache-2.0 MPL-2.0"
+depends="py-cryptography"
+makedepends="python2-dev python3-dev py-setuptools"
+subpackages="py2-${_pkgname}:_py2 py3-${_pkgname}:_py3"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname"
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+check() {
+	cd "$builddir"
+	touch "test/__init__.py"
+	python3 setup.py test
+}
+
+sha512sums="c6ea83e104d77350413156eba4c1aa2635b77ae00d157dce61e5a8539c65aca4dd1dfc5303f9d408359582eeb98ae558aa1e2043a9b1dfcb23415eb8bc9c6a09  fido2-0.3.0.tar.gz"


### PR DESCRIPTION
https://developers.yubico.com/python-fido2/
Provides library functionality for FIDO 2.0, including communication with a device over USB