### PR TITLE
testing/mitmproxy: security upgrade to 4.0.4 and modernize

### DIFF
--- a/testing/mitmproxy/APKBUILD
+++ b/testing/mitmproxy/APKBUILD
@@ -1,26 +1,31 @@
 # Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=mitmproxy
-pkgver=0.18.2
-pkgrel=1
+pkgver=4.0.4
+pkgrel=0
 pkgdesc="An interactive SSL-capable intercepting HTTP proxy"
 url="https://www.mitmproxy.org/"
 arch="noarch"
 license="MIT"
 depends="python2 py-netlib py-flask py-urwid py-$pkgname py-itsdangerous"
-makedepends="python2-dev py-setuptools"
+makedepends="python2-dev py-setuptools openssl-dev"
 subpackages="py-$pkgname:py"
 source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
-	python2 setup.py build || return 1
+	python2 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py test
 }
 
 package() {
 	cd "$builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	python2 setup.py install --prefix=/usr --root="$pkgdir"
 }
 
 py() {
@@ -30,4 +35,4 @@ py() {
 	mv "$pkgdir"/usr/lib/python* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="39836063a041d7fd14bb82ccf2fb53262b8ec14b629197776e27ebfb2fc97103ee5b4af979ffe6db35103e833679e2e5a640295831d55a2cd0f20a602b559064  mitmproxy-0.18.2.tar.gz"
+sha512sums="e08ea8b1c75a95b822c463625509037bbc8a979161cacaa1f0185f98df8d6d7e5400925365dbbe70d18751251b1005824f739a8cd035c0389f7b4aea562adfb3  mitmproxy-4.0.4.tar.gz"


### PR DESCRIPTION
Ref https://github.com/mitmproxy/mitmproxy/releases

Package very outdated