### PR TITLE
main/xmlrpc-c: Modernize and update to 1.39.13

### DIFF
--- a/main/xmlrpc-c/APKBUILD
+++ b/main/xmlrpc-c/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xmlrpc-c
-pkgver=1.39.11
+pkgver=1.39.13
 pkgrel=0
 pkgdesc="This library provides a modular implementation of XML-RPC for C and C++"
 url="http://xmlrpc-c.sourceforge.net/"
@@ -18,7 +18,7 @@ builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
 	cd "$builddir"
-	update_config_sub || return 1
+	update_config_sub
 	export CXXFLAGS="$CXXFLAGS -std=gnu++98"
 	./configure \
 		--build=$CBUILD \
@@ -30,12 +30,12 @@ build() {
 		--disable-libwww-client \
 		--disable-wininet-client \
 		|| return 1
-	make -j1 AR=ar RANLIB=ranlib || return 1
+	make AR=ar RANLIB=ranlib
 }
 
 package() {
 	cd "$builddir"
-	make -j1 DESTDIR="$pkgdir" AR=ar RANLIB=ranlib install || return 1
+	make AR=ar RANLIB=ranlib DESTDIR="$pkgdir" install
 	install -m 644 -D doc/COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 
@@ -70,9 +70,5 @@ abyss() {
 		"$subpkgdir"/usr/lib/
 }
 
-md5sums="503651550379ed72f7c6923a4c3551bd  xmlrpc-c-1.39.11.tar.gz
-d3bee91077d3c7e1c0b80f6d7eeb2e63  host-os-uclibc.patch"
-sha256sums="2e56cdcdd5c5fa564bcdc7a56bca108a88f5b78b34ccc85558366efabdc8b8e8  xmlrpc-c-1.39.11.tar.gz
-0aae483973387c710ddc6103be36287cfe507eaa2e998805e6aa858be8eeaaa5  host-os-uclibc.patch"
-sha512sums="13e7ddf5264436671437c0bcd698380baca35c4469f592edf79cb4cafda254fe8207ecb992ee728ed20ec70457a20bd0cf8e180ce5cf0561a38a21f1e588f584  xmlrpc-c-1.39.11.tar.gz
+sha512sums="0b75d0eef2aff4e86ebca3e84890500e3b72285d7cdece636998e13812423411b83e96712447fb689b21b57815447904f1202c3f890dd7e26097679f9fc5bf93  xmlrpc-c-1.39.13.tar.gz
 30b57c5ffd65ea9781a56d1b4535e53c9d51c16e00d269992b239f1ff611fe3a510eb72b4d6ee96100706161d40738bbdf109580c745bfc9899d540ca6b3f1e5  host-os-uclibc.patch"


### PR DESCRIPTION
This PR updates the xmlrpc-c to the latest release, 1.39.13