### PR TITLE
main/mosquitto: upgrade to 1.5.5

### DIFF
--- a/main/mosquitto/APKBUILD
+++ b/main/mosquitto/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Pedro Filipe <xpecex@outlook.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mosquitto
-pkgver=1.5.4
+pkgver=1.5.5
 pkgrel=0
 pkgdesc="An Open Source MQTT v3.1 Broker"
 url="http://mosquitto.org/"
@@ -87,6 +87,6 @@ clients() {
 	mv "$pkgdir"/usr/bin/mosquitto_[ps]ub "$subpkgdir"/usr/bin/
 }
 
-sha512sums="4e7ae21304afa843d4d48a8ea0bcf0173deca25961bcd294f86eedbdd8ec59eeca3c8cf5f2d72765128756b2cdf9460f5718041a67c66ce6ac76679cdac247c7  mosquitto-1.5.4.tar.gz
+sha512sums="4984a8c3a48450ae87dfca9ea825433332c22a5c1b214b7c6d134789675431ba1bcebaceea2fe32c5d32c91ec47b9ded7b61c0c2caf6551f10e4f8dc455a5351  mosquitto-1.5.5.tar.gz
 fb000f9fa1ef94cbf3811a23b5692c0c8f9e2df945959cef6005462715e99d6f75cf6b31bd496271ffc17634024aed986771a73962fef865c0d386f6c194fb33  config.patch
 16f96d8f7f3a8b06e2b2e04d42d7e0d89a931b52277fc017e4802f7a3bc85aff4dd290b1a0c40382ea8f5568d0ceb7319c031d9be916f346d805231a002b0433  mosquitto.initd"


### PR DESCRIPTION
Fixes CVE-2018-20145