### PR TITLE
main/dovecot: Security upgrade to 2.3.4.1 (CVE-2019-3814)

### DIFF
--- a/main/dovecot/APKBUILD
+++ b/main/dovecot/APKBUILD
@@ -4,10 +4,10 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dovecot
-pkgver=2.3.3
+pkgver=2.3.4.1
 _pkgvermajor=2.3
-pkgrel=2
-_pigeonholever=0.5.3
+pkgrel=0
+_pigeonholever=0.5.4
 _pigeonholevermajor=${_pigeonholever%.*}
 pkgdesc="IMAP and POP3 server"
 url="https://www.dovecot.org/"
@@ -61,11 +61,14 @@ source="https://www.dovecot.org/releases/$_pkgvermajor/$pkgname-$pkgver.tar.gz
 	default-config.patch
 	dovecot.logrotate
 	dovecot.initd
+	mysql-fix-double-close.patch
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 _builddir_pigeonhole="$srcdir/$pkgname-$_pkgvermajor-pigeonhole-$_pigeonholever"
 
 # secfixes:
+#   2.3.4.1-r0:
+#     - CVE-2019-3814
 #   2.3.1-r0:
 #     - CVE-2017-15130
 #     - CVE-2017-14461
@@ -291,10 +294,11 @@ _submv() {
 	done
 }
 
-sha512sums="8666c4f92f7df883067540f85be9d03dbe6815b58a7f5de55b4292e986e9a2a1ef52c7e0c72dde2bc781fe40d57488b78a99b6b813745b8e4683f1a2fdc1f2ff  dovecot-2.3.3.tar.gz
-8403b1976a915836ba875b96825446d46e0d8c7ff245ed1f2b014347fdc78a81f9ed6dbd05bd3b4f1f7072edc5e9a302201cdb375de44436adcbb83919f203f5  dovecot-2.3-pigeonhole-0.5.3.tar.gz
+sha512sums="ff21aa0f0cae17dfa66617291688856727412defa48bad2b6be057cb509fbec1c2e134afbfee69929d06b8692a0fcbd8451671ba02860e1673ae1c9483c2c17e  dovecot-2.3.4.1.tar.gz
+9c82cce7540f8ab66e2e370e0220c99048d6ac53ed680cd763e0b03d0200e2451cee4303ef97b87a16e7248e1c73b92ba91b47a2a20c75cb2cd62695a28046f3  dovecot-2.3-pigeonhole-0.5.4.tar.gz
 fe4fbeaedb377d809f105d9dbaf7c1b961aa99f246b77189a73b491dc1ae0aa9c68678dde90420ec53ec877c08f735b42d23edb13117d7268420e001aa30967a  skip-iconv-check.patch
 794875dbf0ded1e82c5c3823660cf6996a7920079149cd8eed54231a53580d931b966dfb17185ab65e565e108545ecf6591bae82f935ab1b6ff65bb8ee93d7d5  split-protocols.patch
 0d8f89c7ba6f884719b5f9fc89e8b2efbdc3e181de308abf9b1c1b0e42282f4df72c7bf62f574686967c10a8677356560c965713b9d146e2770aab17e95bcc07  default-config.patch
 9f19698ab45969f1f94dc4bddf6de59317daee93c9421c81f2dbf8a7efe6acf89689f1d30f60f536737bb9526c315215d2bce694db27e7b8d7896036a59c31f0  dovecot.logrotate
-d91951b81150d7a3ef6a674c0dc7b012f538164dac4b9d27a6801d31da6813b764995a438f69b6a680463e1b60a3b4f2959654f68e565fe116ea60312d5e5e70  dovecot.initd"
+d91951b81150d7a3ef6a674c0dc7b012f538164dac4b9d27a6801d31da6813b764995a438f69b6a680463e1b60a3b4f2959654f68e565fe116ea60312d5e5e70  dovecot.initd
+07500fdc27e8e76f8325e7160e3ac0dfd80e3dcb6d310499ea3b7d6c7899809bbb76c01aec78c4b8b9bf80cd8260dbc26726a612357d30f3b3c8be80f77f9abd  mysql-fix-double-close.patch"

--- a/main/dovecot/mysql-fix-double-close.patch
+++ b/main/dovecot/mysql-fix-double-close.patch
@@ -1,0 +1,37 @@
+From 3c5101ffdd2a8115e03ed7180d53578765dea4c9 Mon Sep 17 00:00:00 2001
+Patch-Origin: https://github.com/dovecot/core/commit/3c5101ffdd2a8115e03ed7180d53578765dea4c9
+From: Aki Tuomi <aki.tuomi@dovecot.fi>
+Date: Tue, 4 Dec 2018 14:40:04 +0200
+Subject: [PATCH] driver-mysql: Avoid double-closing MySQL connection
+
+Fixes double-free
+---
+ src/lib-sql/driver-mysql.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib-sql/driver-mysql.c b/src/lib-sql/driver-mysql.c
+index c87e825e4b..5dd1c3124f 100644
+--- a/src/lib-sql/driver-mysql.c
++++ b/src/lib-sql/driver-mysql.c
+@@ -173,7 +173,9 @@ static int driver_mysql_connect(struct sql_db *_db)
+ static void driver_mysql_disconnect(struct sql_db *_db)
+ {
+ 	struct mysql_db *db = (struct mysql_db *)_db;
+-	mysql_close(db->mysql);
++	if (db->mysql != NULL)
++		mysql_close(db->mysql);
++	db->mysql = NULL;
+ }
+ 
+ static int driver_mysql_parse_connect_string(struct mysql_db *db,
+@@ -311,7 +313,9 @@ static void driver_mysql_deinit_v(struct sql_db *_db)
+ 	_db->no_reconnect = TRUE;
+ 	sql_db_set_state(&db->api, SQL_DB_STATE_DISCONNECTED);
+ 
+-	mysql_close(db->mysql);
++	if (db->mysql != NULL)
++		mysql_close(db->mysql);
++	db->mysql = NULL;
+ 
+ 	sql_connection_log_finished(_db);
+ 	event_unref(&_db->event);


### PR DESCRIPTION
This PR upgrades dovecot to version 2.3.4.1, which contains the fix for CVE-2019-3814

Release notes:
2.3.4: https://www.dovecot.org/list/dovecot-news/2018-November/000391.html
2.3.4.1: https://www.dovecot.org/list/dovecot-news/2019-February/000394.html

Travis fails because the log is too large:
The job exceeded the maximum log length, and has been terminated.