### PR TITLE
Adding /lib64 sysmlink for ppc64le arch in musl

### DIFF
--- a/main/musl/APKBUILD
+++ b/main/musl/APKBUILD
@@ -132,7 +132,10 @@ compat() {
 		ln -s lib "$subpkgdir"/lib64
 		;;
 	mips* | s390*) _ld="ld.so.1" ;;
-	ppc64le) _ld="ld64.so.2" ;;
+	ppc64le) _ld="ld64.so.2"
+		# go binaries use /lib64/ld64.so.2
+		ln -s lib "$subpkgdir"/lib64
+		;;
 	esac
 	ln -sf "/lib/libc.musl-${CARCH}.so.1" "$subpkgdir/lib/$_ld"
 


### PR DESCRIPTION
Go binaries use ```/lib64/ls64.so.2```. This PR creates the symlink to /lib64, so that binaries can be run on ppc64le.

Fixes: https://bugs.alpinelinux.org/issues/9648