### PR TITLE
testing/flatbuffers: fix broken const cast

### DIFF
--- a/testing/flatbuffers/APKBUILD
+++ b/testing/flatbuffers/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=flatbuffers
 pkgver=1.9.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Memory Efficient Serialization Library"
 url="https://google.github.io/flatbuffers/"
 arch="all !s390x"
@@ -11,7 +11,8 @@ depends_dev=""
 makedepends="$depends_dev cmake"
 install=""
 subpackages="$pkgname-dev"
-source="flatbuffers-$pkgver.tar.gz::https://github.com/google/flatbuffers/archive/v$pkgver.tar.gz"
+source="flatbuffers-$pkgver.tar.gz::https://github.com/google/flatbuffers/archive/v$pkgver.tar.gz
+	fix-broken-cast.patch"
 builddir="$srcdir/flatbuffers-$pkgver"
 
 build() {
@@ -36,4 +37,5 @@ package() {
 		"$pkgdir"/usr/bin/flatc
 }
 
-sha512sums="0ba07dbe5b2fde1d0a6e14ee26ee2816062541d934eda204b846a30c019362f2626761b628c900293928b9b546dba8ca477c13182e022c3e0e0a142fd67f0696  flatbuffers-1.9.0.tar.gz"
+sha512sums="0ba07dbe5b2fde1d0a6e14ee26ee2816062541d934eda204b846a30c019362f2626761b628c900293928b9b546dba8ca477c13182e022c3e0e0a142fd67f0696  flatbuffers-1.9.0.tar.gz
+695410f14810aaa666122b9fb99256f95ef63fb26c9ea440f1e0513050f1742d7e883b20e9ca9bdfd1ec5086ef3bf06762f555ebd1d179c594c5ffcf0d22e3b4  fix-broken-cast.patch"

--- a/testing/flatbuffers/fix-broken-cast.patch
+++ b/testing/flatbuffers/fix-broken-cast.patch
@@ -1,0 +1,11 @@
+--- a/include/flatbuffers/util.h
++++ b/include/flatbuffers/util.h
+@@ -321,7 +321,7 @@
+       break;
+     }
+   }
+-  if ((static_cast<const unsigned char>(**in) << len) & 0x80) return -1;  // Bit after leading 1's must be 0.
++  if ((static_cast<unsigned char>(**in) << len) & 0x80) return -1;  // Bit after leading 1's must be 0.
+   if (!len) return *(*in)++;
+   // UTF-8 encoded values with a length are between 2 and 4 bytes.
+   if (len < 2 || len > 4) { return -1; }


### PR DESCRIPTION
cherry picked fix https://patch-diff.githubusercontent.com/raw/google/flatbuffers/pull/4698.patch
to eliminate build error "error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]" 