### PR TITLE
main/tinc: security upgrade to 1.0.35

### DIFF
--- a/main/tinc/APKBUILD
+++ b/main/tinc/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=tinc
-pkgver=1.0.34
+pkgver=1.0.35
 pkgrel=0
 pkgdesc="Virtual Private Network (VPN) daemon"
 url="https://www.tinc-vpn.org"
@@ -14,6 +14,12 @@ source="https://www.tinc-vpn.org/packages/tinc-$pkgver.tar.gz
 	tincd.lo.initd
 	tinc.networks"
 builddir="$srcdir/$pkgname-$pkgver"
+
+# secfixes:
+#   1.0.35-r0:
+#     - CVE-2018-16737
+#     - CVE-2018-16738
+#     - CVE-2018-16758
 
 check() {
 	cd "$builddir"
@@ -48,7 +54,7 @@ package() {
 		"$pkgdir"/etc/conf.d/tinc.networks
 }
 
-sha512sums="b711a2c532f8efc94c77e9bbe5213ae284d2a3cb598d2760df700448e495a02ac56baa0393bbc6fbc735bf97a26ca5a79133c92952d98a9086a9ffd273eef725  tinc-1.0.34.tar.gz
+sha512sums="037867306c21506d57d69d35c0f246b2936022047978fa3e01464b5f6b65f109760507d9cc740f82f8166f39c5ce44d9f8dde55655a6372dacd5b5974aeaee32  tinc-1.0.35.tar.gz
 81397ee122517b1e33a4b561ed1878329605c0b2bf771097cd076a982a6b3dd690097c50c0cbd035ad2964c0a48fe03c727a2d9584af7301dfd244e2ff5e8609  tincd.initd
 7f5fa69d6e5e500a012f036a7692d19560ea8b9c66de6ab8775f37c2edb55fb4fabd245758f7577d2e1540d2e0c0964ff1e98d761c86bba4fa3c35c0dc6b5413  tincd.lo.initd
 f7cb459c170898e51176bd92c642335386db90b7bca2abb3f6eb2514546efbd74e5fd2c8845060111dd48a0dd2cc1890717a03315c9b86185047c259cdc27135  tinc.networks"


### PR DESCRIPTION
[Release notes](https://tinc-vpn.org/git/browse?p=tinc;a=blob_plain;f=NEWS;h=4a342f7e8cead421763884fdbe4121f054ba34fb;hb=d964d84662b73e351b71905a3c743b666a42aa1d).

Fixes:
- CVE-2018-16737
- CVE-2018-16738
- CVE-2018-16758