### PR TITLE
main/musl: Fix interpreter paths for libc6-compat

### DIFF
--- a/main/musl/APKBUILD
+++ b/main/musl/APKBUILD
@@ -121,20 +121,25 @@ compat() {
 	pkgdesc="compatibility libraries for glibc"
 
 	mkdir -p "$subpkgdir"/lib
+	# definitive source is https://sourceware.org/glibc/wiki/ABIList
 	case "$CARCH" in
-	armel) _ld="ld-linux.so.3" ;;
-	armhf | armv7) _ld="ld-linux-armhf.so.3" ;;
-	aarch64) _ld="ld-linux-aarch64.so.1" ;;
-	x86) _ld="ld-linux.so.2" ;;
-	x86_64) _ld="ld-linux-x86-64.so.2"
-		# go precompiled binary uses /lib64/ld-linux-x86-64.so.2
-		# so we add a symlink
-		ln -s lib "$subpkgdir"/lib64
-		;;
-	mips* | s390*) _ld="ld.so.1" ;;
-	ppc64le) _ld="ld64.so.2" ;;
+	aarch64)	_ld="lib/ld-linux-aarch64.so.1" ;;
+	armel)		_ld="lib/ld-linux.so.3" ;;
+	armhf)		_ld="lib/ld-linux-armhf.so.3" ;;
+	armv7)		_ld="lib/ld-linux-armhf.so.3" ;;
+	mips)		_ld="lib/ld.so.1" ;;
+	mips64)		_ld="lib64/ld.so.1" ;;
+	mipsel)		_ld="lib/ld.so.1" ;;
+	mips64el)	_ld="lib64/ld.so.1" ;;
+	ppc)		_ld="lib/ld.so.1" ;;
+	ppc64)		_ld="lib64/ld64.so.1" ;;
+	ppc64le)	_ld="lib64/ld64.so.2" ;;
+	s390x)		_ld="lib/ld64.so.1" ;;
+	x86)		_ld="lib/ld-linux.so.2" ;;
+	x86_64)		_ld="lib64/ld-linux-x86-64.so.2";;
 	esac
-	ln -sf "/lib/libc.musl-${CARCH}.so.1" "$subpkgdir/lib/$_ld"
+	mkdir -p "$subpkgdir/${_ld%/*}"
+	ln -sf "/lib/libc.musl-${CARCH}.so.1" "$subpkgdir/$_ld"
 
 	for i in libc.so.6 libcrypt.so.1 libm.so.6 libpthread.so.0 librt.so.1 libutil.so.1; do
 		ln -sf "/lib/libc.musl-${CARCH}.so.1" "$subpkgdir/lib/$i"


### PR DESCRIPTION
Paths for mips and ppc64el were wrong, several CARCH'es were missing.

On x86_64, this changes /lib64 from being a symlink to a directory containg a symlink.

I added a link to official glibc documentation to avoid guesswork in the future.

This supersedes #5661.

