### PR TITLE
community/php7-pecl-oauth: renamed from php7-oauth, modernize

### DIFF
--- a/community/php7-pecl-oauth/APKBUILD
+++ b/community/php7-pecl-oauth/APKBUILD
@@ -1,17 +1,19 @@
 # Contributor: Fabio Ribeiro <fabiorphp@gmail.com>
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
-pkgname=php7-oauth
+pkgname=php7-pecl-oauth
 _pkgreal=oauth
 pkgver=2.0.3
-pkgrel=0
+pkgrel=1
 pkgdesc="OAuth is an authorization protocol built on top of HTTP."
-url="http://pecl.php.net/package/$_pkgreal"
+url="https://pecl.php.net/package/oauth"
 arch="all"
 license="PHP"
-depends=
+depends="php7-common"
 makedepends="php7-dev autoconf pcre-dev curl-dev"
 source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir"/$_pkgreal-$pkgver
+provides="php7-oauth=$pkgver-r$pkgrel" # for backward compatibility
+replaces="php7-oauth" # for backward compatibility
 
 build() {
 	cd "$builddir"


### PR DESCRIPTION
Renamed according https://bugs.alpinelinux.org/issues/9277