### PR TITLE
community/google-authenticator: upgrade to 1.05

### DIFF
--- a/community/google-authenticator/APKBUILD
+++ b/community/google-authenticator/APKBUILD
@@ -1,16 +1,16 @@
 # Contributor: Fabio Napoleoni <f.napoleoni@gmail.com>
 # Maintainer: Fabio Napoleoni <f.napoleoni@gmail.com>
 pkgname=google-authenticator
-pkgver=1.02
-pkgrel=1
+pkgver=1.05
+pkgrel=0
 pkgdesc="Google Authenticator PAM module"
-url="https://github.com/google/google-authenticator"
+url="https://github.com/google/google-authenticator-libpam"
 arch="all"
 license="Apache-2.0"
 makedepends="autoconf automake libtool linux-pam-dev m4 libressl-dev"
 subpackages="$pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/google/google-authenticator/archive/$pkgver.tar.gz"
-builddir="$srcdir/$pkgname-$pkgver/libpam"
+source="$pkgname-$pkgver.tar.gz::https://github.com/google/google-authenticator-libpam/archive/$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-libpam-$pkgver"
 
 prepare() {
 	cd "$builddir"
@@ -39,4 +39,9 @@ package() {
 		> "$pkgdir/etc/pam.d/google-authenticator"
 }
 
-sha512sums="8bf81beaf705f0b12f0ed947960dbbc8155add6d83878b651dc1d6658d520dfbbdbe8085b1f244bcfa06d0dd4dfb4cd2177c0a27df4aab5fd1bc4308eef3f7b0  google-authenticator-1.02.tar.gz"
+check() {
+	cd "$builddir"
+	make check
+}
+
+sha512sums="d97b26c6181dbce0612628484db37b1bf61e984fb2fb3d4974d04038e564404aa17415368dba524f0d17d96ec8d57ae4129b27f0c672d849d16ef03941d87996  google-authenticator-1.05.tar.gz"


### PR DESCRIPTION
This updates the `google-authenticator` package to the latest version 1.05.

Changes that have been done:

- The source code repository has been moved by Google to https://github.com/google/google-authenticator-libpam. As such archive download URL, software URL and build path have been updated.
- Added `check` function that runs the unit tests shipped with the source code.
