### PR TITLE
testing/wlroots: new aport

### DIFF
--- a/main/wayland-protocols/APKBUILD
+++ b/main/wayland-protocols/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=wayland-protocols
-pkgver=1.16
+pkgver=1.17
 pkgrel=0
 pkgdesc="Protocols and protocol extensions complementing the Wayland core protocol"
 url="http://wayland.freedesktop.org"
@@ -34,4 +34,4 @@ package() {
 	make -C "$builddir" DESTDIR="$pkgdir" install
 }
 
-sha512sums="8ab33021854f3e8f6bca7a9e69427e7a3e53297cc0abd4c006de7e55fac66da3ad88489a6eb4e6c28c7ba2addd96e7f055309f3c8918643b18ef78a4fb637f84  wayland-protocols-1.16.tar.xz"
+sha512sums="5f3aacbba58717092036659d9b665dc10ff05ee51df61b1de38b22f0417285a74fd8a6d15ca049ad60d204f28203aa13d773c52140c7c02db2c498a6964c2643  wayland-protocols-1.17.tar.xz"

--- a/testing/wlroots/APKBUILD
+++ b/testing/wlroots/APKBUILD
@@ -1,0 +1,41 @@
+# Contributor: Henrik Riomar <henrik.riomar@gmail.com>
+# Maintainer:
+pkgname=wlroots
+pkgver=0.2
+pkgrel=0
+pkgdesc="A modular Wayland compositor library"
+url="https://github.com/swaywm/wlroots"
+arch="all"
+license="MIT"
+options="!check" # contains no test suite
+makedepends="ctags
+	eudev-dev
+	libcap-dev
+	libinput-dev
+	libxcb-dev
+	libxkbcommon-dev
+	mesa-dev
+	meson
+	ninja
+	pixman-dev
+	wayland-dev
+	wayland-protocols
+	xcb-util-image-dev
+	xcb-util-wm-dev
+	"
+subpackages="$pkgname-dev"
+source="$pkgname-$pkgver.tar.gz::https://github.com/swaywm/$pkgname/archive/$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	meson build --prefix /usr
+	ninja -C build
+}
+
+package() {
+	cd "$builddir"
+	DESTDIR="$pkgdir" ninja -C build install
+}
+
+sha512sums="b7727b29ed7e5188d5fa6099687f8e6f48b6b3f17f7a6e136956ad6b607054595de3779118bffd4b9730115eaca2f00c2d30d52f4915b2753a749432ec0c3f2a  wlroots-0.2.tar.gz"


### PR DESCRIPTION
While at it upgrade main/wayland-protocols

Note this change requires https://github.com/alpinelinux/aports/pull/5591 to be commited as well