### PR TITLE
community/live-media: fix broken download source link

### DIFF
--- a/community/live-media/APKBUILD
+++ b/community/live-media/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=live-media
-pkgver=2018.04.25
+pkgver=2018.12.14
 pkgrel=0
 pkgdesc="A set of C++ libraries for multimedia streaming"
 url="http://live555.com/liveMedia"
@@ -53,4 +53,4 @@ utils() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="93010f5ff82af84a7c048ea3fd8fa15b86741abb7fbe078b447b5e0a78c36300713e1a4dde64a60ae00b951c7cf106a91ae106dc2c0db57dbb58286e05348c15  live.2018.04.25.tar.gz"
+sha512sums="8668f088e33c34a4a20a537e70c4f6678a93b275a77ce25697b95798f0b75d1d0f6a7f2d5284c0649330fa783d06946995e065241528169396460de548f5e44f  live.2018.12.14.tar.gz"


### PR DESCRIPTION
http://live555.com/liveMedia/public/live.2018.04.25.tar.gz source is no longer downloadable. Move forward to http://live555.com/liveMedia/public/live.2018.12.14.tar.gz