### PR TITLE
testing/ossp-uuid: new aport

### DIFF
--- a/testing/ossp-uuid/APKBUILD
+++ b/testing/ossp-uuid/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: "Andrzej Trzaska <atrzaska2@gmail.com>"
+# Maintainer: "Andrzej Trzaska <atrzaska2@gmail.com>"
+pkgname=ossp-uuid
+pkgver=1.6.2
+pkgrel=0
+pkgdesc="Open Source Software Project Universally Unique Identifier (UUID)"
+url="http://www.ossp.org/pkg/lib/uuid/"
+arch="all"
+license="MIT"
+subpackages="$pkgname-doc"
+source="https://mirrors.ocf.berkeley.edu/debian/pool/main/o/ossp-uuid/ossp-uuid_1.6.2.orig.tar.gz"
+builddir="$srcdir/uuid-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure --prefix=/usr --without-pgsql --without-perl --without-php
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="16c7e016ce08d7679cc6ee7dec43a886a8c351960acdde99f8f9b590c7232d521bc6e66e4766d969d22c3f835dcc2814fdecc44eef1cd11e7b9b0f9c41b5c03e  ossp-uuid_1.6.2.orig.tar.gz"


### PR DESCRIPTION
http://www.ossp.org/pkg/lib/uuid/

This package provides OSSP UUID library

Build based on https://github.com/Homebrew/homebrew-core/blob/master/Formula/ossp-uuid.rb