### PR TITLE
community/go: Fix the `cannot find runtime/cgo`-warning

### DIFF
--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=go
 pkgver=1.11
-pkgrel=2
+pkgrel=3
 pkgdesc="Go programming language compiler"
 url="http://www.golang.org/"
 arch="all"
@@ -124,5 +124,5 @@ package() {
 }
 
 sha512sums="2758b7924b4b8cffc30b56fbf039b8e23d1a3c42506ed4997bd64531ba742e2c60e95d1fa70cae2ccda45d1959fadccfd2404af87d962530e4b1d3556c4aaf43  go1.11.src.tar.gz
-a8f3afd97992f03ccf2680cde214eefccac47daeb9eeb689b5e0b206ea3c19cfb23d448a4eb532894d830d4b91cd97b249e88f04c17feba02d9e243b40243bd0  default-buildmode-pie.patch
+effff60c1fb4ff18f1be1d34b4fa326a284b2197d0e9151223d19062dd315fde3d565ce2193aa53f7481c6542eb56daef834a3526957b65a275400f9af5d21b3  default-buildmode-pie.patch
 faf8de430df185842902322f064254f3e9ecee0884b3075b5550c85da15ff61ea6c2bb8d0fb7cf3887abc0e40974bd73ee8f8c14da7f914dde7e9220177c4e2a  set-external-linker.patch"

--- a/community/go/default-buildmode-pie.patch
+++ b/community/go/default-buildmode-pie.patch
@@ -1,8 +1,19 @@
-diff --git a/src/cmd/go/internal/work/init.go b/src/cmd/go/internal/work/init.go
-index 7f894f5..a37cbf3 100644
---- a/src/cmd/go/internal/work/init.go
-+++ b/src/cmd/go/internal/work/init.go
-@@ -111,7 +111,8 @@ func buildModeInit() {
+diff -upr go.orig/src/cmd/go/internal/load/pkg.go go/src/cmd/go/internal/load/pkg.go
+--- go.orig/src/cmd/go/internal/load/pkg.go	2018-08-24 22:38:35.000000000 +0200
++++ go/src/cmd/go/internal/load/pkg.go	2018-09-06 22:18:36.756408760 +0200
+@@ -1578,7 +1578,7 @@ func LinkerDeps(p *Package) []string {
+ func externalLinkingForced(p *Package) bool {
+ 	// Some targets must use external linking even inside GOROOT.
+ 	switch cfg.BuildContext.GOOS {
+-	case "android":
++	case "android", "linux":
+ 		return true
+ 	case "darwin":
+ 		switch cfg.BuildContext.GOARCH {
+diff -upr go.orig/src/cmd/go/internal/work/init.go go/src/cmd/go/internal/work/init.go
+--- go.orig/src/cmd/go/internal/work/init.go	2018-08-24 22:38:35.000000000 +0200
++++ go/src/cmd/go/internal/work/init.go	2018-09-06 22:18:03.942821296 +0200
+@@ -123,7 +123,8 @@ func buildModeInit() {
  		ldBuildmode = "c-shared"
  	case "default":
  		switch platform {


### PR DESCRIPTION
This is basically a follow-up for #5068. As described in this PR our go compiler currently emits a `loadinternal: cannot find runtime/cgo`-warning when compiling certain software. For instance, a simple hello world program. This PR attempts to fix this.

---

This warning seems to be emitted since we build with `-shared` for PIE
by default through our `default-buildmode-pie.patch`. Building with
shared linkage requires depending on CGO. The patch, however, doesn't
force a dependency on CGO. As with android we need to force external
linkage in order to always depend on CGO thereby resolving this warning.
    
I am unsure whether this is really the best way to fix the problem since
I don't know enough about the internals of the go compiler. However, I
am under the impression that the person who originally committed the
patch isn't familiar with the compiler internals either. Thus it's
probably ok to push this as is.
    
The other problem with this patch being that the static buildmode is no
longer supported. Running `go build -buildmode static` no longer works.
I would therefore propose creating a PIE and non-PIE go package, the
Arch Linux folks also seem to have chosen this solution.