### PR TITLE
testing/firefox: upgrade to 66.0.4

### DIFF
--- a/testing/firefox/APKBUILD
+++ b/testing/firefox/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor:
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox
-pkgver=65.0
+pkgver=66.0.4
 _pkgver=$pkgver
 _xulver=$pkgver
 pkgrel=4
@@ -18,6 +18,7 @@ makedepends="
 	bsd-compat-headers
 	bzip2-dev
 	cargo
+	cbindgen
 	clang-dev
 	dbus-glib-dev
 	ffmpeg-dev
@@ -38,6 +39,7 @@ makedepends="
 	libxcomposite-dev
 	llvm5-dev
 	mesa-dev
+	nasm
 	nodejs
 	nspr-dev
 	nss-dev>=3.26
@@ -80,8 +82,6 @@ ldpath="$_mozappdir"
 
 prepare() {
 	default_prepare
-
-	cargo install cbindgen
 
 	cp "$srcdir"/stab.h toolkit/crashreporter/google-breakpad/src/
 	# https://bugzilla.mozilla.org/show_bug.cgi?id=1341234
@@ -130,7 +130,6 @@ build() {
 		\
 		--with-system-bz2 \
 		--with-system-icu \
-		--with-system-jpeg \
 		--with-system-libevent \
 		--with-system-nspr \
 		--with-system-nss \
@@ -216,18 +215,18 @@ __EOF__
 	rm -f "$pkgdir"/${_mozappdirdev}/sdk/lib/libxul.so
 }
 
-sha512sums="10ab04612c55f020fd4fe9ba7184f77e27bb62e7204ebd4e2e8e4af9fbb97b5594dd057b3c9c1fd960a48cedfd09c11939210dba873cc66ee651dc83dc9cbed2  firefox-65.0.source.tar.xz
+sha512sums="5c1ff2b98ff387af8fd66fc4e76e08bb246e5f6c81a264050ae4c2b7ff0df0afd537a90e30dbb1f78841dc57cfd031b7bead986c0acd5862713854b53f77f12b  firefox-66.0.4.source.tar.xz
 0b3f1e4b9fdc868e4738b5c81fd6c6128ce8885b260affcb9a65ff9d164d7232626ce1291aaea70132b3e3124f5e13fef4d39326b8e7173e362a823722a85127  stab.h
 2f4f15974d52de4bb273b62a332d13620945d284bbc6fe6bd0a1f58ff7388443bc1d3bf9c82cc31a8527aad92b0cd3a1bc41d0af5e1800e0dcbd7033e58ffd71  fix-fortify-system-wrappers.patch
 09bc32cf9ee81b9cc6bb58ddbc66e6cc5c344badff8de3435cde5848e5a451e0172153231db85c2385ff05b5d9c20760cb18e4138dfc99060a9e960de2befbd5  fix-fortify-inline.patch
 183a4ef62cd79728117797235fe46ecd3e4336c008d615c2b2a64c707477e403aed1ee5e19feb86611b93ebecc00df339aa28a73735e045e38f0d1ce3080341b  fix-seccomp-bpf.patch
-7f8be807c525b7e176bb65631efe8eb8e0cc829c459949761138c4568e9d7a96311e336f167c6a22fde71ce4ac1a111e2a339bb90bce1306f449f82b111df798  fix-toolkit.patch
+ded76edfbc43637cd2e73100ea2244f97d95d452af61b9cd4f2db341cb0dbae8a5e846edeb4eafbe47dc1d30724869407d188e42b06518c67c4701745ea9adfa  fix-toolkit.patch
 48683964624bb58b5a2a2a5c89da56e3b8dcd04f8d42c6910bea5365010a77d6d82bdd48259774ca54341edc05b6768eaa6aa1b453718c02f760361197e78b52  fix-tools.patch
-bdcd1b402d2ec94957ba5d08cbad7b1a7f59c251c311be9095208491a05abb05a956c79f27908e1f26b54a3679387b2f33a51e945b650671ad85c0a2d59a5a29  mallinfo.patch
+4ea267fbe395ed8865f3ec18dd129d1c78cdbf23983a9c6c9e70b0536cdf2de8953e36444a10dfbdbd522a638fd90a6a51b2f7d5396ef6c98084ddd1ea34d0ff  mallinfo.patch
 3671bf7623c1825c977668efec62b57873bc6052becfd8a68ddcbc2d0ba96e0c3966c61b24716e6c48167d44280d3e690a4ff986907ceba5811a653e87770fff  mozilla-build-arm.patch
-9a7026283057d899b5d00afb815f768eb48db2f0853fcf8d8aa6a9c6bf18b9bfccfa608ffe038b83cc6aa3119b36cd7461ccfb362fa616a3946f559d507428e8  disable-moz-stackwalk.patch
+019ab248a050bef305637dc4229596c06d9596879bbb1db985b96c5a680211996d714d4a1f6e9a66544cc4562a80364b1ee37ecf7964eb974ffef2566c5c2986  disable-moz-stackwalk.patch
 42cc44fda4b05259b38f055d6f51461746aa89a474cedc5e92fb9d20879da0d12b1b515b273a549e7302cda9c7eddde20d5fdba09853e5c658784ad6d0b20078  fix-rust-target.patch
-a50b412edf9573a0bd04a43578b1c927967a616b73a5995eefb15bfa78fd2bd14e36ec05315a0703f6370ecd524e6bcb012e7285beb1245e9add9b8553acb79e  fix-bug-1261392.patch
+8b776f0da8dfad0ae81670623fa55ddcff91b78a1a569bb5e6b5f5130392249dfbebe84752c846c8aa5b4878643f0369cd7d9bfaf2b9dd0c841af302dcb48896  fix-bug-1261392.patch
 40768d2458adb87fc15ad17b430cf0bebabde583910e55624bf282d4a69b3f9b9165289a7a9c2b50bfb9de1a16e2546f8d0b5ce33c1920000cffb588410b9e9e  fix-webrtc-glibcisms.patch
 f3b7c3e804ce04731012a46cb9e9a6b0769e3772aef9c0a4a8c7520b030fdf6cd703d5e9ff49275f14b7d738fe82a0a4fde3bc3219dff7225d5db0e274987454  firefox.desktop
 5dcb6288d0444a8a471d669bbaf61cdb1433663eff38b72ee5e980843f5fc07d0d60c91627a2c1159215d0ad77ae3f115dcc5fdfe87e64ca704b641aceaa44ed  firefox-safe.desktop"

--- a/testing/firefox/disable-moz-stackwalk.patch
+++ b/testing/firefox/disable-moz-stackwalk.patch
@@ -1,18 +1,18 @@
 diff --git a/mozglue/misc/StackWalk.cpp b/mozglue/misc/StackWalk.cpp
-index a208bad..14e1f0d 100644
+index 7d62921..adcfa44 100644
 --- a/mozglue/misc/StackWalk.cpp
 +++ b/mozglue/misc/StackWalk.cpp
 @@ -32,13 +32,7 @@ using namespace mozilla;
- #define MOZ_STACKWALK_SUPPORTS_MACOSX 0
+ #  define MOZ_STACKWALK_SUPPORTS_MACOSX 0
  #endif
-
+ 
 -#if (defined(linux) &&                                            \
 -     ((defined(__GNUC__) && (defined(__i386) || defined(PPC))) || \
 -      defined(HAVE__UNWIND_BACKTRACE)))
