### PR TITLE
main/libmaa: fix ppc64le bld break for sprintf Werror

### DIFF
--- a/main/libmaa/APKBUILD
+++ b/main/libmaa/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: ScrumpyJack <scrumpyjack@st.ilet.to>
 pkgname=libmaa
 pkgver=1.3.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Provides many low-level data structures which are helpful for writing compilers"
 url="https://sourceforge.net/projects/dict/"
 arch="all"
@@ -12,7 +12,8 @@ depends_dev=""
 makedepends="libtool perl flex"
 install=""
 subpackages="$pkgname-dev"
-source="https://downloads.sourceforge.net/dict/${pkgname}-${pkgver}.tar.gz"
+source="https://downloads.sourceforge.net/dict/${pkgname}-${pkgver}.tar.gz
+	fix-ppc64le-build-snprinf-buflen.patch"
 options="libtool"
 
 builddir="${srcdir}/${pkgname}-${pkgver}"
@@ -29,6 +30,5 @@ package() {
         make DESTDIR="${pkgdir}" install || return 1
 }
 
-md5sums="01dab2cde2e0a322653e45bfa63537ee  libmaa-1.3.2.tar.gz"
-sha256sums="59a5a01e3a9036bd32160ec535d25b72e579824e391fea7079e9c40b0623b1c5  libmaa-1.3.2.tar.gz"
-sha512sums="dde91e8bf1c08515ff4662282d16a03b18a1dfb16eb7b95be980ba398ed1e65d8cd88e58d454e03a03f48a5ecca8bf23b4ebaf475a98630a9178318c12a1b176  libmaa-1.3.2.tar.gz"
+sha512sums="dde91e8bf1c08515ff4662282d16a03b18a1dfb16eb7b95be980ba398ed1e65d8cd88e58d454e03a03f48a5ecca8bf23b4ebaf475a98630a9178318c12a1b176  libmaa-1.3.2.tar.gz
+8efab0163bbdb0e16cc4914779cddccd53b6107c0ddc5b8c370e408f837d6ababd490e52e91386df7bc69d3a973a38f19e3721f379528b17913b5a32bfab6101  fix-ppc64le-build-snprinf-buflen.patch"

--- a/main/libmaa/fix-ppc64le-build-snprinf-buflen.patch
+++ b/main/libmaa/fix-ppc64le-build-snprinf-buflen.patch
@@ -1,0 +1,11 @@
+--- a/log.c
++++ b/log.c
+@@ -297,7 +297,7 @@
+ {
+    va_list ap_copy;
+    time_t t;
+-   static char   buf [4096] = "";
++   static char   buf [4356] = "";
+    static char   buf_main [4096] = "";
+    static char   buf_preamble [256] = "";
+ 


### PR DESCRIPTION
With gcc8 and Werror enabled build fails the errors listed below. Can be fixed by increasing size of buf[].

log.c:331:35: error: '%s' directive output may be truncated writing up to 4095 bytes into a region of size between 3841 and 4096 [-Werror=format-truncation=]
   snprintf (buf, sizeof (buf), "%s%s\n",
                                   ^~
      buf_preamble, buf_main);
                    ~~~~~~~~
log.c:331:3: note: 'snprintf' output between 2 and 4352 bytes into a destination of size 4096
   snprintf (buf, sizeof (buf), "%s%s\n",
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      buf_preamble, buf_main);
      ~~~~~~~~~~~~~~~~~~~~~~~
log.c:328:40: error: '%s' directive output may be truncated writing up to 4095 bytes into a region of size between 3838 and 4093 [-Werror=format-truncation=]
   snprintf (buf, sizeof (buf), "%s(%s) %s\n",
                                        ^~
      buf_preamble, routine, buf_main);
                             ~~~~~~~~
log.c:328:3: note: 'snprintf' output 5 or more bytes (assuming 4355) into a destination of size 4096
   snprintf (buf, sizeof (buf), "%s(%s) %s\n",
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      buf_preamble, routine, buf_main);
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
