### PR TITLE
main/perl-sys-hostname-long: Use hostname -f instead of -fqdn

### DIFF
--- a/main/perl-sys-hostname-long/APKBUILD
+++ b/main/perl-sys-hostname-long/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=perl-sys-hostname-long
 _realname=Sys-Hostname-Long
 pkgver=1.5
-pkgrel=0
+pkgrel=1
 pkgdesc="Perl Module to get full hostname"
 url="http://search.cpan.org/~scott/"
 arch="noarch"
@@ -12,24 +12,24 @@ depends="perl"
 makedepends="perl-dev"
 install=
 subpackages=""
-source="http://search.cpan.org/CPAN/authors/id/S/SC/SCOTT/$_realname-$pkgver.tar.gz"
+source="http://search.cpan.org/CPAN/authors/id/S/SC/SCOTT/$_realname-$pkgver.tar.gz
+	hostname-f.patch"
 
-_builddir="$srcdir/$_realname-$pkgver"
+builddir="$srcdir/$_realname-$pkgver"
 
 build() {
-	cd $_builddir
+	cd $builddir
 	PERL_MM_USE_DEFAULT=1 perl Makefile.PL INSTALLDIRS=vendor || return 1
 	make || return 1
 }
 
 package() {
-	cd $_builddir
+	cd $builddir
 	make DESTDIR="$pkgdir" install
 	# creates file collision among perl modules
 	find "$pkgdir" -name perllocal.pod -delete
 
 }
 
-md5sums="a7d7a36fa6905bded4f6b7da94e37532  Sys-Hostname-Long-1.5.tar.gz"
-sha256sums="e9186df3706a877efd6149f2c711d6cf87dd6cf72f6ab935ba8121b225b265cb  Sys-Hostname-Long-1.5.tar.gz"
-sha512sums="e34a5f17e65eb9c8d3aa213a6d930be4d0b6981dae3bf600e782b0e9863e6584061285a894f9f54daff7520bcadbb3e8cd6b1f9f973ad1c1b72c79e9f588133b  Sys-Hostname-Long-1.5.tar.gz"
+sha512sums="e34a5f17e65eb9c8d3aa213a6d930be4d0b6981dae3bf600e782b0e9863e6584061285a894f9f54daff7520bcadbb3e8cd6b1f9f973ad1c1b72c79e9f588133b  Sys-Hostname-Long-1.5.tar.gz
+47ea5f1a35ac286f9f858fb42e8f4b59801cf99d8c61238238095abb8aee6ff706a8763e5d564dd4582bd7d80c3b966632833958cee1b007b71b5ca10b2f0c90  hostname-f.patch"

--- a/main/perl-sys-hostname-long/hostname-f.patch
+++ b/main/perl-sys-hostname-long/hostname-f.patch
@@ -1,0 +1,26 @@
+When running with busybox "hostname", there is no "--fqdn" switch.
+The same functionality is provided using the "-f" switch.
+
+--- a/lib/Sys/Hostname/Long.pm
++++ b/lib/Sys/Hostname/Long.pm
+@@ -69,7 +69,7 @@
+ 	},
+ 
+ 	'exec_hostname_fqdn' => {
+-		'title' => 'Execute "hostname --fqdn"',
++		'title' => 'Execute "hostname -f"',
+ 		'description' => '',
+ 		'exec' => sub {
+ 			# Skip for Solaris, and only run as non-root
+@@ -77,9 +77,9 @@
+ 			my $tmp;
+ 			if ( $^O ne 'darwin' ) {
+ 				if ($< == 0) {
+-					$tmp = `su nobody -c "hostname --fqdn"`;
++					$tmp = `su nobody -c "hostname -f"`;
+ 				} else {
+-					$tmp = `hostname --fqdn`;
++					$tmp = `hostname -f`;
+ 				}
+ 				$tmp =~ tr/\0\r\n//d;
+ 			}


### PR DESCRIPTION
The hostname bundled with busybox doesn't know the -fqdn switch. The
same functionality can be reached using the -f switch.