### PR TITLE
testing/log4cpp: fix unable to guess system type build error

### DIFF
--- a/testing/log4cpp/APKBUILD
+++ b/testing/log4cpp/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 pkgname=log4cpp
 pkgver=1.1.3
-pkgrel=0
+pkgrel=1
 pkgdesc="Log for C++, modeled after Log4j."
 url="http://log4cpp.sourceforge.net/"
 arch="all"
@@ -16,6 +16,7 @@ builddir="$srcdir/"
 
 build() {
 	cd "$builddir/$pkgname"
+	update_config_guess
 	./configure \
 		--prefix=/usr \
 		--sysconfdir=/etc \


### PR DESCRIPTION
Build on ppc64le fails with:
checking build system type... config/config.guess: unable to guess system type

fix by adding update_config_guess