### PR TITLE
qt5-qtwebengine: rebuild after libavformat.so bump [skip ci]

### DIFF
--- a/community/qt5-qtwebengine/APKBUILD
+++ b/community/qt5-qtwebengine/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=qt5-qtwebengine
 pkgver=5.10.1
-pkgrel=5
+pkgrel=6
 pkgdesc="Qt5 - QtWebEngine components"
 url="http://qt-project.org/"
 # ppc64le, s390x: not supported


### PR DESCRIPTION
Currently, qt5-qtwebengine can't be installed because it depends on so:libavformat.so.57.