### PR TITLE
main/lighttpd: upgrade to 1.4.50

### DIFF
--- a/main/lighttpd/APKBUILD
+++ b/main/lighttpd/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=lighttpd
-pkgver=1.4.49
-pkgrel=1
+pkgver=1.4.50
+pkgrel=0
 pkgdesc="Secure, fast, compliant and very flexible web-server"
 url="http://www.lighttpd.net"
 arch="all"
@@ -103,7 +103,7 @@ mod_webdav() {
 	_mv_mod mod_webdav
 }
 
-sha512sums="de766da68b4cacfb6c322210eafe819b6423334272e9fae4688c2282a66a2e55aaf580c5fdbf02676ed6f7b32d13f2f28cefd22518f77127055ec336ec5d6784  lighttpd-1.4.49.tar.xz
+sha512sums="54b8a99d84ca25f39254fb0dabaae978fcdf559d58da4ed7b7ab08d5ee856201e5302ee8a5732d3e2493bb3cd67c3f2196cedbb476a3ea21003a21c552b2402c  lighttpd-1.4.50.tar.xz
 f2f3c5c7731550237fd75a8de66275f427eaf897cffff7ac7ef44178328ad8fad6c4ec6654759bfc665cbaf7991ddcdf0aaa916831c8b6aa440192d57b242038  lighttpd.initd
 9d2ab5deb7353ebf290e90936b511941df440859c78589d0bcf130ef69a5e9c79e4d318548b6b118df002083c46f7476230a28954b7a10a9dbd05040e02b1291  lighttpd.confd
 0536b4f21d2e8659f7831b45998c13d9f6051ae7ecde13be01f372f837d255bfc4e211de48a7686cc743d53aa9c08ab3f10ec19788896dcf8356b90053ca7a16  lighttpd.logrotate


### PR DESCRIPTION
Some security related changes but no CVEs http://www.lighttpd.net/2018/8/13/1.4.50/