### PR TITLE
testing/gcc6: fix ppc64le build break due to vector parsing

### DIFF
--- a/testing/gcc6/APKBUILD
+++ b/testing/gcc6/APKBUILD
@@ -3,7 +3,7 @@ pkgname=gcc6
 pkgver=6.4.0
 _ver=${pkgver%%.*}
 pkgname="$pkgname"
-pkgrel=7
+pkgrel=8
 pkgdesc="The GNU Compiler Collection"
 url="http://gcc.gnu.org"
 arch="all"
@@ -63,6 +63,7 @@ source="ftp://gcc.gnu.org/pub/gcc/releases/gcc-${_pkgbase:-$pkgver}/gcc-${_pkgba
 	fix-rs6000-pie.patch
 	fix-linux-header-use-in-libgcc.patch
 	gcc-pure64-mips.patch
+	fix-ppc64le-coercion-r261621.patch
 	"
 
 sonameprefix="$pkgname:"
@@ -346,4 +347,5 @@ abe9aaf9aa956058d0386a4396a511d176a46bb3906b90e952383646cdc158cbeb0a5dc616a1ccb1
 f4ef08454e28c8732db69115e4998ec153399e8d229dd27f923dbdcf57b68128a65640d026cc7f45b58ba8764ab1eb575d4eb6d6dfc550a87a183f8b94e76181  320-libffi-gnulinux.patch
 01c71cd5881fc07ea3b9b980697e89b3ca0fe98502958ceafc3fca18b2604c844e2f457feab711baf8e03f00a5383b0e38aac7eb954034e306f43d4a37f165ed  fix-rs6000-pie.patch
 34a818d5be67eb1f34e44a80b83c28a9b9c17d37fc9fac639f490d6bb5b53ebe3318140d09c236a17d7c98f5a7792ae3d6cefccda8067a5e942d6305b9d1f87c  fix-linux-header-use-in-libgcc.patch
-86be3338cc9c33089608bc4c5e3b7918c4e500a345c338f361b18c342119a6ed69af5495d72950de7106d760f003528b46ad14795e805f8a3331e206dcb234e3  gcc-pure64-mips.patch"
+86be3338cc9c33089608bc4c5e3b7918c4e500a345c338f361b18c342119a6ed69af5495d72950de7106d760f003528b46ad14795e805f8a3331e206dcb234e3  gcc-pure64-mips.patch
+aae9d510326bed6eca0b1f680d2caf64dd804e73fb9d726c8932faa845c07e1be6ab12920972d8fb80a33dafedcaafca71487b0eaf10e6d5fa7deb853926b933  fix-ppc64le-coercion-r261621.patch"

--- a/testing/gcc6/fix-ppc64le-coercion-r261621.patch
+++ b/testing/gcc6/fix-ppc64le-coercion-r261621.patch
@@ -1,0 +1,11 @@
+--- a/libcpp/lex.c
++++ b/libcpp/lex.c
+@@ -568,7 +568,7 @@
+     {
+       vc m_nl, m_cr, m_bs, m_qm;
+ 
+-      data = *((const vc *)s);
++      data = __builtin_vec_vsx_ld (0, s);
+       s += 16;
+ 
+       m_nl = (vc) __builtin_vec_cmpeq(data, repl_nl);


### PR DESCRIPTION
Adding fix https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=261621

to overcome build error on ppc64le: 
build/genmatch --gimple /home/buildozer/aports/testing/gcc6/src/gcc-6.4.0/gcc/match.pd \
    > tmp-gimple-match.c
/home/buildozer/aports/testing/gcc6/src/gcc-6.4.0/gcc/match.pd:120:1 error: expected (, got NAME
   negative value by 0 gives -0, not +0.  */