### PR TITLE
Add py-automat and fix Deluge dependecy

### DIFF
--- a/testing/deluge/APKBUILD
+++ b/testing/deluge/APKBUILD
@@ -2,14 +2,15 @@
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=deluge
 pkgver=1.3.15
-pkgrel=2
+pkgrel=3
 pkgdesc="A lightweight, Free Software, cross-platform BitTorrent client"
 url="https://deluge-torrent.org"
 arch="noarch"
 license="GPL-3.0"
 depends="libtorrent-rasterbar librsvg py-cffi py-chardet py-cryptography
 	py-enum34 py-gtk py-mako py-openssl py-setuptools py-six py-twisted py-xdg
-	xdg-utils py-constantly py-incremental py-attrs py-service_identity"
+	xdg-utils py-constantly py-incremental py-attrs py-service_identity
+	py-automat"
 makedepends="intltool librsvg-dev py-gtk-dev py-mako py-setuptools"
 subpackages="$pkgname-lang $pkgname-doc"
 source="https://download.deluge-torrent.org/source/$pkgname-$pkgver.tar.bz2"

--- a/testing/py-automat/APKBUILD
+++ b/testing/py-automat/APKBUILD
@@ -1,0 +1,57 @@
+# Contributor: Tiago Ilieve <tiago.myhro@gmail.com>
+# Maintainer: Tiago Ilieve <tiago.myhro@gmail.com>
+pkgname=py-automat
+_pkgname=Automat
+pkgver=0.7.0
+pkgrel=0
+pkgdesc="Self-service finite-state machines for the programmer on the go"
+url="https://automat.readthedocs.io/"
+arch="noarch"
+license="MIT"
+depends="py-attrs py-six"
+makedepends="python2-dev python3-dev py-setuptools graphviz py2-graphviz
+	py-incremental py-twisted pytest"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+
+	python2 setup.py build
+	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+
+	py.test-2 automat/_test
+	py.test-3 automat/_test
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="a6f307d312a3ceb721071b5212297c73d2306894b5fafd39265578041a2859bd6f041ac43a654bdda4175a70a4e90e0db1ee35cd43fa620cd5c594b5d1988a74  Automat-0.7.0.tar.gz"


### PR DESCRIPTION
Reported on [issue #9423][1].

~One thing that's missing is that there's no way to run Python 3 tests until there's a `py3-twisted` package. They are mostly integration tests and are properly skipped on Python 2 when Graphviz/Twisted isn't available, but somehow the test discovery in Python 3 works differently and they fail. Therefore they had to be skipped.~

Edit: nevermind. Running tests using `pytest` fixed the issue. All tests run on Python 2, but Twisted ones are skipped on Python 3.

[1]: https://bugs.alpinelinux.org/issues/9423