### PR TITLE
testing/py3-pathlib2: New aport

### DIFF
--- a/testing/py3-pathlib2/APKBUILD
+++ b/testing/py3-pathlib2/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Simon Frankenberger <simon-alpine@fraho.eu>
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
+pkgname=py3-pathlib2
+_pkgname=pathlib2
+pkgver=2.3.2
+pkgrel=0
+pkgdesc="Object-oriented filesystem paths"
+url="https://pypi.org/project/pathlib2/"
+arch="noarch"
+license="MIT"
+makedepends="python3-dev py3-setuptools"
+source="$_pkgname-$pkgver.tar.gz::https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python3 setup.py check
+}
+
+package() {
+	cd "$builddir"
+	python3 setup.py install --prefix=/usr \
+		--root="$pkgdir" --optimize=1
+}
+
+sha512sums="46ba0cc8b26006bc4cb914118b7c453dc49cc8a80147ea7a4b3d5a17e97d5538c5d73a3029bd7e5b59f42f256baba30ea273382e57468df1a459ac6f7c237ddc  pathlib2-2.3.2.tar.gz"


### PR DESCRIPTION
This PR adds python pathlib2, a library to work with filesystem paths in an object-oriented way.