### PR TITLE
testing/py-ev: upgrade to 0.9.5 and modernize

### DIFF
--- a/testing/py-ev/APKBUILD
+++ b/testing/py-ev/APKBUILD
@@ -1,41 +1,32 @@
 # Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=py-ev
-_pkgname=pyev
-pkgver=0.9.0
-pkgrel=1
+_pkgname=pyev-static
+pkgver=0.9.5
+pkgrel=0
 pkgdesc="A Python libev interface"
-url="https://pythonhosted.org/pyev/"
+url="https://pypi.org/project/pyev-static/"
 arch="all"
 license="GPL-3.0"
 depends="python2"
-depends_dev=""
 makedepends="python2-dev py-setuptools libev-dev"
-install=""
-subpackages=""
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 
-_builddir="$srcdir"/$_pkgname-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/$_pkgname-$pkgver
 
 build() {
-	cd "$_builddir"
-	python2 setup.py build || return 1
+	cd "$builddir"
+	python2 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py test
 }
 
 package() {
-	cd "$_builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	cd "$builddir"
+	python2 setup.py install --prefix=/usr --root="$pkgdir"
 }
 
-md5sums="9d7466c84c4fc57a5d2f02d89da82b7b  pyev-0.9.0.tar.gz"
-sha256sums="5d030a993cb0e9a74034e57b2e1e3f6378f25083bb886583badf68c0e800c665  pyev-0.9.0.tar.gz"
-sha512sums="05eafd70b843be8ee84a9a384fea9f222445930de00c5a6ac38c6e798f22165914fab3825be8e98e84fa68fdfe9e477718190a6939737667868b4badeb1eafa8  pyev-0.9.0.tar.gz"
+sha512sums="8f20c4821a8d4bde5c01cebaa3ec90e292460ccb4ae51af8384c3bc524c05ec291033005798926bdd27b8c7c538efff69b89178ffb05bf0540905f4b7017f422  pyev-static-0.9.5.tar.gz"


### PR DESCRIPTION
The package is moved and that's why build failed http://build.alpinelinux.org/buildlogs/build-edge-ppc64le/testing/py-ev/py-ev-0.9.0-r1.log

