### PR TITLE
main/cmake: upgrade to 3.12.3

### DIFF
--- a/main/cmake/APKBUILD
+++ b/main/cmake/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cmake
-pkgver=3.12.0
-pkgrel=1
+pkgver=3.12.3
+pkgrel=0
 pkgdesc="Cross-platform, open-source make system"
 url="https://www.cmake.org"
 arch="all"
@@ -69,4 +69,4 @@ bashcomp() {
                 "$subpkgdir"/usr/share/bash-completion/
 }
 
-sha512sums="e1d5764023d6c8dd4e8d087614e0329a097f1bc587c08c7d22ce7600867bcd7f6750d513458c7c4042570a9526060b89778243e6ea6137efb1727e409ca031ab  cmake-3.12.0.tar.gz"
+sha512sums="2b5b006bd0fa09431eb525a7f419c64b811afbe1cc81d34e6167e04112966d9f48f28652b21b5a04c889de6227315db57dd2099a17ea6329e27f3e97eac9051c  cmake-3.12.3.tar.gz"


### PR DESCRIPTION
mostly bugfixes
- https://blog.kitware.com/cmake-3-12-1-available-for-download/
- https://blog.kitware.com/cmake-3-12-2-available-for-download/
- https://blog.kitware.com/cmake-3-12-3-available-for-download/