### PR TITLE
testing/py-tox: upgrade to 3.2.1

### DIFF
--- a/testing/py-tox/APKBUILD
+++ b/testing/py-tox/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=py-tox
 _pkgname=${pkgname#py-*}
-pkgver=2.7.0
+pkgver=3.2.1
 pkgrel=0
 pkgdesc="virtualenv management and test command line tool"
 url="https://tox.readthedocs.org/"
@@ -14,7 +14,7 @@ makedepends="python2-dev python3-dev py-setuptools"
 options="!check" # temp disable as requires itself
 #checkdepends="py-tox"
 subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
-source="$pkgname-$pkgver.tar.gz::https://github.com/tox-dev/$_pkgname/archive/$pkgver.tar.gz"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
@@ -54,4 +54,4 @@ check() {
 	tox
 }
 
-sha512sums="ff300e2ee21f66a50365709ea71b68394b2207496e9858ff09012dfcd63527ba8404835a233d30b732a603ea774d8b86a169f874db8ca8cc66733a545cd41e19  py-tox-2.7.0.tar.gz"
+sha512sums="79f5a1c8f6e818fbb8444754e3767d880fc1fdfe63b46c518d37440fe2b2f3ce572865aff83d9492c24486fded49893cc31bd9b11254bac4db507260304bc76f  tox-3.2.1.tar.gz"


### PR DESCRIPTION
Ref https://tox.readthedocs.io/en/latest/changelog.html

Needed to run selftests, should be moved to main later