### PR TITLE
main/imagemagick: disable openmp for stability for 3.8

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -25,10 +25,6 @@ build() {
 	sed -i -e \
 		's:DOCUMENTATION_PATH="${DATA_DIR}/doc/${DOCUMENTATION_RELATIVE_PATH}":DOCUMENTATION_PATH="/usr/share/doc/imagemagick":g' \
 		configure
-	local _openmp=
-	case "$CARCH" in
-	s390x) _openmp="--disable-openmp"
-	esac
 
 	./configure \
 		--build=$CBUILD \
@@ -38,7 +34,7 @@ build() {
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--disable-static \
-		$_openmp \
+		--disable-openmp \
 		--with-threads \
 		--with-x \
 		--with-tiff \

--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
-pkgver=7.0.7.32
+pkgver=7.0.8.14
 _abiver=7
 _pkgver=${pkgver%.*}-${pkgver##*.}
 pkgrel=0
@@ -76,4 +76,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="6fa38dcaf6236a8442e5004b9cae267572974614bea182474cc2d667ff611f2c1bdae929bcdd9d73fbd825515f18758253c834b00675c62f0ac814aee74f3bf6  ImageMagick-7.0.7-32.tar.xz"
+sha512sums="0a5f3357f4ce5b245d60b178d81b58c3483effb45b669791d4686514a8c3b0ad04244e31caf0a4a614e73e3e071c17d851992670917ebcf2761c977d77c58dd6  ImageMagick-7.0.8-14.tar.xz"


### PR DESCRIPTION
https://bugs.alpinelinux.org/issues/9190