### PR TITLE
main/rsyslog: upgrade to 8.37.0

### DIFF
--- a/main/rsyslog/APKBUILD
+++ b/main/rsyslog/APKBUILD
@@ -4,7 +4,7 @@
 # Contributor: Ashley Sommer <ashleysommer@gmail.com>
 # Maintainer: Cameron Banta <cbanta@gmail.com>
 pkgname=rsyslog
-pkgver=8.36.0
+pkgver=8.37.0
 pkgrel=0
 pkgdesc="Enhanced multi-threaded syslogd with database support and more."
 url="https://www.rsyslog.com/"
@@ -113,7 +113,7 @@ elasticsearch() {
 		 "$subpkgdir"/usr/lib/rsyslog/
 }
 
-sha512sums="b0c8689374b5b0fb5ad9675ad8983ce67bd04d34ad07d39cf8f91498fd2fd21a173f1077e5fa1b66a89a9d93ab011fc6345ac1a3be9961f4794fc9e152c32a50  rsyslog-8.36.0.tar.gz
+sha512sums="2989eb7ed3333151e979a720fa0e95e330bda9b40f65009f7969069bcbbeee8f493c6a3189f67bbbc2529d3a2ac14a022d7e8c4f2d0dae42b67d7508d7611fa0  rsyslog-8.37.0.tar.gz
 9a4b184076a82e0899da79ab3749e1c67eac03f36c4460d34ed0385f4a3ffad53681a1cc25dd514e835c9399a9abd01c235743535ad549d5be7f66d9e127b9dc  rsyslog.initd
 a4d969671800227129be870b0318961b79d16365663754111a136734bbf7005abd4da24853dfdc07b3b6691ab5a7b215f0ac6c19022b4c5c8dab06165a42431b  rsyslog.confd
 d54377ddf39197656811a84272568ea761f984e19dd04fc54f372dd04a9244e66d02b26ab33073d0344d054f031660ec611f3c7a18c266e7b68cef5e2c47f06f  rsyslog.logrotate


### PR DESCRIPTION
https://www.adiscon.com/news/news-release/rsyslog-8-37-0-v8-stable-released/

Maybe makes sense to add `openrc` subpackage