### PR TITLE
main/bind: update root hint file contents and naming

### DIFF
--- a/main/bind/named.cache
+++ b/main/bind/named.cache
@@ -1,85 +1,92 @@
-;       This file holds the information on root name servers needed to
+;       This file holds the information on root name servers needed to 
 ;       initialize cache of Internet domain name servers
 ;       (e.g. reference this file in the "cache  .  <file>"
-;       configuration file of BIND domain name servers).
-;
+;       configuration file of BIND domain name servers). 
+; 
 ;       This file is made available by InterNIC 
 ;       under anonymous FTP as
-;           file                /domain/named.root
+;           file                /domain/named.cache 
 ;           on server           FTP.INTERNIC.NET
 ;       -OR-                    RS.INTERNIC.NET
+; 
+;       last update:     November 14, 2018 
+;       related version of root zone:     2018111402
+; 
+; FORMERLY NS.INTERNIC.NET 
 ;
-;       last update:    Feb 04, 2008
-;       related version of root zone:   2008020400
-;
-; formerly NS.INTERNIC.NET
-;
-.                        3600000  IN  NS    A.ROOT-SERVERS.NET.
+.                        3600000      NS    A.ROOT-SERVERS.NET.
 A.ROOT-SERVERS.NET.      3600000      A     198.41.0.4
-A.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:BA3E::2:30
-;
-; formerly NS1.ISI.EDU
+A.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:ba3e::2:30
+; 
+; FORMERLY NS1.ISI.EDU 
 ;
 .                        3600000      NS    B.ROOT-SERVERS.NET.
-B.ROOT-SERVERS.NET.      3600000      A     192.228.79.201
-;
-; formerly C.PSI.NET
+B.ROOT-SERVERS.NET.      3600000      A     199.9.14.201
+B.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:200::b
+; 
+; FORMERLY C.PSI.NET 
 ;
 .                        3600000      NS    C.ROOT-SERVERS.NET.
 C.ROOT-SERVERS.NET.      3600000      A     192.33.4.12
-;
-; formerly TERP.UMD.EDU
+C.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2::c
+; 
+; FORMERLY TERP.UMD.EDU 
 ;
 .                        3600000      NS    D.ROOT-SERVERS.NET.
-D.ROOT-SERVERS.NET.      3600000      A     128.8.10.90
-;
-; formerly NS.NASA.GOV
+D.ROOT-SERVERS.NET.      3600000      A     199.7.91.13
+D.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2d::d
+; 
+; FORMERLY NS.NASA.GOV
 ;
 .                        3600000      NS    E.ROOT-SERVERS.NET.
 E.ROOT-SERVERS.NET.      3600000      A     192.203.230.10
-;
-; formerly NS.ISC.ORG
+E.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:a8::e
+; 
+; FORMERLY NS.ISC.ORG
 ;
 .                        3600000      NS    F.ROOT-SERVERS.NET.
 F.ROOT-SERVERS.NET.      3600000      A     192.5.5.241
 F.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2f::f
-;
-; formerly NS.NIC.DDN.MIL
+; 
+; FORMERLY NS.NIC.DDN.MIL
 ;
 .                        3600000      NS    G.ROOT-SERVERS.NET.
 G.ROOT-SERVERS.NET.      3600000      A     192.112.36.4
-;
-; formerly AOS.ARL.ARMY.MIL
+G.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:12::d0d
+; 
+; FORMERLY AOS.ARL.ARMY.MIL
 ;
 .                        3600000      NS    H.ROOT-SERVERS.NET.
-H.ROOT-SERVERS.NET.      3600000      A     128.63.2.53
-H.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:1::803f:235
-;
-; formerly NIC.NORDU.NET
+H.ROOT-SERVERS.NET.      3600000      A     198.97.190.53
+H.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:1::53
+; 
+; FORMERLY NIC.NORDU.NET
 ;
 .                        3600000      NS    I.ROOT-SERVERS.NET.
 I.ROOT-SERVERS.NET.      3600000      A     192.36.148.17
-;
-; operated by VeriSign, Inc.
+I.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fe::53
+; 
+; OPERATED BY VERISIGN, INC.
 ;
 .                        3600000      NS    J.ROOT-SERVERS.NET.
 J.ROOT-SERVERS.NET.      3600000      A     192.58.128.30
-J.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:C27::2:30
-;
-; operated by RIPE NCC
+J.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:c27::2:30
+; 
+; OPERATED BY RIPE NCC
 ;
 .                        3600000      NS    K.ROOT-SERVERS.NET.
-K.ROOT-SERVERS.NET.      3600000      A     193.0.14.129 
+K.ROOT-SERVERS.NET.      3600000      A     193.0.14.129
 K.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fd::1
-;
-; operated by ICANN
+; 
+; OPERATED BY ICANN
 ;
 .                        3600000      NS    L.ROOT-SERVERS.NET.
 L.ROOT-SERVERS.NET.      3600000      A     199.7.83.42
-;
-; operated by WIDE
+L.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:9f::42
+; 
+; OPERATED BY WIDE
 ;
 .                        3600000      NS    M.ROOT-SERVERS.NET.
 M.ROOT-SERVERS.NET.      3600000      A     202.12.27.33
 M.ROOT-SERVERS.NET.      3600000      AAAA  2001:dc3::35
-; End of File
+; End of file

--- a/main/bind/named.conf.recursive
+++ b/main/bind/named.conf.recursive
@@ -86,7 +86,7 @@ options {
 
 zone "." IN {
 	type hint;
-	file "named.ca";
+	file "named.cache";
 };
 
 zone "localhost" IN {


### PR DESCRIPTION
I noticed when spinning up a simple bind container (https://hub.docker.com/r/resystit/bind9/) that the defaults for the root hints are a smidge out of date. It *works*, but it's possibly somewhat sub-optimal, so thought I'd suggest updating the file accordingly.

(also, if this isn't the right way to submit a PR, let me know - the contrib guidelines start by saying to *not* do a PR via the web interface.. but then in the detailed steps talk about going to github.com and creating the pull?)

 - update to the current (2018111402) root hints from
   ftp://rs.internic.net/domain/named.cache

 - rename file to named.cache from named.ca to match source
   and update recursive named.conf example to match
