### PR TITLE
community/php7-pecl-event: fix check() to skip online tests

### DIFF
--- a/community/php7-pecl-event/APKBUILD
+++ b/community/php7-pecl-event/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=php7-pecl-event
 _pkgname=event
 pkgver=2.4.1
-pkgrel=1
+pkgrel=2
 pkgdesc="PHP extension that provides interface to libevent library - PECL"
 url="https://pecl.php.net/package/event"
 arch="all"
@@ -27,7 +27,7 @@ check() {
 	cd "$builddir"
 	# Tests require sockets extension which is not bundled
 	sed -i 's#PHP_TEST_SHARED_EXTENSIONS =  `#PHP_TEST_SHARED_EXTENSIONS = -d extension=/usr/lib/php7/modules/sockets.so `#' Makefile
-	make NO_INTERACTION=1 REPORT_EXIT_STATUS=1 test
+	make NO_INTERACTION=1 REPORT_EXIT_STATUS=1 SKIP_ONLINE_TESTS=1 test
 }
 
 package() {


### PR DESCRIPTION
Builders randomly fail on it