### PR TITLE
Use generic travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: trusty
+language: generic
 sudo: required
 install:
   - sudo .travis/install-alpine


### PR DESCRIPTION
Simple change to travis.yml to use a "generic" image - saves a minute per build, see https://docs.travis-ci.com/user/languages/minimal-and-generic/ for details.