### PR TITLE
gcc: patch libgnarl to not use function missing from musl

### DIFF
--- a/main/gcc/APKBUILD
+++ b/main/gcc/APKBUILD
@@ -6,7 +6,7 @@ pkgver=8.2.0
 [ "$CHOST" != "$CTARGET" ] && _target="-$CTARGET_ARCH" || _target=""
 
 pkgname="$pkgname$_target"
-pkgrel=0
+pkgrel=1
 pkgdesc="The GNU Compiler Collection"
 url="http://gcc.gnu.org"
 arch="all"
@@ -167,6 +167,7 @@ source="https://gcc.gnu.org/pub/gcc/releases/gcc-${_pkgbase:-$pkgver}/gcc-${_pkg
 	fix-cxxflags-passing.patch
 	ada-shared.patch
 	ada-musl.patch
+	libgnarl-musl.patch
 
 	320-libffi-gnulinux.patch
 
@@ -580,5 +581,6 @@ fa62556719449caec6b2b434355bfbcaa5ae55ffe017b3e1f827f66a2aae21b79c571ee7a4ce723e
 35d6d59f0b7b968f282f56767c9e0823a7bdc5aa0d450aca50fbd802649a7ca608b47671244a3faa208a9b0d6832cabb5a22724157dc817b2c0ad63d09f93282  fix-cxxflags-passing.patch
 3f5bc334d9f73d06f5f7c876738d02356acdd08958bea0e4d2095ebf15c2c2ec4e411abdae0297505ae9a1699ca01b17338e853184e84663203b192b0d35fc19  ada-shared.patch
 50537add461714f44dc6a778e0c6d0e15d6a782591c8aff38d1fb559191ddac2b5ee14a43a3005b389fdf98d2e7468ff4e64c88ba024cf94f9fe0d9854b9e9c8  ada-musl.patch
+a1f7750bc7b8b7d916a5dee34fcc736bd4fb249c96538b547d495794e6cfd49356aa3974506a15074b4cb58edd5d7e2868607c902dd003e8c464d5066fd4a575  libgnarl-musl.patch
 f4ef08454e28c8732db69115e4998ec153399e8d229dd27f923dbdcf57b68128a65640d026cc7f45b58ba8764ab1eb575d4eb6d6dfc550a87a183f8b94e76181  320-libffi-gnulinux.patch
 86be3338cc9c33089608bc4c5e3b7918c4e500a345c338f361b18c342119a6ed69af5495d72950de7106d760f003528b46ad14795e805f8a3331e206dcb234e3  gcc-pure64-mips.patch"

