### PR TITLE
community/php7-pecl-mailparse: renamed from php7-mailparse, modernize…

### DIFF
--- a/community/php7-mailparse/APKBUILD
+++ b/community/php7-mailparse/APKBUILD
@@ -3,29 +3,35 @@
 pkgname=php7-mailparse
 _pkgreal=mailparse
 pkgver=3.0.2
-pkgrel=2
-_phpver=${pkgname#php}
-_phpver=${_phpver%%-*}
-pkgdesc="PHP$_phpver extension for parsing and working with email messages"
-url="http://pecl.php.net/package/mailparse"
+pkgrel=3
+pkgdesc="PHP extension for parsing and working with email messages - PECL"
+url="https://pecl.php.net/package/mailparse"
 arch="all"
 license="PHP"
-depends="php$_phpver-common php$_phpver-mbstring"
-makedepends="php$_phpver-dev autoconf"
+depends="php7-common php7-mbstring"
+makedepends="php7-dev autoconf re2c"
 source="$pkgname-$pkgver.tgz::https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
-options="!check" # tests fail - mbstring not loaded
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 build() {
 	cd "$builddir"
 
-	phpize$_phpver
-	./configure --prefix=/usr --with-php-config=php-config$_phpver
+	phpize7
+	./configure --prefix=/usr --with-php-config=php-config7
 	make
 }
 
+check() {
+	cd "$builddir"
+	# Tests require mbstring extension which is not bundled
+	sed -i 's#PHP_TEST_SHARED_EXTENSIONS =  `#PHP_TEST_SHARED_EXTENSIONS = -d extension=/usr/lib/php7/modules/mbstring.so `#' Makefile
+	# Current upstream package has no test data for following tests
+	rm -f tests/011.phpt tests/bug001.phpt tests/parse_test_messages.phpt
+	make NO_INTERACTION=1 REPORT_EXIT_STATUS=1 test
+}
+
 package() {
-	local confdir="$pkgdir/etc/php$_phpver/conf.d"
+	local confdir="$pkgdir/etc/php7/conf.d"
 	cd "$builddir"
 
 	make INSTALL_ROOT="$pkgdir" install

--- a/community/php7-pecl-mailparse/APKBUILD
+++ b/community/php7-pecl-mailparse/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Fabio Ribeiro <fabiorphp@gmail.com>
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
-pkgname=php7-mailparse
+pkgname=php7-pecl-mailparse
 _pkgreal=mailparse
 pkgver=3.0.2
-pkgrel=3
+pkgrel=4
 pkgdesc="PHP extension for parsing and working with email messages - PECL"
 url="https://pecl.php.net/package/mailparse"
 arch="all"
@@ -12,6 +12,8 @@ depends="php7-common php7-mbstring"
 makedepends="php7-dev autoconf re2c"
 source="$pkgname-$pkgver.tgz::https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
+provides="php7-mailparse=$pkgver-r$pkgrel" # for backward compatibility
+replaces="php7-mailparse" # for backward compatibility
 
 build() {
 	cd "$builddir"
@@ -40,4 +42,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$confdir"/60_$_pkgreal.ini
 }
 
-sha512sums="be04e15cf3577542447186d7ead4e31159c171c99de0a255d4ee2f6f760b80ecb44be056bd9089180601f622b9a71f4331f194e1adaa702d1d964009682896f6  php7-mailparse-3.0.2.tgz"
+sha512sums="be04e15cf3577542447186d7ead4e31159c171c99de0a255d4ee2f6f760b80ecb44be056bd9089180601f622b9a71f4331f194e1adaa702d1d964009682896f6  php7-pecl-mailparse-3.0.2.tgz"


### PR DESCRIPTION
… and add check 

Renamed according https://bugs.alpinelinux.org/issues/9277