### PR TITLE
main/pixman: fix ppc64le build failure by including vmx patch

### DIFF
--- a/main/pixman/APKBUILD
+++ b/main/pixman/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=pixman
 pkgver=0.34.0
-pkgrel=5
+pkgrel=6
 pkgdesc="Low-level pixel manipulation library"
 url="http://xorg.freedesktop.org"
 arch="all"
@@ -11,6 +11,7 @@ makedepends="perl linux-headers"
 source="https://www.x.org/releases/individual/lib/$pkgname-$pkgver.tar.bz2
 	float-header-fix.patch
 	stacksize-reduction.patch
+	fix-ppc64le-vmx.patch
 	"
 
 builddir="$srcdir/$pkgname-$pkgver"
@@ -45,4 +46,5 @@ static() {
 
 sha512sums="755a3f5596e7bd9710abc8e5bfd341adaf2177f5b21f7aaae7f85b8fb57580ea48df586ad32bf6adef6ce0430e7cadaa57754a2fa466bc4b15bf70ee64cd1418  pixman-0.34.0.tar.bz2
 5064da221fe406e58169df0b07df7123ccf65487e654dba9e0903122480363c2b4e11ec0a14ac546658c747934509f2f66e3d0d078d6dd0ac92505c24b0e9ee9  float-header-fix.patch
-3d75e7328e6eaaa6e8f4defa4402db815764369f94b81be38fba07933267fe24b03b591dd4c3f3544cb090650153728bfbdd81a91acaf19524c3d08f61427f63  stacksize-reduction.patch"
+3d75e7328e6eaaa6e8f4defa4402db815764369f94b81be38fba07933267fe24b03b591dd4c3f3544cb090650153728bfbdd81a91acaf19524c3d08f61427f63  stacksize-reduction.patch
+244dfe9fe6d64aca9e330d11490271e96ffc80b1a3f1bf3231c081683f227e0777e3cf9394639325f98c07f31d0f4f99dd21372787e40a0ec74e73dc48b7aae9  fix-ppc64le-vmx.patch"

--- a/main/pixman/fix-ppc64le-vmx.patch
+++ b/main/pixman/fix-ppc64le-vmx.patch
@@ -1,0 +1,12 @@
+--- a/pixman/pixman-vmx.c
++++ b/pixman/pixman-vmx.c
+@@ -227,7 +227,7 @@
+ #define COMPUTE_SHIFT_MASKC(dest, source, mask)
+ 
+ # define LOAD_VECTOR(source)				\
+-    v ## source = *((typeof(v ## source)*)source);
++    v ## source = (typeof(v ## source))vec_xl(0, source);
+ 
+ # define LOAD_VECTORS(dest, source)			\
+     LOAD_VECTOR(source);				\
+


### PR DESCRIPTION
per https://bugzilla.redhat.com/show_bug.cgi?id=1572540 VMX code in the pixman library produces wrong results when compiled with gcc8 and is causing test failures. Including recommended patch fixes the issue.