### PR TITLE
testing/php7-pecl-grpc: new aport

### DIFF
--- a/testing/php7-pecl-grpc/APKBUILD
+++ b/testing/php7-pecl-grpc/APKBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Andy Postnikov <apostnikov@gmail.com>
+pkgname=php7-pecl-grpc
+_pkgreal=grpc
+pkgver=1.18.0
+pkgrel=0
+pkgdesc="PHP extension provide a concrete implementation of the gRPC protocol, layered over HTTP/2."
+url="https://pecl.php.net/package/grpc"
+arch="all"
+license="Apache-2.0"
+depends="php7-common"
+makedepends="php7-dev autoconf re2c openssl-dev protobuf-dev zlib-dev"
+source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
+builddir="$srcdir"/$_pkgreal-$pkgver
+
+build() {
+	cd "$builddir"
+	phpize7
+	./configure --prefix=/usr --with-php-config=php-config7
+	make
+}
+
+check() {
+	cd "$builddir"
+	# Test suite is not a part of pecl release.
+	php7 -d extension="$builddir"/modules/$_pkgreal.so --ri $_pkgreal
+}
+
+package() {
+	cd "$builddir"
+	make INSTALL_ROOT="$pkgdir"/ install
+	install -d "$pkgdir"/etc/php7/conf.d
+	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/50_$_pkgreal.ini
+}
+
+sha512sums="f1688050be3c544b6df7de6ccc02e48b85702a50bc12a5b5021597686f93c836be710053509f5ca5be19e71d3a4e445ffc14d927b51e213791b3a878d5c30fe7  grpc-1.18.0.tgz"


### PR DESCRIPTION
Follow-up to upgrade to enable php extension package

Build picked from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=grpc#n68