### PR TITLE
non-free/b43-firmware: fix

### DIFF
--- a/non-free/b43-firmware/APKBUILD
+++ b/non-free/b43-firmware/APKBUILD
@@ -12,11 +12,20 @@ install=
 subpackages=
 arch="noarch"
 source="https://mirror2.openwrt.org/sources/broadcom-wl-$pkgver.tar.bz2"
+builddir="$srcdir/broadcom-wl-$pkgver"
 
 build() {
-	install -d "$pkgdir"/lib/firmware
-	b43-fwcutter -w "$pkgdir"/lib/firmware \
+	cd "$builddir"
+	install -d "$builddir"/lib/firmware
+	b43-fwcutter -w "$builddir"/lib/firmware \
 		"$srcdir"/broadcom-wl-$pkgver/driver/wl_apsta_mimo.o
 }
 
-md5sums="0c6ba9687114c6b598e8019e262d9a60  broadcom-wl-4.150.10.5.tar.bz2"
+package() {
+	cd "$builddir"
+	for i in lib/firmware/b43/*; do
+		install -D "$i" "$pkgdir"/"$i"
+	done
+}
+
+sha512sums="0ada0cd0446fcc7f753945d1a18eb31844ed45a137df679f2acba85f02e2acb1e3e8bde6241ac9ca2bedee1f74a018682de13fe4e185aced603547a6e03f7a3e  broadcom-wl-4.150.10.5.tar.bz2"


### PR DESCRIPTION
OneManHateGroup on irc was trying to compile it, which failed because the package failed the sanity check for a missing pakckage() function.