### PR TITLE
testing/thefuck: New aport

### DIFF
--- a/testing/py3-pyte/APKBUILD
+++ b/testing/py3-pyte/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Simon Frankenberger <simon-alpine@fraho.eu>
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
+pkgname=py3-pyte
+_pkgname=pyte
+pkgver=0.8.0
+pkgrel=0
+pkgdesc="Pyte is an in memory VTXXX-compatible terminal emulator"
+url="https://github.com/selectel/pyte"
+arch="noarch"
+license="LGPL"
+depends="py3-wcwidth"
+makedepends="py3-setuptools"
+source="pyte-$pkgver.tar.gz::https://github.com/selectel/pyte/archive/$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+check() {
+	cd "$builddir"
+	python3 setup.py check
+}
+
+build() {
+	cd "$builddir"
+	python3 setup.py build
+}
+
+package() {
+	cd "$builddir"
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+
+sha512sums="c488fd0a61c1dc34b27e12ed9ba1109bb2c331626c982da06e7540bdd168008cb5106a17c71e60e38c493f2dd9f21ba3cf05118928744dfa192d62e511b4c4e8  pyte-0.8.0.tar.gz"

--- a/testing/thefuck/APKBUILD
+++ b/testing/thefuck/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Simon Frankenberger <simon-alpine@fraho.eu>
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
+pkgname=thefuck
+pkgver=3.28
+pkgrel=0
+pkgdesc="The Fuck is a magnificent app that corrects errors in previous console commands."
+url="https://github.com/nvbn/thefuck"
+arch="noarch"
+license="MIT"
+depends="py3-colorama py3-six py3-decorator py3-psutil py3-pyte"
+makedepends="py3-setuptools"
+source="thefuck-$pkgver.tar.gz::https://github.com/nvbn/thefuck/archive/$pkgver.tar.gz
+ash.patch"
+builddir="$srcdir"/$pkgname-$pkgver
+
+check() {
+	cd "$builddir"
+	python3 setup.py check
+}
+
+build() {
+	cd "$builddir"
+	python3 setup.py build
+}
+
+package() {
+	cd "$builddir"
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+
+sha512sums="6c3edcfff604567a18209bf46aceb662ed4549efd0e3b0daee1abee8a93fbe3ff4dfa260eb74c3d560b3a798e3cc90f911072d694a0d986a09c8581e951421d2  thefuck-3.28.tar.gz
+2ba9588057e986e47739463ae9c311be17f6248ce60af5d746db8ab9dea2faf7685cd7d9a1999e1e52f2623e1eb23f0b5f756816aae486b721f1782a7265ab64  ash.patch"

--- a/testing/thefuck/ash.patch
+++ b/testing/thefuck/ash.patch
@@ -1,0 +1,15 @@
+This patch replaces the default call to "fc" (which is a builtin
+function in many shells) to a sed command to work on the alpine
+default shell (ash).
+
+--- a/thefuck/shells/generic.py	2018-12-20 16:25:30.217136599 +0000
++++ b/thefuck/shells/generic.py	2018-12-20 16:26:11.156565614 +0000
+@@ -35,7 +35,7 @@
+ 
+     def app_alias(self, alias_name):
+         return "alias {0}='eval $(TF_ALIAS={0} PYTHONIOENCODING=utf-8 " \
+-               "thefuck $(fc -ln -1))'".format(alias_name)
++               "thefuck $(sed -n '\"'x;\\$p'\"' /home/build/.ash_history))'".format(alias_name)
+ 
+     def instant_mode_alias(self, alias_name):
+         warn("Instant mode not supported by your shell")


### PR DESCRIPTION
This PR adds "thefuck", a magnificent app which corrects your previous console command.

After entering an mistyped command just issue the "fuck" command afterwards, and it will try to guess what you really wanted to type (e.g. missing sudo, misspelled command)
This behaviour can be seen in-action in a short gif created by the developer: https://raw.githubusercontent.com/nvbn/thefuck/master/example.gif

This PR depends on #5867 