### PR TITLE
community/elasticsearch: upgrade to 6.4.1

### DIFF
--- a/community/elasticsearch/APKBUILD
+++ b/community/elasticsearch/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=elasticsearch
-pkgver=6.4.0
-pkgrel=3
+pkgver=6.4.1
+pkgrel=0
 pkgdesc="Open Source, Distributed, RESTful Search Engine"
 url="https://www.elastic.co/products/elasticsearch"
 arch="x86 x86_64 ppc64le"
@@ -114,7 +114,7 @@ _x_pack() {
 	rm -rf "$subpkgdir"/$_basedir/modules/x-pack-ml
 }
 
-sha512sums="6f465378a51c487f1f6a84a0843ac1038db60170ee8a5d96874a759f6dbbf2de9f7bcbbf55616f49f28f1098c82f2e585c917267d02b8b1f43627a1984b3da66  elasticsearch-6.4.0.tar.gz
+sha512sums="a023a6db5554dee6f10718dfa297aa06a735c7857542c2db80fa5c2b86ff4bf405bb8167578c5b60741ad05ed96a64b54bc71d128a0ff955468b0449588b053c  elasticsearch-6.4.1.tar.gz
 f7ab61ed3e7e8979d1f476502319b9a3874a88b97f70951c0b39e7642b01c942a11384810b1a92efb1ee2b07717bc80dfed8a95f0189b7fef7ce68885e1280cb  elasticsearch.initd
 2ab1baf1b5c8782f3f371ba221aadd3e841abc62175f0b1ddcfc68d711e2370465124e076f8cc2e549c25a1da9db8c90172b2f410bd6bbe4153f0e831620b6ba  elasticsearch.confd
 6de81485cdc059afef58382862e4155482463fde0b604aaa8dbe904c778b841467c4a383a5e54acd09e3436f1fb7be9923e001fb77bd3d7894e113a5e0f4036b  README.alpine


### PR DESCRIPTION
Ref https://www.elastic.co/guide/en/elasticsearch/reference/6.4/release-notes-6.4.1.html