### PR TITLE
community/gitea upgrade to 1.6.0

### DIFF
--- a/community/gitea/APKBUILD
+++ b/community/gitea/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=gitea
-pkgver=1.5.0
+pkgver=1.6.0
 pkgrel=0
 pkgdesc="A self-hosted Git service written in Go"
 url="https://gitea.io"
@@ -68,7 +68,7 @@ check() {
 	"$builddir"/$pkgname help > /dev/null
 }
 
-sha512sums="06cbcadc138496abf500b8d219d0770c5f6b8af419f9c3733596ee7e20cb50235815433979b2b1daa0a6117e6eb84de9678667236549e018079c49b793f22d68  gitea-1.5.0.tar.gz
+sha512sums="67591fd610bc16909c9cbddc9d55b7b60653934c0f77cf6cb0c3b92c8e3b884bc0b9bdd5ccb70a3897859a86caa4ebe807bb3ab988455f5516dcc95745c8d0a4  gitea-1.6.0.tar.gz
 a7c70a144dc0582d6230e59ff717023fddcac001a6a9c895b46a0df1fbd9639453b2f5027d47dad21f442869c145dbc801eda61b6c50a2dd8103f562b8569009  gitea.initd
 27a202006d6e8d4146659f6356eaa99437f9f596dd369e9430d64b859bc6a1ad16091eef09232aa385fe1bf8ca94bbdf31b94975068220ad10338cded384f726  gitea.ini
 05272f3733dffeb75881579ff6553d32515e4de32113ff9395e521e93946a45101d04d4e435d7d8e7bfe49a512e5e4ac300576d2e79d7bcf314fc0ce526a07f9  allow-to-set-version.patch"


### PR DESCRIPTION
https://blog.gitea.io/2018/11/gitea-1.6.0-is-released/