### PR TITLE
community/geth: fix ppc64le build break by re-enabling isatty termina…

### DIFF
--- a/community/geth/APKBUILD
+++ b/community/geth/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: André Klitzing <aklitzing@gmail.com>
 pkgname=geth
 pkgver=1.8.20
-pkgrel=0
+pkgrel=1
 pkgdesc="Official Go implementation of the Ethereum protocol"
 url="https://geth.ethereum.org/"
 arch="all"
@@ -10,7 +10,8 @@ license="LGPL-3.0"
 makedepends="go linux-headers"
 checkdepends="fuse"
 options="!check"
-source="$pkgname-$pkgver.tar.gz::https://github.com/ethereum/go-ethereum/archive/v$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/ethereum/go-ethereum/archive/v$pkgver.tar.gz
+	fix-ppc64le-isatty.patch"
 builddir="$srcdir/go-ethereum-$pkgver"
 
 build() {
@@ -29,4 +30,5 @@ package() {
 	install -m755 -t "${pkgdir}"/usr/bin build/bin/*
 }
 
-sha512sums="99a414991801f2deed6d40fe8fcd60f35c0bc1b0f54af4427d4e431de111d626855985ae929663dc5c7454a8d224663858d0f7236238d05c78775377b46510ba  geth-1.8.20.tar.gz"
+sha512sums="99a414991801f2deed6d40fe8fcd60f35c0bc1b0f54af4427d4e431de111d626855985ae929663dc5c7454a8d224663858d0f7236238d05c78775377b46510ba  geth-1.8.20.tar.gz
+7f1d4cf22e1d48baebd28725ee099cb878028980af336b6e92d1f580a24a7d11e8b302e2b1f8c14f5b18b1d01313abe43464d8bef631ca18e5b0d613fe0a10a0  fix-ppc64le-isatty.patch"

--- a/community/geth/fix-ppc64le-isatty.patch
+++ b/community/geth/fix-ppc64le-isatty.patch
@@ -1,0 +1,9 @@
+--- a/vendor/github.com/mattn/go-isatty/isatty_linux.go
++++ b/vendor/github.com/mattn/go-isatty/isatty_linux.go
+@@ -1,5 +1,5 @@
+ // +build linux
+-// +build !appengine,!ppc64,!ppc64le
++// +build !appengine
+ 
+ package isatty
+ 


### PR DESCRIPTION
…l functions

https://github.com/ethereum/go-ethereum/pull/17740 disabled building isatty_linux.go for ppc64,ppc64le which makes these functions unavailable when building flags.go and color.go modules for geth. This patch allows the isatty_linux.go module to be built for ppc64le so geth build requirements are fixed. 

A post was added to https://github.com/ethereum/go-ethereum/pull/17740 to try and understand better why this was disabled in the first place for ppc64le.