### PR TITLE
testing/gx: new aport

### DIFF
--- a/testing/gx/APKBUILD
+++ b/testing/gx/APKBUILD
@@ -1,0 +1,43 @@
+# Contributor: Oleg Titov <oleg.titov@gmail.com>
+# Maintainer: Oleg Titov <oleg.titov@gmail.com>
+pkgname=gx
+pkgver=0.14.1
+pkgrel=0
+pkgdesc="Packaging tool build around the distributed, content addressed filesystem IPFS"
+url="https://github.com/whyrusleeping/gx"
+arch="all"
+license="MIT"
+options="!check" # No test suit
+makedepends="git go"
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/whyrusleeping/$pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir/"
+
+prepare() {
+	mkdir -p "$srcdir"/src/github.com/whyrusleeping/
+	ln -fs "$srcdir/$pkgname-$pkgver" "$srcdir"/src/github.com/whyrusleeping/$pkgname
+}
+
+build() {
+	export GOPATH="$srcdir"
+	export GOBIN="$GOPATH/bin"
+	cd "$srcdir"/src/github.com/whyrusleeping/$pkgname
+
+	go get -v
+
+	go install -v
+}
+
+check() {
+	cd "$builddir"
+}
+
+package() {
+	cd "$builddir"
+	install -Dm 755 bin/gx "${pkgdir}/usr/bin/gx"
+
+	cd "$pkgname-$pkgver"
+	install -Dm 644 -t "${pkgdir}/usr/share/licenses/gx" LICENSE
+}
+
+sha512sums="cb61f669e9945604cb68225ce4cee3ff26d944b54078909aa573b781bd72b928a603e94a21eb95644a23ec2e09b0bf4deef84457f588d9be16a0b4dbf8d7f194  gx-0.14.1.tar.gz"


### PR DESCRIPTION
https://github.com/whyrusleeping/gx
Packaging tool build around the distributed, content addressed filesystem IPFS

Needed for addition of go-ipfs, Inter Planetary File System (IPFS) package.