### PR TITLE
main/py-jinja2: add check() and modernize

### DIFF
--- a/main/py-jinja2/APKBUILD
+++ b/main/py-jinja2/APKBUILD
@@ -3,14 +3,14 @@
 pkgname=py-jinja2
 _pkgname=Jinja2
 pkgver=2.10
-pkgrel=1
+pkgrel=2
 pkgdesc="A small but fast and easy to use stand-alone python template engine"
 url="http://jinja.pocoo.org/"
 arch="noarch"
 license="BSD"
-_py2_depends="py2-markupsafe"
-_py3_depends="py3-markupsafe"
-makedepends="python2-dev python3-dev py-setuptools $_py2_depends $_py3_depends"
+depends="py-markupsafe"
+checkdepends="pytest"
+makedepends="python2-dev python3-dev py-setuptools"
 subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3
 	$pkgname-doc $pkgname-vim"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
@@ -22,18 +22,24 @@ build() {
 	python3 setup.py build
 }
 
+check() {
+	cd "$builddir"
+	python2 -m pytest .
+	python3 -m pytest .
+}
+
 package() {
 	mkdir -p "$pkgdir"
 }
 
 _py2() {
-	depends="$_py2_depends"
+	depends="${depends//py-/py2-}"
 	replaces="$pkgname"
 	_py python2
 }
 
 _py3() {
-	depends="$_py3_depends"
+	depends="${depends//py-/py3-}"
 	_py python3
 }
 


### PR DESCRIPTION
The package itself must define its dependency to point right build order
This is why jinja2 was build without its real dependency, adding `check()` should prevent it in future

Ref http://build.alpinelinux.org/buildlogs/build-edge-armv7/main/py-sphinx/py-sphinx-1.8.1-r0.log