### PR TITLE
community/filezilla: upgrade to 3.38.1

### DIFF
--- a/community/filezilla/APKBUILD
+++ b/community/filezilla/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=filezilla
-pkgver=3.37.4
+pkgver=3.38.1
 pkgrel=0
 pkgdesc="FTP Client"
 url="https://filezilla-project.org"
@@ -32,4 +32,4 @@ check() {
 	make check
 }
 
-sha512sums="3f6697fd411b898f0db375bba7e6a34157c73274ee463832c38a4897240d990654c447baad8b0024492cb882106e7e63757d54401c487cfad96038d1f5eabfea  FileZilla_3.37.4_src.tar.bz2"
+sha512sums="a224c6f65253ceeef1f3049fd6304533a7efb427707c73481d3973d06e3b887f2511bc705e718a1018b287940c3d682794c6cf3d0e8d9e3c403a1e2f14ed01fc  FileZilla_3.38.1_src.tar.bz2"

--- a/community/libfilezilla/APKBUILD
+++ b/community/libfilezilla/APKBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=libfilezilla
-pkgver=0.14.0
+pkgver=0.15.0
 pkgrel=0
 pkgdesc="C++ library, offering some basic functionality to build high-performing, platform-independent programs"
 url="https://filezilla-project.org"
 arch="all"
 license="GPL-2.0-or-later"
-makedepends="cppunit-dev"
+makedepends="cppunit-dev nettle-dev"
 subpackages="$pkgname-dev"
 source="https://download.filezilla-project.org/libfilezilla/$pkgname-$pkgver.tar.bz2"
 builddir="$srcdir"/$pkgname-$pkgver
@@ -30,4 +30,4 @@ check() {
 	make check
 }
 
-sha512sums="f20932e14ab81df9562e030ce10009b9ab55b6798f7bfff7249e9f472fc8cae4278eb142a655dffb63fec53894783874973eb33444bfdacdb06fa682c2dd66a6  libfilezilla-0.14.0.tar.bz2"
+sha512sums="64b0e2a8dd4dd06a1c2daf52f3036fcaed60b95240672f28032ec390361ddb1a59cd26a91b7b7c525cfc8262381db09a081a29c723f487cc5b41454ce4e9d47e  libfilezilla-0.15.0.tar.bz2"


### PR DESCRIPTION
Release notes: [libfilezilla](https://lib.filezilla-project.org/) and [filezilla](https://svn.filezilla-project.org/filezilla/FileZilla3/trunk/NEWS?revision=9005&view=markup).