### PR TITLE
main/openssl: enable psk

### DIFF
--- a/main/openssl/APKBUILD
+++ b/main/openssl/APKBUILD
@@ -56,7 +56,7 @@ build() {
 		--openssldir=/etc/ssl \
 		shared no-zlib $_optflags \
 		no-async no-comp no-idea no-mdc2 no-rc5 no-ec2m \
-		no-sm2 no-sm4 no-ssl2 no-ssl3 no-seed no-psk \
+		no-sm2 no-sm4 no-ssl2 no-ssl3 no-seed \
 		no-weak-ssl-ciphers \
 		$CPPFLAGS $CFLAGS $LDFLAGS -Wa,--noexecstack
 	make

--- a/main/py-cryptography/APKBUILD
+++ b/main/py-cryptography/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=py-cryptography
 _pkgname=${pkgname#py-}
 pkgver=2.4.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A package which provides cryptographic recipes and primitives"
 url="https://pypi.python.org/pypi/cryptography"
 arch="all"


### PR DESCRIPTION
There is no need to disable psk. Qt5 supports it. I will bump Qt5 after this.