### PR TITLE
community/php7-pecl-memcached: Update to 3.1.2

### DIFF
--- a/community/php7-pecl-memcached/APKBUILD
+++ b/community/php7-pecl-memcached/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
 pkgname=php7-pecl-memcached
 _pkgreal=memcached
-pkgver=3.0.4
-pkgrel=2
+pkgver=3.1.2
+pkgrel=0
 pkgdesc="PHP extension for interfacing with memcached via libmemcached library"
 url="https://pecl.php.net/package/memcached"
 arch="all"
@@ -37,4 +37,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$confdir"/20_$_pkgreal.ini
 }
 
-sha512sums="d0a0f9e99cbcc6829528554551dfacf0d943d54d4be60c9da708de82913a2a0bed7c51d594ae3ecf0c13b56064739f074ce6ada5d7433bdc7e26e8caf9cf5ca2  php7-pecl-memcached-3.0.4.tgz"
+sha512sums="b69f29804df2ab966473f5b1a947fad64c9e468be8cbc0c26c8111facf401debddfd09319cb4747b394e7dc465ccfa35701d76f9770fc757452ba9e522768f03  php7-pecl-memcached-3.1.2.tgz"


### PR DESCRIPTION
This PR updates the memcached extension to the latest release.

https://pecl.php.net/package-changelog.php?package=memcached&release=3.1.2

Relates to #5863 (requires >= 3.1.0)