### PR TITLE
testing/py-pep8-naming: upgrade to 0.7.0 and modernize

### DIFF
--- a/testing/py-pep8-naming/APKBUILD
+++ b/testing/py-pep8-naming/APKBUILD
@@ -2,17 +2,15 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=py-pep8-naming
 _pkgname=pep8-naming
-pkgver=0.5.0
+pkgver=0.7.0
 pkgrel=0
 pkgdesc="Check PEP-8 naming conventions plugin for flake8"
 url="https://github.com/flintwork/pep8-naming"
 arch="noarch"
 license="MIT"
 depends="python2 python3 py-flake8"
-depends_dev=""
 makedepends="python2-dev python3-dev py-setuptools"
-checkdepends="py-tox py-virtualenv"
-install=""
+checkdepends="py-six py-tox py-virtualenv"
 subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgname-$pkgver"
@@ -53,4 +51,4 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="edf3c85140dda2ccfc172b75b8d65d70623446892e944d1b282fc64196d30ef96e21f02b519b6846e8e738acb28902ac60fdf61e276da59f5d722bba7554694f  pep8-naming-0.5.0.tar.gz"
+sha512sums="02d3a0203d370bf073eb6d207017b91001c89968f29c270f09dd36ced55d5dd85ac1a0c1cc1f010680a9f8657305546a678e051af45b415b7868337b90104ed0  pep8-naming-0.7.0.tar.gz"


### PR DESCRIPTION
One more attempt after https://github.com/alpinelinux/aports/pull/5103