### PR TITLE
testing/py-cli_helpers: upgrade to 1.0.2

### DIFF
--- a/testing/py-cli_helpers/APKBUILD
+++ b/testing/py-cli_helpers/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=py-cli_helpers
 _pkgname=cli_helpers
-pkgver=0.2.2
+pkgver=1.0.2
 pkgrel=0
 pkgdesc="A helper library for command-line interfaces"
 url="https://pypi.python.org/pypi/cli-helpers"
@@ -51,4 +51,4 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="a0a0db3bd83ae366ae5e5fcd249fa19c758c6d5ddacfb7f248c868e28033fffc0e5eaf5ee7e4251a05f1a333a982a887c2cce014806a570b9a87ee1e1f8a9460  py-cli_helpers-0.2.2.tar.gz"
+sha512sums="6338603deaedbaf4e0cb98303219f5edcd8ccdedc3000cad6d727263f2d2875c8fe3b8ce8b1213d72a7bfa404c24a605458d946868d9d526e7781ff58a139699  py-cli_helpers-1.0.2.tar.gz"


### PR DESCRIPTION
required to upgrade pgcli https://github.com/alpinelinux/aports/pull/5100
sametime 1.0.1 is minimally required for mycli already