### PR TITLE
testing/font-siji: new aport

### DIFF
--- a/testing/font-siji/APKBUILD
+++ b/testing/font-siji/APKBUILD
@@ -1,0 +1,24 @@
+# Contributor: Taner Tas <taner76@gmail.com>
+# Maintainer: Taner Tas <taner76@gmail.com>
+pkgname=font-siji
+pkgver=20190218_git
+_pkgver="c691f200c1c66e76daa2afc9cbbd1aa39045c906"
+pkgrel=0
+pkgdesc="Iconic bitmap font based on Stlarch with additional glyphs."
+url="https://github.com/stark/siji/"
+arch="noarch"
+license="GPL-2.0-only"
+depends="encodings font-alias fontconfig mkfontscale mkfontdir"
+options="!check" # No test suite
+source="
+	$pkgname-$pkgver.tar.gz::https://github.com/stark/siji/archive/$_pkgver.tar.gz
+	"
+builddir="$srcdir/${pkgname/font-/}-$_pkgver"
+
+package() {
+	cd "$builddir"
+	install -Dm644 pcf/siji.pcf "$pkgdir"/usr/share/fonts/misc/siji.pcf
+	gzip -9 "$pkgdir"/usr/share/fonts/misc/siji.pcf
+}
+
+sha512sums="399f24bc371681426ee3d89595b0d08ab26b274e85f46453671e08e51b42020c90368f7c49a59c1a3c13f6193fb80cd0fbbecfc0960da239ed435e0a660b3672  font-siji-20190218_git.tar.gz"


### PR DESCRIPTION
https://github.com/stark/siji/
Siji is an iconic bitmap font based on the Stlarch font with additional glyphs.