### PR TITLE
testing/openssl: remove support for TLS compression

### DIFF
--- a/testing/openssl/APKBUILD
+++ b/testing/openssl/APKBUILD
@@ -2,14 +2,13 @@
 pkgname=openssl
 pkgver=1.1.1
 _abiver=${pkgver%.*}
-pkgrel=2
-pkgdesc="Toolkit for SSL v2/v3 and TLS v1"
+pkgrel=3
+pkgdesc="Toolkit for Transport Layer Security (TLS)"
 url="https://www.openssl.org"
 arch="all"
 license="OpenSSL"
-depends_dev="zlib-dev"
 makedepends_build="perl"
-makedepends_host="zlib-dev linux-headers"
+makedepends_host="linux-headers"
 makedepends="$makedepends_host $makedepends_build"
 subpackages="$pkgname-dbg $pkgname-dev $pkgname-doc libcrypto$_abiver:_libcrypto libssl$_abiver:_libssl"
 source="https://www.openssl.org/source/openssl-$pkgver.tar.gz
@@ -48,8 +47,8 @@ build() {
 	perl ./Configure $_target --prefix=/usr \
 		--libdir=lib \
 		--openssldir=/etc/ssl \
-		shared zlib $_optflags \
-		no-async no-mdc2 no-ec2m no-sm2 no-sm4 no-ssl2 no-ssl3 no-weak-ssl-ciphers \
+		shared no-zlib $_optflags \
+		no-async no-comp no-idea no-mdc2 no-ec2m no-seed no-sm2 no-sm4 no-ssl2 no-ssl3 no-weak-ssl-ciphers \
 		$CPPFLAGS $CFLAGS $LDFLAGS -Wa,--noexecstack
 	make
 }


### PR DESCRIPTION
https://en.wikipedia.org/wiki/CRIME_(security_exploit)
It's already disabled in other distros, e.g. Debian.