### PR TITLE
main/nss: upgrade to 3.41

### DIFF
--- a/main/nss/APKBUILD
+++ b/main/nss/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nss
-pkgver=3.39
+pkgver=3.41
 _ver=${pkgver//./_}
 pkgrel=0
 pkgdesc="Mozilla Network Security Services"
@@ -23,6 +23,8 @@ source="https://ftp.mozilla.org/pub/security/$pkgname/releases/NSS_${pkgver//./_
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   3.41-r0:
+#   - CVE-2018-12404
 #   3.39-r0:
 #   - CVE-2018-12384
 
@@ -151,7 +153,7 @@ tools() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="16358c2d8660ca301410b1d39b2eae64fe2ebbbfab797872410e5fcc67f802ef48f4e362edeecb0591626c77013537019094a6a5dfc8d24487b6b6e54564da8f  nss-3.39.tar.gz
+sha512sums="b5a43fe86ded664002fd714c493d9222a64539cd6139b64720625d1742fec5100712cbe401c90c79196e9cbad9ec07d9b4f0f517ce34e4b207beaa3e01c9e114  nss-3.41.tar.gz
 75dbd648a461940647ff373389cc73bc8ec609139cd46c91bcce866af02be6bcbb0524eb3dfb721fbd5b0bc68c20081ed6f7debf6b24317f2a7ba823e8d3c531  nss.pc.in
 0f2efa8563b11da68669d281b4459289a56f5a3a906eb60382126f3adcfe47420cdcedc6ab57727a3afeeffa2bbb4c750b43bef8b5f343a75c968411dfa30e09  nss-util.pc.in
 09c69d4cc39ec9deebc88696a80d0f15eb2d8c94d9daa234a2adfec941b63805eb4ce7f2e1943857b938bddcaee1beac246a0ec627b71563d9f846e6119a4a15  nss-softokn.pc.in


### PR DESCRIPTION
This updates nss to 3.41, which includes the following secfix: CVE-2018-12404 . 
This version is also required to build newer versions of Firefox (#5577)