### PR TITLE
community/mediainfo: update (+lib) to 18.08.1

### DIFF
--- a/community/libmediainfo/APKBUILD
+++ b/community/libmediainfo/APKBUILD
@@ -13,7 +13,7 @@
 # sha2-gladman | custom / GPL  | Source/ThirdParty/sha2-gladman
 
 pkgname=libmediainfo
-pkgver=18.08
+pkgver=18.08.1
 pkgrel=0
 pkgdesc="Shared library for mediainfo"
 url="https://github.com/MediaArea/MediaInfoLib"
@@ -55,4 +55,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="fe1e2b6fe136313f886b58df706d858876c38344af23e628e4ca249761df5e5da164784ae1403a98801b58cf5cd3d4f13527aa44d4dcdbc4a20468c7c7bad928  libmediainfo_18.08.tar.xz"
+sha512sums="0696ee74f6eeaffec97412decb114bdf732b6a44377b4c67925568bb14cac66266f14ec1c5eedd411de8504319add6bb384bad237063cbc3d17a82269080a0f1  libmediainfo_18.08.1.tar.xz"

--- a/community/mediainfo/APKBUILD
+++ b/community/mediainfo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=mediainfo
-pkgver=18.08
+pkgver=18.08.1
 pkgrel=0
 pkgdesc="Supplies technical and tag information about media files (CLI)"
 url="https://mediaarea.net/en/MediaInfo"
@@ -44,4 +44,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="b5c6f366e08d79c8e2db8c708b6bd2a51b6139226bdb073343181a1d757752b42609151ceb172d8d7ae10a4e23bf1993142b35b5b7fe35b6c19b59b30d18c904  mediainfo_18.08.tar.xz"
+sha512sums="ff807138a253dfe8ea79d568a0c742e9391709e1e0ae3c5d0ce0e5345f2306057b541e5eb2bdd6bf0032f287b2387dfc21a506698ccd2c81a9f70679cf518480  mediainfo_18.08.1.tar.xz"


### PR DESCRIPTION
A single minor change, patch notes [from upstream](https://github.com/MediaArea/MediaInfoLib/releases/tag/v18.08.1): 

* Fix XML/MPEG-7/PBCore2 output discarding non ANSI characters

aside from this, it's the same build as the 18.08 release from the other day