### PR TITLE
Expose Travis Environment Variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ sudo: required
 language: minimal
 install:
   - sudo .travis/install-alpine
+  - (source .travis/common.sh && setup_alpine_run_env "$USER")
   - sudo .travis/setup-alpine
 script: |
   source .travis/common.sh
-  alpine_run $USER .travis/build-pkgs
+  setup_alpine_run_env "$USER"
+  alpine_run "$USER" .travis/build-pkgs
 notifications:
   email: false

--- a/.travis/common.sh
+++ b/.travis/common.sh
@@ -35,8 +35,8 @@ alpine_run() {
 	local _sudo=
 	[ "$(id -u)" -eq 0 ] || _sudo='sudo'
 
-	$_sudo chroot "$ALPINE_ROOT" /usr/bin/env -i su -l $user \
-		sh -c "cd $CLONE_DIR; $cmd"
+	$_sudo chroot "$ALPINE_ROOT" /usr/bin/env -i su -l "$user" \
+		sh -c ". /.alpine_run_env ; cd \"\$CLONE_DIR\" ; $cmd"
 }
 
 die() {


### PR DESCRIPTION
None of the variables set by TravisCI were seen by scripts running under `alpine_run`.

This attempts to fix that situation so that `TRAVIS_COMMIT_RANGE` and the like are useful again.