### PR TITLE
testing/gron: new aport

### DIFF
--- a/testing/gron/APKBUILD
+++ b/testing/gron/APKBUILD
@@ -1,0 +1,38 @@
+# Contributor: Tiago Ilieve <tiago.myhro@gmail.com>
+# Maintainer: Tiago Ilieve <tiago.myhro@gmail.com>
+pkgname=gron
+pkgver=0.6.0
+pkgrel=0
+pkgdesc="Make JSON greppable"
+url="https://github.com/tomnomnom/gron"
+arch="all"
+license="MIT"
+depends=""
+makedepends="go>=1.11"
+source="gron-$pkgver.tar.gz::https://github.com/tomnomnom/gron/archive/v${pkgver}.tar.gz
+	go.mod go.sum"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+
+	go build -v -ldflags "-s -w -X main.gronVersion=$pkgver" -o gron
+}
+
+check() {
+	cd "$builddir"
+
+	./gron --version
+	./gron testdata/one.json
+	go test
+}
+
+package() {
+	cd "$builddir"
+
+	install -Dm755 ./gron "$pkgdir"/usr/bin/gron
+}
+
+sha512sums="aa1e2e6d00927b8b0abb5b39593deed9037d7f1fdf669f1c3c2e28ce117b270e10758027afd962499783a1f6f4d848cc6c6a0f6e4323ba8c53be14e1add622fe  gron-0.6.0.tar.gz
+30d5e835903698ae1cb1203c986b4eb4989aa74fcc50b907656b5182fd5060e403ba991dcba3a65a3a215898dfeb5caa46f24ec0bc58535e4f80d937583407bb  go.mod
+8d1898bd5d6dba0e121615b4c6c279b0df031eb2ec900c2afc39126be6006557f1b5e87c1a0572cca2ef45ec66775b7606b5701f28c6dbefaa9fa2fd65587a4d  go.sum"

--- a/testing/gron/go.mod
+++ b/testing/gron/go.mod
@@ -1,0 +1,10 @@
+module github.com/tomnomnom/gron
+
+require (
+	github.com/fatih/color v1.7.0
+	github.com/mattn/go-colorable v0.0.9
+	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/nwidger/jsoncolor v0.0.0-20170215171346-75a6de4340e5
+	github.com/pkg/errors v0.8.0
+	golang.org/x/sys v0.0.0-20180921163948-d47a0f339242 // indirect
+)

--- a/testing/gron/go.sum
+++ b/testing/gron/go.sum
@@ -1,0 +1,12 @@
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
+github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
+github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/nwidger/jsoncolor v0.0.0-20170215171346-75a6de4340e5 h1:d+C3xJdxZT7wNlxqEwbXn3R355CwAhYBL9raVNfSnK0=
+github.com/nwidger/jsoncolor v0.0.0-20170215171346-75a6de4340e5/go.mod h1:GYFm0zZgTNeoK1QxuIofRDasy2ibmaJZhZLzwsMXUF4=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+golang.org/x/sys v0.0.0-20180921163948-d47a0f339242 h1:5DYsa+ZAwcJHjuY0Qet390sUr7qwkpnRsUNjddyc0b8=
+golang.org/x/sys v0.0.0-20180921163948-d47a0f339242/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
It depends on `go>=1.11`, but this won't be a problem unless it is backported to the stable release.