### PR TITLE
community/tomcat-native: rebuild against LibreSSL

### DIFF
--- a/community/tomcat-native/APKBUILD
+++ b/community/tomcat-native/APKBUILD
@@ -1,15 +1,14 @@
 # Contributor: Sean Summers <seansummers@gmail.com>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
-# TODO: Patch for LibreSSL.
 pkgname=tomcat-native
 pkgver=1.2.17
-pkgrel=0
+pkgrel=1
 pkgdesc="Native resources optional component for Apache Tomcat"
-url="http://tomcat.apache.org/native-doc/"
+url="https://tomcat.apache.org/native-doc/"
 arch="all"
 license="Apache-2.0"
 depends="openjdk8-jre-base"
-makedepends="apr-dev chrpath openjdk8 openssl1.0-dev"
+makedepends="apr-dev chrpath openjdk8 libressl-dev"
 subpackages="$pkgname-dev"
 source="https://www-eu.apache.org/dist/tomcat/tomcat-connectors/native/$pkgver/source/$pkgname-$pkgver-src.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver-src/native"


### PR DESCRIPTION
Upstream support has been added in [1.2.13](https://tomcat.apache.org/native-doc/miscellaneous/changelog.html#Changes_in_1.2.13).