### PR TITLE
testing/linux-amlogic: disable armhf and armv7

### DIFF
--- a/testing/linux-amlogic/APKBUILD
+++ b/testing/linux-amlogic/APKBUILD
@@ -6,7 +6,7 @@ case $pkgver in
 *.*.*)	_kernver=${pkgver%.*};;
 *.*)	_kernver=${pkgver};;
 esac
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux kernel for Amlogic"
 url=https://github.com/torvalds/linux
 _commit=e7d199e92956587695510d147c8de795f944cec9
@@ -53,7 +53,7 @@ source="$url/archive/${_commit}.tar.gz
 	off_error_text_offset.patch
 	"
 subpackages=""
-arch="armhf armv7 aarch64"
+arch="aarch64"
 license="GPL-2.0"
 _flavors=
 for _i in $source; do


### PR DESCRIPTION
For now didn't supply kernel config for armhf and armv7, will add them
back when add kernel config.