### PR TITLE
main/gtk+3.0: Remove intltool dependency

### DIFF
--- a/main/gtk+3.0/APKBUILD
+++ b/main/gtk+3.0/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gtk+3.0
 pkgver=3.22.30
-pkgrel=1
+pkgrel=2
 pkgdesc="The GTK+ Toolkit (v3)"
 url="https://www.gtk.org/"
 install="$pkgname.post-install $pkgname.post-upgrade $pkgname.post-deinstall"
@@ -22,7 +22,6 @@ depends_dev="
 	fontconfig-dev
 	gdk-pixbuf-dev
 	glib-dev
-	intltool
 	libepoxy-dev
 	libx11-dev
 	libxcomposite-dev
@@ -42,6 +41,7 @@ depends_dev="
 	"
 makedepends="
 	$depends_dev
+        perl
 	cups-dev
 	expat-dev
 	gettext-dev


### PR DESCRIPTION
It's no longer required since gettext 0.19.7