### PR TITLE
[v3.8] community/php5: backport php5 security & bugfixes from edge

### DIFF
--- a/community/php5/APKBUILD
+++ b/community/php5/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
-pkgver=5.6.37
+pkgver=5.6.38
 pkgrel=0
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
@@ -124,6 +124,8 @@ _confdir=/etc/$pkgname
 _peardir=/usr/share/pear
 
 # secfixes:
+#   5.6.38-r0:
+#     - CVE-2018-17082
 #   5.6.37-r0:
 #     - CVE-2018-14851
 #     - CVE-2018-14883
@@ -521,7 +523,7 @@ pdo_dblib()	{ _mv_ext pdo_dblib "$pkgname-pdo freetds"; }
 wddx()		{ _mv_ext wddx; }
 opcache()	{ _mv_ext opcache; }
 
-sha512sums="9cdd7710893ceb464a4818b853a2a70a02f55ece1d23cafe9a5529fdfa9ac1b23cf0eb944bd812825ec946901967a76254b10a38db835759be048cbc01795776  php-5.6.37.tar.bz2
+sha512sums="d39cf2d56311802dfa81afaabfb1968a2647d37f42df1be54dd9557ff5ced5c444b52a3502c78b27feefd88972324b2663fc1745f985c2eb51096e06ff6191d1  php-5.6.38.tar.bz2
 f7d922cab98617ef910b4c14974e768c85e60424cd1b216f688b34b2d823b642a5b896463008c134ce47c150f9407f5c438823b7e7bc89b3fb440cd3e97b9d7e  php-fpm.initd
 d1dd6a5764e18414476aaaa109efcc568696ac17a61a1afdf7d0621d3e38c5be717a81ee4d11d28963f11e76879af7d3806970e651061f8c4abffb03c4bd5af4  php5-module.conf
 f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c939768584f3e4edbe52e8bd6103fb6777462326a9d94e8ab1f505  php-install-pear-xml.patch

--- a/community/php5/APKBUILD
+++ b/community/php5/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
 pkgver=5.6.38
-pkgrel=0
+pkgrel=1
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
 arch="all"
@@ -12,7 +12,7 @@ license="PHP-3.0"
 depends="$pkgname-cli"
 depends_dev="$pkgname-cli pcre-dev"
 install="$pkgname.post-upgrade"
-provides="$pkgname-cli php-cli php"
+provides="php"
 makedepends="
 	$depends_dev
 	apache2-dev
@@ -108,7 +108,7 @@ subpackages="$pkgname-dbg $pkgname-dev $pkgname-doc $pkgname-common::noarch $pkg
 	$pkgname-opcache
 	"
 
-source="http://php.net/distributions/php-$pkgver.tar.bz2
+source="https://php.net/distributions/php-$pkgver.tar.bz2
 	php-fpm.initd
 	php5-module.conf
 	php-install-pear-xml.patch
@@ -169,6 +169,10 @@ _do_build() {
 	cd "$_builddir"
 	export EXTENSION_DIR=$_extdir
 	export PEAR_INSTALLDIR="$_peardir"
+
+	#http://source.icu-project.org/repos/icu/trunk/icu4c/readme.html#RecBuild
+	export CPPFLAGS="$CPPFLAGS -DU_USING_ICU_NAMESPACE=1"
+
 	"$_srcdir"/configure $@ || return 1
 	sed -ri "s/^(EXTRA_LDFLAGS[ ]*\=.*)/\1 -lpthread/" Makefile  # see #183
 	make || return 1
@@ -371,6 +375,7 @@ cgi() {
 cli() {
 	pkgdesc="PHP Command Line Interface (CLI)"
 	depends="$pkgname-common"
+	provides="php-cli"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/php5 "$subpkgdir"/usr/bin/ || return 1
 	# provide phpize here instead of -dev due to pecl command
@@ -432,6 +437,7 @@ pear() {
 
 phpdbg() {
 	pkgdesc="Interactive PHP debugger"
+	depends="$pkgname-common"
 	provides="php-phpdbg"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/phpdbg* "$subpkgdir"/usr/bin/
@@ -442,12 +448,12 @@ _mv_ext() {
 	local ini=$ext.ini
 	pkgdesc="${ext} extension for PHP"
 	provides="php-$extname"
+	depends="${pkgname}-common"
 
 	# extension dependencies
 	if [ -n "${2-}" ]; then
-		depends="${2-}"
+		depends="${depends} ${2-}"
 	fi
-	depends="${pkgname} ${depends}"
 
 	# work around dependency issue
 	# https://bugs.alpinelinux.org/issues/1848


### PR DESCRIPTION
- d3f643b6a8bf6e4341bca4f133a5de8615978b25 CVE-2018-17082
- 5a139d90 secfix
- 8275d783d8 icu fix
- 8275d783d8 & 8275d783d8 dependecy fixes for https://bugs.alpinelinux.org/issues/9119