### PR TITLE
[v3.5] main/php5: security upgrade to 5.6.40

### DIFF
--- a/main/php5/APKBUILD
+++ b/main/php5/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Matt Smith <mcs@darkregion.net>
 pkgname=php5
-pkgver=5.6.38
+pkgver=5.6.40
 pkgrel=0
 pkgdesc="The PHP language runtime engine"
 url="http://www.php.net/"
@@ -125,6 +125,13 @@ _confdir=/etc/$pkgname
 _peardir=/usr/share/pear
 
 # secfixes:
+#   5.6.40-r0:
+#     - CVE-2016-10166
+#   5.6.39-r0:
+#     - CVE-2018-19158
+#     - CVE-2018-19935
+#   5.6.38-r0:
+#     - CVE-2018-17082
 #   5.6.37-r0:
 #     - CVE-2018-14851
 #     - CVE-2018-14883
@@ -521,7 +528,7 @@ pdo_dblib()	{ _mv_ext pdo_dblib "$pkgname-pdo freetds"; }
 wddx()		{ _mv_ext wddx; }
 opcache()	{ _mv_ext opcache; }
 
-sha512sums="d39cf2d56311802dfa81afaabfb1968a2647d37f42df1be54dd9557ff5ced5c444b52a3502c78b27feefd88972324b2663fc1745f985c2eb51096e06ff6191d1  php-5.6.38.tar.bz2
+sha512sums="acd9fee67a55f5e62c23550777c676138e9932330ce6f056354752a12b169fe1d017b30d85ad66a612ce959f2392edecde68eca9eb200cf99f739f629e0cb857  php-5.6.40.tar.bz2
 1f5cb18f85a2e279e24344d993f5c51c7bfbcbecc0e9bfcf075bebd1b0b893e2ffb793d95a632c9333033597d4b4f74840bfd00520a6dc700444d1a054225da1  php-fpm.initd
 895e94c791bd82060ad820fef049d366a09c932097faa6b7b9a2c2e9e00a18cb7c0f9b128679c7659b404379266fd0f95dba5c0333f626194cf60f7bf6044102  php5-module.conf
 f1177cbf6b1f44402f421c3d317aab1a2a40d0b1209c11519c1158df337c8945f3a313d689c939768584f3e4edbe52e8bd6103fb6777462326a9d94e8ab1f505  php-install-pear-xml.patch


### PR DESCRIPTION
Last php5 relase http://php.net/archive/2018.php#id2018-12-06-2

Last CVE pending https://bugs.php.net/bug.php?id=77143