### PR TITLE
main/py-roman: remove md5sums and sha512sums and force rebuild

### DIFF
--- a/main/py-roman/APKBUILD
+++ b/main/py-roman/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=py-roman
 _pkgname=roman
 pkgver=2.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Integer to Roman numerals converter"
 url="https://pypi.python.org/pypi/roman"
 arch="noarch"
@@ -43,6 +43,4 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-md5sums="aa71d131eec16d45c030fd06a27c9d17  roman-2.0.0.zip"
-sha256sums="90e83b512b44dd7fc83d67eb45aa5eb707df623e6fc6e66e7f273abd4b2613ae  roman-2.0.0.zip"
 sha512sums="d62a95e835232821dbf7a81d0c6b7df63f18c4116cfc7eee0c691a0b31d3d7b69d2dc2e4ea26e0a169a8e24bf080e8bb1e195b853be4adf1491335a5b4d5702c  roman-2.0.0.zip"


### PR DESCRIPTION
main/py-sphinx is failing build with:
ERROR: py3-roman-2.0.0-r3: package mentioned in index not found (try 'apk update')

Force rebuild and remove uneeded checksums