### PR TITLE
testing/obs-studio: fix dependency qt5-x11extras

### DIFF
--- a/testing/obs-studio/APKBUILD
+++ b/testing/obs-studio/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=obs-studio
 pkgver=22.0.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Free and open source software for live streaming and screen recording"
 url="https://obsproject.com/"
 arch="x86 x86_64"
 license="GPL-2.0"
 options="!check"
 makedepends="cmake ffmpeg-dev libxinerama-dev
-	qt5-qtbase-dev qt5-x11extras-dev x264-dev fontconfig-dev
+	qt5-qtbase-dev qt5-qtx11extras-dev x264-dev fontconfig-dev
 	libxcomposite-dev freetype-dev libx11-dev mesa-dev curl-dev
 	pulseaudio-dev jack-dev vlc-dev alsa-lib-dev fdk-aac-dev speexdsp-dev
 	v4l-utils-dev jansson-dev eudev-dev swig mbedtls-dev python3-dev"


### PR DESCRIPTION
http://build.alpinelinux.org/buildlogs/build-edge-x86/testing/obs-studio/obs-studio-22.0.2-r0.log