### PR TITLE
main/py-flake8: upgrade to 3.6.0 and add check()

### DIFF
--- a/main/py-flake8/APKBUILD
+++ b/main/py-flake8/APKBUILD
@@ -2,16 +2,16 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=py-flake8
 _pkgname=${pkgname#py-}
-pkgver=3.4.1
-pkgrel=2
+pkgver=3.6.0
+pkgrel=0
 pkgdesc="A modular source code checker"
 url="https://gitlab.com/pycqa/flake8"
 arch="noarch"
 license="MIT"
 depends="py-mccabe py-pep8 py-pyflakes"
 makedepends="python2-dev python3-dev py-setuptools"
+checkdepends="pytest py-pbr py-atomicwrites py-attrs py-pluggy py-six py-mock"
 subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
-options="!check"  # no testsuite
 source="https://pypi.io/packages/source/f/$_pkgname/$_pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgname-$pkgver"
 
@@ -19,6 +19,12 @@ build() {
 	cd "$builddir"
 	python2 setup.py build
 	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py test
+	python3 setup.py test
 }
 
 package() {
@@ -56,4 +62,4 @@ _py() {
 	done
 }
 
-sha512sums="42df8fa0cf6f4bb4f3e52143028dee14d51a645aef19a0bab05000fef577e5bea3cc29f961acb0c98d92b76e635fdd2f0d689e23663a6c14d435d0410be94c87  flake8-3.4.1.tar.gz"
+sha512sums="f4377bc7806074a88f88b3652c3061583e576ee515b2b741cee9c6dc18f84f34a7807c93fda9dca3d8b006e379dcee60bb3ae20e6a2e62fd216a82a2b36f2eb5  flake8-3.6.0.tar.gz"


### PR DESCRIPTION
Ref http://flake8.pycqa.org/en/latest/release-notes/3.6.0.html

The `check()` still downloads missing dependencies because they are in testing

PS: follow-up to https://github.com/alpinelinux/aports/pull/3468