### PR TITLE
testing/android-tools: enable build on armhf and aarch64

### DIFF
--- a/testing/android-tools/0001-suppress-warnings-to-allow-building-for-armhf-and-aarch64.patch
+++ b/testing/android-tools/0001-suppress-warnings-to-allow-building-for-armhf-and-aarch64.patch
@@ -1,0 +1,38 @@
+diff --git a/vendor/boringssl/crypto/cipher_extra/aead_test.cc b/vendor/boringssl/crypto/cipher_extra/aead_test.cc
+index a40d673..e71a392 100644
+--- a/vendor/boringssl/crypto/cipher_extra/aead_test.cc
++++ b/vendor/boringssl/crypto/cipher_extra/aead_test.cc
+@@ -28,6 +28,8 @@
+ #include "../test/file_test.h"
+ #include "../test/test_util.h"
+ 
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wattributes"
+ 
+ struct KnownAEAD {
+   const char name[40];
+@@ -651,3 +653,5 @@ TEST(AEADTest, AESGCMEmptyNonce) {
+   EXPECT_EQ(ERR_LIB_CIPHER, ERR_GET_LIB(err));
+   EXPECT_EQ(CIPHER_R_INVALID_NONCE_SIZE, ERR_GET_REASON(err));
+ }
++
++#pragma GCC diagnostic pop
+diff --git a/vendor/boringssl/crypto/poly1305/poly1305_test.cc b/vendor/boringssl/crypto/poly1305/poly1305_test.cc
+index 198cca1..c78bf9f 100644
+--- a/vendor/boringssl/crypto/poly1305/poly1305_test.cc
++++ b/vendor/boringssl/crypto/poly1305/poly1305_test.cc
+@@ -25,6 +25,8 @@
+ #include "../test/file_test.h"
+ #include "../test/test_util.h"
+ 
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wattributes"
+ 
+ static void TestSIMD(unsigned excess, const std::vector<uint8_t> &key,
+                      const std::vector<uint8_t> &in,
+@@ -102,3 +104,5 @@ TEST(Poly1305Test, TestVectors) {
+     TestSIMD(48, key, in, mac);
+   });
+ }
++
++#pragma GCC diagnostic pop

--- a/testing/android-tools/APKBUILD
+++ b/testing/android-tools/APKBUILD
@@ -6,13 +6,14 @@ _realver=${pkgver/_p/_r}
 pkgrel=1
 pkgdesc="Android platform tools"
 url="https://sites.google.com/a/android.com/tools/"
-arch="x86 x86_64"
+arch="x86 x86_64 armhf aarch64"
 license="Apache-2.0 MIT"
 depends=""
 depends_dev=""
 options="!check" # upstream doesn't have a test suite
 makedepends="pcre2-dev linux-headers libusb-dev gtest-dev go perl cmake"
-source="https://github.com/nmeum/$pkgname/releases/download/$_realver/$pkgname-$_realver.tar.xz"
+source="https://github.com/nmeum/$pkgname/releases/download/$_realver/$pkgname-$_realver.tar.xz
+	0001-suppress-warnings-to-allow-building-for-armhf-and-aarch64.patch"
 builddir="$srcdir/$pkgname-$_realver"
 
 build() {
@@ -33,4 +34,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="6e4e3064ba667cc5511b0819206348164f64a7127eef8c21198d434032e4a2342794581c043c2754584055f3e09a70ee81a495915e42d26e3076c6349e71fe23  android-tools-9.0.0_r3.tar.xz"
+sha512sums="6e4e3064ba667cc5511b0819206348164f64a7127eef8c21198d434032e4a2342794581c043c2754584055f3e09a70ee81a495915e42d26e3076c6349e71fe23  android-tools-9.0.0_r3.tar.xz
+64d385c4aebe1a778f12c87bcfa68277b5c66e60de27256ff505382e984b284e7a05254995b84bf98c42f70f372de63d52888adee4a35440ae5a1b6eb2ab4c3c  0001-suppress-warnings-to-allow-building-for-armhf-and-aarch64.patch"


### PR DESCRIPTION
This PR will enable compilation of `android-tools` package for `armhf` and `aarch64` architectures.