### PR TITLE
community/java-jna: fix build break by disabling Werror flag

### DIFF
--- a/community/java-jna/APKBUILD
+++ b/community/java-jna/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=java-jna
 _pkgname=${pkgname#java-}
 pkgver=4.5.2
-pkgrel=0
+pkgrel=1
 pkgdesc="JNA provides Java programs easy access to native shared libraries."
 url="https://github.com/java-native-access/jna"
 arch="all"
@@ -12,6 +12,7 @@ depends="openjdk8-jre-base"
 makedepends="apache-ant autoconf automake libffi-dev>=3.2 libtool openjdk8"
 subpackages="$pkgname-native"
 source="$pkgname-$pkgver.tar.gz::https://github.com/java-native-access/$_pkgname/archive/$pkgver.tar.gz
+	disable-Werror.patch
 	0001-jar-without-natives.patch
 	"
 builddir="$srcdir/$_pkgname-$pkgver"
@@ -65,4 +66,5 @@ native() {
 }
 
 sha512sums="c740b5655725d01a1bdb0e86ca9640d70bd416591b36f82976429455bc728f2872a19c78cddbc271657146e8926fa22f8bb2ec48b56d3483379488cff576dac8  java-jna-4.5.2.tar.gz
+2420c6fbf9f9375f6fc8fbe004fa2831ac13799b1a16608da27c2ce09388b023742336b2e4a81e7524a9df4ed6f421864042b82dbb2dbc17fb54b5bc6091d1b6  disable-Werror.patch
 dacfa03e1a957172502dd10007445e844df67288fde07f7ada80a5cbfe3186511aa7a866c8c757a0a94c894829fead9c67ad0993f2105d2fef1f18d22ee01cdb  0001-jar-without-natives.patch"

--- a/community/java-jna/disable-Werror.patch
+++ b/community/java-jna/disable-Werror.patch
@@ -1,0 +1,11 @@
+--- a/native/Makefile
++++ b/native/Makefile
+@@ -336,7 +336,7 @@
+ ifeq ($(CC),gcc)
+     GCC_MAJOR_VERSION = $(shell gcc -dumpversion | cut -f 1 -d '.')
+     ifneq ($(GCC_MAJOR_VERSION),4)
+-	LOC_CC_OPTS=-Wno-unknown-warning-option -Werror -Wno-clobbered -Wno-unused-variable
++	LOC_CC_OPTS=-Wno-unknown-warning-option -Wno-clobbered -Wno-unused-variable
+     endif
+ else
+     LOC_CC_OPTS=-Wno-unknown-warning-option -Werror -Wno-clobbered -Wno-unused-variable


### PR DESCRIPTION
With gcc8 on ppc64le snprintf errors are generated with the Werror flag set. Disabling Werror flag allows build to complete successfully.

dispatch.c:656:9: note: 'snprintf' output between 5 and 1038 bytes into a destination of size 1024
     [exec]          snprintf(msg, sizeof(msg), "[%d] %s", err, STR_ERROR(err, emsg, sizeof(emsg)));
