### PR TITLE
main/nodejs: upgrade to 10.14.0

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -6,6 +6,12 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 #
 # secfixes:
+#   10.14.0-r0:
+#     - CVE-2018-12121
+#     - CVE-2018-12122
+#     - CVE-2018-12123
+#     - CVE-2018-0735
+#     - CVE-2018-0734
 #   8.11.4-r0:
 #     - CVE-2018-12115
 #   8.11.3-r0:
@@ -27,7 +33,7 @@
 pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
-pkgver=10.13.0
+pkgver=10.14.0
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="https://nodejs.org/"
@@ -113,5 +119,5 @@ npm() {
 	mv "$pkgdir"/usr/lib/node_modules/npm "$subpkgdir"/usr/lib/node_modules/
 }
 
-sha512sums="ec30c966467a9fb348b060deeb918d1605d79eb35ca09197d8bccb37f98645d4d75f0dcf97a6e328376d56b132359d3691403ed8b3301269a6258da28adb8cc0  node-v10.13.0.tar.gz
+sha512sums="35506ab4cb2d3fa8ab2540aa3df87df5bd7e254ee092bd8872895bcac256ad0f54eab0277d3f67fed223a2634e75143a3a796657a9c8981fa444d599bc93cecc  node-v10.14.0.tar.gz
 9d09a88074bf0093f35c5b610e73ebf4c5381df2a2b29feb69da1af0b18776a683b13f1276375bbcfc60936cc27769539e1f01b4ba94b22cad2d5f4daae14c46  dont-run-gyp-files-for-bundled-deps.patch"


### PR DESCRIPTION
This updates Node.js to v10.14.0 which includes the following secfixes:
https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/