### PR TITLE
testing/wireguard: upgrade to 0.0.20181119

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -3,7 +3,7 @@
 
 # NOTE: pkgrel must match _toolsrel in wireguard-vanilla
 pkgname=wireguard-tools
-pkgver=0.0.20181115
+pkgver=0.0.20181119
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -43,4 +43,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="622de8d9274e3689debabf122e4569ae7d747f625ff5161779006b3c583b08b7b3a270aba1abf3d56c4390f809aacbf70bed6964b476f5ac72fb2f51923f3b3d  WireGuard-0.0.20181115.tar.xz"
+sha512sums="dc9286e536bb3f4a6545261b98b5bb056a085f2e95b1b571350168af23cda5231a90b915b03dd29d195412fc61efc781b7d57b2a15a42a34b97e989a5105198e  WireGuard-0.0.20181119.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20181115
-_rel=1
+_ver=0.0.20181119
+_rel=2
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="622de8d9274e3689debabf122e4569ae7d747f625ff5161779006b3c583b08b7b3a270aba1abf3d56c4390f809aacbf70bed6964b476f5ac72fb2f51923f3b3d  WireGuard-0.0.20181115.tar.xz"
+sha512sums="dc9286e536bb3f4a6545261b98b5bb056a085f2e95b1b571350168af23cda5231a90b915b03dd29d195412fc61efc781b7d57b2a15a42a34b97e989a5105198e  WireGuard-0.0.20181119.tar.xz"


### PR DESCRIPTION
```
  * chacha20,poly1305: fix up for win64
  * poly1305: only export neon symbols when in use
  * poly1305: cleanup leftover debugging changes
  * crypto: resolve target prefix on buggy kernels
  * chacha20,poly1305: don't do compiler testing in generator and remove xor helper
  * crypto: better path resolution and more specific generated .S
  * poly1305: make frame pointers for auxiliary calls
  * chacha20,poly1305: do not use xlate
  
  This should fix up the various build errors, warnings, and insertion errors
  introduced by the previous snapshot, where we added some significant
  refactoring. In short, we're trying to port to using Andy Polyakov's original
  perlasm files, and this means quite a lot of work to re-do that had stableized
  in our old .S.
```