### PR TITLE
testing/lightdm: add liblightdm-qt5 support

### DIFF
--- a/testing/lightdm/APKBUILD
+++ b/testing/lightdm/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=lightdm
 pkgver=1.28.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A cross-desktop display manager"
 url="https://www.freedesktop.org/wiki/Software/LightDM"
 arch="all"
@@ -10,11 +10,11 @@ license="GPL-3.0-or-later"
 depends="dbus xinit accountsservice"
 makedepends="linux-pam-dev gtk+3.0-dev libxext-dev libxklavier-dev
 	autoconf automake libtool gobject-introspection-dev itstool
-	libgcrypt-dev libxml2-utils intltool"
+	libgcrypt-dev libxml2-utils intltool qt5-qtbase-dev"
 install="$pkgname.pre-install"
 pkgusers="lightdm"
 pkggroups="lightdm"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-lang $pkgname-openrc"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang $pkgname-openrc $pkgname-qt5 $pkgname-qt5-dev:qt5_dev"
 source="https://github.com/CanonicalLtd/${pkgname}/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.xz
 	musl-language.patch
 	musl-is-linux.patch
@@ -47,6 +47,18 @@ package() {
 	install -Dm755 "$srcdir"/lightdm.initd "$pkgdir"/etc/init.d/lightdm
 	install -o lightdm -g lightdm -d "$pkgdir"/var/lib/lightdm-data
 	rm -rf "$pkgdir"/etc/apparmor.d
+}
+
+qt5() {
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/liblightdm-qt5* "$subpkgdir"/usr/lib
+}
+
+qt5_dev() {
+	mkdir -p "$subpkgdir"/usr/lib/pkgconfig "$subpkgdir"/usr/include
+	mv "$pkgdir"/../$pkgname-dev/usr/include/lightdm-qt5-3 "$subpkgdir"/usr/include/
+	mv "$pkgdir"/../$pkgname-dev/usr/lib/liblightdm-qt5-3.* "$subpkgdir"/usr/lib/
+	mv "$pkgdir"/../$pkgname-dev/usr/lib/pkgconfig/liblightdm-qt5-3.pc "$subpkgdir"/usr/lib/pkgconfig/
 }
 
 sha512sums="e1e8a952e723bbcc106043d33a64278b228a5a47a7e54235375817b08483594cc5e46ec52f5cbb9d258266e44b045785bca1d4c62daf83071c0f668b3c480071  lightdm-1.28.0.tar.xz


### PR DESCRIPTION
Suggestions welcome for improving especially the `qt5_dev` function.