### PR TITLE
community/sniproxy: Upgrade to 0.6.0

### DIFF
--- a/community/sniproxy/APKBUILD
+++ b/community/sniproxy/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=sniproxy
-pkgver=0.5.0
+pkgver=0.6.0
 pkgrel=0
 pkgdesc="Proxies incoming HTTP and TLS connections based on the hostname
 	contained in the initial request of the TCP session."
@@ -54,7 +54,7 @@ package() {
 	done
 }
 
-sha512sums="52dbb217193d2b7bf9dea37b13fde395b5c56d0a6627508a245f2807920deb282aae3c1ae7e6b5fa68432990e48998989fd28027b65cb7310f214b29f98e5e5d  sniproxy-0.5.0.tar.gz
+sha512sums="8a99573673bdd57e528c5781cb166d39c80daed699382b24c3fa18a6011d074a1d9e470fee404d24b4450cf067c9995125910b2941b5216d88d189a1d79ebf73  sniproxy-0.6.0.tar.gz
 57f4997f8a96516b4622105c024708bf39002a83d7f3eb76dd857ee0202598309b51d585f6b25b5e72e9710b79c36a3e4f21bc2effcead16dd2c032137c704f3  sniproxy.initd
 f7423cfd48e9333d5db857b4eb61b747664221607e2d47a55167493159b7b838580f101427e98252468c0be9c42693f7f0689ac8bd1acdcd1dfb75638a8f49fb  sniproxy.conf
 8c026af5ed23620776ef5a9a08f09236d30fc5152c9f95de2b95eb7ac48ad001c21010922d74dc7c78071f9e6ef8f794c2a59c11677d8e12be8d57e94bac2b5e  sniproxy.logrotate"


### PR DESCRIPTION
Go easy on me, it's my first time.

Update pkgver, filename, and sha512sums.

https://github.com/dlundquist/sniproxy/blob/master/ChangeLog

2018-12-05  Dustin Lundquist <dustin@null-ptr.net>
	0.6.0 Release

	* PROXY v1 protocol support
	* SO_REUSEPORT support on Linux 3.9 and later
	* Listener ipv6_only directive to accept only IPv6 connections
	* TCP keepalive