### PR TITLE
testing/kitty: fix ppc64le build break because of ioctl data size war…

### DIFF
--- a/testing/kitty/APKBUILD
+++ b/testing/kitty/APKBUILD
@@ -2,10 +2,10 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=kitty
 pkgver=0.12.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A modern, hackable, featureful, OpenGL based terminal emulator"
 url="https://sw.kovidgoyal.net/kitty/"
-arch="all !ppc64le"
+arch="all"
 license="GPL-3.0"
 #some test fails, disabled for now:
 #ERROR: test_box_drawing 
@@ -20,7 +20,8 @@ makedepends="py3-setuptools harfbuzz-dev zlib-dev libpng-dev freetype-dev
 	libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev
 	wayland-protocols wayland-dev py-sphinx"
 subpackages="$pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/kovidgoyal/$pkgname/archive/v$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/kovidgoyal/$pkgname/archive/v$pkgver.tar.gz
+	fix-ppc64le-build-ioctl-with-musl.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -38,4 +39,5 @@ package() {
 	python3 setup.py linux-package --prefix ${pkgdir}/usr
 }
 
-sha512sums="3efdc2ee9d41cddda7ff033fa69531ce48a163ef4b6efa7c5f10ca20511046c26313115383aec6bcef1b2a0fbbac19b2de9a43835130624aada48e12fe54b7df  kitty-0.12.1.tar.gz"
+sha512sums="3efdc2ee9d41cddda7ff033fa69531ce48a163ef4b6efa7c5f10ca20511046c26313115383aec6bcef1b2a0fbbac19b2de9a43835130624aada48e12fe54b7df  kitty-0.12.1.tar.gz
+330f56f5fd60607c57f4f2cffdf33768b3af9e4c3e271a60a05cc3c653d70f7402af91ba0cdfe0257c8b4779884a6440eb52496078bce11799aaa1829ced9245  fix-ppc64le-build-ioctl-with-musl.patch"

--- a/testing/kitty/fix-ppc64le-build-ioctl-with-musl.patch
+++ b/testing/kitty/fix-ppc64le-build-ioctl-with-musl.patch
@@ -1,0 +1,22 @@
+kitty was breaking when building in ppc64le using musl, because ioctl() is defined
+as ioctl(int, int) in musl and mosh is using TIOCSWINSZ macro as parameter. This was
+triggering a gcc warning and make the build fail.
+
+This patch does an explicit integer conversion in TIOCSWINSZ, as no bits get
+lost.
+
+
+--- a/kitty/child-monitor.c
++++ b/kitty/child-monitor.c
+@@ -435,7 +435,11 @@
+ static inline bool
+ pty_resize(int fd, struct winsize *dim) {
+     while(true) {
++#if defined(__powerpc64__) && (!defined(__GLIBC__) && !defined(__UCLIBC__))
++        if (ioctl(fd, (int) TIOCSWINSZ, dim) == -1) {
++#else
+         if (ioctl(fd, TIOCSWINSZ, dim) == -1) {
++#endif
+             if (errno == EINTR) continue;
+             if (errno != EBADF && errno != ENOTTY) {
+                 log_error("Failed to resize tty associated with fd: %d with error: %s", fd, strerror(errno));


### PR DESCRIPTION
…ning. 

kitty was breaking when building in ppc64le using musl, because ioctl() is defined
as ioctl(int, int) in musl and mosh is using TIOCSWINSZ macro as parameter. This was
triggering a gcc warning and make the build fail.

This patch does an explicit integer conversion in TIOCSWINSZ, as no bits get
lost.