### PR TITLE
main/py-typing: upgrade to 3.6.6

### DIFF
--- a/main/py-typing/APKBUILD
+++ b/main/py-typing/APKBUILD
@@ -2,12 +2,14 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=py-typing
 _pkgname=typing
-pkgver=3.6.4
+pkgver=3.6.6
 pkgrel=0
 pkgdesc="Typing – Type Hints for Python"
 url="https://pypi.python.org/pypi/typing/"
 arch="noarch"
 license="PSF"
+# Tests are missing in the release tarball
+options="!check"
 makedepends="python2-dev python3-dev py-setuptools"
 subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="$pkgname-$pkgver.tar.gz::https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
@@ -51,4 +53,4 @@ _py() {
 }
 
 
-sha512sums="f595e0fc395ba13a129ae45681faca7b199fd5c23e8f1573f49e2a6f162b7f2aef680306e76cbf50b978de9f047c674323219981e89c476474295bb8c02211ce  py-typing-3.6.4.tar.gz"
+sha512sums="9baa331a2093276b571f26a21ab6419e85138574109471141eb88ccddb6c30adb6fbda35f11aeb1231adc334191c426c242494b17d593a2b279f09dea1b1f0ca  py-typing-3.6.6.tar.gz"


### PR DESCRIPTION
Also, disabled checks as the tarball doesn't ship the tests at the moment.