### PR TITLE
community/php7-pecl-mcrypt: renamed from php7-mcrypt, modernize

### DIFF
--- a/community/php7-pecl-mcrypt/APKBUILD
+++ b/community/php7-pecl-mcrypt/APKBUILD
@@ -1,16 +1,18 @@
 # Maintainer: TBK <alpine@jjtc.eu>
-pkgname=php7-mcrypt
+pkgname=php7-pecl-mcrypt
 _pkgreal=mcrypt
 pkgver=1.0.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Provides bindings for the unmaintained libmcrypt."
 url="https://pecl.php.net/package/mcrypt"
 arch="all"
 license="PHP"
-depends=""
+depends="php7-common"
 makedepends="pcre-dev php7-dev autoconf libmcrypt-dev"
 source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
+provides="php7-mcrypt=$pkgver-r$pkgrel" # for backward compatibility
+replaces="php7-mcrypt" # for backward compatibility
 
 build() {
 	cd "$builddir"
@@ -23,8 +25,8 @@ build() {
 check() {
 	cd "$builddir"
 
-	# One test fails with PHP 7.2.3
-  	rm tests/bug8040.phpt
+	# One test fails with PHP 7.2.11
+	rm tests/bug8040.phpt
 
 	make NO_INTERACTION=1 REPORT_EXIT_STATUS=1 test
 }


### PR DESCRIPTION
Renamed according https://bugs.alpinelinux.org/issues/9277