### PR TITLE
testing/rakudo: upgrade to 2018.11

### DIFF
--- a/testing/moarvm/APKBUILD
+++ b/testing/moarvm/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=moarvm
-pkgver=2018.10
-pkgrel=1
+pkgver=2018.11
+pkgrel=0
 pkgdesc="A VM for NQP And Rakudo Perl 6"
 url="http://moarvm.org/"
 arch="all"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="24af58d9481cf9cf9bd31d098b18c0059aad870a52c0a826fe6296fcd9d23bb44fe343a2aeffc8a0f694db681b6691c3cafc81218d82e988064cd98bf5c8ea5d  MoarVM-2018.10.tar.gz"
+sha512sums="90cf3d6885dd556fbb6aea61c939504abbce202919268866bcdb90e92f8179650436563fe7de58bd6b278737aa0960fe2bdc54ad380241fa73fb59589fed294d  MoarVM-2018.11.tar.gz"

--- a/testing/nqp/APKBUILD
+++ b/testing/nqp/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=nqp
-pkgver=2018.10
-pkgrel=1
+pkgver=2018.11
+pkgrel=0
 pkgdesc="Not Quite Perl"
 url="https://github.com/perl6/nqp"
 arch="all !x86 !armhf !armv7"
@@ -39,4 +39,4 @@ doc() {
 	done
 }
 
-sha512sums="bed9e3bbee307bf6ea163732a21a542f69290de15ff8fe6ff5e4eda03d1865811180a4428d805a4a3e9aacbdfe6d39858577bf53372a4008455100493c86a790  nqp-2018.10.tar.gz"
+sha512sums="2d5cf38fd153a4fb96e7597347e31315b87771554f0c7fce4fe7957628da95f219baf2111fce2ce2cfead9008125926f7be79515c3ab28b4d5ea8f41bf352ef2  nqp-2018.11.tar.gz"

--- a/testing/rakudo/APKBUILD
+++ b/testing/rakudo/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=rakudo
-pkgver=2018.10
-pkgrel=1
+pkgver=2018.11
+pkgrel=0
 pkgdesc="A compiler for the Perl 6 programming language"
 url="http://rakudo.org/"
 arch="all !x86 !armhf !armv7"
@@ -53,5 +53,5 @@ doc() {
 	done
 }
 
-sha512sums="82ca24e6484dcd2c27287f609b8008f3044e3709a53dc96b259ccd612745c80ff0b2cb20b71460e434387ad7ea10895b751775286552684bfdd4d7d08d9e26da  rakudo-2018.10.tar.gz
+sha512sums="3ade13f51bcfccaa445043368d4b46d3bb2a4d934cd404f04374418a15f81b1bf431125b8133e61936df319b5d11426e77e99b118fd42a35dfbe1efd7267763f  rakudo-2018.11.tar.gz
 74a3e3bff623a8922d2aae2f43e25be1a7b8a2b0b128bc8eb15fa9f03307fe603cb342b644607b7d74b3a084fb936c47113ab6249a0e23bb3107727383201152  perf-increase-tolerance.patch"


### PR DESCRIPTION
Upgrade moarvm, nqp, and rakudo to version 2018.11, must upgrade all three together.