### PR TITLE
main/libssh: security upgrade 0.7.6 - CVE-2018-10933

### DIFF
--- a/main/libssh/APKBUILD
+++ b/main/libssh/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libssh
-pkgver=0.7.5
-pkgrel=3
+pkgver=0.7.6
+pkgrel=0
 pkgdesc="Library for accessing ssh client services through C libraries"
 url="http://www.libssh.org/"
 arch="all"
@@ -10,7 +10,7 @@ license="LGPL"
 makedepends="zlib-dev libressl-dev cmake doxygen"
 subpackages="$pkgname-dev"
 options="!check"
-source="https://red.libssh.org/attachments/download/218/libssh-$pkgver.tar.xz
+source="https://www.libssh.org/files/0.7/libssh-$pkgver.tar.xz
 	fix-includes.patch"
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -28,5 +28,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="6c7f539899caaedf13d66fa2e0fac1a475ecdfe389131abcbdf908bdebc50a0b9e6b0d43e67e52aea85c32f6aa68e46ca2f50695992f82ded83489f445a8e775  libssh-0.7.5.tar.xz
+sha512sums="2a01402b5a9fab9ecc29200544ed45d3f2c40871ed1c8241ca793f8dc7fdb3ad2150f6a522c4321affa9b8778e280dc7ed10f76adfc4a73f0751ae735a42f56c  libssh-0.7.6.tar.xz
 055a8f6b97c65384a5a3ab8fe00c69d94cc30092fe926093dbbc122ce301fbe9d76127aa07b5e6107d7fa9dd2aad6b165fa0958b56520253b5d64428ff42a318  fix-includes.patch"


### PR DESCRIPTION
https://www.libssh.org/2018/10/16/libssh-0-8-4-and-0-7-6-security-and-bugfix-release/