### PR TITLE
testing/gx-go: new aport

### DIFF
--- a/testing/gx-go/APKBUILD
+++ b/testing/gx-go/APKBUILD
@@ -1,0 +1,44 @@
+# Contributor: Oleg Titov <oleg.titov@gmail.com>
+# Maintainer: Oleg Titov <oleg.titov@gmail.com>
+pkgname=gx-go
+pkgver=1.9.0
+pkgrel=0
+pkgdesc="A tool to use with the gx package manager for packages written in go"
+url="https://github.com/whyrusleeping/gx-go"
+arch="all"
+license="MIT"
+options="!check" # No test suit
+depends="musl"
+makedepends="git go"
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/whyrusleeping/$pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir/"
+
+prepare() {
+	mkdir -p "$srcdir"/src/github.com/whyrusleeping/
+	ln -fs "$srcdir/$pkgname-$pkgver" "$srcdir"/src/github.com/whyrusleeping/gx-go
+}
+
+build() {
+	export GOPATH="$srcdir"
+	export GOBIN="$GOPATH/bin"
+	cd "$srcdir"/src/github.com/whyrusleeping/$pkgname
+
+	go get -v
+
+	go install -v
+}
+
+check() {
+	cd "$builddir"
+}
+
+package() {
+	cd "$builddir"
+	install -Dm 755 bin/gx-go "${pkgdir}/usr/bin/gx-go"
+
+	cd "$pkgname-$pkgver"
+	install -Dm 644 -t "${pkgdir}/usr/share/licenses/gx-go" LICENSE
+}
+
+sha512sums="3df8a99d257098afdf99ba6cbf58d50eab196f823ae53db48865a4f4962e38b84a66ffc99d5a342b43ff9891c8245252a77677b75c770d86f93ef1ad3c9e879f  gx-go-1.9.0.tar.gz"


### PR DESCRIPTION
https://github.com/whyrusleeping/gx-go
A tool to use with the gx package manager for packages written in go

Needed for addition of go-ipfs, Inter Planetary File System (IPFS) package.