### PR TITLE
main/pciutils: enable static libraries

### DIFF
--- a/main/pciutils/APKBUILD
+++ b/main/pciutils/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=pciutils
 pkgver=3.6.2
-pkgrel=0
+pkgrel=1
 pkgdesc="PCI bus configuration space access library and tools"
 url="http://mj.ucw.cz/pciutils.html"
 arch="all"
@@ -38,6 +38,7 @@ package() {
 
 	install -d "$pkgdir"/usr/lib
 	ln -s libpci.so.${pkgver%%.*} "$pkgdir"/usr/lib/libpci.so
+	ln -s libpci.a "$pkgdir"/usr/lib/libpci.a
 	install -D -m 644 lib/libpci.pc "$pkgdir"/usr/lib/pkgconfig/libpci.pc
 	for i in config.h header.h pci.h types.h; do
 		install -D -m 644 lib/${i} "$pkgdir"/usr/include/pci/${i}


### PR DESCRIPTION
This fixes [#9472](https://bugs.alpinelinux.org/issues/9472).