### PR TITLE
community/php7-pecl-gmagick: renamed from php7-gmagick, modernize

### DIFF
--- a/community/php7-pecl-gmagick/APKBUILD
+++ b/community/php7-pecl-gmagick/APKBUILD
@@ -1,18 +1,20 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
-pkgname=php7-gmagick
+pkgname=php7-pecl-gmagick
 _pkgreal=gmagick
 pkgver=2.0.5_rc1
 _pkgver=${pkgver/_rc/RC}
-pkgrel=3
-pkgdesc="PHP7 bindings to the GraphicsMagick library"
-url="http://pecl.php.net/package/gmagick"
+pkgrel=4
+pkgdesc="PHP bindings to the GraphicsMagick library - PECL"
+url="https://pecl.php.net/package/gmagick"
 arch="all"
-license="PHP"
-depends="ghostscript-fonts"
+license="PHP-3.01"
+depends="php7-common ghostscript-fonts"
 makedepends="graphicsmagick-dev autoconf libtool php7-dev"
 source="https://pecl.php.net/get/$_pkgreal-$_pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$_pkgver"
+provides="php7-gmagick=$pkgver-r$pkgrel" # for backward compatibility
+replaces="php7-gmagick" # for backward compatibility
 
 build() {
 	cd "$builddir"


### PR DESCRIPTION
Renamed according https://bugs.alpinelinux.org/issues/9277

Fix license https://pecl.php.net/package/gmagick