### PR TITLE
testing/rakudo: upgrade to 2018.08

### DIFF
--- a/testing/moarvm/APKBUILD
+++ b/testing/moarvm/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=moarvm
-pkgver=2018.06
+pkgver=2018.08
 pkgrel=0
 pkgdesc="A VM for NQP And Rakudo Perl 6"
 url="http://moarvm.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="5d256cd7a49472e106326281059f8e9f8eb7591d116bfcdd33daeada42764774362ab8802edf889c5d875d438518ee9f243f5e44f451c9cf3495f7c7641be700  MoarVM-2018.06.tar.gz"
+sha512sums="048fe4f333b017f21dbac34eb385f0569f566ec5ebba9f0e9ee217d325b61fc3542e39e0f1db6fc2cbfa48b09b1acb16c79f02fbe34ed8a5a1946927528c0570  MoarVM-2018.08.tar.gz"

--- a/testing/nqp/APKBUILD
+++ b/testing/nqp/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=nqp
-pkgver=2018.06
+pkgver=2018.08
 pkgrel=0
 pkgdesc="Not Quite Perl"
 url="https://github.com/perl6/nqp"
@@ -39,4 +39,4 @@ doc() {
 	done
 }
 
-sha512sums="b98744403e77ff4086f5ab8dc26f3d7181793c1af404e51d620d245c895976c05c2ef791d2a91e200a5a39b3406c61f4b1a9ec5baf6daca72c2374ba356c5f60  nqp-2018.06.tar.gz"
+sha512sums="0c0a07fc6f233d3e7bf79df96ba5a04c57dde4220e24b95269df815fcac389802d796d83b6c310ac3862f413b044b95e7886be215553ae9ebfb388993756361d  nqp-2018.08.tar.gz"

--- a/testing/rakudo/APKBUILD
+++ b/testing/rakudo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=rakudo
-pkgver=2018.06
+pkgver=2018.08
 pkgrel=0
 pkgdesc="A compiler for the Perl 6 programming language"
 url="http://rakudo.org/"
@@ -41,7 +41,7 @@ dev() {
 	install -Dm755 install/usr/bin/perl6-lldb-m "$subpkgdir"/usr/bin/perl6-lldb-m
 	install -Dm755 install/usr/bin/perl6-m "$subpkgdir"/usr/bin/perl6-m
 	install -Dm755 install/usr/bin/perl6-valgrind-m "$subpkgdir"/usr/bin/perl6-valgrind-m
-	install -Dm755 tools/install-dist.pl "$subpkgdir"/usr/share/perl6/bin/install-dist.pl
+	install -Dm755 tools/install-dist.p6 "$subpkgdir"/usr/share/perl6/bin/install-dist.p6
 }
 
 doc() {
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="b14b19d4952f8725868612e9295e3e1c04523cfe948b55db02a1bab463d5a586bfaf6e32e9218a14d7d063d322b337358de561dceec44e5d59617a7e0e4b60a8  rakudo-2018.06.tar.gz"
+sha512sums="1730b8d5953b1b49e82da8207df4b8925682e0cd96a7406dba959dd54dffec4b0c0a68639289f7522aa7829fa687b93024a7e3c617b59439921b206ab6330183  rakudo-2018.08.tar.gz"


### PR DESCRIPTION
Upgrade moarvm, nqp, and rakudo to version 2018.08, must upgrade all three together.