### PR TITLE
main/xen: add missing CVE refs

### DIFF
--- a/main/xen/APKBUILD
+++ b/main/xen/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=xen
 pkgver=4.11.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Xen hypervisor"
 url="https://www.xenproject.org/"
 arch="x86_64 armhf aarch64" # enable armv7 when builds with gcc8
@@ -119,12 +119,25 @@ options="!strip"
 #     - CVE-2018-8897 XSA-260
 #     - CVE-2018-10982 XSA-261
 #     - CVE-2018-10981 XSA-262
-#   4.11-0-r0:
+#   4.11.0-r0:
 #     - CVE-2018-3639   XSA-263
 #     - CVE-2018-128911 XSA-264
 #     - CVE-2018-12893  XSA-265
 #     - CVE-2018-12892  XSA-266
 #     - CVE-2018-3665   XSA-267
+#   4.11.1-r0:
+#     - CVE-2018-15469  XSA-268
+#     - CVE-2018-15468  XSA-269
+#     - CVE-2018-15470  XSA-272
+#     - CVE-2018-3620   XSA-273
+#     - CVE-2018-3646   XSA-273
+#     - CVE-????-????   XSA-275
+#     - CVE-????-????   XSA-276
+#     - CVE-????-????   XSA-277
+#     - CVE-2018-18883  XSA-278
+#     - CVE-????-????   XSA-279
+#     - CVE-????-????   XSA-280
+#     - CVE-????-????   XSA-282
 
 case "$CARCH" in
 x86*)
@@ -402,7 +415,7 @@ hypervisor() {
 }
 
 bridge() {
-	depends="bridge-utils dnsmasq"
+	depends="dnsmasq"
 	pkgdesc="Bridge interface for XEN with dhcp"
 	mkdir -p "$subpkgdir"/etc/conf.d \
 		"$subpkgdir"/etc/init.d \


### PR DESCRIPTION
While at it, drop depend that was not needed after all