### PR TITLE
testing/logstash: upgrade to 6.4.1

### DIFF
--- a/testing/logstash/APKBUILD
+++ b/testing/logstash/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Steeve Chailloux <steeve@chaahk.com>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=logstash
-pkgver=6.3.1
+pkgver=6.4.1
 pkgrel=0
 pkgdesc="A flexible, open source, data collection, parsing and enrichment pipeline"
 url="http://logstash.net"
@@ -84,7 +84,7 @@ package() {
 	"$pkgdir/$confdir"/jvm.options || return 1
 }
 
-sha512sums="dd9f55384bc5ec6c7530d62c2ba9f25dc1f7db4a736138ede8d3dece9a66705d7ed642877bac842a2252847e5b122afe5dee2b2258d4b0acb3750aa6c22f23bf  logstash-6.3.1.tar.gz
+sha512sums="b496ed0746ee38a375a3efc5eb93677accb61c3482550a75cf9ad5e7b8e104eb8560bce79325ce85a27d22b664299edf1970452837189fcfa9310798c58825c1  logstash-6.4.1.tar.gz
 94b18da3f0ef40f68118b27654563e7aa6dd4a3b90f0d8ad61a8be579d4be62c2bf1b192a32ee6140b81224343eeb442687539f6def1e725787b8cb96c0c70d1  logstash.confd
 828684ea0b9faa53ac51f7fb22bf73d862dc058d605f27958db6a8efbd10f5463a0837fa88b62a3964582c72fdd7ece434057a540b0924eae1fae17b9d5887b4  logstash.initd
 21609c8f44b31a5f298573be4b5c0fdcdc165e603a95c3626570fb6dd44dad114a74ee3f10fbd518f72b537a3d6bdcdbad09798c4bead0ee16f2a3b8e2b00ed3  logstash.conf


### PR DESCRIPTION
release notes:

https://www.elastic.co/guide/en/logstash/current/logstash-6-4-1.html