### PR TITLE
testing/xfce4-genmon-plugin: new aport

### DIFF
--- a/testing/xfce4-genmon-plugin/APKBUILD
+++ b/testing/xfce4-genmon-plugin/APKBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Robert Hencke <robert.hencke@gmail.com>
+pkgname=xfce4-genmon-plugin
+pkgver=4.0.1
+pkgrel=0
+pkgdesc="A generic, script-driven monitoring plugin for the Xfce panel"
+url="http://goodies.xfce.org/projects/panel-plugins/xfce4-genmon-plugin"
+arch="all"
+license="LGPL-2.1"
+makedepends="xfce4-panel-dev libxfce4ui-dev"
+options="!check" # no tests
+subpackages="$pkgname-lang"
+source="http://archive.xfce.org/src/panel-plugins/${pkgname}/${pkgver%.*}/${pkgname}-${pkgver}.tar.bz2
+	"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--libexecdir=/usr/lib \
+		--localstatedir=/var \
+		--disable-static
+	make
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="14590ba4a3b31773e38139d274c93060b2dfdf3cd476dc2235f95f987529b93b74d2422507cc4bf1152f376ec9c6a01bd1da903d422757b95b19c01aa412b35e  xfce4-genmon-plugin-4.0.1.tar.bz2"


### PR DESCRIPTION
https://goodies.xfce.org/projects/panel-plugins/xfce4-genmon-plugin
A generic, script-driven monitoring plugin for the Xfce panel