### PR TITLE
main/arpon: disable werror fixing ppc64le strncpy build error

### DIFF
--- a/main/arpon/APKBUILD
+++ b/main/arpon/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=arpon
 pkgver=3.0
 _realver=3.0-ng
-pkgrel=1
+pkgrel=2
 pkgdesc="Arp handler inspectiON is a handler daemon with tools to handle all ARP aspects"
 url="http://arpon.sourceforge.net/"
 arch="all"
@@ -13,6 +13,7 @@ makedepends="libdnet-dev libpcap-dev libnet-dev cmake"
 install=""
 subpackages="$pkgname-doc"
 source="https://downloads.sourceforge.net/project/${pkgname}/${pkgname}/ArpON-${_realver}.tar.gz
+		fix-ppc64le-werror.patch
 		arpon-gcc8.patch
 		arpon.initd
 		arpon.confd
@@ -35,6 +36,7 @@ package() {
 }
 
 sha512sums="e6338018d65f3f8300958e168a9eb6f6be85cba21ae0aee4b03e9838a29a06afbf2448c2f104367aa18389cc549e4489bcf8dad384ad46eadf2884a0908238af  ArpON-3.0-ng.tar.gz
+d7ac9e46a43ac332926efe959373790ca2b5ae07e9a02186bff257014928ed5a101ff6d8b6224a7291f7bb25fe5555510cbf688a062d85afb7b7d9b3f6285ee9  fix-ppc64le-werror.patch
 eb4b9087a61c31fa99a7c4104e20172101b4ac3abcd448a41bdd31a81768a3dc996c9b220fd50b3c8906c050c4362c0cef300f5625cb02a7f51246783a915786  arpon-gcc8.patch
 9a7c862c3b07e31da091906b61339680b23af154c088eb259f2540916273d8e5f4dc6af5f883564d5b2ede6552b55376aa37b413270f837067ec5ce3d61a076f  arpon.initd
 c368acd8b0f9945a750e5c39a22fdad2a10f117270cd07f641333fbb9c22223cbf18809665d8675732408e820da5a806dac10c78ab0b9f2dae58cacbe58c61c1  arpon.confd"

--- a/main/arpon/fix-ppc64le-werror.patch
+++ b/main/arpon/fix-ppc64le-werror.patch
@@ -1,0 +1,17 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -88,12 +88,12 @@
+     message(STATUS "Build type: Debug")
+ 
+     set(CMAKE_BUILD_TYPE "Debug")
+-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -Wextra -Wformat=2 -Winit-self -Wreturn-type -Wswitch-default -Wswitch-enum -Wunused-parameter -Wuninitialized -Wstrict-aliasing=3 -Wstrict-overflow=5 -Wdeclaration-after-statement -Wundef -Wpointer-arith -Wunsafe-loop-optimizations -Wbad-function-cast -Wcast-qual -Wcast-align -Wwrite-strings -Wconversion -Wsizeof-pointer-memaccess -Wlogical-op -Waggregate-return -Wstrict-prototypes -Wold-style-declaration -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -Wnested-externs -Winline -Wlong-long -Wvariadic-macros -Wvarargs -Wvla -Wdisabled-optimization -Woverlength-strings -O0 -g -ggdb")
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wformat=2 -Winit-self -Wreturn-type -Wswitch-default -Wswitch-enum -Wunused-parameter -Wuninitialized -Wstrict-aliasing=3 -Wstrict-overflow=5 -Wdeclaration-after-statement -Wundef -Wpointer-arith -Wunsafe-loop-optimizations -Wbad-function-cast -Wcast-qual -Wcast-align -Wwrite-strings -Wconversion -Wsizeof-pointer-memaccess -Wlogical-op -Waggregate-return -Wstrict-prototypes -Wold-style-declaration -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -Wnested-externs -Winline -Wlong-long -Wvariadic-macros -Wvarargs -Wvla -Wdisabled-optimization -Woverlength-strings -O0 -g -ggdb")
+ else(cmake_build_type_tolower STREQUAL "debug")
+     message(STATUS "Build type: Release")
+ 
+     set(CMAKE_BUILD_TYPE "Release")
+-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -Wextra -O3 -DNDEBUG")
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -O3 -DNDEBUG")
+ endif(cmake_build_type_tolower STREQUAL "debug")
+ 
+ find_package(Headers)


### PR DESCRIPTION
on gcc8 ppc64le encounters warnings that are treated as errors failing build. Disabling Werror flag fixes build. Warning/error details listed below:

/home/mksully/aports/main/arpon/src/ArpON-3.0-ng/src/darpi.c:69:9: error: 'strncpy' specified bound 18 equals destination size [-Werror=stringop-truncation]
         strncpy(smacsrc, ether_ntoa(macsrc), INTF_ETHERSTRLEN);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/mksully/aports/main/arpon/src/ArpON-3.0-ng/src/darpi.c:72:9: error: 'strncpy' specified bound 16 equals destination size [-Werror=stringop-truncation]
         strncpy(sipsrc, inet_ntoa(*ipsrc), INET_ADDRSTRLEN);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [src/CMakeFiles/arpon.dir/build.make:76: src/CMakeFiles/arpon.dir/darpi.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In function 'arpca_add',
    inlined from 'arpca_overwrite' at /home/mksully/aports/main/arpon/src/ArpON-3.0-ng/src/arpca.c:373:13:
/home/mksully/aports/main/arpon/src/ArpON-3.0-ng/src/arpca.c:439:9: error: 'strncpy' specified bound 16 equals destination size [-Werror=stringop-truncation]
         strncpy(ar.arp_dev, interface, IF_NAMESIZE);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
