### PR TITLE
testing/keepassxc: set release mode

### DIFF
--- a/testing/keepassxc/APKBUILD
+++ b/testing/keepassxc/APKBUILD
@@ -5,8 +5,8 @@
 # Maintainer: Orson Teodoro <orsonteodoro@hotmail.com>
 
 pkgname=keepassxc
-pkgver=2.3.1
-pkgrel=1
+pkgver=2.3.4
+pkgrel=0
 pkgdesc="Community-driven port of the Windows application Keepass Password Safe"
 url="https://keepassxc.org/"
 arch="all"
@@ -14,7 +14,7 @@ license="GPL-3.0 BSD-3-Clause CC0-1.0 LGPL-2.0-only LGPL-2.1-only \
 	LGPL-3.0-or-later Nokia-Qt-exception-1.1 MIT BSL-1.0"
 depends="icu-libs"
 makedepends="cmake qt5-qtbase-dev qt5-qttools-dev libxtst-dev \
-	qt5-x11extras-dev libgcrypt-dev libgpg-error-dev argon2-dev zlib-dev"
+	qt5-qtx11extras-dev libgcrypt-dev libgpg-error-dev argon2-dev zlib-dev"
 source="$pkgname-$pkgver.tar.gz::https://github.com/keepassxreboot/$pkgname/archive/$pkgver.tar.gz"
 builddir="$srcdir"/$pkgname-$pkgver
 subpackages="$pkgname-doc"
@@ -44,4 +44,4 @@ check() {
 	make test
 }
 
-sha512sums="42f21366bacfac856a7d339c1e2dc6a52e1c5a6b06c5fd5215f69cf26e5d07a956ebf651101e336fe93d13afc136b9bc89b5c97c24e86862bfa351aa30f6b1d1  keepassxc-2.3.1.tar.gz"
+sha512sums="630d4d1f77c44c27f3d27a1908c80a94265af9aae8774d80726f86f635eee6a10d8a426b0157ad03efe9f5111d7d67f5c785962ec3715c8374b9f38788fab863  keepassxc-2.3.4.tar.gz"

--- a/testing/keepassxc/APKBUILD
+++ b/testing/keepassxc/APKBUILD
@@ -6,7 +6,7 @@
 
 pkgname=keepassxc
 pkgver=2.3.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Community-driven port of the Windows application Keepass Password Safe"
 url="https://keepassxc.org/"
 arch="all"
@@ -23,7 +23,8 @@ build() {
 	cd "$builddir"
 	cmake -DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=/usr/lib \
-		-DCMAKE_BUILD_TYPE=Release .
+		-DCMAKE_BUILD_TYPE=Release \
+		-DKEEPASSXC_BUILD_TYPE=Release .
 	make
 }
 package() {


### PR DESCRIPTION
unless `KEEPASSXC_BUILD_TYPE` is "Release", the following warning is displayed at startup:

>WARNING: You are using an unstable build of KeePassXC!
>There is a high risk of corruption, maintain a backup of your databases.
>This version is not meant for production use.

This PR also upgrades KeePassXC from 2.3.1 to 2.3.4