### PR TITLE
main/icecast: security upgrade to 2.4.4 (CVE-2018-18820)

### DIFF
--- a/main/icecast/APKBUILD
+++ b/main/icecast/APKBUILD
@@ -1,8 +1,13 @@
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
 # Maintainer:  Francesco Colista <fcolista@alpinelinux.org>
+#
+# secfixes:
+#   2.4.4-r0:
+#     - CVE-2018-18820
+
 pkgname=icecast
-pkgver=2.4.3
-pkgrel=6
+pkgver=2.4.4
+pkgrel=0
 pkgdesc="Open source media server"
 url="http://www.icecast.org"
 arch="all"
@@ -43,7 +48,7 @@ package() {
 	install -d -D -o icecast -g icecast "$pkgdir"/var/log/icecast
 }
 
-sha512sums="70e755ee935e738f2b7310333823992517747897692d101b67d73d5cd40d6385a20c25d089a0430806c116021e6e2055761efee9fec27cd9bccb2b58a2bfd446  icecast-2.4.3.tar.gz
+sha512sums="e9ffb478cac2570891787455591d881a59185e067bb36f51706a7070cd9d82d80425ec8cf151f5ebb17d1b75654449fc760f8b82a1bb05f020b47ec09e46b4d0  icecast-2.4.4.tar.gz
 3de3ed881a60f99d3e4cf656a46cdb157e95abcfa9bd44ebc7e13840a9b0ee84ec9e5b30878d67e42385dac5fa974694c215ad162b910c47b6b7864d474bf636  conf-change-owner.patch
 c78f7e6aa9ff04f7400944e95485994a23493e79d47e0b9799b9235fa5f3ed9d64840be1380a262c30594f9fa2dac96d904226608bfc133d51b3a62ed90d990d  icecast.initd
 7e4299b34207bd4323bc89f2d98abebcb62cbeee3b0931d6d18e1c2c736a17e823b07dfb38364f22a375585843a917031beb1b9efe2fff71de036146371536f3  icecast.confd"


### PR DESCRIPTION
Ref http://icecast.org/news/icecast-release_2_4_4/