### PR TITLE
main/py-pynacl: fix ppc64le build hang during sigfault signal configure test

### DIFF
--- a/main/py-pynacl/APKBUILD
+++ b/main/py-pynacl/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=py-pynacl
 _pkgname=${pkgname/py-/}
 pkgver=1.3.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Python binding to the Networking and Cryptography (NaCl) library"
 url="https://github.com/pyca/pynacl"
 arch="all"
@@ -11,7 +11,8 @@ license="Apache-2.0"
 depends="py-cffi py-six"
 makedepends="py-setuptools python2-dev python3-dev libffi-dev"
 subpackages="py3-${pkgname/py-/}:_py3 py2-${pkgname/py-/}:_py2"
-source="$pkgname-$pkgver.tar.gz::https://github.com/pyca/$_pkgname/archive/$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/pyca/$_pkgname/archive/$pkgver.tar.gz
+	ppc64le-disable-configure-segfaultcheck.patch"
 builddir="$srcdir"/$_pkgname-$pkgver
 
 check() {
@@ -50,4 +51,5 @@ _py3() {
 	_py python3
 }
 
-sha512sums="815c31a2069cbee1091d7e0ebf0b5572875c4a537311af561b5bce0b9d8051028e367a516b46481453d9780e60e9e7e2a4640d320164059c3974b0319d1cf96d  py-pynacl-1.3.0.tar.gz"
+sha512sums="815c31a2069cbee1091d7e0ebf0b5572875c4a537311af561b5bce0b9d8051028e367a516b46481453d9780e60e9e7e2a4640d320164059c3974b0319d1cf96d  py-pynacl-1.3.0.tar.gz
+a96f649bb7d1552612f46668ce1c27dd4bb62e0e6459a02e9769a967c54ebe8467c3e8c515789a65838f5c55c96f381fabea4cc07fde8857a65f7dafa062c07c  ppc64le-disable-configure-segfaultcheck.patch"

--- a/main/py-pynacl/ppc64le-disable-configure-segfaultcheck.patch
+++ b/main/py-pynacl/ppc64le-disable-configure-segfaultcheck.patch
@@ -1,0 +1,14 @@
+--- a/src/libsodium/configure
++++ b/src/libsodium/configure
+@@ -8742,7 +8742,11 @@
+ signal(SIGSEGV, sig);
+ signal(SIGBUS, sig);
+ #if !defined(__SANITIZE_ADDRESS__) && !defined(__EMSCRIPTEN__)
++#ifndef __powerpc64__
+ for (i = 0; i < 10000000; i += 1024) { x[-i] = x[i] = (unsigned char) i; }
++#else
++exit(0);
++#endif
+ #endif
+ free((void *) x);
+ exit(1)


### PR DESCRIPTION
When building for ppc64le, during pynacl-1.3.0/src/libsodium/configure a test is done to see if segfault signal handling is supported (through creation of conftest.c source code generated during ./configure). This test is executed multiple times at different build phases. On ppc64le although the SIGSEGV is invoking the handling routine correctly the parent process doesn't always exit gracefully causing this to sometimes hang this configure check. To work around the hang for now this configure test can be disabled for ppc64le and the support setting turned on explicitly.  Deeper work should be looked at apart from this package at any ppc64le signal handling issues.