### PR TITLE
testing/libell: new aport

### DIFF
--- a/testing/libell/APKBUILD
+++ b/testing/libell/APKBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Pedro Filipe <xpecex@outlook.com>
+pkgname=libell
+pkgver=0.9
+pkgrel=0
+pkgdesc="The Embedded Linux* Library (ELL) provides core, low-level functionality for system daemons."
+url="https://01.org/ell"
+arch="all"
+license="GPL-2.1"
+makedepends="libnl3-dev dbus linux-headers"
+subpackages="$pkgname-dev"
+source="https://mirrors.edge.kernel.org/pub/linux/libs/ell/ell-$pkgver.tar.xz
+	fix-WAIT_ANY-test-dbus.patch
+	"
+builddir="$srcdir/ell-$pkgver"
+options="!check" # testsuite shows unknown error in unit/test-cipher
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--localstatedir=/var
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="e1208066012b9ff927baae271f94116376ccd2577d7f6510cc1444eee912988aa1c25e8e8c9195cccfa39ed48fc8c2f07bd7a414719e6ce76ee1e5bd2a64b8c3  ell-0.9.tar.xz
+456f49b0f9c5ff93b1af2221d59f224b7b61847360e3f25b0d42af733fc4b296d30bb50349e00437c6e235c0bacba74c1a5b502dcc1b0c4bdbc38f101b3d4220  fix-WAIT_ANY-test-dbus.patch"

--- a/testing/libell/fix-WAIT_ANY-test-dbus.patch
+++ b/testing/libell/fix-WAIT_ANY-test-dbus.patch
@@ -1,0 +1,44 @@
+--- a/unit/test-dbus.c
++++ b/unit/test-dbus.c
+@@ -32,6 +32,10 @@
+ 
+ #define TEST_BUS_ADDRESS "unix:path=/tmp/ell-test-bus"
+ 
++#ifndef WAIT_ANY
++#define WAIT_ANY (-1)
++#endif
++
+ static pid_t dbus_daemon_pid = -1;
+ 
+ static void start_dbus_daemon(void)
+
+
+--- a/unit/test-dbus-message-fds.c
++++ b/unit/test-dbus-message-fds.c
+@@ -37,6 +37,10 @@
+ 
+ #define TEST_BUS_ADDRESS "unix:path=/tmp/ell-test-bus"
+ 
++#ifndef WAIT_ANY
++#define WAIT_ANY (-1)
++#endif
++
+ static pid_t dbus_daemon_pid = -1;
+ 
+ static bool start_dbus_daemon(void)
+
+
+--- a/unit/test-dbus-properties.c
++++ b/unit/test-dbus-properties.c
+@@ -34,6 +34,10 @@
+ 
+ #define TEST_BUS_ADDRESS "unix:path=/tmp/ell-test-bus"
+ 
++#ifndef WAIT_ANY
++#define WAIT_ANY (-1)
++#endif
++
+ static pid_t dbus_daemon_pid = -1;
+ 
+ static bool start_dbus_daemon(void)
+


### PR DESCRIPTION
> The Embedded Linux* Library (ELL) provides core, low-level functionality for system daemons. It typically has no dependencies other than the Linux kernel, C standard library, and libdl (for dynamic linking). While ELL is designed to be efficient and compact enough for use on embedded Linux platforms, it is not limited to resource-constrained systems.

ref https://01.org/ell

This library is necessary for upgrade [Bluez](https://github.com/xpecex/aports/tree/master/main/bluez) to [5.50](http://www.bluez.org/release-of-bluez-5-50/)

