### PR TITLE
main/bitlbee: add check()

### DIFF
--- a/main/bitlbee/APKBUILD
+++ b/main/bitlbee/APKBUILD
@@ -8,6 +8,7 @@ url="https://www.bitlbee.org/"
 arch="all"
 license="GPL-2.0"
 makedepends="python3 glib-dev openssl-dev libotr-dev"
+checkdepends="check-dev"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-otr $pkgname-openrc"
 source="http://get.bitlbee.org/src/$pkgname-$pkgver.tar.gz
 	openssl-1.1.patch
@@ -28,6 +29,11 @@ build() {
 		--prefix=/usr \
 		--etcdir=/etc/bitlbee
 	make
+}
+
+check() {
+	cd "$builddir"
+	make check
 }
 
 package() {


### PR DESCRIPTION
naming python properly fixes build but check fails locally