### PR TITLE
main/cmake: upgrade to 3.13.0

### DIFF
--- a/main/cmake/APKBUILD
+++ b/main/cmake/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cmake
-pkgver=3.12.4
+pkgver=3.13.0
 pkgrel=0
 pkgdesc="Cross-platform, open-source make system"
 url="https://www.cmake.org"
@@ -69,4 +69,4 @@ bashcomp() {
                 "$subpkgdir"/usr/share/bash-completion/
 }
 
-sha512sums="c3449d3cb0a89679e3de703313362881e796c89e36a4861c8a62222a08c17450ed4531577ceee25dc8f3b0c46af10443eca97eee3bf69d2b6e091f19784575c1  cmake-3.12.4.tar.gz"
+sha512sums="c353d20afc657f84e71aa5d6e9aa93caaca4eba33e3d1d75d25a504e50a1a8651bce1a27989998629449f36b3ed5c3be4c0a11b7f490f22abec9e73c1aa9073e  cmake-3.13.0.tar.gz"


### PR DESCRIPTION
Ref https://blog.kitware.com/cmake-3-13-0-available-for-download/