### PR TITLE
main/llvm: upgrade to 7.0.1

### DIFF
--- a/main/llvm/0001-Disable-dynamic-lib-tests-for-musl-s-dlclose-is-noop.patch
+++ b/main/llvm/0001-Disable-dynamic-lib-tests-for-musl-s-dlclose-is-noop.patch
@@ -1,0 +1,22 @@
+From f8e83c4c7866ae830abe9bec15cfe805dd825b6e Mon Sep 17 00:00:00 2001
+From: xentec <xentec@aix0.eu>
+Date: Tue, 12 Sep 2017 07:18:38 +0200
+Subject: [PATCH] Disable dynamic lib tests for musl's dlclose() is noop
+
+---
+ unittests/Support/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/unittests/Support/CMakeLists.txt b/unittests/Support/CMakeLists.txt
+index 641163e..4f508d9 100644
+--- a/unittests/Support/CMakeLists.txt
++++ b/unittests/Support/CMakeLists.txt
+@@ -75,4 +75,4 @@ set_source_files_properties(AlignOfTest.cpp PROPERTIES COMPILE_FLAGS -w)
+ # ManagedStatic.cpp uses <pthread>.
+ target_link_libraries(SupportTests LLVMTestingSupport ${LLVM_PTHREAD_LIB})
+ 
+-add_subdirectory(DynamicLibrary)
++# add_subdirectory(DynamicLibrary)
+-- 
+2.14.1
+

--- a/main/llvm/APKBUILD
+++ b/main/llvm/APKBUILD
@@ -4,13 +4,13 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 _pkgname=llvm
-pkgver=7.0.0
+pkgver=7.0.1
 _majorver=${pkgver%%.*}
 pkgname=$_pkgname$_majorver
 pkgrel=0
 pkgdesc="Low Level Virtual Machine compiler system, version $_majorver"
 arch="all"
-url="http://llvm.org/"
+url="https://llvm.org/"
 license="UOI-NCSA"
 depends_dev="$pkgname=$pkgver-r$pkgrel"
 makedepends="binutils-dev chrpath cmake file libffi-dev paxmark python2 py-setuptools zlib-dev"
@@ -245,7 +245,7 @@ _mv() {
 	mv $@
 }
 
-sha512sums="bdc9b851c158b17e1bbeb7ac5ae49821bfb1251a3826fe8a3932cd1a43f9fb0d620c3de67150c1d9297bf0b86fa917e75978da29c3f751b277866dc90395abec  llvm-7.0.0.src.tar.xz
+sha512sums="ac43a3cb71a53deb55e3693653847cf20bf6f5d9056f224e6956c96d63bc59ebee9404f088eec9cabe65337b4607a905ef931354b373cf64e0004c6905a6b5df  llvm-7.0.1.src.tar.xz
 49c47f125014b60d0ea7870f981a2c1708ad705793f89287ed846ee881a837a4dc0170bf467e03f2ef56177473128945287749ac80dc2d13cfabcf8b929ba58a  disable-FileSystemTest.CreateDir-perms-assert.patch
 695502bd3b5454c2f5630c59a8cf5f8aeb0deac16a76a8a4df34849e1e35c12ed4234572a320fe4c7e96f974f572f429eb816c5aa3dcfb17057f550eac596495  0001-Disable-dynamic-lib-tests-for-musl-s-dlclose-is-noop.patch
 e6d925ddc71f9f2ce8a859ac519dad51cba99c07129e378a5388bb1dd2f7d5b9d5ed392e85267fd20043789c7460a7d705eb8f970b2d130edbf5a934e9505ac4  fix-memory-mf_exec-on-aarch64.patch

