### PR TITLE
community/imagemagick6: fix broken download link

### DIFF
--- a/community/imagemagick6/APKBUILD
+++ b/community/imagemagick6/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=imagemagick6
 _pkgname=ImageMagick
-pkgver=6.9.9.47
+pkgver=6.9.9.51
 _pkgver=${pkgver%.*}-${pkgver##*.}
 _abiver=${pkgname#imagemagick}
 pkgrel=0
@@ -106,4 +106,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="7bf7ae7fc276c2857f546370851ef7aaf1704c1b5bbad1a739d964e8e48a4ece9d9274e154a5aaa18c24f31e60e03d2df661cca922a3fff780cbcddd86524cb5  ImageMagick-6.9.9-47.tar.xz"
+sha512sums="052b843297e6bf40d0286fd90a038ced0b1d8dd64659dfad8296df6dc1b012608b976352159b1560ab6b48deee224049d719bd98dec997c051b43c776681fea9  ImageMagick-6.9.9-51.tar.xz"


### PR DESCRIPTION
https://www.imagemagick.org/download/releases/ImageMagick-6.9.9-47.tar.xz is no longer available for download. Moving forward to https://www.imagemagick.org/download/releases/ImageMagick-6.9.9-51.tar.xz