### PR TITLE
main/samba: Upgrade to 4.8.7

### DIFF
--- a/main/samba/APKBUILD
+++ b/main/samba/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=samba
-pkgver=4.8.5
+pkgver=4.8.7
 pkgrel=0
 pkgdesc="Tools to access a server's filespace and printers via SMB"
 url="http://www.samba.org"
@@ -85,6 +85,11 @@ pkggroups="winbind"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   4.8.7-r0:
+#     - CVE-2018-14629
+#     - CVE-2018-16841
+#     - CVE-2018-16851
+#     - CVE-2018-16853
 #   4.8.4-r0:
 #     - CVE-2018-1139
 #     - CVE-2018-1140
@@ -549,7 +554,7 @@ libs() {
 		"$pkgdir"/usr
 }
 
-sha512sums="23a88c48214c3bf4cbc135cb84873bb8d12f32187ccbda47b02495fa4a12458f103de5e968e8f9a5958c116f618332cfffbf54d084e4f1e363fbf079b897e3a0  samba-4.8.5.tar.gz
+sha512sums="6b9de9f47dd0b75a45356a25d3a49ce4723b1af0cd3ec1df3aa36eb41883ac9cf7416cffe93d632dfcd9ff66dc24acc969b24eff71db16234df5f0a16e4527cf  samba-4.8.7.tar.gz
 62d373dbaee75121a1d73f2c09cdca7239705808ff807b171d1d5a28fd4ffc66bdb52494b62786d7aaba8aeece5c08433b532ca96a28d712452fe9daac8d8d2e  domain.patch
 0d4fd9862191554dc9c724cec0b94fd19afbfd0c4ed619e4c620c075e849cb3f3d44db1e5f119d890da23a3dd0068d9873703f3d86c47b91310521f37356208b  getpwent_r.patch
 a99e771f28d787dc22e832b97aa48a1c5e13ddc0c030c501a3c12819ff6e62800ef084b62930abe88c6767d785d5c37e2e9f18a4f9a24f2ee1f5d9650320c556  musl_uintptr.patch


### PR DESCRIPTION
Fix:
CVE-2018-14629
CVE-2018-16841
CVE-2018-16851
CVE-2018-16853

https://www.samba.org/samba/history/samba-4.8.7.html