### PR TITLE
testing/gnome-control-center: fix deprecated set_color call

### DIFF
--- a/testing/gnome-control-center/APKBUILD
+++ b/testing/gnome-control-center/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=gnome-control-center
 pkgver=3.26.0
-pkgrel=2
+pkgrel=3
 pkgdesc="GNOME control center"
 url="https://www.gnome.org/"
 # limited by gnome-online-accounts
@@ -29,12 +29,14 @@ makedepends="clutter-dev clutter-gtk-dev
 	itstool
 	libxml2-utils
 	libxslt
+	transmission-lang
 
 	docbook-xml docbook-xsl
 
 	$depends_dev"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 source="https://download.gnome.org/sources/$pkgname/${pkgver%.*}/$pkgname-$pkgver.tar.xz
+	migrate-set-color.patch	
 	wayland.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -63,4 +65,5 @@ package() {
 }
 
 sha512sums="c0656b072b1918e13447eaca13a1ea1b997c37faa30952d3ab48109077a570768d5fd57479817558ce6f34105903b763553900e3db61cef53f5c756cd86b395a  gnome-control-center-3.26.0.tar.xz
+b5dde4906d857d8d4bf1427fb236dc787c90638e485b6f5e5b4fd458eed0b908dc4b020401d1bd8ae7fd182be825222c561f3ca771d9e84aedf38766fd7a7b10  migrate-set-color.patch
 3f17e2f00798e4d2a99a1d77c66ee5be29501417ea4b4c65387f24d8c27700c36e2f5fb2b476c3c0c88b18b497f48e7e2c09a4baadb6b532b7ecc112f504db48  wayland.patch"

--- a/testing/gnome-control-center/migrate-set-color.patch
+++ b/testing/gnome-control-center/migrate-set-color.patch
@@ -1,0 +1,11 @@
+--- a/panels/background/cc-background-item.c
++++ b/panels/background/cc-background-item.c
+@@ -172,7 +172,7 @@
+                 gdk_color_parse (item->priv->secondary_color, &scolor);
+         }
+ 
+-        gnome_bg_set_color (item->priv->bg, item->priv->shading, &pcolor, &scolor);
++        gnome_bg_set_rgba (item->priv->bg, item->priv->shading, &pcolor, &scolor);
+         gnome_bg_set_placement (item->priv->bg, item->priv->placement);
+ }
+ 


### PR DESCRIPTION
migrate gnome_bg_set_color() to gnome_bg_set_rgba(). Also fix abuild check failure by adding transmission-lang package so test-endianess.c won't fail.