### PR TITLE
main/glib: don't depend on perl

### DIFF
--- a/main/glib/APKBUILD
+++ b/main/glib/APKBUILD
@@ -9,7 +9,7 @@ arch="all"
 license="GPL"
 depends=
 triggers="$pkgname.trigger=/usr/share/glib-2.0/schemas:/usr/lib/gio/modules"
-depends_dev="perl python2 gettext-dev zlib-dev bzip2-dev libffi-dev
+depends_dev="python2 gettext-dev zlib-dev bzip2-dev libffi-dev
 	util-linux-dev libxml2-utils libxslt docbook-xml docbook-xsl"
 makedepends="$depends_dev pcre-dev autoconf automake libtool"
 source="https://download.gnome.org/sources/$pkgname/${pkgver%.*}/$pkgname-$pkgver.tar.xz


### PR DESCRIPTION
All glib perl scrips have been ported to python