### PR TITLE
community/fzf: fix build break during packaging phase

### DIFF
--- a/community/fzf/APKBUILD
+++ b/community/fzf/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Kevin Daudt <ops@ikke.info>
 pkgname=fzf
 pkgver=0.17.5
-pkgrel=0
+pkgrel=1
 pkgdesc="A command-line fuzzy finder"
 url="https://github.com/junegunn/fzf"
 arch="all !s390x !aarch64 !armhf"
@@ -20,7 +20,6 @@ prepare() {
 	default_prepare
 	cd "$builddir"
 	export GOPATH="$startdir"
-	HOME=$GOPATH
 	glide install
 }
 


### PR DESCRIPTION
The fzf/APKBUILD sets HOME=$GOPATH in the prepare() phase. This interferes during the normal apkbuild process when trying to discover the conf and keys in ~/.abuild. Deleting this line in the APKBUILD files still seems to allow the package to build ok and avoids the later conflicts.