### PR TITLE
testing/lzbench: new aport

### DIFF
--- a/testing/lzbench/APKBUILD
+++ b/testing/lzbench/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Oleg Titov <oleg.titov@gmail.com>
+# Maintainer: Oleg Titov <oleg.titov@gmail.com>
+pkgname=lzbench
+pkgver=1.7.3
+pkgrel=0
+pkgdesc="lzbench is an in-memory benchmark of open-source LZ77/LZSS/LZMA compressors"
+url="https://github.com/inikep/lzbench"
+arch="x86_64 x86"
+license="GPL zlib MIT Unlicense BSD Apache-2.0 CDDL CC0 custom"
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/inikep/lzbench/archive/v$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver/"
+
+build() {
+	cd "$builddir"
+	make
+}
+
+check() {
+	cd "$builddir"
+	./lzbench
+}
+
+package() {
+	cd "$builddir"
+	install -Dm 755 lzbench "$pkgdir"/usr/bin/lzbench
+
+	install -Dm 644 -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
+}
+
+sha512sums="affd289492e00c83e26ec1a126bd5479a45fc4710471184e2234a1d7247e85e3652816e691c035174ca3fe4708979691bfbcb1e6bd196de452cc50af31ddeae8  lzbench-1.7.3.tar.gz"


### PR DESCRIPTION
https://github.com/inikep/lzbench
lzbench is an in-memory benchmark of open-source LZ77/LZSS/LZMA compressors