### PR TITLE
main/postgresql: security upgrade to 11.1 - CVE-2018-16850

### DIFF
--- a/main/postgresql/APKBUILD
+++ b/main/postgresql/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: G.J.R. Timmer <gjr.timmer@gmail.com>
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=postgresql
-pkgver=11.0
-pkgrel=1
+pkgver=11.1
+pkgrel=0
 pkgdesc="A sophisticated object-relational DBMS"
 url="https://www.postgresql.org/"
 arch="all"
@@ -36,6 +36,8 @@ builddir="$srcdir/$pkgname-$pkgver"
 options="!checkroot"
 
 # secfixes:
+#   11.1-r0:
+#   - CVE-2018-16850
 #   10.5-r0:
 #   - CVE-2018-10915
 #   - CVE-2018-10925
@@ -297,11 +299,11 @@ _submv() {
 	done
 }
 
-sha512sums="2cf471618dfaabdcbcbd68be3b85b6083376c97fdadce36d2ceb28438b7c736816118eacb1d4f12d48c39f584d78d7ffa89fa6d65858d440045a53921429970a  postgresql-11.0.tar.bz2
+sha512sums="35d00984e9f5f063a5b96e97aa1b40381ab76d07b2336bda5981fd80bef1324f56eefca5069ae78770ecd6ece5df85264e599fdb3478ecb71d4fdd0d7b6becca  postgresql-11.1.tar.bz2
 1f8e7dc58f5b0a12427cf2fd904ffa898a34f23f3332c8382b94e0d991c007289e7913a69e04498f3d93fc5701855796c207b4b1cc4a0b366f586050124d7fcc  initdb.patch
 5f9d8bb4957194069d01af8ab3abc6d4d83a7e7f8bd7ebe1caae5361d621a3e58f91b14b952958138a794e0a80bc154fbb7e3e78d211e2a95b9b7901335de854  perl-rpath.patch
 8439a6fdfdea0a4867daeb8bc23d6c825f30c00d91d4c39f48653f5ee77341f23282ce03a77aad94b5369700f11d2cb28d5aee360e59138352a9ab331a9f9d0f  conf-unix_socket_directories.patch
-81832b4e6b6024fb149580709a7ef48e2f875513e4163fdc644502e496e1fe00e1d073993b2294a745be05bad692025aeb7866cf43bb4051ea06793383b807f3  disable-broken-tests.patch
+274e0a5a6e7d179f5327ae2da0274f13d9198d9acbe45f90e2bdadf454f1e32aceac6a1d4ef2b1744c4468994e93b14a38abea877b419b3fd28b8a3273b5d574  disable-broken-tests.patch
 224e80f9e62843fd248e625abdd0d9fe477729ff3f9a64fc5c86dd37bb7176d3504107fbed7ce578e3a1db7f60b8cf2abf5fe4862c81f76b6d026e29ca495cfc  postgresql.initd
 a6d9cba5c7270484b3a22083b2b37742faefb01b6643040050c92235840c601b2e206ebda32804937b729c6cf42c79a558b921900e52fc420df2a03b5f29e1f7  postgresql.confd
 f5a1cba051e7d846c2d16703514601cb25729ed96b677c9bd0c199d64552120a8b14b238af01917fdb87106681e12dee6fff7447558155ba273e4f96be5e2892  pg-restore.initd

--- a/main/postgresql/disable-broken-tests.patch
+++ b/main/postgresql/disable-broken-tests.patch
@@ -70,8 +70,8 @@ have no idea. :(
  # ----------
  # Another group of parallel tests
  # ----------
--test: brin gin gist spgist privileges init_privs security_label collate matview lock replica_identity rowsecurity object_address tablesample groupingsets drop_operator password func_index
-+test: brin gin gist spgist privileges init_privs security_label collate matview lock replica_identity rowsecurity tablesample groupingsets drop_operator password func_index
+-test: brin gin gist spgist privileges init_privs security_label collate matview lock replica_identity rowsecurity object_address tablesample groupingsets drop_operator password
++test: brin gin gist spgist privileges init_privs security_label collate matview lock replica_identity rowsecurity tablesample groupingsets drop_operator password
  
  # ----------
  # Another group of parallel tests


### PR DESCRIPTION
Ref https://www.postgresql.org/about/news/1905/

PS: older branches needs work