### PR TITLE
testing/wireguard: upgrade to 0.0.20181218

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -3,7 +3,7 @@
 
 # NOTE: pkgrel must match _toolsrel in wireguard-vanilla
 pkgname=wireguard-tools
-pkgver=0.0.20181119
+pkgver=0.0.20181218
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -43,4 +43,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="dc9286e536bb3f4a6545261b98b5bb056a085f2e95b1b571350168af23cda5231a90b915b03dd29d195412fc61efc781b7d57b2a15a42a34b97e989a5105198e  WireGuard-0.0.20181119.tar.xz"
+sha512sums="73c8e9b37d857349b75df776607c15ea2082814952acdba3ad6379c4ce631601db2767603e46ecadf1bce9348a0c26d07f4f6b5857ddd72bb4f4411d1d13d88c  WireGuard-0.0.20181218.tar.xz"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20181119
-_rel=0
+_ver=0.0.20181218
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="dc9286e536bb3f4a6545261b98b5bb056a085f2e95b1b571350168af23cda5231a90b915b03dd29d195412fc61efc781b7d57b2a15a42a34b97e989a5105198e  WireGuard-0.0.20181119.tar.xz"
+sha512sums="73c8e9b37d857349b75df776607c15ea2082814952acdba3ad6379c4ce631601db2767603e46ecadf1bce9348a0c26d07f4f6b5857ddd72bb4f4411d1d13d88c  WireGuard-0.0.20181218.tar.xz"


### PR DESCRIPTION
```
  * jerry-rig: replace S_shipped with pl
  
  This fixes our jerry rig script, so that people can patch WireGuard into
  arbitrary kernel trees, instead of building as a standalone module.
  
  * chacha20,poly1305: simplify perlasm fanciness
  
  Numerous cleanups and correctness fixes in the assembly generators.
  
  * compat: don't undef BUILD_BUG_ON for Clang >=8
  
  The clang bug was finally fixed upstream, so we remove the workaround, while
  retaining the hack in our compat layer.
  
  * embeddable-wg-library: do not warn on unrecognized netlink attributes
  
  This brings behavior into parity with wg(8), and also allows more graceful
  addition of netlink attributes.
  
  * chacha20: do not define unused asm function
  
  This not only decreases code size, but also makes PaX's RAP happier.
  
  * compat: account for Clang CFI
  
  It turns out that RAP is no longer the only game in town, when it comes to CFI
  on kernels before Kees' epic timer_list refactoring. The Pixel 3/3XL kernels
  are based on 4.9 and come with Clang CFI on by default, so we account for this
  in our compat layer, so that we don't get CFI violation's and thus crashes.
  
  * wg-quick: bring interface up while setting MTU
  
  A small optimization to save a fork/exec.
  
  * makefile: use immediate expansion and use correct template patterns
  
  Coming up with the right combination of makefile template params that work on
  many kernels hasn't been easy, but hopefully this should solve building in a
  number of strange circumstances. If you're still having issues and you're
  using ccache, be sure to flush your cache first, as the cache might be serving
  stale copies of gcc's dependency info.
```