### PR TITLE
community/drupal7: upgrade to 7.61 and update dependencies to php7

### DIFF
--- a/community/drupal7/APKBUILD
+++ b/community/drupal7/APKBUILD
@@ -1,15 +1,32 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
-_php=php5
 pkgname=drupal7
-pkgver=7.60
+pkgver=7.61
 pkgrel=0
 pkgdesc="An open source content management platform"
 url="https://www.drupal.org/"
 arch="noarch"
 license="GPL"
-depends="${_php}-fpm ${_php}-xml ${_php}-json ${_php}-gd ${_php}-ftp ${_php}-posix ${_php}-curl ${_php}-zlib
-	${_php}-dom ${_php}-ctype ${_php}-sockets"
+depends="php7-fpm
+	php7-bcmath
+	php7-ctype
+	php7-curl
+	php7-dom
+	php7-gd
+	php7-gmp
+	php7-iconv
+	php7-json
+	php7-mbstring
+	php7-opcache
+	php7-openssl
+	php7-pcntl
+	php7-pdo_mysql
+	php7-pdo_sqlite
+	php7-session
+	php7-simplexml
+	php7-tokenizer
+	php7-xml
+	"
 makedepends="$depends_dev"
 subpackages="$pkgname-doc"
 pkggroups="www-data"
@@ -59,4 +76,4 @@ package() {
 		"$pkgdir"/var/lib/$pkgname/sites/default/files
 }
 
-sha512sums="fee59cf303a6c44e3fa3cbeda4912f7d61ffe8294282f9ad0416a6536cc6ea65cf114a6a801dd1f68572185c2b1e300f58f907f9bd61f96beaba3706c527d512  drupal-7.60.tar.gz"
+sha512sums="8f0bdd5b7ef33e62d09698b3889726fab1edb14df6263635bca65c9bbe0400df618dbf02ef298eeee169d48ab554d3b58d867bd4ce0d429b4b9167979917db51  drupal-7.61.tar.gz"


### PR DESCRIPTION
Part of #5569 and finally all dependencies fixed

Ref https://www.drupal.org/project/drupal/releases/7.61