### PR TITLE
[3.8] main/libressl: upgrade to 2.7.5

### DIFF
--- a/main/libressl/APKBUILD
+++ b/main/libressl/APKBUILD
@@ -10,11 +10,11 @@
 #     - CVE-2017-8301
 #
 pkgname=libressl
-pkgver=2.7.4
+pkgver=2.7.5
 _namever=${pkgname}${pkgver%.*}
 pkgrel=0
 pkgdesc="Version of the TLS/crypto stack forked from OpenSSL"
-url="http://www.libressl.org/"
+url="https://www.libressl.org/"
 arch="all"
 license="custom"
 depends=""
@@ -24,7 +24,7 @@ makedepends="$makedepends_host $makedepends_build"
 replaces="openssl"
 subpackages="$pkgname-dbg $_namever-libcrypto:_libs $_namever-libssl:_libs
 	$_namever-libtls:_libs $pkgname-dev $pkgname-doc"
-source="http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/$pkgname-$pkgver.tar.gz
+source="https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/$pkgname-$pkgver.tar.gz
 	starttls-ldap.patch
 	ssl-libcompat.patch
 	s_client-add-options-verify_.patch
@@ -85,7 +85,7 @@ _libs() {
 	fi
 }
 
-sha512sums="1cd82a1bff4f655251b5feb0c850f4164e0fd548e4b404407370f74dcc75c205f42efc7787a157eecac84cbbe46af48cb63f46b3fef75f4a0a9ea19a5863a691  libressl-2.7.4.tar.gz
+sha512sums="00828dd115f6395186ce4c9cadb604612763f67f2ad2236a331062add8115f6494a655cbec237ae069e373ffb915ed4025c993e06456c3da69b279e5f7e2b8d4  libressl-2.7.5.tar.gz
 9f1628fbc2a697b6570353920d784b161ca0a122047066d8bee15225bad1e5271aa2ed72b145506bcd4ffe58b35da2caf38c4a048db7e014dabd16b5eba44581  starttls-ldap.patch
 ef8150843f5aae577a859198439673591764fb3ab1da03436607328962f084356fd7f793484c3ad5f2294bd9e8dad15644c311b0da811acbc83eed4b71c0145a  ssl-libcompat.patch
 4c992872addbe4fd612ba9e3f859b5ba69b448aafa7676751ca7ca09bbcfc47a2a1cad468c235f8d1a65c65e8efb38f27c512a32b444346c39ec0d8dcfbcd346  s_client-add-options-verify_.patch"


### PR DESCRIPTION
> Added a blinding value when generating DSA and ECDSA signatures, in
> order to reduce the possibility of a side-channel attack leaking the
> private key.

https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.7.5-relnotes.txt