### PR TITLE
community/ripmime: fix ppc64le build by disable Werror to fix snprint…

### DIFF
--- a/community/ripmime/APKBUILD
+++ b/community/ripmime/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Carlo Landmeter <clandmeter@alpinelinux.org>
 pkgname=ripmime
 pkgver=1.4.0.10
-pkgrel=1
+pkgrel=2
 pkgdesc="Tool to extract the attached files out of a MIME package"
 url="https://pldaniels.com/ripmime/"
 arch="all"
@@ -14,6 +14,7 @@ subpackages="$pkgname-doc"
 source="https://pldaniels.com/ripmime/ripmime-$pkgver.tar.gz
 	ripmime-1.4.0.10-makefile.patch
 	ripmime-1.4.0.10-gcc8.patch
+	ripmime-disable-werror.patch
 	"
 builddir="$srcdir/ripmime-$pkgver"
 
@@ -34,4 +35,5 @@ package() {
 
 sha512sums="e1eae0ad93a50e19ab1966a6f95ae8704e59bc081f89da1e2894a3bb2a2eaea8b0fc4709ec29d126053517d56c72d6ee2a77f0d8e3fb5f223255d45e0b515ab0  ripmime-1.4.0.10.tar.gz
 a400e446a8de8ffa3c167155a601a5291b795e9875f51910c34b2f037cf5bf4cefb7e344bc3099878a36aa009d97e84c170dc6a5180721b4a82b7a1484a9c11d  ripmime-1.4.0.10-makefile.patch
-3a07e8b6716c06e264cc25a15aeac0a6449322e55b037b37e44bcca2e7fa59adc2eb6925374529a7bef91f128b5b67480f60463e5a96b1f5e5ad9f6da4f2a43c  ripmime-1.4.0.10-gcc8.patch"
+3a07e8b6716c06e264cc25a15aeac0a6449322e55b037b37e44bcca2e7fa59adc2eb6925374529a7bef91f128b5b67480f60463e5a96b1f5e5ad9f6da4f2a43c  ripmime-1.4.0.10-gcc8.patch
+6d8d19cd97c757572cf8316ad90e3988d038dcf30644e3b7a01276cef3bf2592875badefe77358fb6d4b59859ffeb41835ff696184fd6c3515983ca83bb2e3e0  ripmime-disable-werror.patch"

--- a/community/ripmime/ripmime-disable-werror.patch
+++ b/community/ripmime/ripmime-disable-werror.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
++++ b/Makefile
+@@ -15,7 +15,7 @@
+ #	use our recommended settings.
+ #CFLAGS ?= -Wall -g -O2 -Werror $(CPU_OPTS)
+ #CFLAGS=-Wall -g -O2 -Wundef -Wshadow -Wsign-compare -I.
+-CFLAGS=-Wall -g -I. -O2 -Werror
++CFLAGS=-Wall -g -I. -O2
+ 
+ # OLE decoding is still considered to be 'beta' mode - so it 
+ #	disabled in the stable release of ripMIME for now


### PR DESCRIPTION
…f warnings.

With gcc8 and Werror enabled a number of snprintf warnings are treated as errors and halt building on ppc64le unless Werror is disabled.


Errors generated are of this type:
mime.c:1432:39: error: 'snprintf' output may be truncated before the last format character [-Werror=format-truncation=]
     snprintf(hinfo->filename, 128, "%s", hinfo->uudec_name);
