### PR TITLE
community/numix-themes: upgrade to 2.6.7

### DIFF
--- a/community/numix-themes/APKBUILD
+++ b/community/numix-themes/APKBUILD
@@ -1,10 +1,11 @@
+# Contributor: Pedro Filipe <xpecex@outlook.com>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=numix-themes
 _pkgname=numix-gtk-theme
-pkgver=2.6.4
+pkgver=2.6.7
 pkgrel=0
 pkgdesc="A modern flat theme with a combination of light and dark elements, GTK 2 and 3"
-url="http://shimmerproject.org/project/Numix/"
+url="https://numixproject.github.io/"
 arch="noarch"
 license="GPL-3.0"
 subpackages="$pkgname-gtk2 $pkgname-gtk3 $pkgname-metacity $pkgname-xfwm4 $pkgname-xfce4-notifyd:_notify
@@ -57,6 +58,4 @@ xfwm4() { _mv "Numix Xfce4 themes" xfwm4 xfwm4; }
 _notify() { _mv "Numix Xfce4-notifyd themes" xfce4-notifyd xfce-notify-4.0; }
 _openbox() { _mv "Numix openbox themes" openbox openbox-3; }
 
-md5sums="cdaca5ede2a40000d383d200e01c0395  numix-2.6.4.tar.gz"
-sha256sums="f70cad6608d9a1b4819eaf6b51fc03d5c75971ff8f08080ac2eb9a5d8e386e6f  numix-2.6.4.tar.gz"
-sha512sums="a546f6214095a1b1d808e317ff4f3471962afacd20b5b3b4e1bc46bb604d5d9d4162b2358048dcf02f4fb2d7290ce5cfbc82a4f4e1bf07ca186ca6f54789d586  numix-2.6.4.tar.gz"
+sha512sums="a034644a08173e70de496b88b40c8749d3c3dc988da0c09a03eca77a5263704b001114678e0492988831b1664593d4054f2d7c0d90d95f5b05dcd05914577a03  numix-2.6.7.tar.gz"


### PR DESCRIPTION
Ref: https://github.com/numixproject/numix-gtk-theme/blob/2.6.7/CHANGES#L1


I updated the URL to the official website of the Numix project => https://numixproject.github.io/