### PR TITLE
main/lddtree: Fix ldso.conf parsing for musl binaries

### DIFF
--- a/main/lddtree/0001-use-musl-ldso-conf.patch
+++ b/main/lddtree/0001-use-musl-ldso-conf.patch
@@ -1,0 +1,79 @@
+Author: Ain <41307858+nero@users.noreply.github.com>
+
+    Fix ldso configuration parsing for musl binaries
+    
+    Previously, lddtree always checked for the glibc library paths, even
+    when ran on a musl binary. This resulted in incorrect results on
+    multiarch systems with both musl and glibc.
+
+diff --git a/lddtree.sh b/lddtree.sh
+index 5f06813..74ca830 100755
+--- a/lddtree.sh
++++ b/lddtree.sh
+@@ -107,7 +107,7 @@ c_ldso_paths_loaded='false'
+ find_elf() {
+ 	_find_elf=''
+ 
+-	local elf=$1 needed_by=$2
++	local interp elf=$1 needed_by=$2
+ 	if [ "${elf}" != "${elf##*/}" ] && [ -e "${elf}" ] ; then
+ 		_find_elf=${elf}
+ 		return 0
+@@ -151,28 +151,36 @@ find_elf() {
+ 		if ! ${c_ldso_paths_loaded} ; then
+ 			c_ldso_paths_loaded='true'
+ 			c_ldso_paths=
+-			if [ -r ${ROOT}etc/ld.so.conf ] ; then
+-				read_ldso_conf() {
+-					local line p
+-					for p ; do
+-						# if the glob didnt match anything #360041,
+-						# or the files arent readable, skip it
+-						[ -r "${p}" ] || continue
+-						while read line ; do
+-							case ${line} in
+-								"#"*) ;;
+-								"include "*) read_ldso_conf ${line#* } ;;
+-								*) c_ldso_paths="$c_ldso_paths:${ROOT}${line#/}";;
+-							esac
+-						done <"${p}"
+-					done
+-				}
+-				# the 'include' command is relative
+-				local _oldpwd="$PWD"
+-				cd "$ROOT"etc >/dev/null
++			read_ldso_conf() {
++				local line p
++				for p ; do
++					# if the glob didnt match anything #360041,
++					# or the files arent readable, skip it
++					[ -r "${p}" ] || continue
++					while read line ; do
++						case ${line} in
++							"#"*) ;;
++							"include "*) read_ldso_conf ${line#* } ;;
++							*) c_ldso_paths="$c_ldso_paths:${ROOT}${line#/}";;
++						esac
++					done <"${p}"
++				done
++			}
++			# the 'include' command is relative
++			local _oldpwd="$PWD"
++			cd "$ROOT"etc >/dev/null
++			interp=$(elf_interp "${needed_by}")
++			case "$interp" in
++			*/ld-musl-*)
++				musl_arch=${interp%.so*}
++				musl_arch=${musl_arch##*-}
++				read_ldso_conf "${ROOT}"etc/ld-musl-${musl_arch}.path
++				;;
++			*/ld-linux*|*/ld.so*) # glibc
+ 				read_ldso_conf "${ROOT}"etc/ld.so.conf
+-				cd "$_oldpwd"
+-			fi
++				;;
++			esac
++			cd "$_oldpwd"
+ 		fi
+ 		if [ -n "${c_ldso_paths}" ] ; then
+ 			check_paths "${elf}" "${c_ldso_paths}" && return 0

--- a/main/lddtree/APKBUILD
+++ b/main/lddtree/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=lddtree
 pkgver=1.26
-pkgrel=1
+pkgrel=2
 pkgdesc="List dynamic dependencies as a tree"
 url="https://github.com/ncopa/lddtree"
 arch="noarch"
@@ -14,6 +14,7 @@ install=""
 subpackages=""
 options="!check"
 source="lddtree-$pkgver.tar.gz::https://github.com/ncopa/lddtree/archive/v$pkgver.tar.gz
+	0001-use-musl-ldso-conf.patch
 	"
 
 build() {
@@ -25,4 +26,5 @@ package() {
 	install -Dm755 lddtree.sh "$pkgdir"/usr/bin/lddtree
 }
 
-sha512sums="9c244cf47627e6cfb396f4187e7c35b438bcb8e3978e43a91ad5a5d034233eaaffd1319e98b6a26b8bbcb570ede3eeb809a14720b50771587a96dde5f6516340  lddtree-1.26.tar.gz"
+sha512sums="9c244cf47627e6cfb396f4187e7c35b438bcb8e3978e43a91ad5a5d034233eaaffd1319e98b6a26b8bbcb570ede3eeb809a14720b50771587a96dde5f6516340  lddtree-1.26.tar.gz
+de2e9321a955697860a74a6bd383e7c77a4a10733247b2cb0c5ccbb4586c24d60cd7ee3d30cc4f33620cb971247d84b9550073ff0f7a11ef7a46af75c5fcf920  0001-use-musl-ldso-conf.patch"


### PR DESCRIPTION
lddtree was incorrectly honoring the glibc-specific /etc/ld.so.conf even for musl binaries. This resulted in an broken initramfs when glibc libraries were registered in the system.