### PR TITLE
testing/wireguard: upgrade to 0.0.20180918

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 pkgname=wireguard-tools
-pkgver=0.0.20180910
+pkgver=0.0.20180918
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -42,4 +42,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="644d617d9d53f688c93cafb438d46075b642805b4ddfc328a8c1046a4a2baef3048a5a5af7f71986d753868ad8da8546ea7063572ef56c50bfcd07f3c147899f  WireGuard-0.0.20180910.tar.xz"
+sha512sums="8e9cf26303d7bcc8b8becc8b2a174c54ac46a32d4eb0bda357aef5b71f50e3e860de3b7db955698c88965f1c7f680097463e20e49ec6dff5bf140e789a85ac56  WireGuard-0.0.20180918.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20180910
-_rel=1
+_ver=0.0.20180918
+_rel=2
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="644d617d9d53f688c93cafb438d46075b642805b4ddfc328a8c1046a4a2baef3048a5a5af7f71986d753868ad8da8546ea7063572ef56c50bfcd07f3c147899f  WireGuard-0.0.20180910.tar.xz"
+sha512sums="8e9cf26303d7bcc8b8becc8b2a174c54ac46a32d4eb0bda357aef5b71f50e3e860de3b7db955698c88965f1c7f680097463e20e49ec6dff5bf140e789a85ac56  WireGuard-0.0.20180918.tar.xz"


### PR DESCRIPTION
```
  * blake2s-x86_64: fix whitespace errors
  * crypto: do not use compound literals in selftests
  * crypto: make sure UML is properly disabled
  * kconfig: make NEON depend on CPU_V7
  * poly1305: rename finish to final
  * chacha20: add constant for words in block
  * curve25519-x86_64: remove useless define
  * poly1305: precompute 5*r in init instead of blocks
  * chacha20-arm: swap scalar and neon functions
  * simd: add __must_check annotation
  * poly1305: do not require simd context for arch
  * chacha20-x86_64: cascade down implementations
  * crypto: pass simd by reference
  * chacha20-x86_64: don't activate simd for small blocks
  * poly1305-x86_64: don't activate simd for small blocks
  * crypto: do not use -include trick
  * crypto: turn Zinc into individual modules
  * chacha20poly1305: relax simd between sg chunks
  * chacha20-x86_64: more limited cascade
  * crypto: allow for disabling simd in zinc modules
  * poly1305-x86_64: show full struct for state
  * chacha20-x86_64: use correct cut off for avx512-vl
  * curve25519-arm: only compile if symbols will be used
  * chacha20poly1305: add __init to selftest helper functions
  * chacha20: add independent self test
  
  Tons of improvements all around the board to our cryptography library,
  including some performance boosts with how we handle SIMD for small packets.
  
  * send/receive: reduce number of sg entries
  
  This quells a powerpc stack usage warning.
  
  * global: remove non-essential inline annotations
  
  We now allow the compiler to determine whether or not to inline certain
  functions, while still manually choosing so for a few performance-critical
  sections.
```