--- a/main/llvm/APKBUILD
+++ b/main/llvm/APKBUILD
@@ -1,0 +1,252 @@
+# Contributor: Martell Malone <martell@marinelayer.io>
+# Contributor: Travis Tilley <ttilley@gmail.com>
+# Contributor: Mitch Tishmack <mitch.tishmack@gmail.com>
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
+# Maintainer: Jakub Jirutka <jakub@jirutka.cz>
+_pkgname=llvm
+pkgver=7.0.0
+_majorver=${pkgver%%.*}
+pkgname=$_pkgname$_majorver
+pkgrel=0
+pkgdesc="Low Level Virtual Machine compiler system, version $_majorver"
+arch="all"
+url="http://llvm.org/"
+license="UOI-NCSA"
+depends_dev="$pkgname=$pkgver-r$pkgrel"
+makedepends="binutils-dev chrpath cmake file libffi-dev paxmark python2 py-setuptools zlib-dev"
+subpackages="$pkgname-static $pkgname-libs $pkgname-dev $pkgname-test-utils:_test_utils"
+source="https://llvm.org/releases/$pkgver/llvm-$pkgver.src.tar.xz
+	disable-FileSystemTest.CreateDir-perms-assert.patch
+	0001-Disable-dynamic-lib-tests-for-musl-s-dlclose-is-noop.patch
+	fix-memory-mf_exec-on-aarch64.patch
+	fix-LLVMConfig-cmake-install-prefix.patch
+	"
+builddir="$srcdir/$_pkgname-$pkgver.src"
+options="!checkroot"
+
+# ARM has few failures in test suite that we don't care about currently and
+# also it takes forever to run them on the builder.
+case "$CARCH" in
+	arm*) options="$options !check";;
+esac
+
+# Whether is this package the default (latest) LLVM version.
+_default_llvm="yes"
+
+if [ "$_default_llvm" = yes ]; then
+	provides="llvm=$pkgver-r$pkgrel"
+	replaces="llvm"
+fi
+
+# NOTE: It seems that there's no (sane) way how to change includedir, sharedir
+# etc. separately, just the CMAKE_INSTALL_PREFIX. Standard CMake variables and
+# even  LLVM-specific variables, that are related to these paths, actually
+# don't work (in llvm 3.7).
+#
+# When building a software that depends on LLVM, utility llvm-config should be
+# used to discover where is LLVM installed. It provides options to print
+# path of bindir, includedir, and libdir separately, but in its source, all
+# these paths are actually hard-coded against INSTALL_PREFIX. We can patch it
+# and move paths manually, but I'm really not sure what it may break...
+#
+# Also note that we should *not* add version suffix to files in llvm bindir!
+# It breaks build system of some software that depends on LLVM, because they
+# don't expect these files to have a sufix.
+#
+# So, we install all the LLVM files into /usr/lib/llvm$_majorver.
+# BTW, Fedora and Debian do the same thing.
+#
+_prefix="usr/lib/llvm$_majorver"
+
+prepare() {
+	default_prepare
+	cd "$builddir"
+	mkdir -p "$builddir"/build
+}
+
+build() {
+	cd "$builddir"/build
+
+	# Auto-detect it by guessing either.
+	local ffi_include_dir="$(pkg-config --cflags-only-I libffi | sed 's|^-I||g')"
+
+	cmake -Wno-dev \
+		-DCMAKE_BUILD_TYPE=MinSizeRel \
+		-DCMAKE_C_FLAGS_MINSIZEREL_INIT="$CFLAGS" \
+		-DCMAKE_CXX_FLAGS_MINSIZEREL_INIT="$CXXFLAGS" \
+		-DCMAKE_EXE_LINKER_FLAGS_MINSIZEREL_INIT="$LDFLAGS" \
+		-DCMAKE_INSTALL_PREFIX=/$_prefix \
+		\
+		-DFFI_INCLUDE_DIR="$ffi_include_dir" \
+		-DLLVM_BINUTILS_INCDIR=/usr/include \
+		-DLLVM_BUILD_DOCS=OFF \
+		-DLLVM_BUILD_EXAMPLES=OFF \
+		-DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON \
+		-DLLVM_BUILD_LLVM_DYLIB=ON \
+		-DLLVM_BUILD_TESTS=ON \
+		-DLLVM_DEFAULT_TARGET_TRIPLE="$CBUILD" \
+		-DLLVM_ENABLE_ASSERTIONS=OFF \
+		-DLLVM_ENABLE_CXX1Y=ON \
+		-DLLVM_ENABLE_FFI=ON \
+		-DLLVM_ENABLE_LIBCXX=OFF \
+		-DLLVM_ENABLE_PIC=ON \
+		-DLLVM_ENABLE_RTTI=ON \
+		-DLLVM_ENABLE_SPHINX=OFF \
+		-DLLVM_ENABLE_TERMINFO=ON \
+		-DLLVM_ENABLE_ZLIB=ON \
+		-DLLVM_HOST_TRIPLE="$CHOST" \
+		-DLLVM_INCLUDE_EXAMPLES=OFF \
+		-DLLVM_LINK_LLVM_DYLIB=ON \
+		-DLLVM_TARGETS_TO_BUILD='X86;ARM;AArch64;PowerPC;SystemZ;AMDGPU;NVPTX;Mips;BPF' \
+		-DLLVM_APPEND_VC_REV=OFF \
+		"$builddir"
+
+	make llvm-tblgen
+	make
+
+	paxmark m \
+		bin/llvm-rtdyld \
+		bin/lli \
+		bin/lli-child-target \
+		unittests/ExecutionEngine/MCJIT/MCJITTests \
+		unittests/ExecutionEngine/Orc/OrcJITTests \
+		unittests/Support/SupportTests
+
+	python2 ../utils/lit/setup.py build
+}
+
+check() {
+	cd "$builddir"/build
+
+	make check-llvm
+}
+
+package() {
+	cd "$builddir"/build
+
+	make DESTDIR="$pkgdir" install
+
+	cd "$pkgdir"/$_prefix
+
+	# Remove RPATHs.
+	file lib/*.so bin/* \
+		| awk -F: '$2~/ELF/{print $1}' \
+		| xargs -r chrpath -d
+
+	# Symlink files from /usr/lib/llvm*/bin to /usr/bin.
+	mkdir -p "$pkgdir"/usr/bin
+	local name newname path
+	for path in bin/*; do
+		name=${path##*/}
+		# Add version infix/suffix to the executable name.
+		case "$name" in
+			llvm-*) newname="llvm$_majorver-${name#llvm-}";;
+			*) newname="$name$_majorver";;
+		esac
+		# If this package provides=llvm (i.e. it's the default/latest
+		# llvm package), omit version infix/suffix.
+		if [ "$_default_llvm" = yes ]; then
+			newname=$name
+		fi
+		case "$name" in
+			FileCheck | obj2yaml | yaml2obj) continue;;
+		esac
+		ln -s ../lib/llvm$_majorver/bin/$name "$pkgdir"/usr/bin/$newname
+	done
+
+	# Move /usr/lib/$pkgname/include/ into /usr/include/$pkgname/
+	# and symlink it back.
+	_mv include/* "$pkgdir"/usr/include/$pkgname/
+	rmdir include
+	ln -s ../../include/$pkgname include
+
+	# Move /usr/lib/$pkgname/lib/cmake/llvm/ into /usr/lib/cmake/$pkgname/
+	# and symlink it back.
+	_mv lib/cmake/llvm/* "$pkgdir"/usr/lib/cmake/$pkgname/
+	rmdir lib/cmake/llvm
+	ln -s ../../../cmake/$pkgname lib/cmake/llvm
+}
+
+static() {
+	pkgdesc="LLVM $_majorver static libraries"
+	_common_subpkg
+
+	_mv "$pkgdir"/$_prefix/lib/*.a "$subpkgdir"/$_prefix/lib/
+}
+
+libs() {
+	pkgdesc="LLVM $_majorver runtime library"
+	local soname="libLLVM-$_majorver.so"
+	local soname2="libLLVM-$pkgver.so"
+	_common_subpkg
+
+	mkdir -p "$subpkgdir"
+	cd "$subpkgdir"
+
+	# libLLVM should be in /usr/lib. This is needed for binaries that are
+	# dynamically linked with libLLVM, so they can find it on default path.
+	_mv "$pkgdir"/$_prefix/lib/$soname usr/lib/
+	ln -s $soname usr/lib/$soname2
+
+	# And also symlink it back to the LLVM prefix.
+	mkdir -p $_prefix/lib
+	ln -s ../../$soname $_prefix/lib/$soname
+	ln -s ../../$soname $_prefix/lib/$soname2
+}
+
+dev() {
+	_common_subpkg
+	default_dev
+	cd "$subpkgdir"
+
+	_mv "$pkgdir"/$_prefix/lib $_prefix/
+	_mv "$pkgdir"/$_prefix/include $_prefix/
+
+	_mv "$pkgdir"/$_prefix/bin/llvm-config $_prefix/bin/
+
+	if [ "$_default_llvm" = yes ]; then
+		ln -sf llvm$_majorver/lib/LLVMgold.so usr/lib/
+		ln -sf llvm$_majorver/lib/libLTO.so usr/lib/
+		ln -sf llvm$_majorver usr/lib/cmake/llvm
+	fi
+}
+
+_test_utils() {
+	pkgdesc="LLVM $_majorver utilities for executing LLVM and Clang style test suites"
+	depends="python2 py-setuptools"
+	_common_subpkg
+	replaces=""
+
+	local litver=$(python2 "$builddir"/utils/lit/setup.py --version 2>/dev/null \
+		| sed 's/\.dev.*$//')
+	test -n "$litver"
+	provides="$provides lit=$litver-r$pkgrel"
+
+	cd "$builddir"/build
+
+	install -D -m 755 bin/count "$subpkgdir"/$_prefix/bin/count
+	install -D -m 755 bin/FileCheck "$subpkgdir"/$_prefix/bin/FileCheck
+	install -D -m 755 bin/not "$subpkgdir"/$_prefix/bin/not
+
+	python2 ../utils/lit/setup.py install --prefix=/usr --root="$subpkgdir"
+	ln -s ../../../bin/lit "$subpkgdir"/$_prefix/bin/lit
+}
+
+_common_subpkg() {
+	if [ "$_default_llvm" = yes ]; then
+		replaces="llvm${subpkgname#$pkgname}"
+		provides="$replaces=$pkgver-r$pkgrel"
+	fi
+}
+
+_mv() {
+	local dest; for dest; do true; done  # get last argument
+	mkdir -p "$dest"
+	mv $@
+}
+
+sha512sums="bdc9b851c158b17e1bbeb7ac5ae49821bfb1251a3826fe8a3932cd1a43f9fb0d620c3de67150c1d9297bf0b86fa917e75978da29c3f751b277866dc90395abec  llvm-7.0.0.src.tar.xz
+49c47f125014b60d0ea7870f981a2c1708ad705793f89287ed846ee881a837a4dc0170bf467e03f2ef56177473128945287749ac80dc2d13cfabcf8b929ba58a  disable-FileSystemTest.CreateDir-perms-assert.patch
+695502bd3b5454c2f5630c59a8cf5f8aeb0deac16a76a8a4df34849e1e35c12ed4234572a320fe4c7e96f974f572f429eb816c5aa3dcfb17057f550eac596495  0001-Disable-dynamic-lib-tests-for-musl-s-dlclose-is-noop.patch
+e6d925ddc71f9f2ce8a859ac519dad51cba99c07129e378a5388bb1dd2f7d5b9d5ed392e85267fd20043789c7460a7d705eb8f970b2d130edbf5a934e9505ac4  fix-memory-mf_exec-on-aarch64.patch
+7d4825d16107e56a14b7b05be847f03d75e2e05952bea0742a1233b5b0441c9934d8058e612abb6471272884372d9bfd3348355fbd3c19cba82a554003cc3eec  fix-LLVMConfig-cmake-install-prefix.patch"

--- a/main/llvm/disable-FileSystemTest.CreateDir-perms-assert.patch
+++ b/main/llvm/disable-FileSystemTest.CreateDir-perms-assert.patch
@@ -1,0 +1,61 @@
+Do not assert permissions of file created in /tmp directory.
+
+This assertion fails, probably due to some specific setup of /tmp
+on build servers.
+
+    FAIL: LLVM-Unit :: Support/SupportTests/FileSystemTest.CreateDir (1293 of 17222)
+    ******************** TEST 'LLVM-Unit :: Support/SupportTests/FileSystemTest.CreateDir' FAILED ********************
+    Note: Google Test filter = FileSystemTest.CreateDir
+    [==========] Running 1 test from 1 test case.
+    [----------] Global test environment set-up.
+    [----------] 1 test from FileSystemTest
+    [ RUN      ] FileSystemTest.CreateDir
+    /home/buildozer/aports/testing/llvm3.9/src/llvm-3.9.1.src/unittests/Support/Path.cpp:591: Failure
+    Value of: fs::perms::owner_read | fs::perms::owner_exe
+      Actual: 320
+    Expected: Status.permissions() & fs::perms::all_all
+    Which is: 448
+
+--- a/unittests/Support/Path.cpp
++++ b/unittests/Support/Path.cpp
+@@ -579,23 +579,23 @@
+   ASSERT_NO_ERROR(fs::remove(Twine(TestDirectory) + "foo"));
+ 
+ #ifdef LLVM_ON_UNIX
+-  // Set a 0000 umask so that we can test our directory permissions.
+-  mode_t OldUmask = ::umask(0000);
+-
+-  fs::file_status Status;
+-  ASSERT_NO_ERROR(
+-      fs::create_directory(Twine(TestDirectory) + "baz500", false,
+-                           fs::perms::owner_read | fs::perms::owner_exe));
+-  ASSERT_NO_ERROR(fs::status(Twine(TestDirectory) + "baz500", Status));
+-  ASSERT_EQ(Status.permissions() & fs::perms::all_all,
+-            fs::perms::owner_read | fs::perms::owner_exe);
+-  ASSERT_NO_ERROR(fs::create_directory(Twine(TestDirectory) + "baz777", false,
+-                                       fs::perms::all_all));
+-  ASSERT_NO_ERROR(fs::status(Twine(TestDirectory) + "baz777", Status));
+-  ASSERT_EQ(Status.permissions() & fs::perms::all_all, fs::perms::all_all);
+-
+-  // Restore umask to be safe.
+-  ::umask(OldUmask);
++//  // Set a 0000 umask so that we can test our directory permissions.
++//  mode_t OldUmask = ::umask(0000);
++//
++//  fs::file_status Status;
++//  ASSERT_NO_ERROR(
++//      fs::create_directory(Twine(TestDirectory) + "baz500", false,
++//                           fs::perms::owner_read | fs::perms::owner_exe));
++//  ASSERT_NO_ERROR(fs::status(Twine(TestDirectory) + "baz500", Status));
++//  ASSERT_EQ(Status.permissions() & fs::perms::all_all,
++//            fs::perms::owner_read | fs::perms::owner_exe);
++//  ASSERT_NO_ERROR(fs::create_directory(Twine(TestDirectory) + "baz777", false,
++//                                       fs::perms::all_all));
++//  ASSERT_NO_ERROR(fs::status(Twine(TestDirectory) + "baz777", Status));
++//  ASSERT_EQ(Status.permissions() & fs::perms::all_all, fs::perms::all_all);
++//
++//  // Restore umask to be safe.
++//  ::umask(OldUmask);
+ #endif
+ 
+ #ifdef LLVM_ON_WIN32

--- a/main/llvm/fix-LLVMConfig-cmake-install-prefix.patch
+++ b/main/llvm/fix-LLVMConfig-cmake-install-prefix.patch
@@ -1,0 +1,24 @@
+Fix LLVMConfig.cmake being generated to use correct LLVM_INSTALL_PREFIX
+(e.g. /usr/lib/llvm5).
+
+This is needed e.g. for building lldb.
+
+--- a/cmake/modules/CMakeLists.txt
++++ b/cmake/modules/CMakeLists.txt
+@@ -75,15 +75,7 @@
+ 
+ # Generate LLVMConfig.cmake for the install tree.
+ set(LLVM_CONFIG_CODE "
+-# Compute the installation prefix from this LLVMConfig.cmake file location.
+-get_filename_component(LLVM_INSTALL_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)")
+-# Construct the proper number of get_filename_component(... PATH)
+-# calls to compute the installation prefix.
+-string(REGEX REPLACE "/" ";" _count "${LLVM_INSTALL_PACKAGE_DIR}")
+-foreach(p ${_count})
+-  set(LLVM_CONFIG_CODE "${LLVM_CONFIG_CODE}
+-get_filename_component(LLVM_INSTALL_PREFIX \"\${LLVM_INSTALL_PREFIX}\" PATH)")
+-endforeach(p)
++set(LLVM_INSTALL_PREFIX \"${CMAKE_INSTALL_PREFIX}\")")
+ set(LLVM_CONFIG_INCLUDE_DIRS "\${LLVM_INSTALL_PREFIX}/include")
+ set(LLVM_CONFIG_LIBRARY_DIRS "\${LLVM_INSTALL_PREFIX}/lib\${LLVM_LIBDIR_SUFFIX}")
+ set(LLVM_CONFIG_CMAKE_DIR "\${LLVM_INSTALL_PREFIX}/${LLVM_INSTALL_PACKAGE_DIR}")

--- a/main/llvm/fix-memory-mf_exec-on-aarch64.patch
+++ b/main/llvm/fix-memory-mf_exec-on-aarch64.patch
@@ -1,0 +1,33 @@
+Fix failures in AllocationTests/MappedMemoryTest.* on aarch64:
+
+    Failing Tests (8):
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.AllocAndRelease/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.DuplicateNear/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.EnabledWrite/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.MultipleAllocAndRelease/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.SuccessiveNear/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.UnalignedNear/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.ZeroNear/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.ZeroSizeNear/3
+
+Upstream-Issue: https://bugs.llvm.org/show_bug.cgi?id=14278#c10
+
+--- a/lib/Support/Unix/Memory.inc
++++ b/lib/Support/Unix/Memory.inc
+@@ -54,7 +54,7 @@
+       llvm::sys::Memory::MF_EXEC:
+     return PROT_READ | PROT_WRITE | PROT_EXEC;
+   case llvm::sys::Memory::MF_EXEC:
+-#if defined(__FreeBSD__)
++#if defined(__FreeBSD__) || (defined(__linux__) && defined(__aarch64__))
+     // On PowerPC, having an executable page that has no read permission
+     // can have unintended consequences.  The function InvalidateInstruction-
+     // Cache uses instructions dcbf and icbi, both of which are treated by
+@@ -62,6 +62,7 @@
+     // executing these instructions will result in a segmentation fault.
+     // Somehow, this problem is not present on Linux, but it does happen
+     // on FreeBSD.
++    // The same problem is present even on aarch64 Linux (at least on musl).
+     return PROT_READ | PROT_EXEC;
+ #else
+     return PROT_EXEC;

--- a/main/llvm5/APKBUILD
+++ b/main/llvm5/APKBUILD
@@ -35,7 +35,7 @@ case "$CARCH" in
 esac
 
 # Whether is this package the default (latest) LLVM version.
-_default_llvm="yes"
+_default_llvm="no"
 
 if [ "$_default_llvm" = yes ]; then
 	provides="llvm=$pkgver-r$pkgrel"


### PR DESCRIPTION
Taking simple steps and adding a main/llvm package.
I presume the latest should always be this version.
older versions can be main/llvm6 or main/llvm5 etc