### PR TITLE
main/xorg-server: security upgrade to 1.20.3

### DIFF
--- a/main/xorg-server/APKBUILD
+++ b/main/xorg-server/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xorg-server
-pkgver=1.20.1
+pkgver=1.20.3
 pkgrel=0
 pkgdesc="X.Org X servers"
 url="http://xorg.freedesktop.org"
@@ -65,6 +65,8 @@ source="https://www.x.org/releases/individual/xserver/$pkgname-$pkgver.tar.bz2
 builddir="$srcdir"/$pkgname-$pkgver
 
 # secfixes:
+#   1.20.3-r0:
+#     - CVE-2018-14665
 #   1.19.5-r0:
 #     - CVE-2017-12176
 #     - CVE-2017-12177
@@ -179,7 +181,7 @@ xwayland() {
 	mv "$pkgdir"/usr/bin/Xwayland "$subpkgdir"/usr/bin/
 }
 
-sha512sums="ef2b93a61683c8ca8d1f14b771e70db65ba119a73db8a46e7cdbf2ac2243e3f4b2732068eb5aa5d7b76f460db995a3c04390870198a5210ec30df4360ad9f94b  xorg-server-1.20.1.tar.bz2
+sha512sums="ee44554f86df4297f54c5871fe7a18954eeef4338775a25f36d6577b279c4775f61128da71b86cfaeadcc080838d6749dede138d4db178866579da2056543fba  xorg-server-1.20.3.tar.bz2
 4dcaa60fbfc61636e7220a24a72bba19984a6dc752061cb40b1bd566c0e614d08927b6c223ffaaaa05636765fddacdc3113fde55d25fd09cd0c786ff44f51447  autoconfig-nvidia.patch
 30a78f4278edd535c45ee3f80933427cb029a13abaa4b041f816515fdd8f64f00b9c6aef50d4eba2aaf0d4f333e730399864fd97fa18891273601c77a6637200  autoconfig-sis.patch
 b799e757a22a61ac283adbd7a8df1ad4eccce0bb6cac38a0c962ba8438bba3cf6637a65bb64859e7b32399fca672283a49960207e186c271ba574580de360d09  fix-musl-arm.patch


### PR DESCRIPTION
Fixes:
- [CVE-2018-14665](https://lists.x.org/archives/xorg-announce/2018-October/002928.html)