### PR TITLE
community/php7-pecl-ssh2: renamed from php7-ssh2, modernize

### DIFF
--- a/community/php7-pecl-ssh2/APKBUILD
+++ b/community/php7-pecl-ssh2/APKBUILD
@@ -1,18 +1,19 @@
 # Contributor: Andy Postnikov <apostnikov@gmail.com>
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
-pkgname=php7-ssh2
+pkgname=php7-pecl-ssh2
 _pkgreal=ssh2
 pkgver=1.1.2
-pkgrel=2
+pkgrel=3
 pkgdesc="PHP extension provide bindings for the libssh2 library"
-url="http://pecl.php.net/package/ssh2"
+url="https://pecl.php.net/package/ssh2"
 arch="all"
-license="PHP"
-depends=""
-makedepends="php7-dev autoconf libssh2-dev"
-#options="!check" # Depends on setup of user, cert & running ssh server
+license="PHP-3.01"
+makedepends="php7-dev autoconf libssh2-dev re2c"
+options="!check" # Depends on setup of user, cert & running ssh server
 source="$pkgname-$pkgver.tgz::https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
+provides="php7-ssh2=$pkgver-r$pkgrel" # for backward compatibility
+replaces="php7-ssh2" # for backward compatibility
 
 build() {
 	cd "$builddir"
@@ -31,4 +32,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/$_pkgreal.ini
 }
 
-sha512sums="36793191448745b8a9b3cc628fe9fb431480792c7a2ff0bf2eccd58cda1cf944933be1d301c455d4a6f3dabf7e04ffef248bc402a8ff99bfafcba0deddb25c36  php7-ssh2-1.1.2.tgz"
+sha512sums="36793191448745b8a9b3cc628fe9fb431480792c7a2ff0bf2eccd58cda1cf944933be1d301c455d4a6f3dabf7e04ffef248bc402a8ff99bfafcba0deddb25c36  php7-pecl-ssh2-1.1.2.tgz"


### PR DESCRIPTION
Renamed according https://bugs.alpinelinux.org/issues/9277