### PR TITLE
main/gtk+3.0: Fix touchscreen tapping menu items on X11

### DIFF
--- a/main/gtk+3.0/10-Revert-gdkseatdefault-Grab-touch-events-where-applic.patch
+++ b/main/gtk+3.0/10-Revert-gdkseatdefault-Grab-touch-events-where-applic.patch
@@ -1,0 +1,28 @@
+diff --git a/gdk/gdkseatdefault.c b/gdk/gdkseatdefault.c
+index ce4bdc82d2..9650f4b121 100644
+--- a/gdk/gdkseatdefault.c
++++ b/gdk/gdkseatdefault.c
+@@ -134,22 +134,9 @@ gdk_seat_default_grab (GdkSeat                *seat,
+ 
+   if (capabilities & GDK_SEAT_CAPABILITY_ALL_POINTING)
+     {
+-      /* ALL_POINTING spans 3 capabilities; get the mask for the ones we have */
+-      GdkEventMask pointer_evmask = 0;
+-
+-      /* We let tablet styli take over the pointer cursor */
+-      if (capabilities & (GDK_SEAT_CAPABILITY_POINTER |
+-                          GDK_SEAT_CAPABILITY_TABLET_STYLUS))
+-        {
+-          pointer_evmask |= POINTER_EVENTS;
+-        }
+-
+-      if (capabilities & GDK_SEAT_CAPABILITY_TOUCH)
+-        pointer_evmask |= TOUCH_EVENTS;
+-
+       status = gdk_device_grab (priv->master_pointer, window,
+                                 GDK_OWNERSHIP_NONE, owner_events,
+-                                pointer_evmask, cursor,
++                                POINTER_EVENTS, cursor,
+                                 evtime);
+     }
+ 

--- a/main/gtk+3.0/APKBUILD
+++ b/main/gtk+3.0/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gtk+3.0
 pkgver=3.24.1
-pkgrel=0
+pkgrel=1
 pkgdesc="The GTK+ Toolkit (v3)"
 url="https://www.gtk.org/"
 install="$pkgname.post-install $pkgname.post-upgrade $pkgname.post-deinstall"
@@ -50,7 +50,8 @@ makedepends="
 	libice-dev
 	tiff-dev
 	zlib-dev"
-source="https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-$pkgver.tar.xz"
+source="https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-$pkgver.tar.xz
+	10-Revert-gdkseatdefault-Grab-touch-events-where-applic.patch"
 
 
 builddir="$srcdir"/gtk+-$pkgver
@@ -88,4 +89,5 @@ package() {
 	rm -f "$pkgdir"/usr/share/man/man1/gtk-update-icon-cache.1
 }
 
-sha512sums="13ddb1099a2a0eb44ea53fa4be5054a403e1b27468a33862646ba111577b7bb72b9bbe4f6aea15889c2a2bee1238023bc23524b901cf2dbb3adf0e126eb6ea5d  gtk+-3.24.1.tar.xz"
+sha512sums="13ddb1099a2a0eb44ea53fa4be5054a403e1b27468a33862646ba111577b7bb72b9bbe4f6aea15889c2a2bee1238023bc23524b901cf2dbb3adf0e126eb6ea5d  gtk+-3.24.1.tar.xz
+e4ea76484b70bd9beb65b2964bbcff3b3f78f5f6fe70b12309a7721ca134e3735e8aaac09803f93b393a6130a703f8f346c0df89ad45d18c580dac1e0e922276  10-Revert-gdkseatdefault-Grab-touch-events-where-applic.patch"


### PR DESCRIPTION
On GTK+3.0 and X11 tapping menus are broken since GTK 3.22.30 and higher.
This bug has been reported upstream[1] but there hasn't been a solution to
it.

The cause of the problem is an upstream GTK commit[2] which fixes
a particular touchscreen issues with Inkscape[3].

The scope of issue addressed in the breaking commit is much narrower
than tapping menus which affects any application that uses menus.
This patch reverts the upstream commit so that touchscreen devices using
GTK 3.0 on X11 are more usable again.

[1] https://gitlab.gnome.org/GNOME/gtk/issues/945
[2] https://gitlab.gnome.org/GNOME/gtk/commit/5c700cf575a341482d802edce999789feb17849a
[3] https://bugzilla.gnome.org/show_bug.cgi?id=781757