### PR TITLE
community/gitea: security upgrade to 1.6.2

### DIFF
--- a/community/gitea/APKBUILD
+++ b/community/gitea/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=gitea
-pkgver=1.6.1
+pkgver=1.6.2
 pkgrel=0
 pkgdesc="A self-hosted Git service written in Go"
 url="https://gitea.io"
@@ -68,7 +68,7 @@ check() {
 	"$builddir"/$pkgname help > /dev/null
 }
 
-sha512sums="c02f70c1fa7fde0f2ed968ad69f031937fe0fefe27bbce6a6eb4ac975ea9773b34ff3a4cf1083fcc9da7312006911cdb7467f5732d8ed7a14c0eecefceebab57  gitea-1.6.1.tar.gz
+sha512sums="de2b8f7275175b9aedbf0f5ffb20194431ff629bd31c37508ba0bafb4ec7009d6f8501acc8fee5d00507a89ab4936cb1f60778e7dff1be32c548c29554f92ec7  gitea-1.6.2.tar.gz
 a7c70a144dc0582d6230e59ff717023fddcac001a6a9c895b46a0df1fbd9639453b2f5027d47dad21f442869c145dbc801eda61b6c50a2dd8103f562b8569009  gitea.initd
 27a202006d6e8d4146659f6356eaa99437f9f596dd369e9430d64b859bc6a1ad16091eef09232aa385fe1bf8ca94bbdf31b94975068220ad10338cded384f726  gitea.ini
 05272f3733dffeb75881579ff6553d32515e4de32113ff9395e521e93946a45101d04d4e435d7d8e7bfe49a512e5e4ac300576d2e79d7bcf314fc0ce526a07f9  allow-to-set-version.patch"


### PR DESCRIPTION
https://blog.gitea.io/2018/12/release-of-1.6.2/