### PR TITLE
community/php7-pecl-msgpack: fix aarch64 build

### DIFF
--- a/community/php7-pecl-msgpack/APKBUILD
+++ b/community/php7-pecl-msgpack/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=php7-pecl-msgpack
 _pkgreal=msgpack
 pkgver=2.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc="PHP extension provides API for communicating with MessagePack serialization - PECL"
 url="https://pecl.php.net/package/msgpack"
 arch="all"
@@ -29,6 +29,9 @@ check() {
 	cd "$builddir"
 	# Tests require session and sockets extensions which are not bundled
 	sed -i 's#PHP_TEST_SHARED_EXTENSIONS =  `#PHP_TEST_SHARED_EXTENSIONS = -d extension=/usr/lib/php7/modules/session.so -d extension=/usr/lib/php7/modules/sockets.so `#' Makefile
+	case "$CARCH" in
+		aarch64 | armv7) rm -f tests/035.phpt # https://github.com/msgpack/msgpack-php/issues/123#issuecomment-451620789 ;;
+	esac
 	make NO_INTERACTION=1 REPORT_EXIT_STATUS=1 test
 }
 


### PR DESCRIPTION
RM test considers aarch64 serialize slow for the arch 

Ref https://github.com/msgpack/msgpack-php/issues/123#issuecomment-451620789

https://build.alpinelinux.org/buildlogs/build-edge-aarch64/community/php7-pecl-msgpack/php7-pecl-msgpack-2.0.3-r1.log