### PR TITLE
testing/mxml: upgrade to 2.12, use https

### DIFF
--- a/testing/mxml/APKBUILD
+++ b/testing/mxml/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mxml
-pkgver=2.11
-pkgrel=1
+pkgver=2.12
+pkgrel=0
 pkgdesc="Small XML library that you can use to read and write XML files"
-url="http://www.msweet.org/mxml/"
+url="https://www.msweet.org/mxml/"
 arch="all"
 license="LGPL-2.0"
 subpackages="$pkgname-dev $pkgname-doc"
-source="https://github.com/michaelrsweet/$pkgname/releases/download/v2.11/$pkgname-$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/michaelrsweet/mxml/archive/v${pkgver}.tar.gz"
 
-builddir="$srcdir"
+builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
@@ -26,4 +26,4 @@ package() {
 	make BUILDROOT="$pkgdir" install
 }
 
-sha512sums="046421f91eea16f0ca99fbf611891c367ea9c3c54d04080d08acf108d7749ad9bbf2f4b3ef234a5130f00f77618196e2c5a245f32230daf645c1f775e961d378  mxml-2.11.tar.gz"
+sha512sums="49233a0087f3ef73a01ef71bb79511af36bb72027e3d9f6df919385e9ff0b03a489a3ccc590941bc4af1f558f82b2ed9bf8ff641863300a7791ce6dddfd56e77  mxml-2.12.tar.gz"

--- a/testing/mxml/APKBUILD
+++ b/testing/mxml/APKBUILD
@@ -21,6 +21,11 @@ build() {
 	make
 }
 
+check() {
+	cd "$builddir"
+	make testmxml
+}
+
 package() {
 	cd "$builddir"
 	make BUILDROOT="$pkgdir" install


### PR DESCRIPTION
[Release notes](https://github.com/michaelrsweet/mxml/releases/tag/v2.12).