### PR TITLE
community/php7-pecl-xdebug: Update to 2.7.0beta1

### DIFF
--- a/community/php7-pecl-xdebug/APKBUILD
+++ b/community/php7-pecl-xdebug/APKBUILD
@@ -4,16 +4,17 @@
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
 pkgname=php7-pecl-xdebug
 _pkgname=xdebug
-pkgver=2.6.1
-pkgrel=2
+pkgver=2.7.0b1
+_pkgver=2.7.0beta1
+pkgrel=0
 pkgdesc="PHP extension that provides functions for function traces and profiling - PECL"
 url="https://pecl.php.net/package/xdebug"
 arch="all"
 license="PHP"
 depends="php7-common"
 makedepends="php7-dev autoconf re2c"
-source="$pkgname-$pkgver.tgz::https://pecl.php.net/get/$_pkgname-$pkgver.tgz"
-builddir="$srcdir/$_pkgname-$pkgver"
+source="$pkgname-$_pkgver.tgz::https://pecl.php.net/get/$_pkgname-$_pkgver.tgz"
+builddir="$srcdir/$_pkgname-$_pkgver"
 provides="php7-xdebug=$pkgver-r$pkgrel" # for backward compatibility
 replaces="php7-xdebug" # for backward compatibility
 
@@ -44,4 +45,4 @@ package() {
 	EOF
 }
 
-sha512sums="31f26e592b3888d7cc74c6a7c51e0cc1151cf8a32100dda78098fb5b3e307cf8d0445b97247986c75b303a787f89b3937bc042dc52f19ca995753a6843bbd80b  php7-pecl-xdebug-2.6.1.tgz"
+sha512sums="4872b4cec44eab8cd03309dad854c8a35e159474deb7d3fcbc8f12764fa88e761e3bdc04d7f94425aa14f0a57bdfd52f7a2c88715b2f3e385eacadadcfd79888  php7-pecl-xdebug-2.7.0beta1.tgz"


### PR DESCRIPTION
This PR updates the pecl extension for xdebug to the latest release.
https://pecl.php.net/package-changelog.php?package=xdebug&release=2.7.0beta1

This is needed for the upgrade to PHP 7.3
Relates to #5863 