### PR TITLE
community/php7-pecl-timezonedb: upgrade to 2018.6

### DIFF
--- a/community/php7-pecl-timezonedb/APKBUILD
+++ b/community/php7-pecl-timezonedb/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
 pkgname=php7-pecl-timezonedb
 _pkgreal=timezonedb
-pkgver=2018.5
-pkgrel=1
+pkgver=2018.6
+pkgrel=0
 pkgdesc="Timezone Database to be used with PHP's date and time functions."
 url="https://pecl.php.net/package/timezonedb"
 arch="all"
 license="PHP"
 depends="php7-common"
-makedepends="php7-dev autoconf"
+makedepends="php7-dev autoconf re2c"
 source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
 options="!check"  # upstream does not provide tests yet
@@ -30,4 +30,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/40_$_pkgreal.ini
 }
 
-sha512sums="6e06c1735e7cd0bddf360ed270ca05ab49c2115569d24a9ef235c25496726ab90c3df0320bd329237867336164f35a949fa048cd404077420bc83c2d8d36b899  timezonedb-2018.5.tgz"
+sha512sums="e5703dc0d4f5edb0192951e48c710725b8ec9588edc66e94ce9edcba7d5ee636dee04ffebe13cd6ca70da077cdc71daee75bb1b1a54469d5018f8e29e8f27633  timezonedb-2018.6.tgz"


### PR DESCRIPTION
Ref https://pecl.php.net/package-changelog.php?package=timezonedb&release=2018.6