### PR TITLE
[various]: enable stripping of go binaries

### DIFF
--- a/community/git-lfs/APKBUILD
+++ b/community/git-lfs/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=git-lfs
 pkgver=2.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Git extension for versioning large files"
 url="https://git-lfs.github.io/"
 arch="all"
@@ -10,8 +10,6 @@ license="MIT"
 depends="git"
 checkdepends="bash coreutils git-daemon perl-utils"
 makedepends="go ronn"
-# Go doesn't play well with strip tool. http://bit.ly/2jlJsSU
-options="!strip"
 subpackages="$pkgname-doc"
 install="$pkgname.post-install $pkgname.pre-deinstall"
 source="$pkgname-$pkgver.tar.gz::https://github.com/git-lfs/$pkgname/archive/v$pkgver.tar.gz

--- a/community/glide/APKBUILD
+++ b/community/glide/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Aaron Hurt <ahurt@ena.com>
 pkgname="glide"
 pkgver=0.13.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Vendor Package Management for Golang"
 url="https://github.com/Masterminds/glide"
 arch="all"
@@ -13,7 +13,6 @@ install=""
 subpackages=""
 source="$pkgname-$pkgver.tar.gz::https://github.com/Masterminds/glide/archive/v$pkgver.tar.gz"
 builddir="$srcdir/go/src/github.com/Masterminds/glide"
-options="!strip"
 
 prepare() {
 	mkdir -p "$srcdir/go/src/github.com/Masterminds"

--- a/community/gogs/APKBUILD
+++ b/community/gogs/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: 7heo <7heo@mail.com>
 pkgname=gogs
 pkgver=0.11.34
-pkgrel=1
+pkgrel=2
 pkgdesc="A self-hosted Git service written in Go"
 url="https://gogs.io/"
 arch="all"
@@ -12,7 +12,6 @@ makedepends="go perl libcap"
 install="$pkgname.pre-install"
 pkgusers="gogs"
 pkggroups="www-data"
-options="!strip"
 source="${pkgname}-${pkgver}.tar.gz::https://github.com/gogits/$pkgname/archive/v$pkgver.tar.gz
 	$pkgname.initd
 	$pkgname.confd

--- a/testing/consul-replicate/APKBUILD
+++ b/testing/consul-replicate/APKBUILD
@@ -2,14 +2,13 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=consul-replicate
 pkgver=0.4.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Consul cross-DC KV replication daemon"
 url="https://www.consul.io/"
 arch="all"
 license="MPL-2.0"
 depends=""
 makedepends="go"
-options="!strip"
 source="$pkgname-$pkgver.tar.gz::https://github.com/hashicorp/$pkgname/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 

--- a/testing/consul-template/APKBUILD
+++ b/testing/consul-template/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=consul-template
 pkgver=0.19.4
-pkgrel=0
+pkgrel=1
 pkgdesc="Generic template rendering and notifications with Consul"
 url="https://www.consul.io/"
 arch="all"
 license="MPL-2.0"
 depends=""
 makedepends="go"
-options="!strip !check"
+options="!check"
 source="$pkgname-$pkgver.tar.gz::https://github.com/hashicorp/$pkgname/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 

--- a/testing/dockerize/APKBUILD
+++ b/testing/dockerize/APKBUILD
@@ -1,13 +1,12 @@
 # Maintainer: Christian Kampka <christian@kampka.net>
 pkgname=dockerize
 pkgver=0.6.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Utility to simplify running applications in docker containers."
 url="https://github.com/jwilder/dockerize"
 arch="x86 x86_64 ppc64le"
 license="MIT"
 makedepends="git go"
-options="!strip"
 source="http://dev.alpinelinux.org/archive/$pkgname/$pkgname-$pkgver.tar"
 
 _giturl="git://github.com/jwilder/${pkgname}.git"

--- a/testing/envconsul/APKBUILD
+++ b/testing/envconsul/APKBUILD
@@ -2,14 +2,13 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=envconsul
 pkgver=0.7.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Read and set environmental variables for processes from Consul."
 url="https://www.consul.io/"
 arch="all"
 license="MPL-2.0"
 depends=""
 makedepends="go"
-options="!strip"
 source="$pkgname-$pkgver.tar.gz::https://github.com/hashicorp/$pkgname/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 

--- a/testing/etcd/APKBUILD
+++ b/testing/etcd/APKBUILD
@@ -2,13 +2,12 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=etcd
 pkgver=3.3.9
-pkgrel=1
+pkgrel=2
 pkgdesc="A highly-available key value store for shared configuration and service discovery"
 url="https://github.com/coreos/etcd"
 arch="x86_64 ppc64le"
 license="Apache-2.0"
 makedepends="go bash"
-options="!strip"
 install="$pkgname.pre-install"
 pkgusers="$pkgname"
 pkggroups="$pkgname"

--- a/testing/hub/APKBUILD
+++ b/testing/hub/APKBUILD
@@ -3,13 +3,13 @@
 # Maintainer: Roberto Oliveira <robertoguimaraes8@gmail.com>
 pkgname=hub
 pkgver=2.5.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Extends git with extra features for GitHub"
 url="http://hub.github.com/"
 arch="all !x86" # FIXME: tests fails on x86
 license="MIT"
 makedepends="go dep bash ca-certificates"
-options="!strip net !checkroot"
+options="net !checkroot"
 subpackages="
 	$pkgname-doc
 	$pkgname-bash-completion:bashcomp:noarch

--- a/testing/keybase-client/APKBUILD
+++ b/testing/keybase-client/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=keybase-client
 pkgver=2.5.0
 _ver=${pkgver/_p/-}
-pkgrel=0
+pkgrel=1
 pkgdesc="CLI client for keybase.io"
 url="https://github.com/keybase/client"
 arch="all"
@@ -13,7 +13,6 @@ depends_dev=""
 makedepends="$depends_dev go"
 install=""
 subpackages=""
-options="!strip"
 source="$pkgname-$pkgver.tar.gz::https://github.com/${pkgname/-//}/archive/v${_ver}.tar.gz"
 
 builddir="$srcdir/client-${_ver}"

--- a/testing/telegraf/APKBUILD
+++ b/testing/telegraf/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Katie Holly <holly@fuslvz.ws>
 pkgname=telegraf
 pkgver=1.7.4
-pkgrel=0
+pkgrel=1
 pkgdesc="A plugin-driven server agent for collecting & reporting metrics, part of the InfluxDB project"
 url="https://www.influxdata.com/time-series-platform/telegraf/"
 arch="x86_64"
@@ -11,7 +11,7 @@ makedepends="go glide"
 pkgusers="telegraf"
 pkggroups="telegraf"
 install="$pkgname.pre-install"
-options="!strip !net"
+options="!net"
 source="$pkgname-$pkgver.tar.gz::https://github.com/influxdata/$pkgname/archive/$pkgver.tar.gz
 	telegraf-makefile-ldflags.patch
 	telegraf.initd


### PR DESCRIPTION
Stripping go binaries used to be an issue but nowadays it should work as
expected.

> We don't intentionally do anything that would make stripping a binary
> not OK, and strip has worked for the past five years or so.

https://groups.google.com/forum/?_escaped_fragment_=topic/golang-dev/ABppMOjYP6w#!topic/golang-dev/ABppMOjYP6w