### PR TITLE
testing/mutter: upgrade to 3.28.2

### DIFF
--- a/testing/mutter/APKBUILD
+++ b/testing/mutter/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=mutter
-pkgver=3.28.0
-pkgrel=1
+pkgver=3.28.2
+pkgrel=0
 pkgdesc="clutter-based window manager and compositor"
 url="https://github.com/GNOME/mutter"
 arch="all"
@@ -40,5 +40,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="b197598bcd81f96c0a6eb4233ad627807e8a8c0055637074695b87389844780fb5901e9acd639368cc0f4c3800c070f9773310371ffe433cce6685f756f24b14  mutter-3.28.0.tar.xz
+sha512sums="b5b718eb5b8b9317b17a08c059d01760aa60edd46abc4b3780bd7e15e1c9702ac7808ee8039d0ec59fd7b9ddfcbc518019fac57c12742e7d4e46fa75b276d84f  mutter-3.28.2.tar.xz
 034b7dfb8a785e00ca08d6b727f58f62442e191e1eb7abb9ed4eebc6b644eb74502200487c6af1ecc50640dfe670d9d0b5b1bffb02dc473ad8734917c68afbf7  fix-format-error.patch"


### PR DESCRIPTION
Currently it linked to wrong `gnome-desktop` - `libgnome-desktop-3.so.12`
so blocking gnome-shell build https://pkgs.alpinelinux.org/contents?file=libgnome-desktop*&path=&name=&branch=edge