### PR TITLE
main/ghostscript: security upgrade 9.25 - CVE-2018-16802

### DIFF
--- a/main/ghostscript/APKBUILD
+++ b/main/ghostscript/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Cameron Banta <cbanta@gmail.com>
 # Maintainer: Cameron Banta <cbanta@gmail.com>
 pkgname=ghostscript
-pkgver=9.24
+pkgver=9.25
 pkgrel=0
 pkgdesc="An interpreter for the PostScript language and for PDF"
 url="https://ghostscript.com/"
@@ -18,6 +18,8 @@ source="https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   9.25-r0:
+#     - CVE-2018-16802
 #   9.24-r0:
 #     - CVE-2018-15908
 #     - CVE-2018-15909
@@ -112,6 +114,6 @@ gtk() {
 	mv "$pkgdir"/usr/bin/gsx "$subpkgdir"/usr/bin/
 }
 
-sha512sums="a85050c9604d7671d58e2415682482fb60852cb4de746cd07ee5a51585507f73f3ae61d6b52764230e333fb45d6a31666bf3cbad77215d997b6a5c3c64cf71cd  ghostscript-9.24.tar.gz
+sha512sums="6710bf00e6246bf07173d4012c7742dd2315b6888b883d63372c0dc2fef76e8be5672f10e4c529244ba153f4ae8ab713403209365a3f7a76c469d69d797761b1  ghostscript-9.25.tar.gz
 70721e3a335afa5e21d4e6cf919119010bd4544a03ab8f53f5325c173902221ad9b88c118b4bfeee80b3e1956bcdbaf4c53f64ae7fb81f5ba57dbc956750c482  ghostscript-system-zlib.patch
 beefcf395f7f828e1b81c088022c08a506e218f27535b9de01e0f0edf7979b435316c318fa676771630f6ad16ff1ab059cd68aa128ed97e5a9f2f3fa840200c4  fix-sprintf.patch"


### PR DESCRIPTION
Refs
- https://www.ghostscript.com/doc/9.25/News.htm
- https://security-tracker.debian.org/tracker/CVE-2018-16802