### PR TITLE
main/opensmtpd: checkconfig should only output messages on error

### DIFF
--- a/main/opensmtpd/APKBUILD
+++ b/main/opensmtpd/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Jonathan Curran <jonathan@curran.in>
 pkgname=opensmtpd
 pkgver=6.0.3p1
-pkgrel=1
+pkgrel=2
 pkgdesc="secure, reliable, lean, and easy-to configure SMTP server"
 url="http://www.opensmtpd.org"
 arch="all"
@@ -59,7 +59,7 @@ package() {
 }
 
 sha512sums="e579818a0ddbe637deb5a4e40f43eaf797783903ceac18fd89a57581b135b9e407d424e1a70ff7b4b06a0ee50bafb6e8ab2451371917887904b06ff1b55d320f  opensmtpd-6.0.3p1.tar.gz
-8d3b27c760df84804baadc90c23b34f3e99980fae97c685f98ab096c3e84ab293316cd7c49317fa3cffac7ab5e63217ada6a2c5b245f352bafe880b087e7705e  smtpd.initd
+20f06174769b78e25f13ac0b5273dae2e122ba586e370c1db5864229640c09252ff9fc7434b857b62d12651b33099cf8e198dfd9a3b8ed9a90a79f2e48f04087  smtpd.initd
 51d47b34eb3d728daa45f29d6434cc75db28dfa69b6fb3ecd873121df85b296a2d2c81016d765a07778aa26a496e4b29c09a30b82678cf42596a536734b5deca  aliases
 37104cc605569f142ceffa902f200e8a7e9e1114ebe5394ed1eac0ed6ce25454e1610270921c45246de8396eee04b7c8ab5a112a231036a6ef14e7e229b264e3  autoconf-decl-checks.patch
 cd6b60e478703890af1112d93c2d2ac0c87c5ad394d91a7903ca11532c4d2c8763330a8c20ef9b8d5a79632760faee5ee1437a43d37d1727aef2e1431d1d030c  fix-segfault-in-crypt_checkpass.patch"

--- a/main/opensmtpd/smtpd.initd
+++ b/main/opensmtpd/smtpd.initd
@@ -23,5 +23,10 @@ start_pre() {
 }
 
 checkconfig() {
-	$command -n
+	# Don't output anything unless something is *not* ok.
+	output=$($command -n 2>&1)
+	ret=$?
+
+	[ $ret -ne 0 ] && echo $output 1>&2
+	return $ret
 }


### PR DESCRIPTION
Other OpenRC services don't output anything on standard error unless
something is not ok as well. The message `configuration OK` is therefore
pretty much useless.

Discussion: This is somewhat ugly. A proper fix would be to patch smtpd
and make sure that the "configuration ok" message is written to standard
output instead of standard error (which is were it belongs anyhow). After
doing so the message can simply be suppressed by running `smtpd -n >/dev/null`.

@jirutka You originally committed the checkconfig function in
47b9ff1206f. Any objections to the changes purposed here?