### PR TITLE
main/nghttp2: Update to 1.35.1

### DIFF
--- a/main/nghttp2/APKBUILD
+++ b/main/nghttp2/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=nghttp2
-pkgver=1.34.0
+pkgver=1.35.1
 pkgrel=0
 pkgdesc="Experimental HTTP/2 client, server and proxy"
 url="https://nghttp2.org"
@@ -50,5 +50,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="5ddc4ab443c51ce286a656d2013421172fc37608f14c0a7ea02fa9e5a0dd155e162d5602b55f34dacc69709525a9a8110dc4c42d92607bbad1951075d094c6a0  nghttp2-1.34.0.tar.xz
+sha512sums="fcd3f79f913afbeee1c75003bb39df918e6122bbf728b3ad4192d5849d8fb96705e04f5505465d63f25a565b2f1da6abd8fabdebb6e3347500f7abd31980861d  nghttp2-1.35.1.tar.xz
 d3f6a66ad6522babb5ad2b3721d52c1c2af88e57ed2895cf87037da1032ca42dcb95dacc23ea277b9507b4116cec117b5c9a3313759dc56b48199b687b74dd9a  remove-mruby-tests.patch"


### PR DESCRIPTION
This PR updates nghttp2 to the latest version, 1.35.1

https://nghttp2.org/blog/2018/12/10/nghttp2-v1-35-1/