### PR TITLE
testing/rakudo: upgrade to 2018.09

### DIFF
--- a/testing/moarvm/APKBUILD
+++ b/testing/moarvm/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=moarvm
-pkgver=2018.08
+pkgver=2018.09
 pkgrel=0
 pkgdesc="A VM for NQP And Rakudo Perl 6"
 url="http://moarvm.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="048fe4f333b017f21dbac34eb385f0569f566ec5ebba9f0e9ee217d325b61fc3542e39e0f1db6fc2cbfa48b09b1acb16c79f02fbe34ed8a5a1946927528c0570  MoarVM-2018.08.tar.gz"
+sha512sums="14d5ca1f6a8c77ee89fd05d66057b640b1e222391fded17631a4e11801de25e1fb3eb6b8b4dd977990e64952f7067482bf405a9ef5ebb6fdacdfa7c11bee21b1  MoarVM-2018.09.tar.gz"

--- a/testing/nqp/APKBUILD
+++ b/testing/nqp/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=nqp
-pkgver=2018.08
+pkgver=2018.09
 pkgrel=0
 pkgdesc="Not Quite Perl"
 url="https://github.com/perl6/nqp"
@@ -39,4 +39,4 @@ doc() {
 	done
 }
 
-sha512sums="0c0a07fc6f233d3e7bf79df96ba5a04c57dde4220e24b95269df815fcac389802d796d83b6c310ac3862f413b044b95e7886be215553ae9ebfb388993756361d  nqp-2018.08.tar.gz"
+sha512sums="2fcbd39b61cfe4e1cd4315b59bb5fdeee42e2842b27f0c0a9bc97d4678a2d44d7f0be6537889acca7b26e2e372e76f4063461e29c07fb231ec9be7c7e1bb88d3  nqp-2018.09.tar.gz"

--- a/testing/rakudo/APKBUILD
+++ b/testing/rakudo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=rakudo
-pkgver=2018.08
+pkgver=2018.09
 pkgrel=0
 pkgdesc="A compiler for the Perl 6 programming language"
 url="http://rakudo.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="1730b8d5953b1b49e82da8207df4b8925682e0cd96a7406dba959dd54dffec4b0c0a68639289f7522aa7829fa687b93024a7e3c617b59439921b206ab6330183  rakudo-2018.08.tar.gz"
+sha512sums="1a40fd71b78393d487c62b2d2316a4fcd7a0e1102913c0c83d7c2479860b1f56f555c45ae4b43804e9025eeb8bf8bf763e0603aef8e9813a6b4aa0f62fa182ba  rakudo-2018.09.tar.gz"


### PR DESCRIPTION
Upgrade moarvm, nqp, and rakudo to version 2018.09, must upgrade all three together.
