### PR TITLE
testing/lxd: fix ppc64le with update_config_guess and libcap-dev make…

### DIFF
--- a/testing/lxd/APKBUILD
+++ b/testing/lxd/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=lxd
 pkgver=3.8
-pkgrel=2
+pkgrel=3
 pkgdesc="a container hypervisor and a new user experience for LXC"
 url="https://linuxcontainers.org/lxd/"
 arch="all"
@@ -10,7 +10,7 @@ license="Apache-2.0"
 depends="acl xz netcat-openbsd cgmanager squashfs-tools rsync shadow-uidmap lxc ip6tables 
 dnsmasq ca-certificates"
 makedepends="lxc-dev protobuf-dev rsync go gettext-dev linux-headers acl-dev 
-	tcl-dev libtool autoconf automake libuv-dev intltool"
+	tcl-dev libtool autoconf automake libuv-dev intltool libcap-dev"
 subpackages="$pkgname-scripts:scripts $pkgname-bash-completion:bashcomp:noarch $pkgname-openrc"
 install="$pkgname.pre-install"
 options="!check"
@@ -32,6 +32,7 @@ prepare() {
 build() {
 	export GOPATH="$builddir/dist"
 	export CGO_LDFLAGS="$CGO_LDFLAGS -lintl"
+	update_config_guess
 	cd "$GOPATH"/sqlite
 	./configure \
 		--prefix=/usr \


### PR DESCRIPTION
…depend.

ppc64le build breaks with unknown architecture message. Adding update_config_guess during build phase fixes this. A second failure occurs with:
dist/src/github.com/lxc/lxd/shared/idmap/shift_linux.go:27:10: fatal error: sys/capability.h: No such file or directory
 #include <sys/capability.h>

Adding libcap-dev make dependancy will fix this. 