### PR TITLE
main/xen: xen-bridge needs bridge-utils

### DIFF
--- a/main/xen/APKBUILD
+++ b/main/xen/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=xen
 pkgver=4.10.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Xen hypervisor"
 url="http://www.xen.org/"
 arch="x86_64 armhf aarch64"
@@ -407,7 +407,7 @@ hypervisor() {
 }
 
 bridge() {
-	depends="dnsmasq"
+	depends="bridge-utils dnsmasq"
 	pkgdesc="Bridge interface for XEN with dhcp"
 	mkdir -p "$subpkgdir"/etc/conf.d \
 		"$subpkgdir"/etc/init.d \


### PR DESCRIPTION
Was fixed in
 66ff4f8a6b main/xen: upgrade to 4.11.0
for @edge, this is a backport.