### PR TITLE
community/go: upgrade to 1.11.1

### DIFF
--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=go
-pkgver=1.11
-pkgrel=4
+pkgver=1.11.1
+pkgrel=0
 pkgdesc="Go programming language compiler"
 url="http://www.golang.org/"
 arch="all"
@@ -120,6 +120,6 @@ package() {
 		-exec rm -rf \{\} \+
 }
 
-sha512sums="2758b7924b4b8cffc30b56fbf039b8e23d1a3c42506ed4997bd64531ba742e2c60e95d1fa70cae2ccda45d1959fadccfd2404af87d962530e4b1d3556c4aaf43  go1.11.src.tar.gz
+sha512sums="9c19f40b24f2180563705511a5692932c0db3585939053e6d78eea1f394902d37f05b0386f0e7d0c0266178de7e9bd7b003324ed232ce2e5050c9faafafdd979  go1.11.1.src.tar.gz
 effff60c1fb4ff18f1be1d34b4fa326a284b2197d0e9151223d19062dd315fde3d565ce2193aa53f7481c6542eb56daef834a3526957b65a275400f9af5d21b3  default-buildmode-pie.patch
 faf8de430df185842902322f064254f3e9ecee0884b3075b5550c85da15ff61ea6c2bb8d0fb7cf3887abc0e40974bd73ee8f8c14da7f914dde7e9220177c4e2a  set-external-linker.patch"


### PR DESCRIPTION
Ref https://golang.org/doc/devel/release.html#go1.11.minor