### PR TITLE
community/qt5-qtbase: Enable the X11 Accessibility Bridge

### DIFF
--- a/community/qt5-qtbase/APKBUILD
+++ b/community/qt5-qtbase/APKBUILD
@@ -7,7 +7,7 @@ _ver=${_ver/_/-}
 _ver=${_ver/beta0/beta}
 _ver=${_ver/rc0/rc}
 _V=${_ver/rc/RC}
-pkgrel=0
+pkgrel=1
 pkgdesc="Qt5 - QtBase components"
 url="http://qt-project.org/"
 arch="all"
@@ -18,6 +18,7 @@ depends_dev="mesa-dev libice-dev libsm-dev libx11-dev libxext-dev
 	libressl-dev fontconfig-dev freetype-dev glib-dev libpng-dev zlib-dev
 	sqlite-dev dbus-dev perl $_sub"
 makedepends="$depends_dev
+	at-spi2-atk-dev
 	bison
 	cups-dev
 	eudev-dev


### PR DESCRIPTION
Otherwise `QtLinuxAccessibilitySupport` ~~(and maybe more)~~ is missing from Qt

For a list of files, see https://travis-ci.org/alpinelinux/aports/builds/435315439#L8241