### PR TITLE
community/fzf: upgrade to 0.17.5

### DIFF
--- a/community/fzf/APKBUILD
+++ b/community/fzf/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Kevin Daudt <ops@ikke.info>
 # Maintainer: Kevin Daudt <ops@ikke.info>
 pkgname=fzf
-pkgver=0.17.4
+pkgver=0.17.5
 pkgrel=0
 pkgdesc="A command-line fuzzy finder"
 url="https://github.com/junegunn/fzf"
@@ -9,14 +9,12 @@ arch="x86 x86_64"
 license="MIT"
 makedepends="go glide bash tmux"
 subpackages="
-	$pkgname-doc
 	$pkgname-tmux::noarch
 	$pkgname-bash-completion:bashcomp:noarch
 	$pkgname-zsh-completion:zshcomp:noarch
 	"
 source="$pkgname-$pkgver.tar.gz::https://github.com/junegunn/fzf/archive/$pkgver.tar.gz
 	no-glide-install.patch"
-builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
 	default_prepare
@@ -39,10 +37,6 @@ package() {
 	cd "$builddir"
 	make install # Just copies the target binary to $buildir/bin
 	install -Dm0755 bin/fzf "$pkgdir"/usr/bin/fzf
-
-	mkdir -p "$pkgdir"/usr/share/doc/$pkgname/examples/
-	install -m0644 shell/key-bindings.* \
-		"$pkgdir"/usr/share/doc/$pkgname/examples/
 }
 
 tmux() {
@@ -61,17 +55,21 @@ bashcomp() {
 	cd "$builddir"
 	install -Dm0644 shell/completion.bash \
 		"$subpkgdir"/usr/share/bash-completion/completions/$pkgname
+	mkdir -p "$subpkgdir"/usr/share/fzf/
+	install -m0644 shell/key-bindings.bash "$subpkgdir"/usr/share/fzf/
 }
 
 zshcomp() {
-	pkgdesc="additional scripts for zsf like shell completion and keybindings"
+	pkgdesc="additional scripts for zsh like shell completion and keybindings"
 	depends=""
 	install_if="$pkgname=$pkgver-r$pkgrel zsh"
 
 	cd "$builddir"
 	install -Dm0644 shell/completion.zsh \
 		"$subpkgdir"/usr/share/zsh/site-functions/_$pkgname
+	mkdir -p "$subpkgdir"/usr/share/fzf/
+	install -m0644 shell/key-bindings.zsh "$subpkgdir"/usr/share/fzf/
 }
 
-sha512sums="bfdddf40f7051e15b0a0ecc0e0da6ccb9a212473175b2ee37de5b79d745f5e0213b29c0a678eb05bf1d70de91be4addc8d6d1d73b3dd09724ad0078381b9de06  fzf-0.17.4.tar.gz
+sha512sums="adb5290317362c32d053294a2dd9a2aa11711521635c1cb1fc11001dea1b06e27856a7c54e7316d211abee3304cc56b8a9ee60773bb99cb4132b533f5464a430  fzf-0.17.5.tar.gz
 daa16985079e3b55ccf5e74dde356e1e13e43865c9809e432b5d272b053f541f1eacd402f3b04957ee855fb8c0ca1820b507d08e408f55dc80004990a949874c  no-glide-install.patch"


### PR DESCRIPTION
Drop `*-doc` package and move keybindings to the respective shell
completions package, making them consistent with their descriptions.