### PR TITLE
community/php7-pecl-mongodb: renamed from php7-mongodb, fix license

### DIFF
--- a/community/php7-pecl-mongodb/APKBUILD
+++ b/community/php7-pecl-mongodb/APKBUILD
@@ -1,19 +1,21 @@
 # Contributor: Fabio Ribeiro <fabiorphp@gmail.com>
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
-pkgname=php7-mongodb
+pkgname=php7-pecl-mongodb
 _pkgreal=mongodb
 pkgver=1.5.3
 _pkgver=${pkgver/_rc/RC}
-pkgrel=0
+pkgrel=1
 pkgdesc="PHP7 MongoDB driver"
 url="https://pecl.php.net/package/mongodb"
 arch="all"
-license="PHP"
+license="Apache-2.0"
 depends="php7-json"
 makedepends="libressl-dev pcre-dev php7-dev autoconf"
 source="https://pecl.php.net/get/$_pkgreal-$_pkgver.tgz"
 options="!check"  # tests requires additional dependencies (vagrant)
 builddir="$srcdir"/$_pkgreal-$_pkgver
+provides="php7-mongodb=$pkgver-r$pkgrel" # for backward compatibility
+replaces="php7-mongodb" # for backward compatibility
 
 build() {
 	cd "$builddir"


### PR DESCRIPTION
Renamed according https://bugs.alpinelinux.org/issues/9277

https://pecl.php.net/package/mongodb points and tarball contains apache-2 license