### PR TITLE
testing/rhythmbox: fix invalid preprocessing token build break

### DIFF
--- a/testing/rhythmbox/APKBUILD
+++ b/testing/rhythmbox/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=rhythmbox
 pkgver=3.4.2
-pkgrel=1
+pkgrel=2
 pkgdesc="GNOME audio player"
 url="https://wiki.gnome.org/Apps/Rhythmbox"
 arch="all !s390x"
@@ -11,7 +11,9 @@ depends_dev="gnome-desktop-dev gstreamer-dev libpeas-dev"
 makedepends="$depends_dev tdb-dev libsoup-dev json-glib-dev totem-pl-parser-dev gmime-dev libmtp-dev gst-plugins-base-dev py-gobject3-dev libxslt libxml2-utils docbook-xml docbook-xsl itstool intltool"
 install=""
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
-source="https://download.gnome.org/sources/rhythmbox/3.4/rhythmbox-$pkgver.tar.xz"
+source="https://download.gnome.org/sources/rhythmbox/3.4/rhythmbox-$pkgver.tar.xz
+	fix-preprocess-token.patch	
+	"
 builddir="$srcdir/rhythmbox-$pkgver"
 
 build() {
@@ -31,4 +33,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="275f7c6344c88c7331d433895d479517e7a4b854f6ae660abd79b3c324f5e7a06132fa44387443ec9ce50b20187e1abf1ec9683ec4bedbd4b17da6efece8399b  rhythmbox-3.4.2.tar.xz"
+sha512sums="275f7c6344c88c7331d433895d479517e7a4b854f6ae660abd79b3c324f5e7a06132fa44387443ec9ce50b20187e1abf1ec9683ec4bedbd4b17da6efece8399b  rhythmbox-3.4.2.tar.xz
+55f64648826eeb6cd97baf17907a70f24263c2ac41dfd6c136ea0de6f7c0c1574ac77164014dd0774c5b6f06eb4fbcedb463f259051ed708452c72ce098e7aba  fix-preprocess-token.patch"

--- a/testing/rhythmbox/fix-preprocess-token.patch
+++ b/testing/rhythmbox/fix-preprocess-token.patch
@@ -1,0 +1,11 @@
+--- a/plugins/fmradio/rb-fm-radio-gst-src.c
++++ b/plugins/fmradio/rb-fm-radio-gst-src.c
+@@ -178,7 +178,7 @@
+ 
+ GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
+ 		   GST_VERSION_MINOR,
+-		   "rbsilencesrc",
++		   rbsilencesrc,
+ 		   "element to output silence",
+ 		   plugin_init,
+ 		   VERSION,


### PR DESCRIPTION
cherry picked fix from https://bugzilla.gnome.org/show_bug.cgi?id=788706 to eliminate build breaks due to errors:
rb-fm-radio-gst-src.c:181:6: error: pasting ""rbsilencesrc"" and "_get_desc" does not give a valid preprocessing token