### PR TITLE
main/ghostscript: security upgrade to 9.24

### DIFF
--- a/main/ghostscript/APKBUILD
+++ b/main/ghostscript/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Cameron Banta <cbanta@gmail.com>
 # Maintainer: Cameron Banta <cbanta@gmail.com>
 pkgname=ghostscript
-pkgver=9.22
+pkgver=9.24
 pkgrel=0
 pkgdesc="An interpreter for the PostScript language and for PDF"
 url="https://ghostscript.com/"
@@ -18,6 +18,11 @@ source="https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   9.24-r0:
+#     - CVE-2018-15908
+#     - CVE-2018-15909
+#     - CVE-2018-15910
+#     - CVE-2018-15911
 #   9.21-r2:
 #     - CVE-2017-8291
 #   9.21-r3:
@@ -30,7 +35,7 @@ prepare() {
 	default_prepare || return 1  # apply patches
 
 	# force it to use system-libs
-	rm -r jpeg libpng zlib tiff lcms2 cups/libs jbig2dec \
+	rm -r jpeg libpng zlib tiff lcms2mt cups/libs jbig2dec \
 		freetype || return 1
 
 	# fix parallel builds
@@ -113,6 +118,6 @@ gtk() {
 	mv "$pkgdir"/usr/bin/gsx "$subpkgdir"/usr/bin/
 }
 
-sha512sums="599ba003e168d302e327ea7c2b83a4247059a1b7222452cbea4966dac448a79e8d7f07a1f287fa0c14cfa5269bb623382ed02fb3ea3a0e526dae08aaa1cd8b89  ghostscript-9.22.tar.gz
+sha512sums="a85050c9604d7671d58e2415682482fb60852cb4de746cd07ee5a51585507f73f3ae61d6b52764230e333fb45d6a31666bf3cbad77215d997b6a5c3c64cf71cd  ghostscript-9.24.tar.gz
 70721e3a335afa5e21d4e6cf919119010bd4544a03ab8f53f5325c173902221ad9b88c118b4bfeee80b3e1956bcdbaf4c53f64ae7fb81f5ba57dbc956750c482  ghostscript-system-zlib.patch
 beefcf395f7f828e1b81c088022c08a506e218f27535b9de01e0f0edf7979b435316c318fa676771630f6ad16ff1ab059cd68aa128ed97e5a9f2f3fa840200c4  fix-sprintf.patch"


### PR DESCRIPTION
CVE-2018-15908, CVE-2018-15909, CVE-2018-15910, CVE-2018-15911

Ref https://www.ghostscript.com/doc/9.24/News.htm