### PR TITLE
community/nodejs-current: upgrade to 11.3.0

### DIFF
--- a/community/nodejs-current/APKBUILD
+++ b/community/nodejs-current/APKBUILD
@@ -2,6 +2,12 @@
 # Maintainer: Jose-Luis Rivas <ghostbar@riseup.net>
 #
 # secfixes:
+#   11.3.0-r0:
+#     - CVE-2018-12121
+#     - CVE-2018-12122
+#     - CVE-2018-12123
+#     - CVE-2018-0735
+#     - CVE-2018-0734
 #   9.10.0-r0:
 #     - CVE-2018-7158
 #     - CVE-2018-7159
@@ -12,7 +18,7 @@
 #
 pkgname=nodejs-current
 # The current stable version, i.e. non-LTS.
-pkgver=11.1.0
+pkgver=11.3.0
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - current stable version"
 url="https://nodejs.org/"
@@ -78,5 +84,5 @@ package() {
 	rm "$pkgdir"/usr/bin/npm "$pkgdir"/usr/bin/npx
 }
 
-sha512sums="ba4c3c895f69e01e76c900ae0ca92463d1ecdabbe567954dd84338c4786203716ce561bf4ae64057d4091b8032ae4a87f5d50d7e6e94784e282078dd44c97a12  node-v11.1.0.tar.gz
+sha512sums="dd1475bd61dbc2aac563e12ced0b9423bf1f5fc421d0699526799b60254d89cbb8d01530f2f029fe146777aecadc4aa54ad62d7b33fb9195f16d8a54b1278588  node-v11.3.0.tar.gz
 9145a28bc3c2ebfc5e29e7416f8387a68808607eea4d87830a14a27c80628177a02ef4ed54b0efe2384c39fedf7356d12c267567d06d53d669c55d6211bfcf8a  dont-run-gyp-files-for-bundled-deps.patch"


### PR DESCRIPTION
This updates Node.js to v11.3.0 which includes the following secfixes:
https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/