### PR TITLE
testing/enscript: fix ppc64le bld break adding update_config_guess

### DIFF
--- a/testing/enscript/APKBUILD
+++ b/testing/enscript/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Steffen Nurpmeso <steffen@sdaoden.eu>
 pkgname=enscript
 pkgver=1.6.6
-pkgrel=0
+pkgrel=1
 pkgdesc="GNU Enscript converts ASCII files to PostScript, HTML, or RTF"
 url="https://www.gnu.org/software/enscript/"
 arch="all"
@@ -21,6 +21,7 @@ build() {
 	C_INCLUDE_PATH=/usr/include
 	LD_LIBRARY_PATH=/lib:/usr/lib
 	export PATH C_INCLUDE_PATH LD_LIBRARY_PATH
+	update_config_guess
 
 	./configure --prefix=/usr --disable-nls
 	make


### PR DESCRIPTION
Build on ppc64le encounters error:
configure: error: cannot guess build type; you must specify one

fix by adding update_config_guess