### PR TITLE
testing/usbip-utils: fix ppc64le build by disabling Werror

### DIFF
--- a/testing/usbip-utils/APKBUILD
+++ b/testing/usbip-utils/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: wener <wenermail@gmail.com>
 pkgname=usbip-utils
 pkgver=4.18.13
-pkgrel=0
+pkgrel=1
 pkgdesc="Utilities for USB device sharing over IP network"
 url="https://kernel.org/doc/readme/drivers-staging-usbip-userspace-README"
 arch="all"
@@ -14,7 +14,8 @@ install=""
 subpackages="$pkgname-dev $pkgname-doc"
 source="https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-$pkgver.tar.gz
 	usbip.initd
-	usbip.confd"
+	usbip.confd
+	fix-ppc64le-disable-werror.patch"
 
 _baseurl="linux-$pkgver/tools/usb/usbip"
 builddir="$srcdir/usbip"
@@ -65,4 +66,5 @@ package() {
 
 sha512sums="d8b6076617f1b6e88bb485165c0a36567bb6ab9c372ecabf749515f5b5c7de3a8c38a1a262d3b9f2feeda5a76a3fede493fe098811a01f06fe079fe5f7656ecb  linux-4.18.13.tar.gz
 fcbd64d844c9bc187d08cef5995e91a46c0df78deb24e96ac9210c0e2c730eca0301970d9b8ffbf003df274682d05072431a26b59d8c491f396618268a12ec92  usbip.initd
-eb8de617e27c4d5fdfee9c442e8f74b0afb4d0fe7b59eca3a19629eb70fea7e09b3c125bc968aa8810d845ce661c829bd0f3fdb2288664f2cccf423bc0ae6ae8  usbip.confd"
+eb8de617e27c4d5fdfee9c442e8f74b0afb4d0fe7b59eca3a19629eb70fea7e09b3c125bc968aa8810d845ce661c829bd0f3fdb2288664f2cccf423bc0ae6ae8  usbip.confd
+473d194edc7677d0eb9864cf1e3922264ddd2d89e1015188f09c59e50a84a77f08d1e5c99700d4f3c8c01bea318aa614482f7902f0c97f5d87d6fbe388e840f8  fix-ppc64le-disable-werror.patch"

--- a/testing/usbip-utils/fix-ppc64le-disable-werror.patch
+++ b/testing/usbip-utils/fix-ppc64le-disable-werror.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -18,7 +18,7 @@
+ # Silent build for automake >= 1.11
+ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+ 
+-AC_SUBST([EXTRA_CFLAGS], ["-Wall -Werror -Wextra -std=gnu99"])
++AC_SUBST([EXTRA_CFLAGS], ["-Wall -Wextra -std=gnu99"])
+ 
+ # Checks for programs.
+ AC_PROG_CC


### PR DESCRIPTION
With gcc8 on ppc64le build fails with errors: 
usbip_device_driver.c:106:2: error: 'strncpy' specified bound 256 equals destination size [-Werror=stringop-truncation]
  strncpy(dev->path, path, SYSFS_PATH_MAX);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
usbip_device_driver.c:125:2: error: 'strncpy' specified bound 32 equals destination size [-Werror=stringop-truncation]
  strncpy(dev->busid, name, SYSFS_BUS_ID_SIZE);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

modify configure.ac to remove Werror flag by default to fix build.