### PR TITLE
main/xf86-input-libinput: upgrade to 0.28.1

### DIFF
--- a/main/xf86-input-libinput/APKBUILD
+++ b/main/xf86-input-libinput/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xf86-input-libinput
-pkgver=0.28.0
-pkgrel=2
+pkgver=0.28.1
+pkgrel=0
 pkgdesc="X.Org input driver based on libinput"
 url="https://xorg.freedesktop.org"
 arch="all"
@@ -36,4 +36,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="4276b6aea87ddc83fa1f5e8d8949e34ad117186a6b5b599549231cb90424cd0fa69f3a4701ce529739c676665bb5c936eb447817c9420511d23bc048f6be92a4  xf86-input-libinput-0.28.0.tar.bz2"
+sha512sums="2b8cabfbc3490edbe928771ed9d62a0d4a423bc1373fc6cf9d3a6b5937e17ddc48ebb1b70f1191e507024e4b8220c137495cbba825292b51e50709daa7d31623  xf86-input-libinput-0.28.1.tar.bz2"


### PR DESCRIPTION
[Release notes](https://lists.x.org/archives/xorg-announce/2018-October/002923.html).