### PR TITLE
community/php7-pecl-imagick: Fix build against PHP 7.3

### DIFF
--- a/community/php7-pecl-imagick/APKBUILD
+++ b/community/php7-pecl-imagick/APKBUILD
@@ -3,14 +3,14 @@
 pkgname=php7-pecl-imagick
 _pkgreal=imagick
 pkgver=3.4.4
-pkgrel=0
+pkgrel=1
 pkgdesc="PHP extension provides a wrapper to the ImageMagick library - PECL"
 url="https://pecl.php.net/package/imagick"
 arch="all"
 license="PHP-3.01"
 depends="php7-common"
 checkdepends="ghostscript-fonts"
-makedepends="php7-dev autoconf libtool imagemagick-dev pcre-dev re2c"
+makedepends="php7-dev autoconf libtool imagemagick-dev pcre2-dev re2c"
 subpackages="$pkgname-dev"
 source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz
 	fix-affineTransformImage-test.patch


### PR DESCRIPTION
When building against PHP 7.3.0 the build fails due to missing pcre2
headers. This commit adds this dependency.
```
 gcc -I/usr/include/ImageMagick-7 -DMAGICKCORE_HDRI_ENABLE=1 -DMAGICKCORE_QUANTUM_DEPTH=16 -I. -I/aports/community/php7-pecl-imagick/src/imagick-3.4.3 -DPHP_ATOM_INC -I/aports/community/php7-pecl-imagick/src/imagick-3.4.3/include -I/aports/community/php7-pecl-imagick/src/imagick-3.4.3/main -I/aports/community/php7-pecl-imagick/src/imagick-3.4.3 -I/usr/include/php7 -I/usr/include/php7/main -I/usr/include/php7/TSRM -I/usr/include/php7/Zend -I/usr/include/php7/ext -I/usr/include/php7/ext/date/lib -I/usr/include/ImageMagick-7 -Os -fomit-frame-pointer -DHAVE_CONFIG_H -Os -fomit-frame-pointer -c /aports/community/php7-pecl-imagick/src/imagick-3.4.3/imagick.c  -fPIC -DPIC -o .libs/imagick.o
In file included from /usr/include/php7/ext/spl/spl_iterators.h:25,
                 from /aports/community/php7-pecl-imagick/src/imagick-3.4.3/imagick.c:37:
/usr/include/php7/ext/pcre/php_pcre.h:27:10: fatal error: pcre2.h: No such file or directory
 #include "pcre2.h"
          ^~~~~~~~~
compilation terminated.
```
Relates to #5863