### PR TITLE
community/py-greenlet: add ppc64le patch

### DIFF
--- a/community/py-greenlet/APKBUILD
+++ b/community/py-greenlet/APKBUILD
@@ -11,7 +11,8 @@ license="MIT"
 depends=""
 makedepends="python2-dev py-setuptools python3-dev"
 subpackages="py3-${pkgname/py-/}:_py3 py2-${pkgname/py-/}:_py2"
-source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz
+	ppc64le_clobbering.patch"
 
 builddir="$srcdir/$_pkgname-$pkgver"
 
@@ -50,4 +51,5 @@ _py3() {
 	_py python3
 }
 
-sha512sums="a3b7856aadc988fe153f5cf62552dd6219358f35ee2ca136e5eb5c9871cb7545986753af299e6b3e95877e9aa564559e95c548785f78e680766630b047a1ec89  greenlet-0.4.15.tar.gz"
+sha512sums="a3b7856aadc988fe153f5cf62552dd6219358f35ee2ca136e5eb5c9871cb7545986753af299e6b3e95877e9aa564559e95c548785f78e680766630b047a1ec89  greenlet-0.4.15.tar.gz
+3770c57f6a2cf36d33a5d39d5a3d12596a5b3255727fa24b6a7f1c18eda18c491ad140ff12bc804e818975e31461ff37d6705448de7ed7a0e5c3cd60137962d9  ppc64le_clobbering.patch"

--- a/community/py-greenlet/ppc64le_clobbering.patch
+++ b/community/py-greenlet/ppc64le_clobbering.patch
@@ -1,0 +1,10 @@
+--- greenlet-0.4.15/platform/switch_ppc64_linux.h.a
++++ greenlet-0.4.15/platform/switch_ppc64_linux.h
+@@ -66,7 +66,6 @@
+ 
+ #define REGS_TO_SAVE "r14", "r15", "r16", "r17", "r18", "r19", "r20",  \
+        "r21", "r22", "r23", "r24", "r25", "r26", "r27", "r28", "r29",  \
+-       "r31",                                                    \
+        "fr14", "fr15", "fr16", "fr17", "fr18", "fr19", "fr20", "fr21", \
+        "fr22", "fr23", "fr24", "fr25", "fr26", "fr27", "fr28", "fr29", \
+        "fr30", "fr31", \


### PR DESCRIPTION
Follow-up to https://github.com/alpinelinux/aports/pull/5459

PS: in chroot py3 tests does not pass
```
test_circular_greenlet (tests.test_gc.GCTests) ... ok
test_dead_circular_ref (tests.test_gc.GCTests) ... qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault (core dumped)
```