### PR TITLE
testing/py-tabulate: new aport

### DIFF
--- a/testing/py-tabulate/APKBUILD
+++ b/testing/py-tabulate/APKBUILD
@@ -1,0 +1,54 @@
+# Maintainer: Kevin Daudt <kdaudt@alpinelinux.org>
+pkgname=py-tabulate
+pkgver=0.8.2
+pkgrel=0
+pkgdesc="Pretty-print tabular data"
+url="https://bitbucket.org/astanin/python-tabulate"
+arch="noarch"
+license="MIT"
+makedepends="python2-dev python3-dev"
+checkdepends="pytest py-nose"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="https://files.pythonhosted.org/packages/source/t/tabulate/tabulate-$pkgver.tar.gz"
+builddir="$srcdir/${pkgname#py-}-$pkgver"
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+	python2 setup.py test
+	python3 setup.py test
+}
+
+package() {
+	cd "$builddir"
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="9e34fb84e16f4b2c1378c0f53c5ef803438fcae7bc1637ac8975f358a11653f641bba0ea19529858e8e62aa45bb5bccd3b6f0492fd2d9d9c9a3bf963dd1ac0a7  tabulate-0.8.2.tar.gz"


### PR DESCRIPTION
required for `py-cli_helpers`