### PR TITLE
testing/py-backcall: enable test suite

### DIFF
--- a/testing/py-backcall/APKBUILD
+++ b/testing/py-backcall/APKBUILD
@@ -8,14 +8,22 @@ url="https://github.com/takluyver/backcall"
 arch="noarch"
 license="BSD-3-Clause"
 makedepends="python2-dev python3-dev"
-options="!check" # pytest broken on alpine
+checkdepends="pytest"
 subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="https://files.pythonhosted.org/packages/source/b/backcall/backcall-$pkgver.tar.gz"
 builddir="$srcdir/${pkgname#py-}-$pkgver"
 
 build() {
 	cd "$builddir"
-	python setup.py build
+	python2 setup.py build
+	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+
+	py.test-2
+	py.test-3
 }
 
 package() {


### PR DESCRIPTION
pytest was broken due to missing dependencies, so the test suite did not
work. This has been fixed in the mean time, so the test suite can now be
run.