### PR TITLE
testing/shairport-sync: Fix abuild warnings

### DIFF
--- a/testing/shairport-sync/APKBUILD
+++ b/testing/shairport-sync/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 pkgname=shairport-sync
 pkgver=3.2.2
-pkgrel=0
+pkgrel=1
 pkgdesc="AirTunes emulator. Shairport Sync adds multi-room capability with Audio Synchronisation"
 url="https://github.com/mikebrady/shairport-sync"
 arch="all"
@@ -10,10 +10,11 @@ license="custom"
 depends="avahi"
 makedepends="autoconf automake libtool alsa-lib-dev libdaemon-dev popt-dev
 	openssl-dev soxr-dev avahi-dev libconfig-dev"
-subpackages="$pkgname-doc"
+subpackages="$pkgname-doc $pkgname-openrc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/mikebrady/$pkgname/archive/$pkgver.tar.gz
 	$pkgname.initd"
 builddir="$srcdir/$pkgname-$pkgver"
+options=!check
 
 prepare() {
 	default_prepare


### PR DESCRIPTION
Skip test's as they do not exist.
Added openrc subpackage.