### PR TITLE
testing/aws-ena-driver-vanilla: update to 1.6.0

### DIFF
--- a/testing/aws-ena-driver-vanilla/APKBUILD
+++ b/testing/aws-ena-driver-vanilla/APKBUILD
@@ -10,7 +10,7 @@ _kpkgver="$_kver-r$_krel"
 _kabi="$_kver-$_krel-$_flavor"
 _kabi_virt="$_kver-$_krel-virt"
 
-_ver=1.5.3
+_ver=1.6.0
 _rel=0
 
 pkgname=$_name-$_flavor
@@ -85,5 +85,5 @@ _common() {
 	mv "$pkgdir"/etc/ "$subpkgdir"/
 }
 
-sha512sums="c1d1409230499280e965a02ac5bebf19541eb5d5acf2dfd6444d0269228398847c9428a01a25f27bb6e800585bb7d166789005be310b61da53f608ec01fbc9f7  ena_linux_1.5.3.tar.gz
+sha512sums="3106ed2f098ae0963875443e6d6f96c6ccb6e379abd5616e8f4dd8c11f0adad45d2d2699729e658819b2141e87eff97517518b43b27ce94de1c0bf593ba77ad7  ena_linux_1.6.0.tar.gz
 479a96de0284c815cb4bc60ee129be831f97424f121ede3c14c3dfead162ebb5a3f16c535cc412caf0bdcf2de70c6c3f6cc1c83ff2d4aae1f5e3848279f927d2  ena.conf"


### PR DESCRIPTION
Should move out of testing, probably to community next...