### PR TITLE
main/nginx: security upgrade to 1.14.1

### DIFF
--- a/main/nginx/APKBUILD
+++ b/main/nginx/APKBUILD
@@ -6,12 +6,16 @@
 # secfixes:
 #   1.12.1-r0:
 #     - CVE-2017-7529
+#   1.14.1-r0:
+#     - CVE-2018-16843
+#     - CVE-2018-16844
+#     - CVE-2018-16845
 #
 pkgname=nginx
 # NOTE: Upgrade only to even-numbered versions (e.g. 1.14.z, 1.16.z)!
 # Odd-numbered versions are mainline (development) versions.
-pkgver=1.14.0
-pkgrel=1
+pkgver=1.14.1
+pkgrel=0
 # Revision of nginx-tests to use for check().
 _tests_hgrev=d6daf03478ad
 _njs_ver=0.2.0
@@ -279,7 +283,7 @@ _module() {
 	echo "load_module \"modules/$soname\";" > ./etc/nginx/modules/$name.conf
 }
 
-sha512sums="40f086c9f741727e6f55802b6c3a66f081f7c49c38646dc1491aa3e3c35bae12b65ea6594386609fc849bcd99a60d7cd8ecb3f8d519e0e9ab8db01d653e930e9  nginx-1.14.0.tar.gz
+sha512sums="906c9f44462c0a6b3d9d968641038511012de2662d8490bdb863e540988c2fb15f5cf8a8172e65267dab525e5edf2e9945d7da42a0aa2de5ac81de33fadcd9f3  nginx-1.14.1.tar.gz
 775f8fcc55e0e670f7b509974cc9e9cfb56e4bd2a88d1c7716c96b63ad87c14fd6d07f293545639972e798fb20f81414ef6483451d00ae5a4eaa262ccf2cbc98  nginx-tests-d6daf03478ad.tar.gz
 be07e635f5e0e50a28366b28180344568b5cca9d67c79bc80d0c6758d8d4097ff9428393fb6951ed239c6e9c9e3f84b46f9c92a6e2c313f1f35e677b3662512f  nginx-njs-0.2.0.tar.gz
 cd6983c164383100e0239be85dfeddc7879ab9c29589aecdd9bb4b6772d1f0a5d4cd70bf728d0fb5181765cbed77b7e4c99fd85c0ec59c55826c52e923510017  njs~fix-test-exit-code.patch


### PR DESCRIPTION
Ref http://mailman.nginx.org/pipermail/nginx-announce/2018/000219.html
- CVE-2018-16843
- CVE-2018-16844
- CVE-2018-16845

PS needs backport to 3.8 and dig http://mailman.nginx.org/pipermail/nginx-announce/2018/000221.html
Older releases http://mailman.nginx.org/pipermail/nginx-announce/2018/000220.html