### PR TITLE
testing/openocd: enable bcm2835gpio for ARM (RPi) architectures

### DIFF
--- a/testing/openocd/APKBUILD
+++ b/testing/openocd/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Sören Tempel <soeren+alpine@soeren-tempel.net>
 pkgname=openocd
 pkgver=0.10.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Free and Open On-Chip Debugging, In-System Programming and Boundary-Scan Testing"
 url="http://openocd.org/"
 arch="all"
@@ -26,7 +26,8 @@ build() {
 		--localstatedir=/var \
 		--disable-werror \
 		--enable-cmsis-dap \
-		--enable-sysfsgpio
+		--enable-sysfsgpio \
+		--enable-bcm2835gpio
 	make
 }
 


### PR DESCRIPTION
Follow-up to 958a8ae7e7 because the 0.10.0 [release notes] also request `--enable-bcm2835gpio` for builds that support Raspberry Pi:

> 7.  Please add --enable-sysfsgpio for all targets running Linux, the
> kernel (esp. useful for SBCs), additionally for builds that support
> RaspberryPi, please add --enable-bcm2835gpio

`--enable-bcm2835gpio` is ignored when building on non-ARM architectures.  This configuration is also consistent with the [Debian packaging].

[release notes]: https://sourceforge.net/p/openocd/mailman/message/35570895/
[Debian packaging]: https://salsa.debian.org/electronics-team/openocd/blob/debian/0.10.0-4/debian/rules#L33