### PR TITLE
main/libjpeg-turbo: Backport fix for CVE-2018-1152

### DIFF
--- a/main/libjpeg-turbo/0001-tjLoadImage-Fix-FPE-triggered-by-malformed-BMP.patch
+++ b/main/libjpeg-turbo/0001-tjLoadImage-Fix-FPE-triggered-by-malformed-BMP.patch
@@ -1,0 +1,49 @@
+From f1322acf6cdc8c25db0075d7d32dc2f25ed9d477 Mon Sep 17 00:00:00 2001
+From: DRC <information@libjpeg-turbo.org>
+Date: Tue, 12 Jun 2018 20:27:00 -0500
+Subject: [PATCH] rdbmp.c: Fix FPE triggered by malformed BMP
+
+In rdbmp.c, it is necessary to guard against 32-bit overflow/wraparound
+when allocating the row buffer, because since BMP files have 32-bit
+width and height fields, the value of biWidth can be up to 4294967295.
+Specifically, high values of biWidth could cause the samplesperrow
+argument in alloc_sarray() to wrap around to 0, triggering a division by
+zero error at line 460 in jmemmgr.c, or to wrap around to a small
+number, likely triggering a buffer overflow.
+
+This fix is not documented in the change log for this branch, because
+the bug was exposed using the tjLoadImage() function in the 2.0.x
+branch.  However, it is posited that the issue could be triggered using
+TJBench in this branch.
+---
+ rdbmp.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/rdbmp.c b/rdbmp.c
+index eaa7086..6b73f7c 100644
+--- a/rdbmp.c
++++ b/rdbmp.c
+@@ -6,7 +6,7 @@
+  * Modified 2009-2010 by Guido Vollbeding.
+  * libjpeg-turbo Modifications:
+  * Modified 2011 by Siarhei Siamashka.
+- * Copyright (C) 2015, D. R. Commander.
++ * Copyright (C) 2015, 2018, D. R. Commander.
+  * For conditions of distribution and use, see the accompanying README.ijg
+  * file.
+  *
+@@ -434,6 +434,11 @@ start_input_bmp (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
+     progress->total_extra_passes++; /* count file input as separate pass */
+   }
+ 
++  /* Ensure that biWidth * 3 doesn't exceed the maximum value of the
++     JDIMENSION type.  This is only a danger with BMP files, since their width
++     and height fields are 32-bit integers. */
++  if ((unsigned long long)biWidth * 3ULL > 0xFFFFFFFFULL)
++    ERREXIT(cinfo, JERR_WIDTH_OVERFLOW);
+   /* Allocate one-row buffer for returned data */
+   source->pub.buffer = (*cinfo->mem->alloc_sarray)
+     ((j_common_ptr) cinfo, JPOOL_IMAGE,
+-- 
+2.17.1
+

--- a/main/libjpeg-turbo/APKBUILD
+++ b/main/libjpeg-turbo/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libjpeg-turbo
 pkgver=1.5.3
-pkgrel=1
+pkgrel=2
 pkgdesc="accelerated baseline JPEG compression and decompression library"
 url="https://libjpeg-turbo.org/"
 arch="all"
@@ -11,7 +11,12 @@ depends=""
 makedepends="nasm"
 replaces="libjpeg"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-utils"
-source="https://downloads.sourceforge.net/libjpeg-turbo/libjpeg-turbo-$pkgver.tar.gz"
+source="https://downloads.sourceforge.net/libjpeg-turbo/libjpeg-turbo-$pkgver.tar.gz
+        0001-tjLoadImage-Fix-FPE-triggered-by-malformed-BMP.patch"
+
+# secfixes:
+#   1.5.3-r2:
+#   - CVE-2018-1152
 
 builddir="$srcdir"/libjpeg-turbo-$pkgver
 
@@ -57,4 +62,5 @@ dev() {
 	replaces="jpeg-dev"
 }
 
-sha512sums="b611b1cc3d1ddedddad871854b42449d053a5f910ed1bdfa45c98e0270f4ecc110fde3a10111d2b876d847a826fa634f09c0bb8c357056c9c3a91c9065eb5202  libjpeg-turbo-1.5.3.tar.gz"
+sha512sums="b611b1cc3d1ddedddad871854b42449d053a5f910ed1bdfa45c98e0270f4ecc110fde3a10111d2b876d847a826fa634f09c0bb8c357056c9c3a91c9065eb5202  libjpeg-turbo-1.5.3.tar.gz
+d6465d96427289d90c342e94316018565eb1711ea0028121ea0a962900b7c7599a7457e42201bcfd288da30019ae3b841ce319cfbe02705d49749d660ef04b74  0001-tjLoadImage-Fix-FPE-triggered-by-malformed-BMP.patch"


### PR DESCRIPTION
Cherry-pick commit f1322ac from the 1.5.x branch

Signed-off-by: Euan Harris <euan.harris@docker.com>