### PR TITLE
main/putty: fix ppc64le bld break by disabling Werror

### DIFF
--- a/main/putty/APKBUILD
+++ b/main/putty/APKBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Jeff Bilyk <jbilyk@alpinelinux.org>
 pkgname=putty
 pkgver=0.70
-pkgrel=0
+pkgrel=1
 pkgdesc="SSH and telnet client"
 url="https://www.chiark.greenend.org.uk/~sgtatham/putty/"
 arch="all"
 license="custom"
 subpackages="$pkgname-doc"
-source="http://the.earth.li/~sgtatham/putty/$pkgver/putty-$pkgver.tar.gz"
+source="http://the.earth.li/~sgtatham/putty/$pkgver/putty-$pkgver.tar.gz
+	fix-ppc64le-disable-werror.patch"
 builddir="$srcdir"/putty-$pkgver
 
 build() {
@@ -24,4 +25,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="2aaf4fa2b4ad2d82eb5cdc4419ade79e0c5d8bd3c093db92b3c048e6107f85a5f1647f9d8203cda0906ce2b926725a75319f981cb32e6f1ebf50b1f738564fed  putty-0.70.tar.gz"
+sha512sums="2aaf4fa2b4ad2d82eb5cdc4419ade79e0c5d8bd3c093db92b3c048e6107f85a5f1647f9d8203cda0906ce2b926725a75319f981cb32e6f1ebf50b1f738564fed  putty-0.70.tar.gz
+408f113f659bcb0df99d2941d243950b59159fb06a7c1640fdb92b79e1f4f9c7304c36910143797c448577282b17cd6297b98fefe83d9beeeab0ffc3657aebf7  fix-ppc64le-disable-werror.patch"

--- a/main/putty/fix-ppc64le-disable-werror.patch
+++ b/main/putty/fix-ppc64le-disable-werror.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -5853,7 +5853,7 @@
+ 
+ if test "x$GCC" = "xyes"; then
+   :
+-  WARNINGOPTS='-Wall -Werror'
++  WARNINGOPTS='-Wall '
+ 
+ else
+   :


### PR DESCRIPTION
ppc64le with Werror flag enabled generates error:
pscp.c:886:22: error: '%s' directive writing up to 39 bytes into a region of size 34 [-Werror=format-overflow=]
  sprintf(buf, "C%04o %s ", (int)(permissions & 07777), sizestr);
                      ^~                                ~~~~~~~
pscp.c:886:2: note: 'sprintf' output between 8 and 47 bytes into a destination of size 40
  sprintf(buf, "C%04o %s ", (int)(permissions & 07777), sizestr);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Disable Werror in configure