### PR TITLE
testing/vault: bump to 0.11.5

### DIFF
--- a/testing/vault/APKBUILD
+++ b/testing/vault/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Christian Kampka <christian@kampka.net>
 # Maintainer: Gennady Feldman <gena01@gmail.com>
 pkgname=vault
-pkgver=0.11.0
+pkgver=0.11.5
 pkgrel=0
 pkgdesc="Vault is a tool for securely accessing secrets"
 url="https://www.vaultproject.io/"
@@ -50,7 +50,7 @@ package() {
 	install -m750 -o vault -g vault -d "$pkgdir/var/lib/$pkgname"
 }
 
-sha512sums="33e1e76a0e16803a8d0d6ed8ec0b6d1f8876d54ecf35a70bc4969404bd7991ef0cc5986eae958885d288bb316396e0594a5571b7a11f8b052b22b445388f03c7  vault-0.11.0.tar.gz
+sha512sums="b290523ee94199d241bbd2477ca686076f645804953181996aefe2a425bc5114db3d375fd5c832d1fa257a790947544406f50777317e854ccf2d4d4477ab6ffd  vault-0.11.5.tar.gz
 6f3f30e5c9d9dd5117f18fce0e669f0cd752a6be4910405d6b394f15273372731ee887a5ba4c700293e5b8bc2bf40fd69d4337156f77b03549d2dc2c0a666bec  vault.confd
 8c064aa5dcca84822c1fa85e9d0ff520df46f794b2e9c689a9b4f81f74279387b3aebc08b3ca26cf786c2fcf1a330e765bf5a511074c24f87e5346672346ba1c  vault.hcl
 1e436932647b191e691f5c60bec4ad926588cee5119c7cbe61345249a6768472387b6dd8b19b954c8ac80fb97f6e68f93749229b216300b0438dbeb0bdb57957  vault.initd"


### PR DESCRIPTION
Changelog from upstream:

 * auth/userpass: Fix minor timing issue that could leak the presence of a username [GH-5614]
 * cli: Fix panic that could occur if parameters were not provided [GH-5603]
 * core: Fix buggy behavior if trying to remount into a namespace
 * identity: Fix duplication of entity alias entity during alias transfer between entities [GH-5733]
 * ui: Fix bug where editing secrets as JSON doesn't save properly [GH-5660]
 * ui: Fix issue where IE 11 didn't render the UI and also had a broken form when trying to use tool/hash [GH-5714]
 * agent: Fix issue when specifying two file sinks [GH-5610]
 * autounseal/alicloud: Fix issue interacting with the API
 * autounseal/azure: Fix key version tracking
 * namespaces: Fix tuning of auth mounts in a namespace