### PR TITLE
community/z3: fix ppc64le build break to skip use of immintrin.h

### DIFF
--- a/community/z3/APKBUILD
+++ b/community/z3/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Sören Tempel <soeren+alpine@soeren-tempel.net>
 pkgname=z3
 pkgver=4.8.3
-pkgrel=0
+pkgrel=1
 pkgdesc="Theorem prover from Microsoft Research"
 url="https://github.com/Z3Prover/z3"
 arch="all !s390x !aarch64"
@@ -12,6 +12,7 @@ makedepends="cmake python3"
 install=""
 subpackages="$pkgname-dev py3-$pkgname:py3:noarch"
 source="https://github.com/Z3Prover/$pkgname/archive/$pkgname-$pkgver.tar.gz
+	fix-ppc64le-immintrin.patch
 	fix-ppc64le-ptr-size.patch"
 builddir="$srcdir/$pkgname-$pkgname-$pkgver"
 
@@ -55,4 +56,5 @@ py3() {
 }
 
 sha512sums="34a2dca0083ed469fdaf5ac062dda26248633245607ddd9ef90629c5f76ae30f87bfa4191c04ba9be7a617bf182a1bd00b59fd2274699e12ece69b86088c8044  z3-4.8.3.tar.gz
+ad5fce045ee4cf10fdfc34f7c88d56da27e8ec6bfaee2f80bdeee41a8cf78d361ed9587b1d9c1def72a402101517705b96e0103a4760946722d1cff4a7021eec  fix-ppc64le-immintrin.patch
 3d019959a104b5fd5f72eeb3738cacbdb145764ad4844eeb2539b36fa3a8228ffa062a0899465d4881b6c226301aa09b129ef06a798744b2eec9f943e0d9d366  fix-ppc64le-ptr-size.patch"

--- a/community/z3/fix-ppc64le-immintrin.patch
+++ b/community/z3/fix-ppc64le-immintrin.patch
@@ -1,0 +1,12 @@
+--- a/src/util/mpz.cpp
++++ b/src/util/mpz.cpp
+@@ -30,7 +30,9 @@
+ #else
+ #error No multi-precision library selected.
+ #endif
++#ifndef __powerpc64__
+ #include <immintrin.h> 
++#endif
+ 
+ // Available GCD algorithms
+ // #define EUCLID_GCD


### PR DESCRIPTION
Upgrade to z3 version 4.8.3 includes new use of immintrin.h in mpz.cpp resulting in error on ppc64.  This file only exists in the x86_64 gcc-8.2.0-r1 package. This patch adds condition to not include it on ppc64le. 

Build error:
/home/buildozer/aports/community/z3/src/z3-z3-4.8.3/src/util/mpz.cpp:33:10: fatal error: immintrin.h: No such file or directory
 #include <immintrin.h>
          ^~~~~~~~~~~~~
compilation terminated.