### PR TITLE
testing/brotli: upgrade to 1.0.7

### DIFF
--- a/testing/brotli/APKBUILD
+++ b/testing/brotli/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: prspkt <prspkt@protonmail.com>
 # Maintainer: prspkt <prspkt@protonmail.com>
 pkgname=brotli
-pkgver=1.0.6
+pkgver=1.0.7
 pkgrel=0
 pkgdesc="Generic lossless compressor"
 url="https://github.com/google/brotli"
@@ -46,4 +46,4 @@ package() {
 	done
 }
 
-sha512sums="b9847375471de3ae815ef4bb45a29653c343fad0a891a79d5132fcdee34c85caafd82289c8b413c3ef609049f2e8c4af9f9abd1736a2408ba44544c5fefc0010  brotli-1.0.6.tar.gz"
+sha512sums="a82362aa36d2f2094bca0b2808d9de0d57291fb3a4c29d7c0ca0a37e73087ec5ac4df299c8c363e61106fccf2fe7f58b5cf76eb97729e2696058ef43b1d3930a  brotli-1.0.7.tar.gz"


### PR DESCRIPTION
[Release notes](https://github.com/google/brotli/releases/tag/v1.0.7).