### PR TITLE
testing/openttd: fix crash on save due to insufficient stacksize

### DIFF
--- a/testing/openttd/APKBUILD
+++ b/testing/openttd/APKBUILD
@@ -10,7 +10,6 @@ license="GPL-2.0-only"
 depends=""
 makedepends="fontconfig-dev freetype-dev libpng-dev lzo-dev sdl-dev xz-dev zlib-dev"
 subpackages="$pkgname-doc $pkgname-lang::noarch"
-options="!check"
 source="https://binaries.openttd.org/releases/$pkgver/$pkgname-$pkgver-source.tar.xz
 	fix-pthread-stacksize.patch"
 builddir="$srcdir/$pkgname-$pkgver"
@@ -35,6 +34,11 @@ build() {
 		--with-fontconfig \
 		--without-icu
 	make
+}
+
+check() {
+	cd "$builddir"
+	bin/openttd --version
 }
 
 package() {

--- a/testing/openttd/APKBUILD
+++ b/testing/openttd/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Adrian Siekierka <kontakt@asie.pl>
 pkgname=openttd
 pkgver=1.8.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Open source version of the Transport Tycoon Deluxe simulator"
 url="http://openttd.org"
 arch="all"
@@ -10,7 +10,9 @@ license="GPL-2.0-only"
 depends=""
 makedepends="fontconfig-dev freetype-dev libpng-dev lzo-dev sdl-dev xz-dev zlib-dev"
 subpackages="$pkgname-doc $pkgname-lang::noarch"
-source="https://binaries.openttd.org/releases/$pkgver/$pkgname-$pkgver-source.tar.xz"
+options="!check"
+source="https://binaries.openttd.org/releases/$pkgver/$pkgname-$pkgver-source.tar.xz
+	fix-pthread-stacksize.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -52,4 +54,5 @@ lang() {
 	done
 }
 
-sha512sums="a2d61b3c94a550c8f3a581127df8c3459b1ddff5ba924942c468cbc70e88e0bf4405cecb68a91243b544ead64f215aa8d489a07b38dce507ae7d59e8ec155d7a  openttd-1.8.0-source.tar.xz"
+sha512sums="a2d61b3c94a550c8f3a581127df8c3459b1ddff5ba924942c468cbc70e88e0bf4405cecb68a91243b544ead64f215aa8d489a07b38dce507ae7d59e8ec155d7a  openttd-1.8.0-source.tar.xz
+90db187919cb802ea6abddc03f09e85fe278175f5830f26e86d4a3b98f60bf233b0acaafd7e7a8f01c8e9a6bc059c171c88f8fcf36fc713624f972a8a8ad073f  fix-pthread-stacksize.patch"

--- a/testing/openttd/fix-pthread-stacksize.patch
+++ b/testing/openttd/fix-pthread-stacksize.patch
@@ -1,0 +1,15 @@
+Only in openttd-1.8.0-mod: src/saveload/.saveload.cpp.swp
+--- openttd-1.8.0/src/thread/thread_pthread.cpp
++++ openttd-1.8.0-mod/src/thread/thread_pthread.cpp
+@@ -38,7 +38,10 @@
+ 		self_destruct(self_destruct),
+ 		name(name)
+ 	{
+-		pthread_create(&this->thread, NULL, &stThreadProc, this);
++		pthread_attr_t attrs;
++		pthread_attr_init(&attrs);
++		pthread_attr_setstacksize(&attrs, 1048576);
++		pthread_create(&this->thread, &attrs, &stThreadProc, this);
+ 	}
+ 
+ 	/* virtual */ bool Exit()


### PR DESCRIPTION
Seems like a pretty straightforward fix to me.