### PR TITLE
main/alpine-baselayout: preserve value of PATH

### DIFF
--- a/main/alpine-baselayout/profile
+++ b/main/alpine-baselayout/profile
@@ -1,5 +1,5 @@
 export CHARSET=UTF-8
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
 export PAGER=less
 export PS1='\h:\w\$ '
 umask 022


### PR DESCRIPTION
In order to exercise interoperability with wsl, subsystem process
injects PATH variable to the Linux OS, this delta preserves its value.

ref: https://github.com/Microsoft/WSL/issues/3710

cc @agowa338