### PR TITLE
testing/pgcli: upgrade to 2.0.0 and add check()

### DIFF
--- a/testing/pgcli/APKBUILD
+++ b/testing/pgcli/APKBUILD
@@ -1,31 +1,32 @@
 # Contributor: Thomas Boerger <thomas@webhippie.de>
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=pgcli
-pkgver=1.7.0
+pkgver=2.0.0
 pkgrel=0
 pkgdesc="Postgres CLI with autocompletion and syntax highlighting"
-url="http://pgcli.com"
+url="https://www.pgcli.com"
 arch="noarch"
 license="BSD"
 depends="python3
 	py3-pgspecial
 	py3-click
 	py3-pygments
-	py3-prompt_toolkit<1.1.0
+	py3-prompt_toolkit>2.0.0
 	py3-psycopg2
 	py3-sqlparse<0.3.0
 	py3-configobj
 	py3-humanize
 	py3-wcwidth
-	py3-cli_helpers<1.0.0
+	py3-cli_helpers>1.0.0
 	py3-setproctitle"
+checkdepends="pytest py3-mock"
 makedepends="python3-dev"
 source="$pkgname-$pkgver.tar.gz::https://files.pythonhosted.org/packages/source/${pkgname:0:1}/$pkgname/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 check() {
 	cd "$builddir"
-	python3 setup.py check
+	python3 -m pytest tests
 }
 
 build() {
@@ -38,4 +39,4 @@ package() {
 	python3 setup.py install --prefix=/usr --root="$pkgdir"
 }
 
-sha512sums="1918ffc2922067fb9fb150e645cb4c9bcb7505ab5c9733fe794a828a9060f3182918936407eb71cb52fe05b2e72531b04961076fab6a8090429c5d25401a069c  pgcli-1.7.0.tar.gz"
+sha512sums="a8c0a0a359816a483a6a6ce9b4f9d7af4a9ed9b7efff7d89b451f644ee90c7590f31869ca459f7fd0aacf8f855bc5047e3f54174083d92af7eb725bd8f489f41  pgcli-2.0.0.tar.gz"


### PR DESCRIPTION
Ref https://www.pgcli.com/v2.0.0.html

2.0.0 moved to `prompt-toolkit 2.0` so this depends on https://github.com/alpinelinux/aports/pull/5457