### PR TITLE
community/graphicsmagick: disable openmp for stability

### DIFF
--- a/community/graphicsmagick/APKBUILD
+++ b/community/graphicsmagick/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=graphicsmagick
 pkgver=1.3.30
-pkgrel=0
+pkgrel=1
 pkgdesc="Image processing system"
 url="http://www.graphicsmagick.org/"
 arch="all"
@@ -56,6 +56,7 @@ build() {
 		--localstatedir=/var \
 		--enable-shared \
 		--disable-static \
+		--disable-openmp \
 		--with-modules \
 		--with-threads \
 		--with-gs-font-dir=/usr/share/fonts/Type1 \


### PR DESCRIPTION
This is a blocker for #5449 

Performance gain is not huge enough and can't compensate stability http://www.graphicsmagick.org/OpenMP.html

Also the same was done for imagemagick in https://github.com/alpinelinux/aports/commit/a23a75a8962b419f92fe63ba60317496bbfbe712

Related issue for imagemagick is https://github.com/alpinelinux/aports/pull/5402