### PR TITLE
testing/rakudo: upgrade to 2018.10

### DIFF
--- a/testing/moarvm/APKBUILD
+++ b/testing/moarvm/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=moarvm
-pkgver=2018.09
+pkgver=2018.10
 pkgrel=0
 pkgdesc="A VM for NQP And Rakudo Perl 6"
 url="http://moarvm.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="14d5ca1f6a8c77ee89fd05d66057b640b1e222391fded17631a4e11801de25e1fb3eb6b8b4dd977990e64952f7067482bf405a9ef5ebb6fdacdfa7c11bee21b1  MoarVM-2018.09.tar.gz"
+sha512sums="24af58d9481cf9cf9bd31d098b18c0059aad870a52c0a826fe6296fcd9d23bb44fe343a2aeffc8a0f694db681b6691c3cafc81218d82e988064cd98bf5c8ea5d  MoarVM-2018.10.tar.gz"

--- a/testing/nqp/APKBUILD
+++ b/testing/nqp/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=nqp
-pkgver=2018.09
+pkgver=2018.10
 pkgrel=0
 pkgdesc="Not Quite Perl"
 url="https://github.com/perl6/nqp"
@@ -39,4 +39,4 @@ doc() {
 	done
 }
 
-sha512sums="2fcbd39b61cfe4e1cd4315b59bb5fdeee42e2842b27f0c0a9bc97d4678a2d44d7f0be6537889acca7b26e2e372e76f4063461e29c07fb231ec9be7c7e1bb88d3  nqp-2018.09.tar.gz"
+sha512sums="bed9e3bbee307bf6ea163732a21a542f69290de15ff8fe6ff5e4eda03d1865811180a4428d805a4a3e9aacbdfe6d39858577bf53372a4008455100493c86a790  nqp-2018.10.tar.gz"

--- a/testing/rakudo/APKBUILD
+++ b/testing/rakudo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=rakudo
-pkgver=2018.09
+pkgver=2018.10
 pkgrel=0
 pkgdesc="A compiler for the Perl 6 programming language"
 url="http://rakudo.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="1a40fd71b78393d487c62b2d2316a4fcd7a0e1102913c0c83d7c2479860b1f56f555c45ae4b43804e9025eeb8bf8bf763e0603aef8e9813a6b4aa0f62fa182ba  rakudo-2018.09.tar.gz"
+sha512sums="82ca24e6484dcd2c27287f609b8008f3044e3709a53dc96b259ccd612745c80ff0b2cb20b71460e434387ad7ea10895b751775286552684bfdd4d7d08d9e26da  rakudo-2018.10.tar.gz"


### PR DESCRIPTION
Upgrade moarvm, nqp, and rakudo to version 2018.10, must upgrade all three together.
