### PR TITLE
testing/brotli: upgrade to 1.0.6

### DIFF
--- a/testing/brotli/APKBUILD
+++ b/testing/brotli/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: prspkt <prspkt@protonmail.com>
 # Maintainer: prspkt <prspkt@protonmail.com>
 pkgname=brotli
-pkgver=1.0.5
+pkgver=1.0.6
 pkgrel=0
 pkgdesc="Generic lossless compressor"
 url="https://github.com/google/brotli"
@@ -46,4 +46,4 @@ package() {
 	done
 }
 
-sha512sums="703cad94c7f250133d2cfe222f3183612c7649b184bba218907b805f423568046d42695f33acf7da95daf684be118c9d631cfa5706e5a195b611c716db4c839a  brotli-1.0.5.tar.gz"
+sha512sums="b9847375471de3ae815ef4bb45a29653c343fad0a891a79d5132fcdee34c85caafd82289c8b413c3ef609049f2e8c4af9f9abd1736a2408ba44544c5fefc0010  brotli-1.0.6.tar.gz"


### PR DESCRIPTION
[Release notes](https://github.com/google/brotli/releases/tag/v1.0.6).