### PR TITLE
main/nfs-utils: Fix and enable rpc.svcgssd

### DIFF
--- a/main/nfs-utils/APKBUILD
+++ b/main/nfs-utils/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nfs-utils
 pkgver=2.3.1
-pkgrel=4
+pkgrel=5
 pkgdesc="kernel-mode NFS"
 url="http://linux-nfs.org"
 arch="all"
@@ -18,8 +18,10 @@ source="https://www.kernel.org/pub/linux/utils/nfs-utils/$pkgver/nfs-utils-$pkgv
 	0011-exportfs-only-do-glibc-specific-hackery-on-glibc.patch
 
 	nfs-utils-mtab-sym.patch
+	nfs-utils-svcgssd_undefined_reference.patch
 	musl-getservbyport.patch
 	musl-res_querydomain.patch
+	musl-svcgssd-sysconf.patch
 	idmapd-dnotify-to-inotify.patch
 	limits.patch
 
@@ -58,6 +60,7 @@ build() {
 		--enable-nfsv4 \
 		--enable-uuid \
 		--enable-gss \
+		--enable-svcgss \
 		--enable-libmount-mount
 	make
 }
@@ -120,8 +123,10 @@ ldap() {
 sha512sums="340201a8e793de9a4755fbcbff6b364dfd13c01a961e34cc54d1c94b576cc10bf0076962b7fc02872aa75f65a25e80cdcd93df44fb7e438c685eb7e10f1afaea  nfs-utils-2.3.1.tar.gz
 e55dbcc6df1626f992b660ae4ca80eac07ad539f3660448a27b34b6cc63764d59074a10c34e97c1b05f356cf60f68ec724f3dbdc1986be024773a2fe957b55fa  0011-exportfs-only-do-glibc-specific-hackery-on-glibc.patch
 674ecf2c4bc8e9364ddd0f34cc03c96674753494cbc5a5d157bd70ed4342ff90356c3e85c544510648dbe90cb43b7fd83ba50653bddffc4b3b5550367b6d0b8e  nfs-utils-mtab-sym.patch
+21361593415c497fa5a0bbd547b2cb0e0512ad8b3deb2397aba6a453cce840876d607015e46d8c3a367cd478395420d8b24e2f3a7f73d0e75d5a2445e4e46ef2  nfs-utils-svcgssd_undefined_reference.patch
 94d7ba23164660f1da9298494dff75c57f5a300cb32b2922bc2226fcdaded7eaaa0c50a59a145ac7c75639d177558b5f5594fb1f03a50f60f4c577c93b135748  musl-getservbyport.patch
 c86c2f01f5534d4cbd612b9f7fe11cb4cb0cdab81172be386ee97ca37e9cc099576c8087e0f52fefeacafad8022c98a1186b7c002366a5429f9c8ee59a17d161  musl-res_querydomain.patch
+3827c725606152ca6b4c79d167323a0eb7659e114132bf8762b423bdc25a67dcd55602823256f9706fa1b39a845f16479225ea8fa2f7ef1aae14b51f31230e09  musl-svcgssd-sysconf.patch
 33410c469348adf5e6b5ec91d8cda6b246f1a38a0b234a52f54a49ab8395ede43dfedd58914a59c342923ba45722f6fd4e4aebeffbe4a730f31c9d1ad19de9a9  idmapd-dnotify-to-inotify.patch
 b75c87917d86ce6e0e8b9bc2651e7f77851170b47b2a9c7628475e8aed73e89c858e7030885e2904e42c2133906705bb1243d19308ccb876d563cbc0655c66ce  limits.patch
 f7feb79cfcab0478affb640d1e5ad059757c88d51cc790fd54cde2fd7ed2e3cfd8f7f4c2de993d99da03e8ce3bdfb2750a4cb997b850fe33d0ef76d9b91c9018  nfs.initd

--- a/main/nfs-utils/musl-svcgssd-sysconf.patch
+++ b/main/nfs-utils/musl-svcgssd-sysconf.patch
@@ -1,0 +1,103 @@
+--- a/support/nfsidmap/libnfsidmap.c
++++ b/support/nfsidmap/libnfsidmap.c
+@@ -481,11 +481,17 @@
+ 
+ 	nobody_user = conf_get_str("Mapping", "Nobody-User");
+ 	if (nobody_user) {
+-		size_t buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++		long scbuflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++		size_t buflen = 1024; /*value on my gentoo glibc system that has _SC_GETPW_R_SIZE_MAX*/
+ 		struct passwd *buf;
+ 		struct passwd *pw = NULL;
+ 		int err;
+ 
++		/*sysconf can return -1 when _SC_GETPW_R_SIZE_MAX is not defined, like on musl systems, if cast to size_t this will lead
++		  to an integer overflow, which leads to a buffer overflow and crashes svcgssd */
++		if (scbuflen > 0)
++			buflen = (size_t)scbuflen;
++
+ 		buf = malloc(sizeof(*buf) + buflen);
+ 		if (buf) {
+ 			err = getpwnam_r(nobody_user, buf, ((char *)buf) + sizeof(*buf), buflen, &pw);
+@@ -502,10 +508,16 @@
+ 
+ 	nobody_group = conf_get_str("Mapping", "Nobody-Group");
+ 	if (nobody_group) {
+-		size_t buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++		long scbuflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++		size_t buflen = 1024; /*value on my gentoo glibc system that has _SC_GETGR_R_SIZE_MAX*/
+ 		struct group *buf;
+ 		struct group *gr = NULL;
+ 		int err;
++
++		/*sysconf can return -1 when _SC_GETGR_R_SIZE_MAX is not defined, like on musl systems, if cast to size_t this will lead
++		  to an integer overflow, which leads to a buffer overflow and crashes svcgssd */
++		if (scbuflen > 0)
++			buflen = (size_t)scbuflen;
+ 
+ 		buf = malloc(sizeof(*buf) + buflen);
+ 		if (buf) {
+--- a/support/nfsidmap/static.c
++++ b/support/nfsidmap/static.c
+@@ -98,10 +98,14 @@
+ {
+ 	struct passwd *pw;
+ 	struct pwbuf *buf;
+-	size_t buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++	long scbuflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++	size_t buflen = 1024;
+ 	char *localname;
+ 	int err;
+ 
++	if (scbuflen > 0)
++		buflen = (size_t)scbuflen;
++
+ 	buf = malloc(sizeof(*buf) + buflen);
+ 	if (!buf) {
+ 		err = ENOMEM;
+@@ -149,9 +153,13 @@
+ {
+ 	struct group *gr;
+ 	struct grbuf *buf;
+-	size_t buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++	long scbuflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++	size_t buflen = 1024;
+ 	char *localgroup;
+ 	int err;
++
++	if (scbuflen > 0)
++		buflen = (size_t)scbuflen;
+ 
+ 	buf = malloc(sizeof(*buf) + buflen);
+ 	if (!buf) {
+--- a/support/nfsidmap/nss.c
++++ b/support/nfsidmap/nss.c
+@@ -90,9 +90,13 @@
+ 	struct passwd *pw = NULL;
+ 	struct passwd pwbuf;
+ 	char *buf;
+-	size_t buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++	long scbuflen = sysconf(_SC_GETPW_R_SIZE_MAX);
++	size_t buflen = 1024;
+ 	int err = -ENOMEM;
+ 
++	if (scbuflen > 0)
++		buflen = (size_t)scbuflen;
++
+ 	buf = malloc(buflen);
+ 	if (!buf)
+ 		goto out;
+@@ -118,8 +122,12 @@
+ 	struct group *gr = NULL;
+ 	struct group grbuf;
+ 	char *buf;
+-	size_t buflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++	long scbuflen = sysconf(_SC_GETGR_R_SIZE_MAX);
++	size_t buflen = 1024;
+ 	int err;
++
++	if (scbuflen > 0)
++		buflen = (size_t)scbuflen;
+ 
+ 	if (domain == NULL)
+ 		domain = get_default_domain();

--- a/main/nfs-utils/nfs-utils-svcgssd_undefined_reference.patch
+++ b/main/nfs-utils/nfs-utils-svcgssd_undefined_reference.patch
@@ -1,0 +1,40 @@
+From 1451d7585bf1c622658ccc04abac7e79ffe40263 Mon Sep 17 00:00:00 2001
+From: Justin Mitchell <jumitche@redhat.com>
+Date: Mon, 8 Jan 2018 09:14:11 -0500
+Subject: [PATCH] svcgssd: Update svcgssd so that it builds
+
+Since a15bd948 the --enable-svcgss option no longer builds
+as svcgssd references functions which were changed at that time.
+Fix those, and other function changes since then.
+
+Signed-off-by: Justin Mitchell <jumitche@redhat.com>
+Signed-off-by: Steve Dickson <steved@redhat.com>
+---
+ utils/gssd/svcgssd.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/utils/gssd/svcgssd.c b/utils/gssd/svcgssd.c
+index 3514ae1..23f0c0b 100644
+--- a/utils/gssd/svcgssd.c
++++ b/utils/gssd/svcgssd.c
+@@ -63,6 +63,8 @@
+ #include "err_util.h"
+ #include "conffile.h"
+ 
++struct state_paths etab;
++
+ void
+ sig_die(int signal)
+ {
+@@ -101,7 +103,7 @@ main(int argc, char *argv[])
+ 	char *principal = NULL;
+ 	char *s;
+ 
+-	conf_init(NFS_CONFFILE); 
++	conf_init_file(NFS_CONFFILE);
+ 
+ 	s = conf_get_str("svcgssd", "principal");
+ 	if (!s)
+-- 
+1.8.3.1
+


### PR DESCRIPTION
enabled svcgssd build flag, applied patch from gentoo to make it
build and wrote another patch to fix segfaults, because musl
returns -1 for sysconf(_SC_GETGR_R_SIZE_MAX), which was not handled
at all, thus allocating a smaller buffer than needed.

(cherry picked from commit 16354c44b431a0c9861ad169a78490e6df3f283a)