### PR TITLE
main/libmemcached: fix ppc64le bld break due to null pointer compare

### DIFF
--- a/main/libmemcached/APKBUILD
+++ b/main/libmemcached/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libmemcached
 pkgver=1.0.18
-pkgrel=2
+pkgrel=3
 pkgdesc="Client library and command line tools for memcached server"
 url="http://libmemcached.org/"
 arch="all"
@@ -13,6 +13,7 @@ makedepends="$depends_dev memcached-dev"
 install=""
 subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
 source="https://launchpad.net/${pkgname}/${pkgver%.*}/${pkgver}/+download/${pkgname}-${pkgver}.tar.gz
+	fix-ppc64le-ptr-check.patch
 	musl-fixes.patch"
 
 builddir="$srcdir/$pkgname-$pkgver"
@@ -40,9 +41,6 @@ package() {
 	make -j1 AM_MAKEFLAGS= DESTDIR="$pkgdir" install
 }
 
-md5sums="b3958716b4e53ddc5992e6c49d97e819  libmemcached-1.0.18.tar.gz
-de32e3cbd74c0bef8c49d50cf57ae764  musl-fixes.patch"
-sha256sums="e22c0bb032fde08f53de9ffbc5a128233041d9f33b5de022c0978a2149885f82  libmemcached-1.0.18.tar.gz
-188bc487122570ba681ec2781633a368abe5bb1613d0727235c767c25d3b155d  musl-fixes.patch"
 sha512sums="2d95fea63b8b6dc7ded42c3a88a54aad74d5a1d417af1247144dae4a88c3b639a3aabc0c2b66661ff69a7609a314efaaae236e10971af9c428a4bca0a0101585  libmemcached-1.0.18.tar.gz
+ca92a91c1cbe6497195013d101a465899b9d84243f0416a9eef6fd4cec9e7f29667763891af5fd7fbbf20094a3ddf222a2d31f322909193bd65fa0dce20c73bc  fix-ppc64le-ptr-check.patch
 ff8f59d2b6d3b7d1d110ff3f1d03dbceba3a000271e69f465ffd02e77c0a092e6904b19ac4aea624a0622cec6a16ecd048f46107e011cb9011027ef71265aaf5  musl-fixes.patch"

--- a/main/libmemcached/fix-ppc64le-ptr-check.patch
+++ b/main/libmemcached/fix-ppc64le-ptr-check.patch
@@ -1,0 +1,20 @@
+--- a/clients/memflush.cc
++++ b/clients/memflush.cc
+@@ -39,7 +39,7 @@
+ {
+   options_parse(argc, argv);
+ 
+-  if (opt_servers == false)
++  if (opt_servers == NULL)
+   {
+     char *temp;
+ 
+@@ -48,7 +48,7 @@
+       opt_servers= strdup(temp);
+     }
+ 
+-    if (opt_servers == false)
++    if (opt_servers == NULL)
+     {
+       std::cerr << "No Servers provided" << std::endl;
+       exit(EXIT_FAILURE);


### PR DESCRIPTION
fixes compile error:
clients/memflush.cc:42:22: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
   if (opt_servers == false)