### PR TITLE
community/ostree: upgrade to 2018.8

### DIFF
--- a/community/ostree/APKBUILD
+++ b/community/ostree/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: André Klitzing <aklitzing@gmail.com>
 # Maintainer: André Klitzing <aklitzing@gmail.com>
 pkgname=ostree
-pkgver=2018.7
+pkgver=2018.8
 pkgrel=0
 pkgdesc="Operating system and container binary deployment and upgrades"
 url="https://github.com/ostreedev/ostree"
@@ -37,5 +37,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="edb3f1d6dddd801ad18bbbc30a04f01ac269081ea175bb5cdf90589f4ab9355aa3bb2ead3c2f96fc0892e02ddd5e9809cac52dfb5e85808da6954d82bf63957a  libostree-2018.7.tar.xz
+sha512sums="43b5401460f1fb80ee9389a3ae27557e13a05a414bcc520627dbcf7bc9d94612d2b44c4f699a8dd56c7cfff7ff4f5c8fb2adfe437931a68bf324b9e8c31e7f62  libostree-2018.8.tar.xz
 539f5020f3380e841372f80c60c71c803ccfeffb719f1b83361b75557022c61d9cd29d9cd36929426420644def9de91fd92f5dd6923352f2ae6e1dd4b676de8c  musl-fixes.patch"


### PR DESCRIPTION
Ref https://github.com/ostreedev/ostree/releases/tag/v2018.8