### PR TITLE
main/clamav: security upgrade to 0.100.2

### DIFF
--- a/main/clamav/APKBUILD
+++ b/main/clamav/APKBUILD
@@ -3,12 +3,12 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=clamav
-pkgver=0.100.1
-pkgrel=1
+pkgver=0.100.2
+pkgrel=0
 pkgusers="clamav"
 pkggroups="clamav"
 pkgdesc="An anti-virus toolkit for UNIX eis-ng backport"
-url="http://www.clamav.net/"
+url="https://www.clamav.net/"
 arch="all"
 license="GPL-2.0"
 depends="$pkgname-scanner $pkgname-daemon"
@@ -53,6 +53,11 @@ builddir="$srcdir/$pkgname-$pkgver"
 #     - CVE-2017-16932
 #     - CVE-2018-0360
 #     - CVE-2018-0361
+#   0.100.2-r0:
+#     - CVE-2018-15378
+#     - CVE-2018-14680
+#     - CVE-2018-14681
+#     - CVE-2018-14682
 
 prepare() {
 	update_config_sub
@@ -230,7 +235,7 @@ milter() {
 		"$subpkgdir"/etc/clamav/clamav-milter.conf
 }
 
-sha512sums="13a4e050e030ac3d1cc07b12bdd56c455e266e0b205a4c9bc9f18e53f6d8913a66eed2296abf857f395227ab0ed5c7bc90bc357bcb314dc9e18a9c6177dcc5b2  clamav-0.100.1.tar.gz
+sha512sums="70b51eafb11dc727188e7d4554b8095a9e0406e76b78778fede94f8a4c78146034478197217039384eb1fd15532e822cfa6b51707e431e9397ec21d5e393a60c  clamav-0.100.2.tar.gz
 ed81be79bf9a25eec071312252121cc76c96838407377b75077bf94922055f1de99f327982ac4dccd5be85003baa95385e5d002fabab32bb851bb30178475edd  clamd.initd
 59c561b3dcb0b616b647cd8e4ebc46a2cc5e7144c8c7ea0054cc1c3021d1da8f67e4dad5c083c3fe712ed887aaabfca91b538f4759537e7c4c9ab71ba4fd5794  clamd.confd
 00daed8afb67a6e4a29893340246c8840cce970dd9103d26557ecdd26ef60b12551d2291c214fc657faaaa339484052079347411b0cad65e3a33ece56d57cf16  freshclam.initd


### PR DESCRIPTION
https://github.com/Cisco-Talos/clamav-devel/blob/dev/0.100/NEWS.md#01002
Please backport this to stable releases.