### PR TITLE
main/debian-archive-keyring: bld break pkg no longer available. Upgra…

### DIFF
--- a/main/debian-archive-keyring/APKBUILD
+++ b/main/debian-archive-keyring/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Sören Tempel <soeren+alpine@soeren-tempel.net>
 pkgname=debian-archive-keyring
-pkgver=2017.7
+pkgver=2018.1
 pkgrel=0
 pkgdesc="GnuPG archive keys of the Debian archive"
 url="http://packages.debian.org/sid/debian-archive-keyring"
@@ -34,4 +34,4 @@ package() {
 	tar -xJf "$srcdir"/data.tar.xz -C "$pkgdir"/
 }
 
-sha512sums="9802058a9de69d941eab9ebf7a8370b1b5af0130444ca8fd46996d1699f940775fec2820f7963fdcf70e49a467682d1ac023a1da72e34f90cf3c09a04dface74  debian-archive-keyring_2017.7_all.deb"
+sha512sums="7bf98cda5b9639d68538a8d47e35d422e552bd8afa067e844f0e8e76a366f9d5e503e0f47dd646789fa0264a47b77d0bfcc22559ad09bdc95453e4a5c2169f0f  debian-archive-keyring_2018.1_all.deb"


### PR DESCRIPTION
…de to 2018.1