### PR TITLE
community/openjdk8: security upgrade to 3.9.0 (java 8u181b13)

### DIFF
--- a/community/openjdk8/APKBUILD
+++ b/community/openjdk8/APKBUILD
@@ -2,10 +2,10 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Timo Teras <timo.teras@iki.fi>
 pkgname=openjdk8
-_icedteaver=3.8.0
+_icedteaver=3.9.0
 # pkgver is <JDK version>.<JDK update>.<JDK build>
 # Check https://icedtea.classpath.org/wiki/Main_Page when updating!
-pkgver=8.171.11
+pkgver=8.181.13
 pkgrel=2
 pkgdesc="OpenJDK 8 provided by IcedTea"
 url="https://icedtea.classpath.org/"
@@ -69,6 +69,14 @@ source="https://icedtea.classpath.org/download/source/icedtea-$_icedteaver.tar.x
 	"
 builddir="$srcdir/icedtea-$_icedteaver"
 
+# secfixes:
+#   8.181.13-r0:
+#     - CVE-2018-2938
+#     - CVE-2018-2940
+#     - CVE-2018-2952
+#     - CVE-2018-2973
+#     - CVE-2018-3639
+
 unpack() {
 	if [ -z "$force" ]; then
 		verify
@@ -82,8 +90,8 @@ unpack() {
 prepare() {
 	cd "$builddir"
 
-	local ver_u=$(sed -En 's/^JDK_UPDATE_VERSION\s*=\s*(\S+).*/\1/p' Makefile.am)
-	local ver_b=$(sed -En 's/^BUILD_VERSION\s*=\s*b(\S+).*/\1/p' Makefile.am)
+	local ver_u=$(sed -En 's/^\s*JDK_UPDATE_VERSION\s*=\s*(\S+).*/\1/p' acinclude.m4)
+	local ver_b=$(sed -En 's/^\s*BUILD_VERSION\s*=\s*b(\S+).*/\1/p' acinclude.m4)
 	[ "${pkgver#*.}" = "$ver_u.$ver_b" ] \
 		|| die "Version mismatch, source is 8.$ver_u.$ver_b, but abuild defines $pkgver!"
 
@@ -265,15 +273,15 @@ demos() {
 		"$subpkgdir"/$_java_home/
 }
 
-sha512sums="6336d35c11dbe16c96bc07eaa760fd849a2cd317416aba72b0732f8f1e52c9e3fedde5398d4a7f5a3057d4b6ae229965d597b3f5df09a76b5f31bbad0ad02a9a  icedtea-3.8.0.tar.xz
-e438a7ab0eb4e4374278afdbd40cab66875c9704f80a8963f0c965ce995744bcf23814c734ffd10e95329c7b767337fff18e3478c3f03481f8e15a5a9bfc853f  openjdk-3.8.0.tar.xz
-a41d53d2d6471b94878ba18caf525f1b64e72c2ae6926a9f1f5dac2e9a9366151d35156fb519cca8aeeda97d8e42cc258a93390170859b3035de4da69e48e321  corba-3.8.0.tar.xz
-3eb04788776612f0de0b058908417c4735e6b1cfb56afaf73748e1f3121b25d6eea710cd1d72ed19f8788c8e00b701265d79237da3542d0947c00d37b4308e9c  jaxp-3.8.0.tar.xz
-1431e71e2281eef893904e686c8d33587c4332ed7cfacd5fd2e278fe0a4e6f225e03d22b8ca73517b030e3e33ffba964f023bed9b9e4f4a6f14b8cced43ce0a5  jaxws-3.8.0.tar.xz
-9f6b6e42e8bea6a00c9833bd9775bfa5c63d1126e25fc376f4ba2cf5601dea8ab6a3f1d442d5fb188de3f74ce0a6410dc3a8463f798b1aa23822a272faa5aa73  jdk-3.8.0.tar.xz
-fd57023505d69246593ed24d90ad7052a88362ef7106900eca59e61ad5cadc247215cc9e8d410f9150e33a72126247ce1bb809540985062515b3d31d77d1535e  langtools-3.8.0.tar.xz
-8c4b060611b867c43fbe6cac3d2f06f6979950781872b387220e12c7066b3efde24160b7bd03189350a6518615b492703425c2ea67a26c6b4d187f843093a780  hotspot-3.8.0.tar.xz
-7c6d51a6565fe8c670a59caf001b1c0821b7fb2e42b2bbe24b35e337df4fc664c87868e0c55dcaa168f9c3e973ab9e75bca93d660e242c07d0f21eff83d674b5  nashorn-3.8.0.tar.xz
+sha512sums="a35b600f7fa7ef19bf980e26e4cc22b57ad7daf363c91ffcf4ab1a52af48bfb316bb5dcba75d0d9966b799d25f71bae2d04fe89ae28103c82f7711ba1e346465  icedtea-3.9.0.tar.xz
+775930ee4806ddcf39d37ddf0f7fbacad1e1bb174cb2754a830bb1f7941a636e013ff5d844e431c4840c423480238fdb88a6c28d345e3c1326ec1dbb1c511c85  openjdk-3.9.0.tar.xz
+644203f6b951b8a6af1291f732c0c1fd5a060ba87e0e371e77e6d40c8e36a094799ce8b29cbf094dd9a53a91aaaeea38f63c7340c8adba162ceff7a2695863ff  corba-3.9.0.tar.xz
+98792ceeea825c91c6642bab14f43dfa8c3aeffcf9091c1b5c9587d154c6613c24bfa9d83a362393baf1eb0a71e424baaca4302729d1a8a30c0eb17c3688b6be  jaxp-3.9.0.tar.xz
+d97f86bc8775cf83b7931f2503fc2c824e4433be46587416b314f6fc114e5d1117071625344305eb99101576e4639c8b24afa8be9c57387c9dd12b376150e835  jaxws-3.9.0.tar.xz
+192093916f442cac6d7a756f831a71e13407b327bb772031a795cb4578d82215c7eb38623e26781064f049ec7532bfac09bacda1d5241aba41f675ec84aa6730  jdk-3.9.0.tar.xz
+20f7a53701621a827f45f8ec18b3a186b4d8ec2e58c11283a253c54e1182878e6c9ca0b6004c9c487c701ead9533912b7fe0d66339cdc8a39dab12a6da909064  langtools-3.9.0.tar.xz
+e7e333695e5871a7ebf9d663d5c5a7d16a31e3eca33a7f974d7d6941598732bb8514cff8f0da8baffa2cff639d404f27aca23f450198e8a45262acc69d89f25f  hotspot-3.9.0.tar.xz
+e149ee35efff265074e57351d5ba4870ec241516e4d73d23cf75a3420f07e666e610847c996f9c1f742586af49d23518776c4c60d8d1051a4e05b39be163ddd0  nashorn-3.9.0.tar.xz
 1f470432275d5beaa8b4e4352a2f24a4a00593546dc4f3bd857794c89e521e8e6d6abc540762bbd769be3e1e3da058e134dc5dc066d12b9b8a1f0656040a795c  fix-paxmark.patch
 09104b19f647dce9ba0835163c05cc7e5e3ec9852b277f22b2d7a02bd483968853544125a09e384e96ba8811f2bbdc9546e05e378582ec6a554ede797ca5ad98  icedtea-hotspot-musl.patch
 e5cf4d70f96fc1e72ae8b97a887adb96092ff36584711cbb8de9d9fa9e859cb8731d638838de0d9591239fc44ffe5c74422d1842bd9f10a0c00dff1627bdeeef  icedtea-hotspot-musl-ppc.patch

--- a/community/openjdk8/APKBUILD
+++ b/community/openjdk8/APKBUILD
@@ -6,7 +6,7 @@ _icedteaver=3.9.0
 # pkgver is <JDK version>.<JDK update>.<JDK build>
 # Check https://icedtea.classpath.org/wiki/Main_Page when updating!
 pkgver=8.181.13
-pkgrel=2
+pkgrel=0
 pkgdesc="OpenJDK 8 provided by IcedTea"
 url="https://icedtea.classpath.org/"
 arch="all"
@@ -133,7 +133,7 @@ build() {
 	echo "icedtea patches: $DISTRIBUTION_PATCHES"
 
 	cd "$builddir"
-	./configure \
+	bash ./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix="$_java_home" \


### PR DESCRIPTION
Note: The location of version number has been changed in https://icedtea.classpath.org/hg/icedtea8/rev/03cdd2506cad

Please backport this change to older Alpine Linux releases.