### PR TITLE
main/duplicity: missing pkgrel bump

### DIFF
--- a/main/duplicity/APKBUILD
+++ b/main/duplicity/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer:  Matt Smith <mcs@darkregion.net>
 pkgname=duplicity
 pkgver=0.7.17
-pkgrel=0
+pkgrel=1
 pkgdesc="Encrypted bandwidth-efficient backup using the rsync algorithm"
 url="http://duplicity.nongnu.org/"
 arch="all"


### PR DESCRIPTION
I forgot to dump the pkgrel in 744aba7e8f1e3b4a003a01bcea425f1d6fe1f0cb, sorry.

This should be backported to 3.8, where that commit also exits.