### PR TITLE
testing/mycli: upgrade to 1.18.2 and run tests

### DIFF
--- a/testing/mycli/APKBUILD
+++ b/testing/mycli/APKBUILD
@@ -1,28 +1,29 @@
 # Contributor: Thomas Boerger <thomas@webhippie.de>
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=mycli
-pkgver=1.15.0
+pkgver=1.18.2
 pkgrel=0
 pkgdesc="MySQL CLI with autocompletion and syntax highlighting"
-url="http://mycli.net"
+url="https://www.mycli.net"
 arch="noarch"
 license="BSD"
 depends="python3
 	py3-click
 	py3-pygments
-	py3-prompt_toolkit<1.1.0
+	py3-prompt_toolkit>2.0.0
 	py3-pymysql
 	py3-sqlparse<0.3.0
 	py3-configobj
 	py3-cryptography
 	py3-cli_helpers"
 makedepends="python3-dev"
+checkdepends="pytest py3-mock"
 source="$pkgname-$pkgver.tar.gz::https://files.pythonhosted.org/packages/source/${pkgname:0:1}/$pkgname/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 check() {
 	cd "$builddir"
-	python3 setup.py check
+	python3 -m pytest test
 }
 
 build() {
@@ -35,4 +36,4 @@ package() {
 	python3 setup.py install --prefix=/usr --root="$pkgdir"
 }
 
-sha512sums="e4100a8fcc1e91f1a9fa336a6f1d4e02c3b334f83e37a078881decd84b0da2fa66e598162e26332c3832effdf1a4b720b3865a2c10caf924aa1d580635139657  mycli-1.15.0.tar.gz"
+sha512sums="6ecdb75cdb1d08755b18f6aff1634577ad8c213cbb0c9dd02dd35a6c2faf15e3e908c647964f70d5d72de75825f333921c145317d90e5e4c131a55b67a1dcf9e  mycli-1.18.2.tar.gz"


### PR DESCRIPTION
1.18.1 with https://github.com/dbcli/mycli/commit/b2d442e0363e3a230fb390c08536170ee7dc31e8 moved to prompt-toolkit 2.0 so this depends on #5457 