### PR TITLE
testing/wireguard-tools: add missing depends

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -10,9 +10,12 @@ arch='all'
 url='https://www.wireguard.com'
 license="GPL-2.0"
 makedepends="libmnl-dev"
+depends="iproute2 procps coreutils"
 subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch"
 options="!check"
-source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$pkgver.tar.xz"
+source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$pkgver.tar.xz
+	alpine-compat.patch
+	"
 builddir="$srcdir"/WireGuard-$pkgver
 
 build() {
@@ -43,4 +46,5 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="73c8e9b37d857349b75df776607c15ea2082814952acdba3ad6379c4ce631601db2767603e46ecadf1bce9348a0c26d07f4f6b5857ddd72bb4f4411d1d13d88c  WireGuard-0.0.20181218.tar.xz"
+sha512sums="73c8e9b37d857349b75df776607c15ea2082814952acdba3ad6379c4ce631601db2767603e46ecadf1bce9348a0c26d07f4f6b5857ddd72bb4f4411d1d13d88c  WireGuard-0.0.20181218.tar.xz
+be16a4b547b9ed60d7cd2b7dddb1ec8001f38faf8340bd76013e631c4c376a2fcd45b757296ac7422b53d7f14c759eecc41376bc6e01159c3bc5bdb121413598  alpine-compat.patch"

--- a/testing/wireguard-tools/alpine-compat.patch
+++ b/testing/wireguard-tools/alpine-compat.patch
@@ -1,0 +1,25 @@
+diff --git a/src/tools/wg-quick/linux.bash b/src/tools/wg-quick/linux.bash
+index 48ce163..a2a0738 100755
+--- a/src/tools/wg-quick/linux.bash
++++ b/src/tools/wg-quick/linux.bash
+@@ -1,9 +1,18 @@
+-#!/bin/bash
++#!/bin/sh
+ # SPDX-License-Identifier: GPL-2.0
+ #
+ # Copyright (C) 2015-2018 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+ #
+ 
++if [ -z "$BASH_VERSION" ]; then
++	if ! type bash >/dev/null 2>&1; then
++		echo "Please run 'apk add bash' and try again." >&2
++		exit 1
++	fi
++	exec bash "$0" "$@"
++fi
++set +o posix
++
+ set -e -o pipefail
+ shopt -s extglob
+ export LC_ALL=C
+


### PR DESCRIPTION
`wg-quick` does not work with some of the `busybox` built-ins.

reported by Nathan Caldwell (`saintdev at gmail dot com`)