### PR TITLE
community/tomcat-native: fix source download location and version

### DIFF
--- a/community/tomcat-native/APKBUILD
+++ b/community/tomcat-native/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sean Summers <seansummers@gmail.com>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=tomcat-native
-pkgver=1.2.18
+pkgver=1.2.19
 pkgrel=0
 pkgdesc="Native resources optional component for Apache Tomcat"
 url="https://tomcat.apache.org/native-doc/"
@@ -40,4 +40,4 @@ dev()  {
 	mv "$subpkgdir"/usr/lib/libtcnative-1.so "$pkgdir"/usr/lib/
 }
 
-sha512sums="66481c1f36dc7ea909bf8d55075a232bf6dea3300b56d36415b13da4aefbee16cb52456f3d44b4a2b09b43cd8c7df628145a0623b9cdfa322bc2432e6c44827f  tomcat-native-1.2.18-src.tar.gz"
+sha512sums="7d69acd5dd684eee9a85c08357b7288a9f083c15a12a9524ba6344f1b9dcdc6ccc512a37b64b9f15b0e697609833e6c68591a60976dcfecce124ec29eb532dba  tomcat-native-1.2.19-src.tar.gz"


### PR DESCRIPTION
https://www-eu.apache.org/dist/tomcat/tomcat-connectors/native/1.2.18/source/tomcat-native-1.2.19-src.tar.gz is no longer available from download location. Moving to https://www-eu.apache.org/dist/tomcat/tomcat-connectors/native/1.2.19/source/tomcat-native-1.2.19-src.tar.gz