### PR TITLE
testing/wireguard: upgrade to 0.0.20180910

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180904
+pkgver=0.0.20180910
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="5eba275fd7bc96a81d7c07f92920bf4e562910756bb7980d1381b204efda184ee93fa710f2ccb0c14667c8647c2fac1cc51fa95be3a51ac25a0567c6204c9018  WireGuard-0.0.20180904.tar.xz"
+sha512sums="644d617d9d53f688c93cafb438d46075b642805b4ddfc328a8c1046a4a2baef3048a5a5af7f71986d753868ad8da8546ea7063572ef56c50bfcd07f3c147899f  WireGuard-0.0.20180910.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180904
-_rel=2
+_ver=0.0.20180910
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="5eba275fd7bc96a81d7c07f92920bf4e562910756bb7980d1381b204efda184ee93fa710f2ccb0c14667c8647c2fac1cc51fa95be3a51ac25a0567c6204c9018  WireGuard-0.0.20180904.tar.xz"
+sha512sums="644d617d9d53f688c93cafb438d46075b642805b4ddfc328a8c1046a4a2baef3048a5a5af7f71986d753868ad8da8546ea7063572ef56c50bfcd07f3c147899f  WireGuard-0.0.20180910.tar.xz"


### PR DESCRIPTION
```
  * curve25519: arm: do not modify sp directly
  * compat: support neon.h on old kernels
  * compat: arch-namespace certain includes
  * compat: move simd.h from crypto to compat since it's going upstream

  This fixes a decent amount of compat breakage and thumb2-mode breakage
  introduced by our move to Zinc.

  * crypto: use CRYPTOGAMS license

  Rather than using code from OpenSSL, use code directly from AndyP.

  * poly1305: rewrite self tests from scratch
  * poly1305: switch to donna

  This makes our C Poly1305 implementation a bit more intensely tested and also
  faster, especially on 64-bit systems. It also sets the stage for moving to a
  HACL* implementation when that's ready.
```