### PR TITLE
main/gzip: upgrade to 1.10

### DIFF
--- a/main/gzip/APKBUILD
+++ b/main/gzip/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Leonardo Arena <rnalrd@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gzip
-pkgver=1.9
+pkgver=1.10
 pkgrel=0
 pkgdesc="A popular data compression program"
 subpackages="$pkgname-doc"
@@ -49,4 +49,4 @@ package() {
 	ln -sf /bin/gunzip "$pkgdir"/usr/bin/uncompress
 }
 
-sha512sums="686cb920701e2e19178143a0714edf46da5456bcdc5f5f99c2c186eb195078bc1039e4552f6e0eb4b870cc9beb1042ca3b8922d0b81e378c27bbbc55ba8f4a2f  gzip-1.9.tar.gz"
+sha512sums="7939043e74554ced0c1c05d354ab4eb36cd6dce89ad79d02ccdc5ed6b7ee390759689b2d47c07227b9b44a62851afe7c76c4cae9f92527d999f3f1b4df1cccff  gzip-1.10.tar.gz"


### PR DESCRIPTION
Ref https://www.mail-archive.com/info-gnu@gnu.org/msg02543.html

* Noteworthy changes in release 1.10 (2018-12-29) [stable]

** Changes in behavior

  Compressed gzip output no longer contains the current time as a
  timestamp when the input is not a regular file.  Instead, the output
  contains a null (zero) timestamp.  This makes gzip's behavior more
  reproducible when used as part of a pipeline.  (As a reminder, even
  regular files will use null timestamps after the year 2106, due to a
  limitation in the gzip format.)

** Bug fixes

  A use of uninitialized memory on some malformed inputs has been fixed.
  [bug present since the beginning]

  A few theoretical race conditions in signal handers have been fixed.
  These bugs most likely do not happen on practical platforms.
  [bugs present since the beginning]