### PR TITLE
community/docker: upgrade to 18.09.0 (containerd and runc splitted into own packages)

### DIFF
--- a/community/containerd/APKBUILD
+++ b/community/containerd/APKBUILD
@@ -1,23 +1,29 @@
-# Maintainer: Natanael Copa <ncopa@alpinelinux.org>
+# Maintainer: Bernhard J. M. Gruen <bernhard.gruen@googlemail.com>
 pkgname=containerd
-pkgver=1.0.0
-pkgrel=2
+pkgver=1.2.0
+pkgrel=0
+_commit=c4446665cb9c30056f4998ed953e6d4ff22c7c39
 pkgdesc="An open and reliable container runtime"
 url="https://containerd.io/"
 arch="all"
 license="Apache-2.0"
+depends="runc"
 makedepends="go linux-headers btrfs-progs-dev protobuf-dev"
 source="containerd-$pkgver.tar.gz::https://github.com/containerd/containerd/archive/v$pkgver.tar.gz
 	"
 
 builddir="$srcdir"/containerd-$pkgver
 
-build() {
+prepare() {
 	cd "$builddir"
 	mkdir src
 	mv vendor/* src
 	ln -s "$builddir" src/github.com/containerd/containerd
-	GOPATH="$PWD" LDFLAGS="" make VERSION="$pkgver" REVISION="$pkgrel"
+}
+
+build() {
+	cd "$builddir"
+	GOPATH="$PWD" LDFLAGS="" make VERSION="v$pkgver" REVISION="$_commit"
 }
 
 check() {
@@ -29,7 +35,7 @@ package() {
 	cd "$builddir"
 
 	install -d "$pkgdir"/usr/bin/
-	install -m755 "$builddir"/bin/* "$pkgdir"/usr/bin/
+	install -Dm755 "$builddir"/bin/* "$pkgdir"/usr/bin/
 }
 
-sha512sums="8c1a03de7f30976675e4482b4f18f4b87da56108de4d92f2e33b4cb4f8c188af5b3fad87971a294eac8442a0fb6ddae48cda81334c363203a8c8bdfc09176a7a  containerd-1.0.0.tar.gz"
+sha512sums="f7e1ede8db253c666dc9d68642951a427722945da60acf8631312377c84aab14c7a8b14e81f9a63ab8f909d25eb55911c0f2eef68f11380c66cd77bada8577bd  containerd-1.2.0.tar.gz"

--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -1,22 +1,18 @@
-# Maintainer: Natanael Copa <ncopa@alpinelinux.org>
-# Contributor: Bernhard J. M. Gruen <bernhard.gruen@googlemail.com>
+# Maintainer: Bernhard J. M. Gruen <bernhard.gruen@googlemail.com>
 pkgname=docker
-pkgver=18.06.1
-_ver=${pkgver/_/-}-ce
+pkgver=18.09.0
 pkgrel=0
-_gitcommit=v$_ver
+_gitcommit=v"$pkgver"
 pkgdesc="Pack, ship and run any application as a lightweight container"
 url="http://www.docker.io/"
 arch="all"
 license="Apache-2.0"
-depends="ca-certificates iptables"
+depends="ca-certificates iptables runc containerd"
 makedepends="go btrfs-progs-dev bash linux-headers coreutils libseccomp-dev cmake lvm2-dev libtool"
 options="!check"
 install="$pkgname.pre-install"
 
-# from "$srcdir"/docker-ce-"$_ver"-ce/components/engine/hack/dockerfile/install/*.installer
-_runc_ver=69663f0bd4b60df09991c08812a60108003fa340
-_containerd_ver=468a545b9edcd5932818eb9de8e72413e616e86e # v1.1.2
+# from "$srcdir"/docker-ce-"$pkgver"/components/engine/hack/dockerfile/install/*.installer
 _tini_ver=fec3683b971d9c3ef73f284f176672c44b448662 # v0.18.0
 _libnetwork_ver=3ac297bc7fd0afec9051bbb47024c9bc1d75bf5b # proxy.installer
 
@@ -33,9 +29,7 @@ subpackages="
 	"
 
 source="
-	docker-$pkgver.tar.gz::https://github.com/docker/docker-ce/archive/v$_ver.tar.gz
-	runc-$_runc_ver.tar.gz::https://github.com/opencontainers/runc/archive/$_runc_ver.tar.gz
-	containerd-$_containerd_ver.tar.gz::https://github.com/containerd/containerd/archive/$_containerd_ver.tar.gz
+	docker-$pkgver.tar.gz::https://github.com/docker/docker-ce/archive/v$pkgver.tar.gz
 	libnetwork-$_libnetwork_ver.tar.gz::https://github.com/docker/libnetwork/archive/$_libnetwork_ver.tar.gz
 	tini-$_tini_ver.tar.gz::https://github.com/krallin/tini/archive/$_tini_ver.tar.gz
 	go-md2man-$_go_md2man_ver.tar.gz::https://github.com/cpuguy83/go-md2man/archive/v$_go_md2man_ver.tar.gz
@@ -45,12 +39,10 @@ source="
 	docker-openrc-busybox-ash.patch
 	"
 
-_dockerdir="$srcdir"/docker-$_ver
+_dockerdir="$srcdir"/docker-$pkgver
 _cli_builddir="$_dockerdir"/components/cli
 _daemon_builddir="$_dockerdir"/components/engine
 _buildtags=""
-_runc_buildtags="seccomp"
-_runc_builddir="$srcdir"/runc-$_runc_ver
 
 _containerd_builddir="$srcdir"/containerd-$_containerd_ver
 _libnetwork_builddir="$srcdir"/libnetwork-$_libnetwork_ver
@@ -71,30 +63,19 @@ _apply_patches() {
 
 prepare() {
 	# Rename 'docker-ce-VER' to 'docker-VER'
-	mv "$srcdir"/docker-ce-$_ver "$_dockerdir"
+	mv "$srcdir"/docker-ce-$pkgver "$_dockerdir"
 
 	_apply_patches "$_daemon_builddir" docker
-	_apply_patches "$_runc_builddir" runc
 	_apply_patches "$_tini_builddir" tini
 }
 
 build() {
 	export AUTO_GOPATH=1
-	#export GOPATH="$srcdir"
-	#export GOBIN="$GOPATH"/bin
-	#export PATH="$GOBIN:$PATH"
 	export DOCKER_GITCOMMIT=$_gitcommit
 	export DOCKER_BUILDTAGS=$_buildtags
 	unset CC # prevent possible ccache issues
 
-	# containerd
-	msg "building containerd"
-	cd "$_containerd_builddir"
-	# Vendor dir only works if it's part of a package in the src dir. Easiest solution is to make it a src dir iself
-	mv vendor src
-	mkdir -p src/github.com/containerd/
-	ln -s "$_containerd_builddir" src/github.com/containerd/containerd
-	GOPATH="$PWD" LDFLAGS="" make GIT_COMMIT="$_containerd_ver"
+
 
 	# libnetwork (docker-proxy)
 	msg "building docker-proxy"
@@ -102,14 +83,6 @@ build() {
 	mkdir -p src/github.com/docker/
 	ln -s "$_libnetwork_builddir" src/github.com/docker/libnetwork
 	GOPATH="$PWD" go build -v -ldflags="-linkmode=external" -o docker-proxy github.com/docker/libnetwork/cmd/proxy
-
-	# runc
-	msg "building runc"
-	cd "$_runc_builddir"
-	mv vendor src
-	mkdir -p src/github.com/opencontainers/
-	ln -s "$_runc_builddir" src/github.com/opencontainers/runc
-	GOPATH="$PWD" make COMMIT="$_runc_ver"
 
 	# tini
 	msg "building tini"
@@ -122,9 +95,8 @@ build() {
 	cd "$_daemon_builddir"
 	mkdir -p src/github.com/docker/
 	ln -s "$_daemon_builddir" src/github.com/docker/docker
-	GOPATH="$PWD" VERSION="$_ver" hack/make.sh dynbinary
+	GOPATH="$PWD" VERSION="$pkgver" hack/make.sh dynbinary
 
-	# Required for building man-pages
 	export GOPATH="$_cli_builddir"
 	export GOBIN="$GOPATH/bin"
 	export PATH="$GOBIN:$PATH"
@@ -136,6 +108,7 @@ build() {
 	ln -s "$_cli_builddir" "$GOPATH"/src/github.com/docker/cli
 	LDFLAGS="" make VERSION="$_ver" dynbinary
 
+
 	# docker man
 	msg "building docker man pages"
 	cd "$srcdir"
@@ -143,15 +116,18 @@ build() {
 	mkdir -p "$GOPATH"/src/github.com/spf13/
 	ln -sf "$PWD"/cobra-$_cobra_ver "$GOPATH"/src/github.com/spf13/cobra
 	# md2man
+	# Required for building man-pages
 	mkdir -p "$GOPATH"/src/github.com/cpuguy83/
-	ln -s "$PWD"/go-md2man-$_go_md2man_ver "$GOPATH"/src/github.com/cpuguy83/go-md2man
-	cd "$GOPATH"/src/github.com/cpuguy83/go-md2man
+	ln -s "$PWD"/go-md2man-$_go_md2man_ver "$GOPATH/src/github.com/cpuguy83/go-md2man"
+	cd "$GOPATH/src/github.com/cpuguy83/go-md2man"
 	go get
+
 
 	# convert md to man pages
 	msg "generating man pages"
 	cd "$_cli_builddir"
 	make manpages
+
 }
 
 package() {
@@ -162,24 +138,11 @@ package() {
 	install -Dm755 "$_cli_builddir"/build/docker \
 		"$pkgdir"/usr/bin/docker
 
-#	install -Dm755 "$_daemon_builddir"/bundles/$ver/dynbinary-daemon/dockerd-$ver \
 	install -Dm755 "$_daemon_builddir"/bundles/dynbinary-daemon/dockerd-$ver \
 		"$pkgdir"/usr/bin/dockerd
 
 	install -Dm755 "$_libnetwork_builddir"/docker-proxy \
 		"$pkgdir"/usr/bin/docker-proxy
-
-	install -Dm755 "$_runc_builddir"/runc \
-		"$pkgdir"/usr/bin/docker-runc
-
-	install -Dm755 "$_containerd_builddir"/bin/containerd \
-		"$pkgdir"/usr/bin/docker-containerd
-
-	install -Dm755 "$_containerd_builddir"/bin/containerd-shim \
-		"$pkgdir"/usr/bin/docker-containerd-shim
-
-	install -Dm755 "$_containerd_builddir"/bin/ctr \
-		"$pkgdir"/usr/bin/docker-containerd-ctr
 
 	install -Dm755 "$_tini_builddir"/tini-static \
 		"$pkgdir"/usr/bin/docker-init
@@ -233,9 +196,7 @@ vim() {
 	done
 }
 
-sha512sums="7375452669bf6576e1f8d193cd7f421cf39a26d575351f2b4e433c7fc89384f441547417dbe8c12a12a0937c9fea3800b5c541f0ba8b58ceffe7445183ceeef1  docker-18.06.1.tar.gz
-9a55bdb8e39830f46cceff48970b7688139927552e3d268b9ef4a6e640ffc3d95164b99c5b05d07d295bedc2ea22daf6062fd520df1548d78b1d481fd928f1e3  runc-69663f0bd4b60df09991c08812a60108003fa340.tar.gz
-0c3cb261a535826f281af2d2df7e5c93e7d37139d5b709d7534148b9e706db56704d06b81a9e76acc2e86180f37475d566b8ddde990bbaae424af70206602347  containerd-468a545b9edcd5932818eb9de8e72413e616e86e.tar.gz
+sha512sums="a6173d9e2dde33c6059b3464720207a3bc0f4d6d79af65ad10cd30b4b437134ad45fc2039cebcaa41b2dfb68a21963010d63a4051ade6a6d25fcd93c8d560c67  docker-18.09.0.tar.gz
 21d3d1bd8aafeab51a3e0a14ada4d559b5b113a48d315e91f7d70e4fa839f5c92d4068b38c28bf6929da9c11cfc61703bafc7148f64b784208d61fa14ee4545d  libnetwork-3ac297bc7fd0afec9051bbb47024c9bc1d75bf5b.tar.gz
 ee46d21467f8bacb4e8be72f5dfcbb23c1964286e90b4b3d3bf67dbbf79a337968ac8a0042a8191e329a65398b20ea160aae3ae5ef20ee03ebae11c2083d7621  tini-fec3683b971d9c3ef73f284f176672c44b448662.tar.gz
 4c52e01c9b07582b5d55d1e94935378a676bd284a3e8230a8a191d4678b1b6ae92b704a249117c542832170069a70c649e58a1752fb2973709259b5bc108db91  go-md2man-1.0.8.tar.gz

--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -1,0 +1,60 @@
+# Maintainer: Bernhard J. M. Gruen <bernhard.gruen@googlemail.com>
+pkgname=runc
+pkgver="1.0.0_git20180309"
+pkgrel=0
+pkgdesc="CLI tool for managing OCI compliant containers"
+url="https://runc.io/"
+arch="all"
+license="Apache-2.0"
+makedepends="go linux-headers btrfs-progs-dev protobuf-dev"
+
+_commit="69663f0bd4b60df09991c08812a60108003fa340"
+_go_md2man_ver="1.0.8"
+
+source="runc-$pkgver.tar.gz::https://github.com/opencontainers/runc/archive/$_commit.tar.gz
+	go-md2man-$_go_md2man_ver.tar.gz::https://github.com/cpuguy83/go-md2man/archive/v$_go_md2man_ver.tar.gz
+	"
+	
+subpackages="
+	$pkgname-doc
+	"
+
+builddir="$srcdir"/runc-$_commit
+go_md2man_builddir="$srcdir"/go-md2man
+
+prepare() {
+	cd "$builddir"
+	mv -f vendor src
+	mkdir -p src/github.com/opencontainers
+	ln -s "$builddir" src/github.com/opencontainers/runc
+}
+
+build() {
+	# Required for building man-pages
+	ln -s  "$go_md2man_builddir"-"$_go_md2man_ver" "$go_md2man_builddir"
+	export GOPATH="$go_md2man_builddir"
+	export GOBIN="$GOPATH/bin"
+	export PATH="$GOBIN:$PATH"
+	cd "$go_md2man_builddir"
+	go get
+	
+
+	cd "$builddir"
+	GOPATH="$PWD" BUILDTAGS="seccomp" make COMMIT="$_commit" runc man
+}
+
+check() {
+	cd "$builddir"
+	./runc --version
+}
+
+package() {
+	cd "$builddir"
+
+	install -Dm755 "$builddir"/runc "$pkgdir"/usr/bin/runc
+	install -d "$pkgdir"/usr/share/man/man8/
+	install -Dm644 "$builddir"/man/man8/* "$pkgdir"/usr/share/man/man8/
+}
+
+sha512sums="9a55bdb8e39830f46cceff48970b7688139927552e3d268b9ef4a6e640ffc3d95164b99c5b05d07d295bedc2ea22daf6062fd520df1548d78b1d481fd928f1e3  runc-1.0.0_git20180309.tar.gz
+4c52e01c9b07582b5d55d1e94935378a676bd284a3e8230a8a191d4678b1b6ae92b704a249117c542832170069a70c649e58a1752fb2973709259b5bc108db91  go-md2man-1.0.8.tar.gz"


### PR DESCRIPTION
community/docker: upgrade to 18.09.0 (containerd and runc splitted into own packages)
community/containerd: upgrade to 1.2.0 (moved from testing)
community/runc: new aport - based on runc 1.0.0rc5 + fixes

