### PR TITLE
testing/scdoc: upgrade to 1.5.2

### DIFF
--- a/testing/scdoc/APKBUILD
+++ b/testing/scdoc/APKBUILD
@@ -2,14 +2,14 @@
 # Contributor: Drew DeVault <sir@cmpwn.com>
 # Maintainer: Henrik Riomar <henrik.riomar@gmail.com>
 pkgname=scdoc
-pkgver="1.5.1"
+pkgver="1.5.2"
 pkgrel=0
 pkgdesc="simple man page generator written for POSIX systems written in C99"
 url="https://git.sr.ht/~sircmpwn/scdoc"
 arch="all"
 license="MIT"
 subpackages="$pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::https://git.sr.ht/~sircmpwn/$pkgname/archive/$pkgver.tar.gz
+source="$pkgname-$pkgver.tar.gz::https://git.sr.ht/~sircmpwn/scdoc/archive/$pkgver.tar.gz
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -28,4 +28,4 @@ package() {
 	make PREFIX="$pkgdir/usr" install
 }
 
-sha512sums="84c9049003bca64c1c4d445849d980e80461302ee87e2910e2ecc86680da72daf9ac96003b13c63cfb3cf1dab072d91ab04710ed57e8c1932c252905532dcf1a  scdoc-1.5.1.tar.gz"
+sha512sums="755c1c7fbae6cbeb75ca2aa2498cb3b2cf644e5118188c3e4a4636d74764b475b1818dcb5bd08ff70e017af9c1f8cb2e351db36a2cc98885724731e4247201eb  scdoc-1.5.2.tar.gz"


### PR DESCRIPTION
[Release notes](https://git.sr.ht/~sircmpwn/scdoc/refs/1.5.2).