### PR TITLE
scripts/mkimg.base.sh: Fix label to search (grub)

### DIFF
--- a/scripts/mkimg.base.sh
+++ b/scripts/mkimg.base.sh
@@ -165,7 +165,7 @@ build_grub_cfg() {
 
 grub_gen_earlyconf() {
 	cat <<- EOF
-	search --no-floppy --set=root --label "alpine-$PROFILE $RELEASE $ARCH"
+	search --no-floppy --set=root --label "alpine-${profile_abbrev:-$PROFILE} $RELEASE $ARCH"
 	set prefix=(\$root)/boot/grub
 	EOF
 }


### PR DESCRIPTION
Since [this commit](https://github.com/alpinelinux/aports/commit/79f771260719243d28b4732989be6e442df0b5f6), Alpine ISO won't boot with EFI because grub is still looking for the old label ($PROFILE instead of $profile_abbrev) and fails to its rescue shell.

This fixes [Bug #9059](https://bugs.alpinelinux.org/issues/9059)