--#define MOZ_STACKWALK_SUPPORTS_LINUX 1
+-#  define MOZ_STACKWALK_SUPPORTS_LINUX 1
 -#else
- #define MOZ_STACKWALK_SUPPORTS_LINUX 0
+ #  define MOZ_STACKWALK_SUPPORTS_LINUX 0
 -#endif
-
+ 
  #if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 1)
- #define HAVE___LIBC_STACK_END 1
+ #  define HAVE___LIBC_STACK_END 1

--- a/testing/firefox/fix-bug-1261392.patch
+++ b/testing/firefox/fix-bug-1261392.patch
@@ -1,8 +1,10 @@
---- a/tools/profiler/core/platform.h	2017-05-27 11:44:06.733119794 +0000
-+++ b/tools/profiler/core/platform.h	2017-05-27 11:46:16.004253520 +0000
-@@ -54,10 +54,11 @@
+diff --git a/tools/profiler/core/platform.h b/tools/profiler/core/platform.h
+index 5f0fb69..086a511 100644
+--- a/tools/profiler/core/platform.h
++++ b/tools/profiler/core/platform.h
+@@ -42,10 +42,11 @@
+ #include "PlatformMacros.h"
  #include <vector>
- #include "StackTop.h"
  
 -// We need a definition of gettid(), but glibc doesn't provide a
 -// wrapper for it.
@@ -10,16 +12,16 @@
 +// We need a definition of gettid(), but Linux libc implementations don't
 +// provide a wrapper for it (except for Bionic)
 +#if defined(__linux__)
- #include <unistd.h>
+ #  include <unistd.h>
 +#if !defined(__BIONIC__)
