### PR TITLE
main/apache-mod-fcgid: update source download location to fix  bld break

### DIFF
--- a/main/apache-mod-fcgid/APKBUILD
+++ b/main/apache-mod-fcgid/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=apache-mod-fcgid
 _pkgreal=mod_fcgid
 pkgver=2.3.9
-pkgrel=1
+pkgrel=2
 pkgdesc="FastCGI module for Apache 2.x"
 url="http://httpd.apache.org/$_pkgreal/"
 arch="all"
@@ -12,7 +12,7 @@ depends="apache2"
 makedepends="apache2-dev"
 install=""
 subpackages="$pkgname-doc"
-source="http://mirror.switch.ch/mirror/apache/dist//httpd/mod_fcgid/$_pkgreal-$pkgver.tar.gz
+source="https://www.apache.org/dist/httpd/mod_fcgid/$_pkgreal-$pkgver.tar.gz
         $_pkgreal.conf
         "
 
@@ -31,9 +31,5 @@ package() {
 	rm -fr "$pkgdir"/etc/apache2/original
 }
 
-md5sums="ece4c66f0c05d216fc96969fcf3d1add  mod_fcgid-2.3.9.tar.gz
-3f4288dad895b6fc65af87d0af3d34bd  mod_fcgid.conf"
-sha256sums="1cbad345e3376b5d7c8f9a62b471edd7fa892695b90b79502f326b4692a679cf  mod_fcgid-2.3.9.tar.gz
-c6df3eb47fb9e6a81a066a83ae8c11a8a796dc6e83b23eb47c7903d406bade22  mod_fcgid.conf"
 sha512sums="cae8bf8ad324512a51e6f34cb32468ea49a17deaabd481f8b581444891656f2516f10d198630f92ebc18db3d575f61dd7254153938a8206fb6c1441c7850be63  mod_fcgid-2.3.9.tar.gz
 e5d7d81905f7cd73b5dbd3baa39c1d84e3c96e3fc3fda41fc52ada1a4353ca5186e53f56d782273d86a858cc9215c72321f34d92643ac176d4232df638a05812  mod_fcgid.conf"


### PR DESCRIPTION
http://mirror.switch.ch/mirror/apache/dist//httpd/mod_fcgid/ no longer valid. Updating to valid apache source location. 