### PR TITLE
main/xfsprogs: fix ppc64le bld break by checking for MAP_SYNC define

### DIFF
--- a/main/xfsprogs/APKBUILD
+++ b/main/xfsprogs/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xfsprogs
 pkgver=4.17.0
-pkgrel=1
+pkgrel=2
 pkgdesc="XFS filesystem utilities"
 url="http://xfs.org/index.php/Main_Page"
 arch="all"
@@ -11,6 +11,7 @@ makedepends="linux-headers util-linux-dev bash gzip python3"
 options="!check"  # no test suite
 subpackages="$pkgname-dev $pkgname-doc $pkgname-libs $pkgname-extra"
 source="https://www.kernel.org/pub/linux/utils/fs/xfs/$pkgname/$pkgname-$pkgver.tar.gz
+	fix-ppc64le_map_sync_check.patch
 	"
 
 builddir="$srcdir/$pkgname-$pkgver"
@@ -49,4 +50,5 @@ extra() {
 	mv "$pkgdir"/usr "$subpkgdir"/
 }
 
-sha512sums="19bdb9b1698b07d42c52976c17ac8dc95170e59bbd7d74e3d6faadd36cba88ed36a8b0c309052cab01ecb3a14e564b42ea982380b76922401be516d463476548  xfsprogs-4.17.0.tar.gz"
+sha512sums="19bdb9b1698b07d42c52976c17ac8dc95170e59bbd7d74e3d6faadd36cba88ed36a8b0c309052cab01ecb3a14e564b42ea982380b76922401be516d463476548  xfsprogs-4.17.0.tar.gz
+260f4d489ce779324602406c72c4b398e23a0713d29d63ee2c36a11a677c341b21847aa6a8a9da5e31b191535c325dda607b9923e56e85839a2fe26aad7e1b30  fix-ppc64le_map_sync_check.patch"

--- a/main/xfsprogs/fix-ppc64le_map_sync_check.patch
+++ b/main/xfsprogs/fix-ppc64le_map_sync_check.patch
@@ -1,0 +1,26 @@
+--- a/io/mmap.c
++++ b/io/mmap.c
+@@ -201,7 +201,11 @@
+ 			prot |= PROT_EXEC;
+ 			break;
+ 		case 'S':
++#if defined(MAP_SYNC) 
+ 			flags = MAP_SYNC | MAP_SHARED_VALIDATE;
++#else
++			flags = 0;
++#endif
+ 
+ 			/*
+ 			 * If MAP_SYNC and MAP_SHARED_VALIDATE aren't defined
+@@ -281,7 +285,11 @@
+ 	mapping->offset = offset;
+ 	mapping->name = filename;
+ 	mapping->prot = prot;
++#if defined(MAP_SYNC)
+ 	mapping->map_sync = (flags == (MAP_SYNC | MAP_SHARED_VALIDATE));
++#else
++	mapping->map_sync = 0;
++#endif
+ 	return 0;
+ }
+ 


### PR DESCRIPTION
/usr/include/bits/mman.h provided by musl-dev-1.1.20-r2 #undef MAP_SYNC causing a build error for undefined variable in mmap.c. This patch checks that the define is present before using it. 