### PR TITLE
testing/kafkacat: new aport

### DIFF
--- a/testing/kafkacat/APKBUILD
+++ b/testing/kafkacat/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Andrey Pustovetov <andrey.pustovetov@gmail.com>
+# Maintainer: Andrey Pustovetov <andrey.pustovetov@gmail.com>
+pkgname=kafkacat
+pkgver=1.3.1
+pkgrel=0
+pkgdesc="Generic command-line non-JVM Apache Kafka producer and consumer"
+url="https://github.com/edenhill/kafkacat"
+arch="all"
+depends="yajl librdkafka"
+license="BSD-2-Clause"
+options="!check" # upstream doesn't have a test suite
+makedepends="bash yajl-dev librdkafka-dev"
+source="$pkgname-$pkgver.tar.gz::https://github.com/edenhill/kafkacat/archive/$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--prefix=/usr \
+		--mandir=/usr/share/man \
+		--enable-json
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="98e51c7ad4a3bb1eda8587af5e4d9ce164d26a9511470799a8379e89d2462397eb51e80ccde6a5c9240b99b014f7ca2c6d494a576de3e0be65df744ebc56d758  kafkacat-1.3.1.tar.gz"


### PR DESCRIPTION
https://github.com/edenhill/kafkacat
Generic command-line non-JVM Apache Kafka producer and consumer