### PR TITLE
testing/py3-pyte: New aport

### DIFF
--- a/testing/py3-pyte/APKBUILD
+++ b/testing/py3-pyte/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Simon Frankenberger <simon-alpine@fraho.eu>
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
+pkgname=py3-pyte
+_pkgname=pyte
+pkgver=0.8.0
+pkgrel=0
+pkgdesc="Pyte is an in memory VTXXX-compatible terminal emulator"
+url="https://github.com/selectel/pyte"
+arch="noarch"
+license="LGPL"
+depends="py3-wcwidth"
+makedepends="py3-setuptools"
+source="pyte-$pkgver.tar.gz::https://github.com/selectel/pyte/archive/$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+check() {
+	cd "$builddir"
+	python3 setup.py check
+}
+
+build() {
+	cd "$builddir"
+	python3 setup.py build
+}
+
+package() {
+	cd "$builddir"
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+
+sha512sums="c488fd0a61c1dc34b27e12ed9ba1109bb2c331626c982da06e7540bdd168008cb5106a17c71e60e38c493f2dd9f21ba3cf05118928744dfa192d62e511b4c4e8  pyte-0.8.0.tar.gz"


### PR DESCRIPTION
This PR adds a new python module for pyte.

From the developers:
It's an in memory VTXXX-compatible terminal emulator. XXX stands for a series of video terminals, developed by DEC between 1970 and 1995. The first, and probably the most famous one, was VT100 terminal, which is now a de-facto standard for all virtual terminal emulators. pyte follows the suit.

This library will be used by another aport I'm about to create right now.