### PR TITLE
main/vim: Update to 8.1.0630

### DIFF
--- a/main/vim/APKBUILD
+++ b/main/vim/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=vim
-pkgver=8.1.0115
+pkgver=8.1.0630
 pkgrel=0
 pkgdesc="Improved vi-style text editor"
 url="http://www.vim.org"
@@ -66,5 +66,5 @@ vimdiff() {
 	mv "$pkgdir"/usr/bin/vimdiff "$subpkgdir"/usr/bin
 }
 
-sha512sums="8da06e76903dc8dbf9c7439ce27288652813c1db0dea527752038e9ec6e756b2d07090f19a8ad9170bd88dbac72ecf029c5d2e91228b35ed7a8a010928b60ba2  vim-8.1.0115.tar.gz
+sha512sums="14f6cb241a61734f4d8c3d72b83666a20003612930e2f9e4db058e7edec68357ce3b91a6c4352ed2db3abf7e365b202f67db70533bb7285b2a2ec22e194b4f8b  vim-8.1.0630.tar.gz
 d9586b777881973cb5e48e18750336a522ed72c3127b2d6b6991e2b943468ca5b694476e7fa39ab469178c1375fc8f52627484e0fe377aea5811a513e35a7b02  vimrc"


### PR DESCRIPTION
This PR updates vim to the latest release, 8.1.0630