### PR TITLE
[WIP] testing/ophcrack: Update to 3.8.0

### DIFF
--- a/testing/ophcrack/APKBUILD
+++ b/testing/ophcrack/APKBUILD
@@ -1,15 +1,15 @@
 # Contributor: Leonardo Arena <rnalrd@alpinelinux.org>
-# Maintainer:
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
 pkgname=ophcrack
-pkgver=3.7.0
-pkgrel=3
+pkgver=3.8.0
+pkgrel=0
 pkgdesc="Windows password cracker based on rainbow tables"
 url="http://ophcrack.sourceforge.net/"
 arch="all"
 license="GPL"
-makedepends="$depends_dev expat-dev openssl-dev qt-dev"
+makedepends="$depends_dev expat-dev openssl-dev qt5-qtbase-dev qt5-qtcharts-dev"
 source="https://downloads.sourceforge.net/project/ophcrack/ophcrack/$pkgver/ophcrack-$pkgver.tar.bz2"
-options="!check"
+#options="!check"
 
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -36,4 +36,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="27e73979ca3d733629b9b34c490488cc27140efb8b90d266f270c0b95572cf40319a3fb658c02448fc7a3b825cf05c18a69f5d91bd0656d8410a30645f8dc8c6  ophcrack-3.7.0.tar.bz2"
+sha512sums="c66276b72299744d3e0c9fc14220c7f568e383bd324c1ede228bda5d51da78db817388421c9f5f8cd2f18687e7e53cfb0c65bcc0354b3d55ac16324c61f62dbd  ophcrack-3.8.0.tar.bz2"


### PR DESCRIPTION
This PR updates ophcrack to the latest release, 3.8.0.

Depends on #5913 

Build fails against latest QT 5.12