### PR TITLE
testing/postfwd2: New aport

### DIFF
--- a/testing/postfwd2/APKBUILD
+++ b/testing/postfwd2/APKBUILD
@@ -1,0 +1,45 @@
+# Contributor: Simon Frankenberger <simon-alpine@fraho.eu>
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
+pkgname=postfwd2
+_pkgname=${pkgname:0:-1}
+pkgver=1.39
+pkgrel=0
+pkgdesc="Combines complex postfix restrictions in a ruleset similar to those of the most firewalls"
+url="https://postfwd.org/"
+arch="noarch"
+license="BSD"
+depends="perl-net-server perl-net-dns perl-io-multiplex"
+subpackages="$pkgname-doc $pkgname-openrc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/$_pkgname/$_pkgname/archive/v$pkgver.tar.gz
+$pkgname.initd
+$pkgname.confd
+"
+options="!tracedeps !check" # package has no tests
+builddir="$srcdir/$_pkgname-$pkgver"
+pkgusers="postfwd2"
+pkggroups="postfwd2"
+
+build() {
+	cd "$builddir"
+	# just print out version to check if all dependencies are met
+	sbin/postfwd2 -V
+}
+
+package() {
+	cd "$builddir"
+	mkdir -p "$pkgdir"/usr/sbin \
+		"$pkgdir"/usr/share/doc/postfwd2 \
+		"$pkgdir"/usr/share/man/man8 \
+		"$pkgdir"/etc/postfwd2 \
+		"$pkgdir"/etc/init.d
+	install -m0755 sbin/postfwd2 "$pkgdir"/usr/sbin
+	install -m0644 doc/* "$pkgdir"/usr/share/doc/postfwd2
+	install -m0644 man/man8/* "$pkgdir"/usr/share/man/man8
+	install -m0644 etc/postfwd.cf.sample "$pkgdir"/etc/postfwd2
+	install -Dm755 "$srcdir"/$pkgname.initd "$pkgdir"/etc/init.d/$pkgname
+	install -Dm644 "$srcdir"/$pkgname.confd "$pkgdir"/etc/conf.d/$pkgname
+}
+
+sha512sums="b292b3d5cb634fedc039b33225e5f3e5653a25e56b5b2d9a5936d0a9d59ddb9a0fef129221f23859a679609eed57f4c7f20299f4895a48600cc78d2e22756a16  postfwd2-1.39.tar.gz
+2d31db1e5b175feda12d73d5cb15ebc4934761a2febe052820f8b627bfc3fe969536d37d82948e9b3ded26ef34bcbd8eb022528a01dc5ace574b79a84e0854d2  postfwd2.initd
+e1ead4e130c593fabf6ce28fdbdf74806bd922556b492976c03b3578112c533ca60645ad11786785763abf6dd94fee37f2e7261661314f712f9f46fad2acd20d  postfwd2.confd"

--- a/testing/postfwd2/postfwd2.confd
+++ b/testing/postfwd2/postfwd2.confd
@@ -1,0 +1,19 @@
+# /etc/conf.d/postfwd2.conf
+
+# User and group to execute postfwd as
+POSTFWD2_USER="postfwd2"
+POSTFWD2_GROUP="postfwd2"
+
+# Configuration file to use
+POSTFWD2_CONFIG="/etc/postfwd2/postfwd.cf"
+
+# The IP address postfwd will listen on
+# WARNING: You _really_ want this to be localhost for security!
+POSTFWD2_LISTEN="127.0.0.1"
+
+# The port postfwd will listen on
+POSTFWD2_PORT="10040"
+
+# Additional options to pass to postfwd
+POSTFWD2_OPTS=""
+

--- a/testing/postfwd2/postfwd2.initd
+++ b/testing/postfwd2/postfwd2.initd
@@ -1,0 +1,20 @@
+#!/sbin/openrc-run
+# Copyright 1999-2011 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+command="/usr/sbin/postfwd2"
+pidfile="/run/postfwd2.pid"
+command_args="--file ${POSTFWD2_CONFIG}
+--interface=${POSTFWD2_LISTEN}
+--port=${POSTFWD2_PORT}
+--user=${POSTFWD2_USER}
+--group=${POSTFWD2_GROUP}
+--pidfile ${pidfile}
+${POSTFWD2_OPTS}
+"
+command_args_background="--daemon"
+
+depend() {
+	need net
+}
+


### PR DESCRIPTION
This PR adds postfwd2, a tool to write postfix restrictions in a ruleset file similar to those of the most firewalls.