### PR TITLE
testing/matchbox-keyboard: new aport; testing/libfakekey: new aport

### DIFF
--- a/testing/libfakekey/APKBUILD
+++ b/testing/libfakekey/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Daniele Debernardi <drebrez@gmail.com>
+# Maintainer: Daniele Debernardi <drebrez@gmail.com>
+pkgname=libfakekey
+pkgver=0.3
+pkgrel=0
+pkgdesc="X virtual keyboard library"
+url="http://matchbox-project.org/"
+arch="all"
+license="GPL"
+depends="libxtst"
+makedepends="autoconf automake libtool libxtst-dev"
+source="http://git.yoctoproject.org/cgit/cgit.cgi/$pkgname/snapshot/$pkgname-$pkgver.tar.gz"
+options="!check" # No test suite present
+
+build() {
+	autoreconf --install
+	./configure \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--localstatedir=/var \
+		--disable-static
+	make AM_LDFLAGS=-lX11
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="9c09007c6ab616095bdf69669cfdf0d176d44beaeb6b2a0fe8e310bb835d3f241ca7499dcb523c1eeeb24968ef908c1951f97352da419fc1bbb3883cb43dd963  libfakekey-0.3.tar.gz"

--- a/testing/matchbox-keyboard/APKBUILD
+++ b/testing/matchbox-keyboard/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Daniele Debernardi <drebrez@gmail.com>
+# Maintainer: Daniele Debernardi <drebrez@gmail.com>
+pkgname=matchbox-keyboard
+pkgver=0.1.1
+pkgrel=0
+pkgdesc="An on screen virtual keyboard"
+url="http://matchbox-project.org/"
+arch="all"
+license="GPL-2.0-only"
+depends="libfakekey libxft cairo gtk+3.0 gtk+2.0 libx11 libxrender"
+makedepends="autoconf automake libtool libxft-dev libxtst-dev cairo-dev gtk+3.0-dev gtk+2.0-dev libx11-dev libxrender-dev"
+source="http://git.yoctoproject.org/cgit/cgit.cgi/$pkgname/snapshot/$pkgname-$pkgver.tar.bz2"
+options="!check" # No test suite present
+
+build() {
+	autoreconf --install
+	./configure \
+		--prefix=/usr \
+		--enable-cairo \
+		--enable-gtk-im \
+		--enable-gtk3-im \
+		LDFLAGS="-lXrender -lX11"
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="388298370cd69155a8a11efb2198522fd2757b48861b110998eea38f31ded490d2ba0ee1a715d4a4f76a8e51411e5b3963229938d0be7d44a796e0543b8afa3e  matchbox-keyboard-0.1.1.tar.bz2"


### PR DESCRIPTION
**testing/matchbox-keyboard:** An on screen virtual keyboard
depends on **testing\libfakekey:** X virtual keyboard library

Project website: http://matchbox-project.org/