### PR TITLE
community/duo_unix: upgrade to 1.10.5

### DIFF
--- a/community/duo_unix/APKBUILD
+++ b/community/duo_unix/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Alan Lacerda <alacerda@alpinelinux.org>
 # Maintainer: Paul Morgan <jumanjiman@gmail.com>
 pkgname=duo_unix
-pkgver=1.10.4
+pkgver=1.10.5
 pkgrel=0
 pkgdesc="duosecurity.com two-factor authentication"
 url="https://duo.com/support/documentation/duounix"
@@ -36,4 +36,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="3a532492423d7242a172744539bac5bedea181ca2af3cd85546d03f7c8a19b01e98f8c696478324b2e24a237e80255746b4eee7d6aa94d7f11684f45ba88c4f9  duo_unix-1.10.4.tar.gz"
+sha512sums="1e0a0b056d5cf3ae98649121cdaaeeeed12124d66aac8247e496b7c7c3f3dc382f3f388ad41710a547afcaf71f1b8c64fc409e6622ad0b22e92cc0dd6425811f  duo_unix-1.10.5.tar.gz"


### PR DESCRIPTION
Changes from 1.10.4 include:

- Fixed an accidental null pointer free on systems where getaddrinfo() is unsuccessful