### PR TITLE
community/erlang: add xmerl to depends for common-test

### DIFF
--- a/community/erlang/APKBUILD
+++ b/community/erlang/APKBUILD
@@ -5,7 +5,7 @@
 pkgname=erlang
 pkgver=20.3.4
 _srcver=$pkgver
-pkgrel=1
+pkgrel=2
 pkgdesc="General-purpose programming language and runtime environment"
 url="http://www.erlang.org/"
 license="Apache-2.0"
@@ -112,7 +112,7 @@ _mv_erlang_lib() {
 }
 
 asn() { _mv_erlang_lib asn1; depends="$depends erlang-crypto"; }
-common_test() { _mv_erlang_lib common_test; }
+common_test() { _mv_erlang_lib common_test; depends="$depends erlang-xmerl"; }
 compiler() { _mv_erlang_lib compiler; depends="$depends erlang-syntax-tools erlang-parsetools erlang-erl-interface"; }
 cos_event() { _mv_erlang_lib cosEvent; }
 cos_event_domain() { _mv_erlang_lib cosEventDomain; }


### PR DESCRIPTION
Without `erlang-xmerl` installed, `ct_run` will fail after trying to load the xmerl module.