### PR TITLE
community/yarn: upgrade to 1.10.1

### DIFF
--- a/community/yarn/APKBUILD
+++ b/community/yarn/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Ed Robinson <ed@reevoo.com>
 # Maintainer: Ed Robinson <ed@reevoo.com>
 pkgname=yarn
-pkgver=1.9.4
+pkgver=1.10.1
 pkgrel=0
 pkgdesc="Fast, reliable, and secure dependency management for Node.js"
 url="https://yarnpkg.com/"
@@ -31,5 +31,5 @@ package() {
 	ln -s /$destdir/bin/yarn "$pkgdir"/usr/bin/yarnpkg
 }
 
-sha512sums="1e3a908cf47a2fe46d7ce8db549b91cd0b3372c7c43c6b0029f1060b044a0a65e5bc3323f4ed6baf20bbbcb49ba358a6bb8f2691a591e4d3e8a01bc31372cb5b  yarn-v1.9.4.tar.gz
+sha512sums="107d07d5fc9f171904e14a46e1bf9509a558e08e3cf08d84c903661a31862a6bec4886f41b76fed4871f1983c8da0a9ad5dbb8de0e190378c7f1f5e5abaa15c6  yarn-v1.10.1.tar.gz
 30431f7aa5fe7382e062b92e413ea8d118e157d89aa043353c18ff7d1721d0e3ecfbe68de1f0058b3b70cee5cf9baa08d28f1718beb5d14fcb0cf2881dff1eac  apk-install-method.patch"


### PR DESCRIPTION
Upgrade yarn to [`1.10.1`](https://github.com/yarnpkg/yarn/releases/tag/v1.10.1)