### PR TITLE
main/libgit2: security upgrade to 0.27.4

### DIFF
--- a/main/libgit2/APKBUILD
+++ b/main/libgit2/APKBUILD
@@ -3,10 +3,10 @@
 # Contributor: Pierre-Gilas MILLON <pgmillon@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libgit2
-pkgver=0.27.3
+pkgver=0.27.4
 pkgrel=0
 pkgdesc="A linkable library for Git"
-url="https://libgit2.github.com/"
+url="https://libgit2.org/"
 arch="all"
 license="GPL-2.0-only-WITH-GCC-exception-2.0"
 depends_dev="curl-dev libssh2-dev"
@@ -21,6 +21,8 @@ options="!check" # FIXME some tests fails
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   0.27.4-r0:
+#   - CVE-2018-15501
 #   0.27.3-r0:
 #   - CVE-2018-10887
 #   - CVE-2018-10888
@@ -60,5 +62,5 @@ tests() {
 	cp -a "$builddir"/tests "$subpkgdir"/usr/src/$pkgname/
 }
 
-sha512sums="e470050b89289908ec64dafaa954ad9bfc8f557ba7dafcab440d9efde474f736c025d8202bfd81a508070d9cf678f3fb1f3687d72a849ce86edd1ee90ad13c3b  libgit2-0.27.3.tar.gz
+sha512sums="d27db86eb1b9f0d4057f8538ba1985ee76c3ca106e57d417fa9bff79d575f91a07ad28693112b58dc1d61d68116a82e6a145f12276158f2806b6c4964d741f61  libgit2-0.27.4.tar.gz
 268e24554282666900a2179a368dc2569cb3bce60ffea187fd53de1bc119a85abc02cddd8be2ab607d44db793c4807acdbb49fc5d1badfc08bf382fa511d7b3e  build-both-static-dynamic.patch"


### PR DESCRIPTION
Fixes CVE-2018-15501