### PR TITLE
main/zip: Fix location for manpages

### DIFF
--- a/main/zip/APKBUILD
+++ b/main/zip/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=zip
 pkgver=3.0
-pkgrel=6
+pkgrel=7
 pkgdesc="Creates PKZIP-compatible .zip files"
 url="http://www.info-zip.org/pub/infozip/Zip.html"
 arch="all"
@@ -24,7 +24,7 @@ build() {
 
 package() {
 	cd "$builddir"
-	make -f unix/Makefile prefix=${pkgdir}/usr MANDIR=${pkgdir}/usr/share/man install
+	make -f unix/Makefile prefix=${pkgdir}/usr MANDIR=${pkgdir}/usr/share/man/man1 install
 	install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 


### PR DESCRIPTION
Previously:

```
nero@rei:/home/nero[0]: ls -la  /usr/share/man/                                                                                                       
total 1052
[snip]
-rw-r--r--    1 root     root         28496 Jul 27 14:26 zip.1.gz
-rw-r--r--    1 root     root           951 Jul 27 14:26 zipcloak.1.gz
-rw-r--r--    1 root     root           793 Jul 27 14:26 zipnote.1.gz
-rw-r--r--    1 root     root           596 Jul 27 14:26 zipsplit.1.gz
```