### PR TITLE
main/sqlite: Update to 3.26.0

### DIFF
--- a/main/sqlite/APKBUILD
+++ b/main/sqlite/APKBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 pkgname=sqlite
-pkgver=3.24.0
-pkgrel=1
+pkgver=3.26.0
+pkgrel=0
 pkgdesc="C library that implements an SQL database engine"
 url="http://www.sqlite.org"
 arch="all"
@@ -90,5 +90,5 @@ static() {
 	mv "$pkgdir"/usr/lib/lib*.a "$subpkgdir"/usr/lib/
 }
 
-sha512sums="eaec866de26003ec36559aab15dd18dc0e6029453002a4eec5e176bb35a712b8b06c235436e6c1a226b67c7eb90d7a26c2b3b3d9a5e6e92a5af485236b77c878  sqlite-autoconf-3240000.tar.gz
+sha512sums="8c3306b3814a0e9bc69b741f62bdb6efc9f1e07163ca3e3a1581994465de163a7924223522e812d6b3663c1525c7012a6f6d73ad333556eba9f97ce9326fbdb8  sqlite-autoconf-3260000.tar.gz
 5bde14bec5bf18cc686b8b90a8b2324c8c6600bca1ae56431a795bb34b8b5ae85527143f3b5f0c845c776bce60eaa537624104cefc3a47b3820d43083f40c6e9  license.txt"


### PR DESCRIPTION
This PR updates sqlite to the latest released version, 3.26.0.

This update also includes the fix for the recently discovered "magellan" remote-code-execution vulnerability. https://www.tenable.com/blog/magellan-remote-code-execution-vulnerability-in-sqlite-disclosed