### PR TITLE
community/gogs: depend on go instead of go-tools

### DIFF
--- a/community/gogs/APKBUILD
+++ b/community/gogs/APKBUILD
@@ -2,13 +2,13 @@
 # Maintainer: 7heo <7heo@mail.com>
 pkgname=gogs
 pkgver=0.11.34
-pkgrel=0
+pkgrel=1
 pkgdesc="A self-hosted Git service written in Go"
 url="https://gogs.io/"
 arch="all"
 license="MIT"
 depends="git"
-makedepends="go-tools perl libcap"
+makedepends="go perl libcap"
 install="$pkgname.pre-install"
 pkgusers="gogs"
 pkggroups="www-data"


### PR DESCRIPTION
go-tools was removed in 11c5f257c586b68e3567ece44133b21c02c88f00. It is
unclear to me why gogs depended on go-tools in the first place. The
build passes without go-tools so I guess it's fine to remove it.