### PR TITLE
testing/postgis: upgrade to 2.5.0

### DIFF
--- a/testing/postgis/APKBUILD
+++ b/testing/postgis/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Bjoern Schilberg <bjoern@intevation.de>
 # Maintainer: Bjoern Schilberg <bjoern@intevation.de>
 pkgname=postgis
-pkgver=2.4.4
+pkgver=2.5.0
 pkgrel=0
 pkgdesc="PostGIS is a spatial database extender for PostgreSQL object-relational database."
-url="http://postgis.net"
+url="https://postgis.net/"
 # geos test fails on other archs
 arch="x86 x86_64"
 license="GPL-2.0-or-later"
@@ -13,7 +13,7 @@ makedepends="postgresql-dev geos-dev gdal-dev libxml2-dev proj4-dev perl-dev
 	json-c-dev pcre-dev"
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://download.osgeo.org/postgis/source/$pkgname-$pkgver.tar.gz"
-builddir="$srcdir/$pkgname-$pkgver"
+options="!check" # tests depends on a running PostgreSQL server
 
 build() {
 	cd "$builddir"
@@ -33,7 +33,6 @@ package() {
 	cd "$builddir"
 
 	make DESTDIR="$pkgdir" install
-	chmod -x "$pkgdir"/usr/include/*.h
 }
 
-sha512sums="3cb38ee24dad72a66677cb210ad5f07b0a97411664ede582a5cdbc0ca2d72573db4e9121b6af2eab9cdee6a41122c3f5c59e618df4ee028a3cae7ee35d8670f2  postgis-2.4.4.tar.gz"
+sha512sums="1ba638dae9fb167e59fc5590b57277cf62b4ceb270a77026cfca3977f6727ef27acbc5505007335652480f5157e1d6c76f782553cc294ab1e5159347dd3c8934  postgis-2.5.0.tar.gz"


### PR DESCRIPTION
Release notes: https://svn.osgeo.org/postgis/tags/2.5.0/NEWS