### PR TITLE
community/php7-pecl-apcu: Fix build against PHP 7.3

### DIFF
--- a/community/php7-pecl-apcu/APKBUILD
+++ b/community/php7-pecl-apcu/APKBUILD
@@ -2,15 +2,14 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=php7-pecl-apcu
 _pkgreal=apcu
-# release 5 is php7+
 pkgver=5.1.17
-pkgrel=0
+pkgrel=1
 pkgdesc="PHP extension APC User Cache - PECL"
 url="https://pecl.php.net/package/apcu"
 arch="all"
 license="PHP-3.01"
 depends="php7-common"
-makedepends="pcre-dev php7-dev autoconf re2c"
+makedepends="pcre2-dev php7-dev autoconf re2c"
 source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
 provides="php7-apcu=$pkgver-r$pkgrel" # for backward compatibility


### PR DESCRIPTION
When building against PHP 7.3.0 the build fails due to missing pcre2
headers. This commit adds this dependency.

```
In file included from /aports/community/php7-pecl-apcu/src/apcu-5.1.16/apc_iterator.h:27,
                 from /aports/community/php7-pecl-apcu/src/apcu-5.1.16/php_apc.c:34:
/usr/include/php7/ext/pcre/php_pcre.h:27:10: fatal error: pcre2.h: No such file or directory
 #include "pcre2.h"
          ^~~~~~~~~
compilation terminated.
make: *** [Makefile:202: php_apc.lo] Error 1
```

Relates to #5863