### PR TITLE
community/drupal7: security upgrade 7.60 - SA-CORE-2018-006

### DIFF
--- a/community/drupal7/APKBUILD
+++ b/community/drupal7/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
 _php=php5
 pkgname=drupal7
-pkgver=7.59
+pkgver=7.60
 pkgrel=0
 pkgdesc="An open source content management platform"
 url="https://www.drupal.org/"
@@ -16,6 +16,7 @@ pkggroups="www-data"
 source="http://ftp.drupal.org/files/projects/drupal-$pkgver.tar.gz"
 
 builddir="$srcdir/drupal-$pkgver"
+options="!check" # This package not have testsuite
 
 # secfixes:
 #   7.59-r0:
@@ -58,4 +59,4 @@ package() {
 		"$pkgdir"/var/lib/$pkgname/sites/default/files
 }
 
-sha512sums="68f02b39d1a4658adc0f0046c22cc1059b68f952f9cd753f5a3e379cf93705be308b4727519e90d77a42437442daebaa78d76745954be4d40e1a5105c319069c  drupal-7.59.tar.gz"
+sha512sums="fee59cf303a6c44e3fa3cbeda4912f7d61ffe8294282f9ad0416a6536cc6ea65cf114a6a801dd1f68572185c2b1e300f58f907f9bd61f96beaba3706c527d512  drupal-7.60.tar.gz"


### PR DESCRIPTION
ref: https://www.drupal.org/SA-CORE-2018-006 and https://www.drupal.org/project/drupal/releases/7.60