### PR TITLE
main/python3: Update to 3.6.7

### DIFF
--- a/main/python3/APKBUILD
+++ b/main/python3/APKBUILD
@@ -3,9 +3,9 @@
 
 pkgname=python3
 # the python2-tkinter's pkgver needs to be synchronized with this.
-pkgver=3.6.6
+pkgver=3.6.7
 _basever="${pkgver%.*}"
-pkgrel=2
+pkgrel=0
 pkgdesc="A high-level scripting language"
 url="http://www.python.org"
 arch="all"
@@ -146,6 +146,6 @@ wininst() {
 		"$subpkgdir"/usr/lib/python$_basever/distutils/command
 }
 
-sha512sums="c71f87c5906e770322a14cacad228655659f782207db826320449d12bf86091c3662f317e1773158dec52f8b052eaedfb4c03b561cc2a6cfcd381597fd2d2b04  Python-3.6.6.tar.xz
+sha512sums="7be753046db8d12fc00f90d9c1b2edcc5ae80ac39e9d0d8d07553081a26f59a60c0d0cf6986006f0729f425d5751273110db3aa2d413d9405fafa9bd6c052fdf  Python-3.6.7.tar.xz
 37b6ee5d0d5de43799316aa111423ba5a666c17dc7f81b04c330f59c1d1565540eac4c585abe2199bbed52ebe7426001edb1c53bd0a17486a2a8e052d0f494ad  fix-xattrs-glibc.patch
 ab8eaa2858d5109049b1f9f553198d40e0ef8d78211ad6455f7b491af525bffb16738fed60fc84e960c4889568d25753b9e4a1494834fea48291b33f07000ec2  musl-find_library.patch"


### PR DESCRIPTION
This PR updates python to the latest 3.6 release.

Nothing special about this update, no further patches required.
Release Notes: https://www.python.org/downloads/release/python-367/