### PR TITLE
testing/wireguard: upgrade to 0.0.20181115

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -3,7 +3,7 @@
 
 # NOTE: pkgrel must match _toolsrel in wireguard-vanilla
 pkgname=wireguard-tools
-pkgver=0.0.20181018
+pkgver=0.0.20181115
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -43,4 +43,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="ab9f42bdae1b12a95faaf51d5b9e17a8635c67386feefaaa40e0395d78c3258b9afa8a1d2f64010fac4867fa0d229a4ed850fab8a24678d6c8aa2ab6e30ae1b3  WireGuard-0.0.20181018.tar.xz"
+sha512sums="622de8d9274e3689debabf122e4569ae7d747f625ff5161779006b3c583b08b7b3a270aba1abf3d56c4390f809aacbf70bed6964b476f5ac72fb2f51923f3b3d  WireGuard-0.0.20181115.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20181018
-_rel=2
+_ver=0.0.20181115
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="ab9f42bdae1b12a95faaf51d5b9e17a8635c67386feefaaa40e0395d78c3258b9afa8a1d2f64010fac4867fa0d229a4ed850fab8a24678d6c8aa2ab6e30ae1b3  WireGuard-0.0.20181018.tar.xz"
+sha512sums="622de8d9274e3689debabf122e4569ae7d747f625ff5161779006b3c583b08b7b3a270aba1abf3d56c4390f809aacbf70bed6964b476f5ac72fb2f51923f3b3d  WireGuard-0.0.20181115.tar.xz"


### PR DESCRIPTION
```
  * Zinc no longer ships generated assembly code. Rather, we now
    bundle in the original perlasm generator for it. The primary purpose
    of this snapshot is to get testing of this.
  * Clarify the peer removal logic and make lifetimes more precise.
  * Use READ_ONCE for is_valid and is_dead.
  * No need to use atomic when the recounter is mutex protected.
  * Fix up macros and annotations in allowedips.
  * Increment drop counter when staged packets are dropped.
  * Use static constants instead of enums for 64-bit values in selftest.
  * Mark large constants as ULL in poly1305-donna64.
  * Fix sparse warnings in allowedips debugging code.
  * Do not use wg_peer_get_maybe_zero in timer callbacks, since we now can
    carefully control the lifetime of these functions and ensure they never
    execute after dropping the last reference.
  * Cleanup hashing in ratelimiter.
  * Do not guard timer removals, since del_timer is always okay.
  * We now check for PM_AUTOSLEEP, which makes the clear*on-suspend decision a
    bit more general.
  * Set csum_level to ~0, since the poly1305 authenticator certainly means
    that no data was modified in transit.
  * Use CHECKSUM_PARTIAL check for skb_checksum_help instead of
    skb_checksum_setup check.
  * wg.8: specify that wg(8) shows runtime info too
  * wg.8: AllowedIPs isn't actually required
  * keygen-html: add missing glue macro
  * wg-quick: android: do not choke on empty allowed-ips
```