--- a/main/gcc/libgnarl-musl.patch
+++ b/main/gcc/libgnarl-musl.patch
@@ -1,0 +1,120 @@
+diff -rup gcc-8.2.0/gcc/ada/libgnarl/s-osinte__linux.ads gcc-8.2.0-new/gcc/ada/libgnarl/s-osinte__linux.ads
+--- gcc-8.2.0/gcc/ada/libgnarl/s-osinte__linux.ads	2018-01-11 00:55:25.000000000 -0800
++++ gcc-8.2.0-new/gcc/ada/libgnarl/s-osinte__linux.ads	2018-11-01 16:16:23.372452951 -0700
+@@ -394,12 +394,6 @@ package System.OS_Interface is
+    PTHREAD_RWLOCK_PREFER_WRITER_NP              : constant := 1;
+    PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP : constant := 2;
+ 
+-   function pthread_rwlockattr_setkind_np
+-     (attr : access pthread_rwlockattr_t;
+-      pref : int) return int;
+-   pragma Import
+-     (C, pthread_rwlockattr_setkind_np, "pthread_rwlockattr_setkind_np");
+-
+    function pthread_rwlock_init
+      (mutex : access pthread_rwlock_t;
+       attr  : access pthread_rwlockattr_t) return int;
+@@ -464,11 +458,6 @@ package System.OS_Interface is
+       protocol : int) return int;
+    pragma Import (C, pthread_mutexattr_setprotocol);
+ 
+-   function pthread_mutexattr_setprioceiling
+-     (attr        : access pthread_mutexattr_t;
+-      prioceiling : int) return int;
+-   pragma Import (C, pthread_mutexattr_setprioceiling);
+-
+    type struct_sched_param is record
+       sched_priority : int;  --  scheduling priority
+    end record;
+diff -rup gcc-8.2.0/gcc/ada/libgnarl/s-taprop__linux.adb gcc-8.2.0-new/gcc/ada/libgnarl/s-taprop__linux.adb
+--- gcc-8.2.0/gcc/ada/libgnarl/s-taprop__linux.adb	2018-01-11 00:55:25.000000000 -0800
++++ gcc-8.2.0-new/gcc/ada/libgnarl/s-taprop__linux.adb	2018-11-13 11:28:36.433964449 -0800
+@@ -202,9 +202,6 @@ package body System.Task_Primitives.Oper
+    pragma Import
+      (C, GNAT_pthread_condattr_setup, "__gnat_pthread_condattr_setup");
+ 
+-   function GNAT_has_cap_sys_nice return C.int;
+-   pragma Import
+-     (C, GNAT_has_cap_sys_nice, "__gnat_has_cap_sys_nice");
+    --  We do not have pragma Linker_Options ("-lcap"); here, because this
+    --  library is not present on many Linux systems. 'libcap' is the Linux
+    --  "capabilities" library, called by __gnat_has_cap_sys_nice.
+@@ -214,38 +211,6 @@ package body System.Task_Primitives.Oper
+    --  Convert Ada priority to Linux priority. Priorities are 1 .. 99 on
+    --  GNU/Linux, so we map 0 .. 98 to 1 .. 99.
+ 
+-   function Get_Ceiling_Support return Boolean;
+-   --  Get the value of the Ceiling_Support constant (see below).
+-   --  Note well: If this function or related code is modified, it should be
+-   --  tested by hand, because automated testing doesn't exercise it.
+-
+-   -------------------------
+-   -- Get_Ceiling_Support --
+-   -------------------------
+-
+-   function Get_Ceiling_Support return Boolean is
+-      Ceiling_Support : Boolean := False;
+-   begin
+-      if Locking_Policy /= 'C' then
+-         return False;
+-      end if;
+-
+-      declare
+-         function geteuid return Integer;
+-         pragma Import (C, geteuid, "geteuid");
+-         Superuser : constant Boolean := geteuid = 0;
+-         Has_Cap : constant C.int := GNAT_has_cap_sys_nice;
+-         pragma Assert (Has_Cap in 0 | 1);
+-      begin
+-         Ceiling_Support := Superuser or else Has_Cap = 1;
+-      end;
+-
+-      return Ceiling_Support;
+-   end Get_Ceiling_Support;
+-
+-   pragma Warnings (Off, "non-static call not allowed in preelaborated unit");
+-   Ceiling_Support : constant Boolean := Get_Ceiling_Support;
+-   pragma Warnings (On, "non-static call not allowed in preelaborated unit");
+    --  True if the locking policy is Ceiling_Locking, and the current process
+    --  has permission to use this policy. The process has permission if it is
+    --  running as 'root', or if the capability was set by the setcap command,
+@@ -348,7 +313,9 @@ package body System.Task_Primitives.Oper
+    -- Init_Mutex --
+    ----------------
+ 
++   pragma Warnings (Off, "formal parameter * is not referenced");
+    function Init_Mutex (L : RTS_Lock_Ptr; Prio : Any_Priority) return C.int is
++   pragma Warnings (On, "formal parameter * is not referenced");
+       Mutex_Attr : aliased pthread_mutexattr_t;
+       Result, Result_2 : C.int;
+ 
+@@ -360,16 +327,7 @@ package body System.Task_Primitives.Oper
+          return Result;
+       end if;
+ 
+-      if Ceiling_Support then
+-         Result := pthread_mutexattr_setprotocol
+-           (Mutex_Attr'Access, PTHREAD_PRIO_PROTECT);
+-         pragma Assert (Result = 0);
+-
+-         Result := pthread_mutexattr_setprioceiling
+-           (Mutex_Attr'Access, Prio_To_Linux_Prio (Prio));
+-         pragma Assert (Result = 0);
+-
+-      elsif Locking_Policy = 'I' then
++      if Locking_Policy = 'I' then
+          Result := pthread_mutexattr_setprotocol
+            (Mutex_Attr'Access, PTHREAD_PRIO_INHERIT);
+          pragma Assert (Result = 0);
+@@ -409,11 +367,6 @@ package body System.Task_Primitives.Oper
+             Result := pthread_rwlockattr_init (RWlock_Attr'Access);
+             pragma Assert (Result = 0);
+ 
+-            Result := pthread_rwlockattr_setkind_np
+-              (RWlock_Attr'Access,
+-               PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+-            pragma Assert (Result = 0);
+-
+             Result := pthread_rwlock_init (L.RW'Access, RWlock_Attr'Access);
+ 
+             pragma Assert (Result in 0 | ENOMEM);


### PR DESCRIPTION
The patch from https://github.com/alpinelinux/aports/pull/5179 ported to gcc 8.2.0, since the issue still exists, plus a fix for another function musl doesn't have.

Without the patch:
```
# ld -lgnarl-8 -lgnat-8
ld: warning: cannot find entry symbol _start; not setting start address
ld: //usr/lib/libgnarl-8.so: undefined reference to `pthread_mutexattr_setprioceiling'
ld: //usr/lib/libgnarl-8.so: undefined reference to `pthread_rwlockattr_setkind_np'
```

With the patch:
```
# ld -lgnarl-8 -lgnat-8
ld: warning: cannot find entry symbol _start; not setting start address
```

Ping @ncopa.