### PR TITLE
community/php5: security upgrade to 5.6.39

### DIFF
--- a/community/php5/APKBUILD
+++ b/community/php5/APKBUILD
@@ -3,8 +3,8 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
-pkgver=5.6.38
-pkgrel=2
+pkgver=5.6.39
+pkgrel=0
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
 arch="all"
@@ -530,7 +530,7 @@ pdo_dblib()	{ _mv_ext pdo_dblib "$pkgname-pdo freetds"; }
 wddx()		{ _mv_ext wddx; }
 opcache()	{ _mv_ext opcache; }
 
-sha512sums="d39cf2d56311802dfa81afaabfb1968a2647d37f42df1be54dd9557ff5ced5c444b52a3502c78b27feefd88972324b2663fc1745f985c2eb51096e06ff6191d1  php-5.6.38.tar.bz2
+sha512sums="362388882f813f9e56e22cd58505e44becdfef87b031b117c957a05aca881b70a30283e462a3c3e50c9935cb055b9994183b7d2555765f876a30266540765753  php-5.6.39.tar.bz2
 f7d922cab98617ef910b4c14974e768c85e60424cd1b216f688b34b2d823b642a5b896463008c134ce47c150f9407f5c438823b7e7bc89b3fb440cd3e97b9d7e  php-fpm.initd
 d1dd6a5764e18414476aaaa109efcc568696ac17a61a1afdf7d0621d3e38c5be717a81ee4d11d28963f11e76879af7d3806970e651061f8c4abffb03c4bd5af4  php5-module.conf
 f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c939768584f3e4edbe52e8bd6103fb6777462326a9d94e8ab1f505  php-install-pear-xml.patch


### PR DESCRIPTION
The last upgrade before EOL https://github.com/alpinelinux/aports/pull/5569 needs backport to 3.8

Ref http://php.net/ChangeLog-5.php#5.6.39