### PR TITLE
community/shellcheck: new aport

### DIFF
--- a/community/shellcheck/APKBUILD
+++ b/community/shellcheck/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Tiago Ilieve <tiago.myhro@gmail.com>
+# Maintainer: Tiago Ilieve <tiago.myhro@gmail.com>
+pkgname=shellcheck
+pkgver=0.5.0
+pkgrel=0
+pkgdesc="ShellCheck, a static analysis tool for shell scripts"
+url="https://www.shellcheck.net/"
+arch="x86_64" # Haskell infrastructure is only supported on x86_64
+license="GPL-3.0-only"
+makedepends="cabal ghc"
+source="shellcheck-$pkgver.tar.gz::https://github.com/koalaman/shellcheck/archive/v${pkgver}.tar.gz"
+
+build() {
+	cd "$builddir"
+
+	cabal update
+	# A symlink to the binary has to be discarded, as it can't be disabled.
+	cabal install --bindir "$builddir" --symlink-bindir /tmp
+}
+
+check() {
+	cd "$builddir"
+
+	cabal test
+	./shellcheck --version
+}
+
+package() {
+	cd "$builddir"
+
+	install -Dm755 ./shellcheck "$pkgdir"/usr/bin/shellcheck
+}
+
+sha512sums="87861cddb353262630e4370e12e508224b3c14e128082909b4b35f0526dfe648a744d68cc27f77f2f8bb098af37a2af7bdc805d88018bba5e48b6c1ff1749f10  shellcheck-0.5.0.tar.gz"


### PR DESCRIPTION
ShellCheck, a static analysis tool for shell scripts - https://www.shellcheck.net

Requested on issues [#6417][1] and [#7105][2], currently part of the [3.9.0 roadmap][3].

I have a couple questions about this aport:

- As it is distributed as a single binary (like the Go ones), I'm considering that its build dependencies doesn't need to be packaged. I think this is OK, based on what I saw on other packages that fetches dependencies from the internet, but I never asked if there's a intention to aim for completely-offline-reproducible-builds.
- Is it enough to distribute it for `x86_64` only? Or should we work improving the Haskell infrastructure to support more architectures before offering it?

[1]: https://bugs.alpinelinux.org/issues/6417
[2]: https://bugs.alpinelinux.org/issues/7105
[3]: https://bugs.alpinelinux.org/versions/127