### PR TITLE
Add ZeroMQ support for bitcoin

### DIFF
--- a/community/bitcoin/APKBUILD
+++ b/community/bitcoin/APKBUILD
@@ -3,13 +3,13 @@
 pkgname=bitcoin
 pkgver=0.17.0
 _ver=${pkgver/_/}
-pkgrel=1
+pkgrel=2
 pkgdesc="Decentralized P2P electronic cash system"
 url="https://www.bitcoin.org"
 arch="all !armhf !armv7"
 license="MIT"
 makedepends="autoconf automake libtool boost-dev openssl-dev db-dev miniupnpc-dev
-	qt5-qtbase-dev qt5-qttools-dev protobuf-dev libqrencode-dev libevent-dev chrpath"
+	qt5-qtbase-dev qt5-qttools-dev protobuf-dev libqrencode-dev libevent-dev chrpath zeromq-dev"
 install="$pkgname.post-install $pkgname.post-upgrade $pkgname.pre-install"
 subpackages="$pkgname-dev $pkgname-qt $pkgname-cli $pkgname-tx $pkgname-tests $pkgname-bench
 	$pkgname-doc $pkgname-openrc"


### PR DESCRIPTION
Bitcoind is automatically compiled with ZeroMQ support if the necessary dependencies are installed. By adding zeromq-dev as a compile-time dependency, this is fulfilled and users of `bitcoin` on alpine can use the ZeroMQ capabilities of bitcoin.

For more information see here:
https://github.com/bitcoin/bitcoin/blob/dac2caa371a1c65faf34966c85dbafc30a0c640a/doc/zmq.md#enabling

/cc @itoffshore 

The relevant line of the build log is:
https://travis-ci.org/alpinelinux/aports/builds/454928017#L1293

Here is the same line in the build-log before this change:
https://travis-ci.org/alpinelinux/aports/builds/437537524#L1299