### PR TITLE
main/mercurial: upgrade to 4.8

### DIFF
--- a/main/mercurial/APKBUILD
+++ b/main/mercurial/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mercurial
-pkgver=4.6.2
+pkgver=4.8
 pkgrel=0
 pkgdesc="Scalable distributed SCM tool"
 url="https://www.mercurial-scm.org"
@@ -63,4 +63,4 @@ bashcomp() {
 		"$subpkgdir"/usr/share/bash-completion/completions/${pkgname}
 }
 
-sha512sums="71afb9ed3f62b1b946563c55851dda1fc8b724afe82a4a253c7f4719ae9e1160d5f9644bed7fd27ee3a21d8e682352364fc9f47bafa552cd4cd7fac7c0d42bdd  mercurial-4.6.2.tar.gz"
+sha512sums="83be5119355da6e43635a8ada3c152420314e72c4a7b98717ac8b5feb628f3ce96c0ca137cb4a624d441e4f800d9ca78ada3351ca403815c06ab151cc720077d  mercurial-4.8.tar.gz"


### PR DESCRIPTION
I've upgraded Mercurial to 4.8.  I tried out a few basic commands (clone, version, help), which are working fine.