- #include <sys/syscall.h>
- static inline pid_t gettid()
- {
-@@ -71,6 +72,7 @@
-   return (pid_t) syscall(SYS_thread_selfid);
- }
+ #  include <sys/syscall.h>
+ static inline pid_t gettid() { return (pid_t)syscall(SYS_gettid); }
+ #elif defined(GP_OS_darwin)
+@@ -61,6 +62,7 @@ static inline pid_t gettid() { return (pid_t)syscall(SYS_thread_selfid); }
+ #    define getpid _getpid
+ #  endif
  #endif
 +#endif
  
- #ifdef XP_WIN
- #include <windows.h>
+ extern mozilla::LazyLogModule gProfilerLog;
+ 

--- a/testing/firefox/fix-toolkit.patch
+++ b/testing/firefox/fix-toolkit.patch
@@ -56,18 +56,18 @@ index 93fdad7..f34e5e0 100644
  #elif defined(__mips__)
  #if _MIPS_SIM == _MIPS_SIM_ABI32
 diff --git a/toolkit/mozapps/update/common/updatedefines.h b/toolkit/mozapps/update/common/updatedefines.h
-index 026e7ed..0801f14 100644
+index 79276f7..4c67976 100644
 --- a/toolkit/mozapps/update/common/updatedefines.h
 +++ b/toolkit/mozapps/update/common/updatedefines.h
 @@ -102,7 +102,7 @@ static inline int mywcsprintf(WCHAR* dest, size_t count, const WCHAR* fmt,
 
- #ifdef SOLARIS
- #include <sys/stat.h>
--#else
-+#elif !defined(__linux__) || defined(__GLIBC__)
- #include <fts.h>
- #endif
- #include <dirent.h>
+ #  ifdef SOLARIS
+ #    include <sys/stat.h>
+-#  else
++#  elif !defined(__linux__) || defined(__GLIBC__)
+ #    include <fts.h>
+ #  endif
+ #  include <dirent.h>
 diff --git a/toolkit/mozapps/update/updater/updater.cpp b/toolkit/mozapps/update/updater/updater.cpp
 index 257ccb4..01314e4 100644
 --- a/toolkit/mozapps/update/updater/updater.cpp

--- a/testing/firefox/mallinfo.patch
+++ b/testing/firefox/mallinfo.patch
@@ -1,20 +1,20 @@
 diff --git a/xpcom/base/nsMemoryReporterManager.cpp b/xpcom/base/nsMemoryReporterManager.cpp
-index 89ee563..eab8cd7 100644
+index 865e1b5430..9a00dafecb 100644
 --- a/xpcom/base/nsMemoryReporterManager.cpp
 +++ b/xpcom/base/nsMemoryReporterManager.cpp
-@@ -153,6 +153,7 @@ ResidentUniqueDistinguishedAmount(int64_t* aN)
+@@ -123,6 +123,7 @@ static MOZ_MUST_USE nsresult ResidentUniqueDistinguishedAmount(int64_t* aN) {
    return GetProcSelfSmapsPrivate(aN);
  }
- 
+
 +#ifdef __GLIBC__
- #define HAVE_SYSTEM_HEAP_REPORTER 1
- nsresult
- SystemHeapSize(int64_t* aSizeOut)
-@@ -172,6 +173,7 @@ SystemHeapSize(int64_t* aSizeOut)
-     *aSizeOut = size_t(info.hblkhd) + size_t(info.uordblks);
-     return NS_OK;
+ #  ifdef HAVE_MALLINFO
+ #    define HAVE_SYSTEM_HEAP_REPORTER 1
+ static MOZ_MUST_USE nsresult SystemHeapSize(int64_t* aSizeOut) {
+@@ -142,6 +143,7 @@ static MOZ_MUST_USE nsresult SystemHeapSize(int64_t* aSizeOut) {
+   return NS_OK;
  }
+ #  endif
 +#endif
- 
- #elif defined(__DragonFly__) || defined(__FreeBSD__) \
-     || defined(__NetBSD__) || defined(__OpenBSD__) \
+
+ #elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || \
+     defined(__OpenBSD__) || defined(__FreeBSD_kernel__)


### PR DESCRIPTION
Some noteworthy changes:

- For Firefox 64+ nodejs is needed for building the package (see https://lists.mozilla.org/pipermail/dev-platform/2018-August/022511.html)
- ~The current cbindgen has to be installed manually via cargo (see e.g. https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Simple_Firefox_build/Linux_and_MacOS_build_preparation#Requirements_for_Debian_Ubuntu_users)~ - no longer thanks to #7483 