### PR TITLE
main/nfs-utils: drop build dep on libnfsidmap-dev

### DIFF
--- a/main/nfs-utils/APKBUILD
+++ b/main/nfs-utils/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nfs-utils
 pkgver=2.3.2
-pkgrel=0
+pkgrel=1
 pkgdesc="kernel-mode NFS"
 url="http://linux-nfs.org"
 arch="all"
@@ -10,9 +10,10 @@ license="GPL-2.0+, BSD-3-Clause"
 depends="rpcbind"
 options="suid"
 makedepends="util-linux-dev libtirpc-dev libcap-dev libevent-dev
-	libnfsidmap-dev keyutils-dev lvm2-dev krb5-dev sqlite-dev
-	autoconf automake libtool bsd-compat-headers"
-subpackages="$pkgname-doc $pkgname-dbg $pkgname-openrc rpcgen"
+	keyutils-dev lvm2-dev krb5-dev sqlite-dev
+	autoconf automake libtool bsd-compat-headers openldap-dev"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-dbg $pkgname-openrc rpcgen
+	libnfsidmap libnfsidmap-ldap"
 source="https://www.kernel.org/pub/linux/utils/nfs-utils/$pkgver/nfs-utils-$pkgver.tar.gz
 	0011-exportfs-only-do-glibc-specific-hackery-on-glibc.patch
 
@@ -86,10 +87,36 @@ package() {
 	done
 }
 
+dev() {
+	replaces="libnfsidmap-dev libnfsidmap-ldap-dev"
+	default_dev
+}
+
+doc() {
+	replaces="libnfsidmap-doc"
+	default_doc
+}
+
 rpcgen() {
 	pkgdesc="Remote Procedure Call (RPC) protocol compiler"
 	install -Dm755 "$builddir"/tools/rpcgen/rpcgen \
 		"$subpkgdir"/usr/bin/rpcgen
+}
+
+libnfsidmap() {
+	pkgdesc="NFSv4 User and Group ID Mapping Library"
+	install -Dm644 "$builddir"/support/nfsidmap/idmapd.conf "$subpkgdir"/etc/idmapd.conf
+	mkdir -p "$subpkgdir"/usr/lib/libnfsidmap
+	mv "$pkgdir"/usr/lib/libnfsidmap.so* "$subpkgdir"/usr/lib/
+	mv "$pkgdir"/usr/lib/libnfsidmap/static* "$subpkgdir"/usr/lib/libnfsidmap/
+	mv "$pkgdir"/usr/lib/libnfsidmap/nsswitch* "$subpkgdir"/usr/lib/libnfsidmap/
+
+}
+
+ldap() {
+	pkgdesc="LDAP plugin for libnfsidmap"
+	mkdir -p "$subpkgdir"/usr/lib/libnfsidmap
+	mv "$pkgdir"/usr/lib/libnfsidmap/*ldap* "$subpkgdir"/usr/lib/libnfsidmap/
 }
 
 sha512sums="0a6f81a838ab8252521468b18f5578a4302b722c0ad99c67437f32248d698bea4e664d3b2d176cad7ae5a8487b2443b554c65262d3719aa9622d237df5e6de54  nfs-utils-2.3.2.tar.gz


### PR DESCRIPTION
libnfsidmap-dev has been integrated into nfs-utils since 2.2.1

Fixes: #8487