### PR TITLE
main/postfix-policyd-spf-perl: Update to 2.011

### DIFF
--- a/main/postfix-policyd-spf-perl/APKBUILD
+++ b/main/postfix-policyd-spf-perl/APKBUILD
@@ -1,20 +1,20 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=postfix-policyd-spf-perl
-pkgver=2.007
-pkgrel=2
+pkgver=2.011
+pkgrel=0
 pkgdesc="A Sender Policy Framework implementation"
 url="http://www.openspf.org/Software"
 arch="all"
 license="GPL"
-depends="perl perl-mail-spf perl-netaddr-ip"
+depends="perl perl-mail-spf perl-netaddr-ip perl-sys-hostname-long"
 makedepends=""
 install=
 subpackages=""
-source="http://www.openspf.org/blobs/$pkgname-$pkgver.tar.gz"
+source="https://launchpad.net/$pkgname/trunk/$pkgver/+download/$pkgname-$pkgver.tar.gz"
 
 package() {
 	cd "$srcdir/$pkgname-$pkgver"
 	install -m755 -D "$srcdir"/$pkgname-$pkgver/$pkgname "$pkgdir"/usr/bin/$pkgname
 }
 
-sha512sums="4b527a5c77415b77c6efa1d656ed40875689e35207ca10b76b305e0833b5d20f6682954f90fc610e8da74411f8ffc6d23a8be1b2d1ff73b5525f80ef1a98379f  postfix-policyd-spf-perl-2.007.tar.gz"
+sha512sums="22fc00bf74912056a67e937a460ac1fd878f1cb1a3bfa7b19bc5f1e6bc1c36d815dcf8c945e818d242ed5e72a6295bb0e1569446e06b09aefb2842993b8016ba  postfix-policyd-spf-perl-2.011.tar.gz"


### PR DESCRIPTION
This PR updates the spf-policyd to 2.011

Depends on #5909 