### PR TITLE
testing/wireguard: upgrade to 0.0.20180904

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180809
+pkgver=0.0.20180904
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="2278cae078cf3ff9e0c43979ff559820d9d99b64c1ccdbc8a7fea3fc1a5fa0818d782a8962aefc07678599cc15f5a4237fd5dd7ffad108d639c39930979e3cc5  WireGuard-0.0.20180809.tar.xz"
+sha512sums="5eba275fd7bc96a81d7c07f92920bf4e562910756bb7980d1381b204efda184ee93fa710f2ccb0c14667c8647c2fac1cc51fa95be3a51ac25a0567c6204c9018  WireGuard-0.0.20180904.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180809
-_rel=1
+_ver=0.0.20180904
+_rel=2
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="2278cae078cf3ff9e0c43979ff559820d9d99b64c1ccdbc8a7fea3fc1a5fa0818d782a8962aefc07678599cc15f5a4237fd5dd7ffad108d639c39930979e3cc5  WireGuard-0.0.20180809.tar.xz"
+sha512sums="5eba275fd7bc96a81d7c07f92920bf4e562910756bb7980d1381b204efda184ee93fa710f2ccb0c14667c8647c2fac1cc51fa95be3a51ac25a0567c6204c9018  WireGuard-0.0.20180904.tar.xz"


### PR DESCRIPTION
```
  * wg-quick: darwin: prefer system paths for tools
  
  The only things wg-quick(8) needs from Homebrew are bash(1) and wg(8).
  Other than that, it's explicitly coded against the native system
  utilities. Since wg-quick(8) and bash(1) are invoked in auto_su by their
  full absolute path (via $SELF and $BASH, respectively), we can simply
  set the $PATH to be prefixed by the default system binary paths. This
  way, if users install tools that conflict with system tools -- such as
  GNU coreutils -- we won't accidently call those.
  
  * wg-quick: check correct variable for route deduplication
  
  This should avoid adding duplicate routes when adding the allowed IPs as
  interface routes automatically.
  
  * Kconfig: use new-style help marker
  * global: run through clang-format
  * uapi: reformat
  * global: satisfy check_patch.pl errors
  * global: prefer sizeof(*pointer) when possible
  * global: always find OOM unlikely
  
  Tons of style cleanups.
  
  * crypto: use unaligned helpers
  
  We now avoid unaligned accesses for generic users of the crypto API.
  
  * crypto: import zinc
  
  More style cleanups and a rearrangement of the crypto routines to fit how this
  is going to work upstream. This required some fairly big changes to our build
  system, so there may be some build errors we'll have to address in subsequent
  snapshots.
  
  * compat: rng_is_initialized made it into 4.19
  
  We therefore don't need it in the compat layer anymore.
  
  * curve25519-hacl64: use formally verified C for comparisons
  
  The previous code had been proved in Z3, but this new code from upstream
  KreMLin is directly generated from the F*, which is preferable. The
  assembly generated is identical.
  
  * curve25519-x86_64: let the compiler decide when/how to load constants
  
  Small performance boost.
  
  * curve25519-arm: reformat
  * curve25519-arm: cleanups from lkml
  * curve25519-arm: add spaces after commas
  * curve25519-arm: use ordinary prolog and epilogue
  * curve25519-arm: do not waste 32 bytes of stack
  * curve25519-arm: prefix immediates with #
  
  This incorporates ASM nits from upstream review.
  
  * netlink: insert peer version placeholder
  * tools: ipc: do not warn on unrecognized netlink attributes
  
  Adds a placeholder so that we can always bump versions without worrying about
  API guarantees.
```