### PR TITLE
testing/libgpiod: new aport

### DIFF
--- a/testing/libgpiod/APKBUILD
+++ b/testing/libgpiod/APKBUILD
@@ -1,0 +1,29 @@
+# Contributor: vinymeuh <vinymeuh@gmail.com>
+# Maintainer: vinymeuh <vinymeuh@gmail.com>
+pkgname=libgpiod
+pkgver=1.2
+pkgrel=0
+pkgdesc="C library and tools for interacting with the linux GPIO character device"
+url="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/"
+arch="all"
+license="LGPL-2.1-or-later"
+options="!check" # no test suite
+makedepends="autoconf automake libtool linux-headers autoconf-archive"
+subpackages="$pkgname-dev"
+source="https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	./autogen.sh \
+		--build=$CBUILD \
+		--enable-tools=yes \
+		--prefix=/usr
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+sha512sums="58a4f0d1c59c754f13de6b45b8cf3c6c69a2860d029ac74f1f8e17bb2da846905c6d4085d7d1b0fe6c09e171dd04e18dc2279cd5a548d183f8f1566f0ef5a67e  libgpiod-1.2.tar.gz"


### PR DESCRIPTION
https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/
C library and tools for interacting with the linux GPIO character device