### PR TITLE
main/gcc: patch to remove call to glibc-specific function in Ada library

### DIFF
--- a/main/gcc/APKBUILD
+++ b/main/gcc/APKBUILD
@@ -6,7 +6,7 @@ pkgver=6.4.0
 [ "$CHOST" != "$CTARGET" ] && _target="-$CTARGET_ARCH" || _target=""
 
 pkgname="$pkgname$_target"
-pkgrel=8
+pkgrel=9
 pkgdesc="The GNU Compiler Collection"
 url="http://gcc.gnu.org"
 arch="all"
@@ -203,6 +203,8 @@ source="http://gcc.gnu.org/pub/gcc/releases/gcc-${_pkgbase:-$pkgver}/gcc-${_pkgb
 	0011-i386-Update-mfunction-return-for-return-with-pop.patch
 	0012-i386-Add-TARGET_INDIRECT_BRANCH_REGISTER.patch
 	0013-i386-Don-t-generate-alias-for-function-return-thunk.patch
+
+	pthread_rwlockattr_setkind_np.patch
 	"
 
 # we build out-of-tree
@@ -695,4 +697,5 @@ baa27a4b912d8e27cd65a556b09cf45289a0e00e86dae3925f2923d1f3752080e80d80e159c996ef
 b7b59f3203bf53168de2170b91738cd456f6ae205b3fe5bf8aacbaa8cc5624dd09c941ad8f1071d1ab8ab4fb5f69068a4bc792c0486fdec1ee2eb9c83688bb78  0010-i386-Pass-INVALID_REGNUM-as-invalid-register-number.patch
 c53d4c5968865abb709ee8a9af9d57917d43ea3ba31ee8312f9e8f338e9b1b44babf5aa3414848da7267e5cf13a9261815eb9185dc153cbd41ee7ce5ea23d2d0  0011-i386-Update-mfunction-return-for-return-with-pop.patch
 955080ba3e42cfe2f604e5dcef46aa6fca7c899c7808398947af655ff3b7954e30807ef85246986a5cc7db36dbc870db151e9fa8d8bc967b89ea56efdf64614c  0012-i386-Add-TARGET_INDIRECT_BRANCH_REGISTER.patch
-3aae3a9cef8e8afe5a5433db8d9f410e1a2882481af01bb1d33232f987dbb74d7780c32be70b868bb391b3601b65ed3a16d777afea946f5eeaff72aa1e7fa3a9  0013-i386-Don-t-generate-alias-for-function-return-thunk.patch"
+3aae3a9cef8e8afe5a5433db8d9f410e1a2882481af01bb1d33232f987dbb74d7780c32be70b868bb391b3601b65ed3a16d777afea946f5eeaff72aa1e7fa3a9  0013-i386-Don-t-generate-alias-for-function-return-thunk.patch
+9973ecbfe37c633df8de0df2fbf48771a9175bf94dc395a481460318212d783366ad5eb8da3ade98db43cff9709bda4483404d0aeec5d8a40ba9a6a9b6a49f72  pthread_rwlockattr_setkind_np.patch"

--- a/main/gcc/pthread_rwlockattr_setkind_np.patch
+++ b/main/gcc/pthread_rwlockattr_setkind_np.patch
@@ -1,0 +1,31 @@
+diff -rup gcc-6.4.0/gcc/ada/s-osinte-linux.ads gcc-6.4.0-new/gcc/ada/s-osinte-linux.ads
+--- gcc-6.4.0/gcc/ada/s-osinte-linux.ads	2015-10-16 06:25:00.234638000 -0700
++++ gcc-6.4.0-new/gcc/ada/s-osinte-linux.ads	2018-09-06 13:47:24.620560129 -0700
+@@ -393,12 +393,6 @@ package System.OS_Interface is
+    PTHREAD_RWLOCK_PREFER_WRITER_NP              : constant := 1;
+    PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP : constant := 2;
+ 
+-   function pthread_rwlockattr_setkind_np
+-     (attr : access pthread_rwlockattr_t;
+-      pref : int) return int;
+-   pragma Import
+-     (C, pthread_rwlockattr_setkind_np, "pthread_rwlockattr_setkind_np");
+-
+    function pthread_rwlock_init
+      (mutex : access pthread_rwlock_t;
+       attr  : access pthread_rwlockattr_t) return int;
+diff -rup gcc-6.4.0/gcc/ada/s-taprop-linux.adb gcc-6.4.0-new/gcc/ada/s-taprop-linux.adb
+--- gcc-6.4.0/gcc/ada/s-taprop-linux.adb	2015-10-16 06:25:00.234638000 -0700
++++ gcc-6.4.0-new/gcc/ada/s-taprop-linux.adb	2018-09-06 13:49:49.113896910 -0700
+@@ -277,11 +277,6 @@ package body System.Task_Primitives.Oper
+             Result := pthread_rwlockattr_init (RWlock_Attr'Access);
+             pragma Assert (Result = 0);
+ 
+-            Result := pthread_rwlockattr_setkind_np
+-              (RWlock_Attr'Access,
+-               PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+-            pragma Assert (Result = 0);
+-
+             Result := pthread_rwlock_init (L.RW'Access, RWlock_Attr'Access);
+ 
+             pragma Assert (Result = 0 or else Result = ENOMEM);


### PR DESCRIPTION
Musl does not provide a pthread_rwlockattr_setkind_np() function.
Fixes https://bugs.alpinelinux.org/issues/9389