### PR TITLE
main/strongswan: security upgrade to 5.7.1

### DIFF
--- a/main/strongswan/APKBUILD
+++ b/main/strongswan/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jesse Young <jlyo@jlyo.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=strongswan
-pkgver=5.7.0
+pkgver=5.7.1
 _pkgver=${pkgver//_rc/rc}
 pkgrel=0
 pkgdesc="IPsec-based VPN solution focused on security and ease of use, supporting IKEv1/IKEv2 and MOBIKE"
@@ -29,6 +29,8 @@ source="https://download.strongswan.org/$pkgname-$_pkgver.tar.bz2
 builddir="$srcdir/$pkgname-$_pkgver"
 
 # secfixes:
+#   5.7.1-r0:
+#     - CVE-2018-17540
 #   5.7.0-r0:
 #     - CVE-2018-16151
 #     - CVE-2018-16152
@@ -122,7 +124,7 @@ package() {
 	install -m755 -D "$srcdir/charon.initd" "$pkgdir/etc/init.d/charon"
 }
 
-sha512sums="811bfa79aa2b17fcf298c45a2b4109cf4235286e90c4def3e09022ed94c7fa481fc25b8d5054529e4ff4e33011ce6f6ba9874595d16c1a8fe13ef924c4ec6395  strongswan-5.7.0.tar.bz2
+sha512sums="43102814434bee7c27a5956be59099cc4ffb9bb5b0d6382ce4c6a80d1d82ed6639f698f5f5544b9ca563554a344638c953525b0e2d39bc6b71b19055c80e07fc  strongswan-5.7.1.tar.bz2
 193d845e2751c23d98cdf84134c7803f2e412197669c6d6c1c9974041608d154b85594ed3d9ffb923ca22a4d5926c7f2373787ddc7da47b52019e284a1d13211  0205-ike-Adhere-to-IKE_SA-limit-when-checking-out-by-conf.patch
 21db8f153f535ef13cc7c9c011f9b90b8c794e0072bd93fda6a0a56dc00d32d04e186b1a72a87a85613b7e511eed5cb96623abf0721c67dd5c96446db969a185  1001-charon-add-optional-source-and-remote-overrides-for-.patch
 f7d98fb99b4855e8bfbb7369292c170536b1987e717feeda71f64ab71b35538e7d462609a773c6a6ed08c8e6ee7a186df12e1ea7d64b9dac0b17d4c7af17dab3  1002-vici-send-certificates-for-ike-sa-events.patch


### PR DESCRIPTION
[Release notes](https://wiki.strongswan.org/projects/strongswan/wiki/Changelog57).

Fixes:
- [CVE-2018-17540](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-17540)