### PR TITLE
community/caddy: upgrade to 0.11.0

### DIFF
--- a/community/caddy/APKBUILD
+++ b/community/caddy/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=caddy
-pkgver=0.10.14
+pkgver=0.11.0
 pkgrel=0
 pkgdesc="Fast, cross-platform HTTP/2 web server with automatic HTTPS"
 url="https://caddyserver.com/"
@@ -61,7 +61,7 @@ package() {
 		"$pkgdir"/etc/$pkgname/$pkgname.conf
 }
 
-sha512sums="b2d7ff08687c1b1331c018430e3458d4a5e4d5923803fabe563536ce372209ac0350efd4112a1099bfbfb517935d4f498613820d6b0685d5947a903227e15636  caddy-0.10.14.tar.gz
+sha512sums="9f8acba8be8db0f39b35ff8a69296764ac13f4cf3263719b082a4699d52eb8a11053282c22ce6710cb751fd0a252099032d9b1f347e714011ac1c51abda7a17c  caddy-0.11.0.tar.gz
 00fe095efd8d801f0c2c69832c7240858080407ea3696ca07f6b53d3304f7e2784566d8a6b447cb83d7dc4542db551f1b4fa48ff031da7e4a1d4a26e59fc05c5  caddy.initd
 7808688e92ab9950403a9b8ad29777f5bd0f75aa8cccc1d49958bb1e5af1b972dfba0c6d31931354f702a3a13933d0a1b8f28b82eed263773d71b79ec95cc15c  caddy.confd
 c24805d17234e6cf40fe1dd102c03f05cf6129d43f58f5567d540a0e4400ce89994820bb0e317f611c65459ae26bcf7110e23a8fecaae11ca78a561892b45d75  caddy.conf"


### PR DESCRIPTION
Ref https://github.com/mholt/caddy/releases/tag/v0.11.0

Also it ships now openrc files so needs review