### PR TITLE
main/gpgme: create a new python bindings package - py3-gpgme

### DIFF
--- a/main/gpgme/APKBUILD
+++ b/main/gpgme/APKBUILD
@@ -25,7 +25,7 @@ build() {
 		--infodir=/usr/share/info \
 		--localstatedir=/var \
 		--enable-languages="python cpp" \
-		PYTHON_VERSIONS="2.7 3.6" \
+		PYTHON_VERSIONS="3.6" \
 	make
 }
 
@@ -42,7 +42,7 @@ check() {
 gpgmepp() {
 	pkgdesc="C++ bindings for GPGME"
 	mkdir -p "$subpkgdir"/usr/lib
-	cp "$pkgdir"/usr/lib/libgpgmepp.so.* "$subpkgdir"/usr/lib/
+	mv "$pkgdir"/usr/lib/libgpgmepp.so.* "$subpkgdir"/usr/lib/
 }
 
 py3() {

--- a/main/gpgme/APKBUILD
+++ b/main/gpgme/APKBUILD
@@ -3,13 +3,13 @@
 pkgname=gpgme
 pkgver=1.12.0
 pkgrel=0
-pkgdesc="gnupg made easy"
+pkgdesc="gnupg made easy - programmatic access to GPG"
 url="http://www.gnupg.org/related_software/gpgme/"
 arch="all"
 license="GPL"
 depends="gnupg"
 depends_dev="libgpg-error-dev libassuan-dev"
-makedepends="$depends_dev python3-dev python2-dev py-setuptools swig"
+makedepends="$depends_dev python3-dev py-setuptools swig"
 subpackages="$pkgname-dev $pkgname-doc gpgmepp py3-gpgme:py3"
 source="ftp://ftp.gnupg.org/gcrypt/$pkgname/$pkgname-$pkgver.tar.bz2"
 builddir="$srcdir"/gpgme-$pkgver
@@ -53,7 +53,5 @@ py3() {
 	mkdir -p "$subpkgdir"/usr/lib/
 	mv "$pkgdir"/usr/lib/python3* "$subpkgdir"/usr/lib/
 }
-
-
 
 sha512sums="c228b3df28377df882be536ada56dc9c73150048a58e591aa4495f89c854af95820152cd60139840f994c249e9c7df50d8b89eb9d6dc4ce02aa80bbfebcdd014  gpgme-1.12.0.tar.bz2"

--- a/main/gpgme/APKBUILD
+++ b/main/gpgme/APKBUILD
@@ -48,7 +48,7 @@ gpgmepp() {
 py3() {
         python=python3
 	pkgdesc="Python 3 bindings for GPGME"
-	depends="$depends python3"
+	depends="$depends python3 gpgme"
 
 	mkdir -p "$subpkgdir"/usr/lib/
 	mv "$pkgdir"/usr/lib/python3* "$subpkgdir"/usr/lib/

--- a/main/gpgme/APKBUILD
+++ b/main/gpgme/APKBUILD
@@ -9,8 +9,8 @@ arch="all"
 license="GPL"
 depends="gnupg"
 depends_dev="libgpg-error-dev libassuan-dev"
-makedepends="$depends_dev"
-subpackages="$pkgname-dev $pkgname-doc gpgmepp"
+makedepends="$depends_dev python3-dev python2-dev py-setuptools swig"
+subpackages="$pkgname-dev $pkgname-doc gpgmepp py3-gpgme:py3"
 source="ftp://ftp.gnupg.org/gcrypt/$pkgname/$pkgname-$pkgver.tar.bz2"
 builddir="$srcdir"/gpgme-$pkgver
 
@@ -23,7 +23,9 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
-		--localstatedir=/var
+		--localstatedir=/var \
+		--enable-languages="python cpp" \
+		PYTHON_VERSIONS="2.7 3.6" \
 	make
 }
 
@@ -40,8 +42,27 @@ check() {
 gpgmepp() {
 	pkgdesc="C++ bindings for GPGME"
 	mkdir -p "$subpkgdir"/usr/lib
-	mv "$pkgdir"/usr/lib/libgpgmepp.so.* "$subpkgdir"/usr/lib/
+	cp "$pkgdir"/usr/lib/libgpgmepp.so.* "$subpkgdir"/usr/lib/
 }
+
+py3() {
+        python=python3
+	pkgdesc="Python 3 bindings for GPGME"
+	depends="$depends python3"
+
+	mkdir -p "$subpkgdir"/usr/lib/
+	mv "$pkgdir"/usr/lib/python3* "$subpkgdir"/usr/lib/
+
+	# mkdir -p "$subpkgdir"/usr/lib/python3/dist-packages/gpg/constants/{data,keylist,sig,tofu}
+	# mv "$pkgdir"/usr/lib/python3*/site-packages/gpg*.egg-info "$subpkgdir"/usr/lib/python3/dist-packages
+	# mv "$pkgdir"/usr/lib/python3*/site-packages/gpg/*.py "$subpkgdir"/usr/lib/python3/dist-packages/gpg
+	# mv "$pkgdir"/usr/lib/python3*/site-packages/gpg/constants/*.py "$subpkgdir"/usr/lib/python3/dist-packages/gpg/constants
+	# for i in data keylist sig tofu
+	# do
+	# 	mv "$pkgdir"/usr/lib/python3*/site-packages/gpg/constants/$i/*.py "$subpkgdir"/usr/lib/python3/dist-packages/gpg/constants/$i
+	# done
+}
+
 
 
 sha512sums="c228b3df28377df882be536ada56dc9c73150048a58e591aa4495f89c854af95820152cd60139840f994c249e9c7df50d8b89eb9d6dc4ce02aa80bbfebcdd014  gpgme-1.12.0.tar.bz2"

--- a/main/gpgme/APKBUILD
+++ b/main/gpgme/APKBUILD
@@ -52,15 +52,6 @@ py3() {
 
 	mkdir -p "$subpkgdir"/usr/lib/
 	mv "$pkgdir"/usr/lib/python3* "$subpkgdir"/usr/lib/
-
-	# mkdir -p "$subpkgdir"/usr/lib/python3/dist-packages/gpg/constants/{data,keylist,sig,tofu}
-	# mv "$pkgdir"/usr/lib/python3*/site-packages/gpg*.egg-info "$subpkgdir"/usr/lib/python3/dist-packages
-	# mv "$pkgdir"/usr/lib/python3*/site-packages/gpg/*.py "$subpkgdir"/usr/lib/python3/dist-packages/gpg
-	# mv "$pkgdir"/usr/lib/python3*/site-packages/gpg/constants/*.py "$subpkgdir"/usr/lib/python3/dist-packages/gpg/constants
-	# for i in data keylist sig tofu
-	# do
-	# 	mv "$pkgdir"/usr/lib/python3*/site-packages/gpg/constants/$i/*.py "$subpkgdir"/usr/lib/python3/dist-packages/gpg/constants/$i
-	# done
 }
 
 


### PR DESCRIPTION
This a change to the main/gpgme package which creates a package, `py3-gpgme` with the python bindings.  

the source for the bindings is in gpgme and can be found online at 
https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=tree;f=lang/python

compared with py3-pygpgme this set of bindings should be more up to date and should be maintained in future by the GNU Privacy Guard project. 

Compared to most other GNUPG related libraries this uses the recommended direct interface and so _should in principle_ reduce the risk of vulnerabilities due to problems with parsing GPG output or due to changes in the format of `gpg` output.