### PR TITLE
testing/rocksdb: fix ppc64le platform detection and re-enable build

### DIFF
--- a/testing/rocksdb/APKBUILD
+++ b/testing/rocksdb/APKBUILD
@@ -2,11 +2,11 @@
 # Maintainer:
 pkgname=rocksdb
 pkgver=5.15.10
-pkgrel=3
+pkgrel=4
 pkgdesc="A persistent key-value store for fast storage environments"
 url="https://rocksdb.org"
 # fails to build on other archs
-arch="x86 x86_64"
+arch="x86 x86_64 ppc64le"
 license="GPL-2.0"
 depends=""
 depends_dev="bzip2-dev snappy-dev zlib-dev lz4-dev zstd-dev"
@@ -15,6 +15,7 @@ install=""
 subpackages="$pkgname-dev $pkgname-doc"
 options="!check" # no upstream/available test-suite
 source="$pkgname-$pkgver.tar.gz::https://github.com/facebook/$pkgname/archive/v$pkgver.tar.gz
+	ppc64le-determine-platform.patch
 	10-support-busybox-install.patch"
 
 _builddir="$srcdir/$pkgname-$pkgver"
@@ -34,4 +35,5 @@ package() {
 }
 
 sha512sums="3faef43cc343c20e044f92af7cd9eae9783612d888bfe17b7d0ae6812090088f43a128e5686600ec56f5a88c100eaa893b2551f8c32df793a4ccd94330c07037  rocksdb-5.15.10.tar.gz
+a7445cf958e414b6eac8a4f05e82fa980c00276da7305a158f3fa77f71bdff606713cd88fae8db0b9fb97125fef646e9e6245fef3a3f2e97d0ef20be259fb37d  ppc64le-determine-platform.patch
 2b33041baa061e6cedfcbc606fd9752d907ebba84cb76ff13641ac4683e614e527530453bcbe0e0c6b67b36415dee477aec268024a05b8815c534f4d6bfb6cc0  10-support-busybox-install.patch"

--- a/testing/rocksdb/ppc64le-determine-platform.patch
+++ b/testing/rocksdb/ppc64le-determine-platform.patch
@@ -1,0 +1,11 @@
+--- a/build_tools/build_detect_platform
++++ b/build_tools/build_detect_platform
+@@ -507,7 +507,7 @@
+ if test -z "$PORTABLE"; then
+   if test -n "`echo $TARGET_ARCHITECTURE | grep ^ppc64`"; then
+     # Tune for this POWER processor, treating '+' models as base models
+-    POWER=`LD_SHOW_AUXV=1 /bin/true | grep AT_PLATFORM | grep -E -o power[0-9]+`
++    POWER=`cat /proc/cpuinfo  | grep -m1 -E -o POWER[0-9]+ | awk '{print tolower($0)}'`
+     COMMON_FLAGS="$COMMON_FLAGS -mcpu=$POWER -mtune=$POWER "
+   elif test -n "`echo $TARGET_ARCHITECTURE | grep ^s390x`"; then
+     COMMON_FLAGS="$COMMON_FLAGS -march=z10 "


### PR DESCRIPTION
build is breaking on ppc64le because values for mcpu and mtune build flags aren't detected properly on Alpine using LD_SHOW_AUXV=1 /bin/true. Instead just get the cpu info from /proc/cpuinfo and use it.