### PR TITLE
community/php7-pecl-timezonedb: renamed from php7-timezonedb, modernize

### DIFF
--- a/community/php7-pecl-timezonedb/APKBUILD
+++ b/community/php7-pecl-timezonedb/APKBUILD
@@ -1,18 +1,20 @@
 # Contributor: Fabio Ribeiro <fabiorphp@gmail.com>
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
-pkgname=php7-timezonedb
+pkgname=php7-pecl-timezonedb
 _pkgreal=timezonedb
 pkgver=2018.5
-pkgrel=0
+pkgrel=1
 pkgdesc="Timezone Database to be used with PHP's date and time functions."
 url="https://pecl.php.net/package/timezonedb"
 arch="all"
 license="PHP"
-depends=""
+depends="php7-common"
 makedepends="php7-dev autoconf"
 source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
 options="!check"  # upstream does not provide tests yet
+provides="php7-timezonedb=$pkgver-r$pkgrel" # for backward compatibility
+replaces="php7-timezonedb" # for backward compatibility
 
 build() {
 	cd "$builddir"


### PR DESCRIPTION
Renamed according https://bugs.alpinelinux.org/issues/9277