### PR TITLE
main/nodejs: upgrade to 10.13.0

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -27,7 +27,7 @@
 pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
-pkgver=8.12.0
+pkgver=10.13.0
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="https://nodejs.org/"
@@ -36,7 +36,7 @@ license="MIT"
 depends="ca-certificates"
 depends_dev="libuv"
 # gold is needed for mksnapshot
-makedepends="$depends_dev python2 openssl1.0-dev zlib-dev libuv-dev linux-headers
+makedepends="$depends_dev python2 openssl-dev zlib-dev libuv-dev linux-headers
 	paxmark binutils-gold http-parser-dev ca-certificates c-ares-dev"
 subpackages="$pkgname-dev $pkgname-doc npm::noarch"
 provides="nodejs-lts=$pkgver"  # for backward compatibility
@@ -113,5 +113,5 @@ npm() {
 	mv "$pkgdir"/usr/lib/node_modules/npm "$subpkgdir"/usr/lib/node_modules/
 }
 
-sha512sums="69cfaf56204c9605254382ae613d36b32eb5966dfd5b0db2aee11a50f3119b38221f425df7c273efb43e453cda77d6c4681bad6f3e5c34a2a2710c5af81e937a  node-v8.12.0.tar.gz
-ba95f21b1e80717ef63941854e7ed412f64a91da068c0dbf0d6d9697333ee266c9f4cd7bf1a01111eeb28aa66adefd8a58cfb3e82debb84b43e35e9dc914dd36  dont-run-gyp-files-for-bundled-deps.patch"
+sha512sums="ec30c966467a9fb348b060deeb918d1605d79eb35ca09197d8bccb37f98645d4d75f0dcf97a6e328376d56b132359d3691403ed8b3301269a6258da28adb8cc0  node-v10.13.0.tar.gz
+9d09a88074bf0093f35c5b610e73ebf4c5381df2a2b29feb69da1af0b18776a683b13f1276375bbcfc60936cc27769539e1f01b4ba94b22cad2d5f4daae14c46  dont-run-gyp-files-for-bundled-deps.patch"

--- a/main/nodejs/dont-run-gyp-files-for-bundled-deps.patch
+++ b/main/nodejs/dont-run-gyp-files-for-bundled-deps.patch
@@ -9,13 +9,13 @@ Node.js 7.2.0
 
 --- a/Makefile
 +++ b/Makefile
-@@ -72,8 +72,7 @@
- 	$(MAKE) -C out BUILDTYPE=Debug V=$(V)
- 	ln -fs out/Debug/$(NODE_EXE) $@
+@@ -123,8 +123,7 @@
+ test-code-cache: with-code-cache
+ 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) code-cache
  
 -out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp \
 -              deps/zlib/zlib.gyp deps/v8/gypfiles/toolchain.gypi \
 +out/Makefile: common.gypi deps/v8/gypfiles/toolchain.gypi \
-               deps/v8/gypfiles/features.gypi deps/v8/src/v8.gyp node.gyp \
+               deps/v8/gypfiles/features.gypi deps/v8/gypfiles/v8.gyp node.gyp \
                config.gypi
  	$(PYTHON) tools/gyp_node.py -f make


### PR DESCRIPTION
Ref https://nodejs.org/en/blog/release/v10.13.0/

Depends on openssl 1.1 & https://github.com/alpinelinux/aports/pull/5561