### PR TITLE
main/git: security upgrade to 2.15.3

### DIFF
--- a/main/git/APKBUILD
+++ b/main/git/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=git
-pkgver=2.15.2
+pkgver=2.15.3
 pkgrel=0
 pkgdesc="A distributed version control system"
 url="https://www.git-scm.com/"
@@ -11,6 +11,8 @@ depends=
 replaces="git-perl"
 
 # secfixes:
+#   2.15.3:
+#   - CVE-2018-17456
 #   2.15.2:
 #   - CVE-2018-11233
 #   - CVE-2018-11235
@@ -243,7 +245,7 @@ _git_perl() {
 }
 
 
-sha512sums="483a14bbc5280a2f486d95743302bf37a089326042b1971f18c2e485461171af16c383b926f388813d3b5f04cd8e6b1b808a22e6b3056fdd4d82b71d1a2f751d  git-2.15.2.tar.xz
+sha512sums="0de84aa3511f3b2bf3311efe4ed6991b1d41c292be72a884d477cb893d28e317ec5ee915c392805d866edae019da755c39f9b5e0259fcbf1973f65a112c7670b  git-2.15.3.tar.xz
 85767b5e03137008d6a96199e769e3979f75d83603ac8cb13a3481a915005637409a4fd94e0720da2ec6cd1124f35eba7cf20109a94816c4b4898a81fbc46bd2  bb-tar.patch
 89528cdd14c51fd568aa61cf6c5eae08ea0844e59f9af9292da5fc6c268261f4166017d002d494400945e248df6b844e2f9f9cd2d9345d516983f5a110e4c42a  git-daemon.initd
 fbf1f425206a76e2a8f82342537ed939ff7e623d644c086ca2ced5f69b36734695f9f80ebda1728f75a94d6cd2fcb71bf845b64239368caab418e4d368c141ec  git-daemon.confd"


### PR DESCRIPTION
fixes [CVE-2018-17456](http://lkml.iu.edu/hypermail/linux/kernel/1810.0/05082.html)