### PR TITLE
community/certbot: add certbot-nginx subpackage

### DIFF
--- a/community/certbot/APKBUILD
+++ b/community/certbot/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=certbot
 pkgver=0.27.1
-pkgrel=0
+pkgrel=1
 pkgdesc="An ACME client that can update Apache/Nginx configurations"
 url="https://github.com/certbot/certbot"
 arch="noarch"
@@ -18,7 +18,7 @@ _depends_acme="py-setuptools py-cryptography py-ndg_httpsclient py-asn1 py-opens
 	py-tz py-rfc3339 py-requests py-six py-werkzeug"
 replaces="letsencrypt"
 makedepends="$depends_dev $_depends_acme"
-subpackages="py-acme:acme"
+subpackages="py-acme:acme certbot-nginx:nginx"
 source="certbot-$pkgver.tar.gz::https://github.com/certbot/certbot/archive/v$pkgver.tar.gz"
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -41,6 +41,14 @@ acme() {
 	pkgdesc="ACME protocol implementation for Python"
 	depends="$_depends_acme"
 	cd "$builddir"/acme
+	python2 setup.py build
+	python2 setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+nginx() {
+	pkgdesc="certbot plugin for nginx"
+	depends="certbot"
+	cd "$builddir"/certbot-nginx
 	python2 setup.py build
 	python2 setup.py install --prefix=/usr --root="$subpkgdir"
 }


### PR DESCRIPTION
This adds a package for the nginx plugin for certbot, allowing it to patch your nginx configuration for SSL support.