### PR TITLE
community/py3-openzwave: disable Werror to fix snprintf build error

### DIFF
--- a/community/py3-openzwave/APKBUILD
+++ b/community/py3-openzwave/APKBUILD
@@ -3,7 +3,7 @@
 _name=python-openzwave
 pkgname=py3-openzwave
 pkgver=0.3.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Python wrapper for openzwave"
 url="http://www.openzwave.com/"
 arch="all"
@@ -12,7 +12,8 @@ depends=" $pkgname-lib $pkgname-api $pkgname-manager"
 makedepends="python3-dev linux-headers eudev-dev coreutils"
 install=""
 subpackages="$pkgname-lib $pkgname-api::noarch $pkgname-manager::noarch"
-source="https://github.com/OpenZWave/python-openzwave/raw/master/archives/${_name}-${pkgver}.tgz"
+source="https://github.com/OpenZWave/python-openzwave/raw/master/archives/${_name}-${pkgver}.tgz
+	disable-Werror.patch"
 builddir="$srcdir/python-openzwave-$pkgver"
 
 
@@ -57,4 +58,5 @@ manager() {
 }
 
 
-sha512sums="f495c2e41a67f715dbf0e312ee13d59ab6c907403dacb12d48c2becbb433ab458a53f3d634e21373e1aa0141ab71e418ec15ebd29f9d4506261700bcfadcbc79  python-openzwave-0.3.2.tgz"
+sha512sums="f495c2e41a67f715dbf0e312ee13d59ab6c907403dacb12d48c2becbb433ab458a53f3d634e21373e1aa0141ab71e418ec15ebd29f9d4506261700bcfadcbc79  python-openzwave-0.3.2.tgz
+5ac0755abf43cff49583305abb2fcaa963a5f926b6e6109dbe75724d6c7dd301621e7fd2e6eb16b45e258ef9ea1686d774b3a32a96ec256c31d703314952bedf  disable-Werror.patch"

--- a/community/py3-openzwave/disable-Werror.patch
+++ b/community/py3-openzwave/disable-Werror.patch
@@ -1,0 +1,11 @@
+--- a/openzwave/cpp/build/Makefile
++++ b/openzwave/cpp/build/Makefile
+@@ -15,7 +15,7 @@
+ # what flags we will use for compiling in debug mode
+ DEBUG_CFLAGS    := -Wall -Wno-unknown-pragmas -Wno-inline -Wno-format -Werror -Wno-error=sequence-point -Wno-sequence-point -ggdb -DDEBUG -fPIC  -DSYSCONFDIR="\"$(PREFIX)/etc/openzwave/\""
+ # what flags we will use for compiling in release mode
+-RELEASE_CFLAGS  := -Wall -Wno-unknown-pragmas -Werror -Wno-format -Wno-error=sequence-point -Wno-sequence-point -O3 -DNDEBUG -fPIC  -DSYSCONFDIR="\"$(PREFIX)/etc/openzwave/\""
++RELEASE_CFLAGS  := -Wall -Wno-unknown-pragmas -Wno-format -Wno-error=sequence-point -Wno-sequence-point -O3 -DNDEBUG -fPIC  -DSYSCONFDIR="\"$(PREFIX)/etc/openzwave/\""
+ #what flags we will use for linking in debug mode
+ DEBUG_LDFLAGS	:= -g
+ 


### PR DESCRIPTION
with gcc8 on ppc64le setting Werror flag results in build break:
home/mksully/aports/community/py3-openzwave/src/python-openzwave-0.3.2/openzwave/cpp/src/command_classes/DoorLockLogging.cpp:312:15: error: passing argument 1 to restrict-qualified parameter aliases with argument 4 [-Werror=restrict]
      snprintf(usercode, sizeof(usercode), "%s %d", usercode, (int)_data[12+i]);   

Patch disables Werror flag