### PR TITLE
testing/micropython: disable float tests for ppc64le

### DIFF
--- a/testing/micropython/APKBUILD
+++ b/testing/micropython/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Marian <marian.buschsieweke@ovgu.de>
 pkgname=micropython
 pkgver=1.9.4
-pkgrel=0
+pkgrel=1
 pkgdesc="A lean and efficient Python implementation for MCUs and constrained systems"
 url="http://www.micropython.org/"
 
 # ../py/persistentcode.c:397:2: error: #error mp_raw_code_save_file not implemented for this platform
-arch="x86 x86_64 armhf !ppc64le"
+arch="x86 x86_64 armhf ppc64le"
 
 license="MIT"
 depends=""
@@ -16,6 +16,7 @@ subpackages="$pkgname-cross"
 source="${pkgname}-${pkgver}.tar.gz::https://github.com/${pkgname}/${pkgname}/archive/v${pkgver}.tar.gz
 	0000-unix-mpconfigport.patch
 	python3.patch
+	skip-float-tests-for-ppc64le.patch
 	"
 builddir="${srcdir}/${pkgname}-${pkgver}"
 
@@ -30,6 +31,11 @@ check() {
 	# ffi callback fails on kernel with PaX
 	rm tests/unix/ffi_callback.py
 
+	case "$CARCH" in
+		ppc64le) export RUN_FLOAT_TESTS=" -e float_parse";;
+		*) ;;
+	esac
+	
 	make -C ports/unix test PYTHON=python3
 }
 
@@ -48,4 +54,5 @@ cross() {
 
 sha512sums="aae15ed4251e56261e7ce0db6c86727e62d466e43d3867bb080c21653c0ef3cd25b6ee4b0438fab2ecc838b4b73f7b59ae7a851ad20ef6c38b9eb8667a7dc364  micropython-1.9.4.tar.gz
 4c1de6a6477453e846998565402c69d1dd716cf692a3bb55aa16b6991722a94d8364c05f0603b981a7dd9e9af577a3f46910a60d501513af547ebbf3ed574711  0000-unix-mpconfigport.patch
-8dbdc52e09f70b5eea461257ebc00031ab9d2c91a9bdbd7522e4ffd1eddddcd0dab3a171361e776543abca827a2f5d6ad01b06c10c8635db861bf79bfa065338  python3.patch"
+8dbdc52e09f70b5eea461257ebc00031ab9d2c91a9bdbd7522e4ffd1eddddcd0dab3a171361e776543abca827a2f5d6ad01b06c10c8635db861bf79bfa065338  python3.patch
+87e3141b0b6c7b936b54d683df34892ae7eff1a6b11c9825409c61f7359966dbda3ca8767c37b9eb4bcc05f8150120cb0c3bcd7d01e60e54a1bfb7c603e2ef05  skip-float-tests-for-ppc64le.patch"

--- a/testing/micropython/skip-float-tests-for-ppc64le.patch
+++ b/testing/micropython/skip-float-tests-for-ppc64le.patch
@@ -1,0 +1,11 @@
+--- a/ports/unix/Makefile
++++ b/ports/unix/Makefile
+@@ -188,7 +188,7 @@
+ 
+ test: $(PROG) $(TOP)/tests/run-tests
+ 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
+-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) ./run-tests
++	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(PROG) ./run-tests $(RUN_FLOAT_TESTS)
+ 
+ # install micropython in /usr/local/bin
+ TARGET = micropython


### PR DESCRIPTION
There are slight differences in float() calculations between python3 and micropython as described in their forum. https://forum.micropython.org/viewtopic.php?f=2&t=802&p=24097&hilit=float+significant#p24097 indicates that anything beyond 6 significant digits on micropython for float() is noise.  I have submitted a forum post to the micropython to clarify/confirm
https://forum.micropython.org/viewtopic.php?f=3&t=5247.  Until then disable the float tests on ppc64le and re-enable the architecture for building. 

Details:
On ppc64le using micropython we see this will cause the tests/float_parse.py comparison between micropython and python3 to fail.
~/aports/testing/micropython/src/micropython-1.9.4/tests $ ../ports/unix/micropython
MicroPython v3.8.0-1909-g685fa426c5-dirty on 2018-09-11; linux version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> float('.' + '9' * 70)
1.000000000000001

~/aports/testing/micropython/src/micropython-1.9.4/tests $ python3
Python 3.6.6 (default, Aug 23 2018, 09:02:39)
[GCC 6.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> float('.' + '9' * 70)
1.0
