### PR TITLE
main/http-parser: upgrade to 2.9.0

### DIFF
--- a/main/http-parser/APKBUILD
+++ b/main/http-parser/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=http-parser
-pkgver=2.8.1
+pkgver=2.9.0
 pkgrel=0
 pkgdesc="HTTP request/response parser for C"
 url="https://github.com/nodejs/http-parser"
@@ -30,4 +30,4 @@ package() {
 	make install DESTDIR="$pkgdir" PREFIX="/usr"
 }
 
-sha512sums="6f52f543d979f39688ccefae236527a8183929b3d30f5370570107b01cf89d0338b448249a81102b78d31615d2e8f6e7c708f8961f55ece08e7d3a40e5ad0883  http-parser-2.8.1.tar.gz"
+sha512sums="40acecbf71b9f0b4ae857c74c3ec0784d7f341a0cb83cf82b308387d0c5b56d38b282241aaf8ca93816970f2a9e67989f3d9d456459f3986c29fe51ab520155e  http-parser-2.9.0.tar.gz"


### PR DESCRIPTION
This is required by recent Node.js versions, builds will fail otherwise (see e.g. https://api.travis-ci.org/v3/job/474337566/log.txt)