### PR TITLE
main/python3: Upgrade to 3.6.8 and patch CVE-2019-5010

### DIFF
--- a/community/python3-tkinter/APKBUILD
+++ b/community/python3-tkinter/APKBUILD
@@ -2,9 +2,9 @@
 # Contributor: Kiyoshi Aman <kiyoshi.aman@gmail.com>
 
 pkgname=python3-tkinter
-pkgver=3.6.7
+pkgver=3.6.8
 _basever="${pkgver%.*}"
-pkgrel=1
+pkgrel=0
 pkgdesc="A graphical user interface for the Python"
 url="https://wiki.python.org/moin/TkInter"
 arch="all"
@@ -110,6 +110,6 @@ _idle() {
 	_mv_files usr/lib/python*/idlelib
 }
 
-sha512sums="7be753046db8d12fc00f90d9c1b2edcc5ae80ac39e9d0d8d07553081a26f59a60c0d0cf6986006f0729f425d5751273110db3aa2d413d9405fafa9bd6c052fdf  Python-3.6.7.tar.xz
+sha512sums="b17867e451ebe662f50df83ed112d3656c089e7d750651ea640052b01b713b58e66aac9e082f71fd16f5b5510bc9b797f5ccd30f5399581e9aa406197f02938a  Python-3.6.8.tar.xz
 ab8eaa2858d5109049b1f9f553198d40e0ef8d78211ad6455f7b491af525bffb16738fed60fc84e960c4889568d25753b9e4a1494834fea48291b33f07000ec2  musl-find_library.patch
 37b6ee5d0d5de43799316aa111423ba5a666c17dc7f81b04c330f59c1d1565540eac4c585abe2199bbed52ebe7426001edb1c53bd0a17486a2a8e052d0f494ad  fix-xattrs-glibc.patch"

--- a/community/python3-tkinter/APKBUILD
+++ b/community/python3-tkinter/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=python3-tkinter
 pkgver=3.6.8
 _basever="${pkgver%.*}"
-pkgrel=0
+pkgrel=1
 pkgdesc="A graphical user interface for the Python"
 url="https://wiki.python.org/moin/TkInter"
 arch="all"
@@ -15,10 +15,15 @@ makedepends="expat-dev openssl-dev zlib-dev ncurses-dev bzip2-dev xz-dev
 	sqlite-dev libffi-dev tcl-dev linux-headers gdbm-dev readline-dev
 	tk tk-dev python3"
 source="https://www.python.org/ftp/python/$pkgver/Python-$pkgver.tar.xz
+	CVE-2019-5010.patch
 	musl-find_library.patch
 	fix-xattrs-glibc.patch
 	"
 builddir="$srcdir/Python-$pkgver"
+
+# secfixes:
+#   3.6.8-r1:
+#   - CVE-2019-5010
 
 prepare() {
 	local _pyapkbuild="$startdir"/../python3/APKBUILD
@@ -111,5 +116,6 @@ _idle() {
 }
 
 sha512sums="b17867e451ebe662f50df83ed112d3656c089e7d750651ea640052b01b713b58e66aac9e082f71fd16f5b5510bc9b797f5ccd30f5399581e9aa406197f02938a  Python-3.6.8.tar.xz
+7859fe12e393995f66f42e38f01ff29abef5f64301747a02d8e49a990ce4e7f529cf2a3420c76bd5f9df09905e64a4e0451a2103c061dde5f99166e7fc370715  CVE-2019-5010.patch
 ab8eaa2858d5109049b1f9f553198d40e0ef8d78211ad6455f7b491af525bffb16738fed60fc84e960c4889568d25753b9e4a1494834fea48291b33f07000ec2  musl-find_library.patch
 37b6ee5d0d5de43799316aa111423ba5a666c17dc7f81b04c330f59c1d1565540eac4c585abe2199bbed52ebe7426001edb1c53bd0a17486a2a8e052d0f494ad  fix-xattrs-glibc.patch"

--- a/community/python3-tkinter/CVE-2019-5010.patch
+++ b/community/python3-tkinter/CVE-2019-5010.patch
@@ -1,0 +1,116 @@
+From bc947d7cd67c96cbfbc55dd53bce52392bd6f80d Mon Sep 17 00:00:00 2001
+From: Christian Heimes <christian@python.org>
+Date: Tue, 15 Jan 2019 23:47:42 +0100
+Subject: [PATCH] bpo-35746: Fix segfault in ssl's cert parser (GH-11569)
+
+Fix a NULL pointer deref in ssl module. The cert parser did not handle CRL
+distribution points with empty DP or URI correctly. A malicious or buggy
+certificate can result into segfault.
+
+Signed-off-by: Christian Heimes <christian@python.org>
+
+https://bugs.python.org/issue35746
+(cherry picked from commit a37f52436f9aa4b9292878b72f3ff1480e2606c3)
+
+Co-authored-by: Christian Heimes <christian@python.org>
+---
+ Lib/test/talos-2019-0758.pem                  | 22 +++++++++++++++++++
+ Lib/test/test_ssl.py                          | 22 +++++++++++++++++++
+ .../2019-01-15-18-16-05.bpo-35746.nMSd0j.rst  |  3 +++
+ Modules/_ssl.c                                |  4 ++++
+ 4 files changed, 51 insertions(+)
+ create mode 100644 Lib/test/talos-2019-0758.pem
+ create mode 100644 Misc/NEWS.d/next/Security/2019-01-15-18-16-05.bpo-35746.nMSd0j.rst
+
+diff --git a/Lib/test/talos-2019-0758.pem b/Lib/test/talos-2019-0758.pem
+new file mode 100644
+index 000000000000..13b95a77fd8a
+--- /dev/null
++++ b/Lib/test/talos-2019-0758.pem
+@@ -0,0 +1,22 @@
++-----BEGIN CERTIFICATE-----
++MIIDqDCCApKgAwIBAgIBAjALBgkqhkiG9w0BAQswHzELMAkGA1UEBhMCVUsxEDAO
++BgNVBAMTB2NvZHktY2EwHhcNMTgwNjE4MTgwMDU4WhcNMjgwNjE0MTgwMDU4WjA7
++MQswCQYDVQQGEwJVSzEsMCoGA1UEAxMjY29kZW5vbWljb24tdm0tMi50ZXN0Lmxh
++bC5jaXNjby5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC63fGB
++J80A9Av1GB0bptslKRIUtJm8EeEu34HkDWbL6AJY0P8WfDtlXjlPaLqFa6sqH6ES
++V48prSm1ZUbDSVL8R6BYVYpOlK8/48xk4pGTgRzv69gf5SGtQLwHy8UPBKgjSZoD
++5a5k5wJXGswhKFFNqyyxqCvWmMnJWxXTt2XDCiWc4g4YAWi4O4+6SeeHVAV9rV7C
++1wxqjzKovVe2uZOHjKEzJbbIU6JBPb6TRfMdRdYOw98n1VXDcKVgdX2DuuqjCzHP
++WhU4Tw050M9NaK3eXp4Mh69VuiKoBGOLSOcS8reqHIU46Reg0hqeL8LIL6OhFHIF
++j7HR6V1X6F+BfRS/AgMBAAGjgdYwgdMwCQYDVR0TBAIwADAdBgNVHQ4EFgQUOktp
++HQjxDXXUg8prleY9jeLKeQ4wTwYDVR0jBEgwRoAUx6zgPygZ0ZErF9sPC4+5e2Io
++UU+hI6QhMB8xCzAJBgNVBAYTAlVLMRAwDgYDVQQDEwdjb2R5LWNhggkA1QEAuwb7
++2s0wCQYDVR0SBAIwADAuBgNVHREEJzAlgiNjb2Rlbm9taWNvbi12bS0yLnRlc3Qu
++bGFsLmNpc2NvLmNvbTAOBgNVHQ8BAf8EBAMCBaAwCwYDVR0fBAQwAjAAMAsGCSqG
++SIb3DQEBCwOCAQEAvqantx2yBlM11RoFiCfi+AfSblXPdrIrHvccepV4pYc/yO6p
++t1f2dxHQb8rWH3i6cWag/EgIZx+HJQvo0rgPY1BFJsX1WnYf1/znZpkUBGbVmlJr
++t/dW1gSkNS6sPsM0Q+7HPgEv8CPDNK5eo7vU2seE0iWOkxSyVUuiCEY9ZVGaLVit
++p0C78nZ35Pdv4I+1cosmHl28+es1WI22rrnmdBpH8J1eY6WvUw2xuZHLeNVN0TzV
++Q3qq53AaCWuLOD1AjESWuUCxMZTK9DPS4JKXTK8RLyDeqOvJGjsSWp3kL0y3GaQ+
++10T1rfkKJub2+m9A9duin1fn6tHc2wSvB7m3DA==
++-----END CERTIFICATE-----
+diff --git a/Lib/test/test_ssl.py b/Lib/test/test_ssl.py
+index 705f1d3245b6..0aeabc10f2a9 100644
+--- a/Lib/test/test_ssl.py
++++ b/Lib/test/test_ssl.py
+@@ -79,6 +79,7 @@ def data_file(*name):
+ BADKEY = data_file("badkey.pem")
+ NOKIACERT = data_file("nokia.pem")
+ NULLBYTECERT = data_file("nullbytecert.pem")
++TALOS_INVALID_CRLDP = data_file("talos-2019-0758.pem")
+ 
+ DHFILE = data_file("ffdh3072.pem")
+ BYTES_DHFILE = os.fsencode(DHFILE)
+@@ -293,6 +294,27 @@ def test_parse_cert(self):
+         self.assertEqual(p['crlDistributionPoints'],
+                          ('http://SVRIntl-G3-crl.verisign.com/SVRIntlG3.crl',))
+ 
++    def test_parse_cert_CVE_2019_5010(self):
++        p = ssl._ssl._test_decode_cert(TALOS_INVALID_CRLDP)
++        if support.verbose:
++            sys.stdout.write("\n" + pprint.pformat(p) + "\n")
++        self.assertEqual(
++            p,
++            {
++                'issuer': (
++                    (('countryName', 'UK'),), (('commonName', 'cody-ca'),)),
++                'notAfter': 'Jun 14 18:00:58 2028 GMT',
++                'notBefore': 'Jun 18 18:00:58 2018 GMT',
++                'serialNumber': '02',
++                'subject': ((('countryName', 'UK'),),
++                            (('commonName',
++                              'codenomicon-vm-2.test.lal.cisco.com'),)),
++                'subjectAltName': (
++                    ('DNS', 'codenomicon-vm-2.test.lal.cisco.com'),),
++                'version': 3
++            }
++        )
++
+     def test_parse_cert_CVE_2013_4238(self):
+         p = ssl._ssl._test_decode_cert(NULLBYTECERT)
+         if support.verbose:
+diff --git a/Misc/NEWS.d/next/Security/2019-01-15-18-16-05.bpo-35746.nMSd0j.rst b/Misc/NEWS.d/next/Security/2019-01-15-18-16-05.bpo-35746.nMSd0j.rst
+new file mode 100644
+index 000000000000..dffe347eec84
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2019-01-15-18-16-05.bpo-35746.nMSd0j.rst
+@@ -0,0 +1,3 @@
++[CVE-2019-5010] Fix a NULL pointer deref in ssl module. The cert parser did
++not handle CRL distribution points with empty DP or URI correctly. A
++malicious or buggy certificate can result into segfault.
+diff --git a/Modules/_ssl.c b/Modules/_ssl.c
+index a188d6a7291a..7365630a5eaf 100644
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -1338,6 +1338,10 @@ _get_crl_dp(X509 *certificate) {
+         STACK_OF(GENERAL_NAME) *gns;
+ 
+         dp = sk_DIST_POINT_value(dps, i);
++        if (dp->distpoint == NULL) {
++            /* Ignore empty DP value, CVE-2019-5010 */
++            continue;
++        }
+         gns = dp->distpoint->name.fullname;
+ 
+         for (j=0; j < sk_GENERAL_NAME_num(gns); j++) {

--- a/main/python3/APKBUILD
+++ b/main/python3/APKBUILD
@@ -5,7 +5,7 @@ pkgname=python3
 # the python2-tkinter's pkgver needs to be synchronized with this.
 pkgver=3.6.8
 _basever="${pkgver%.*}"
-pkgrel=0
+pkgrel=1
 pkgdesc="A high-level scripting language"
 url="https://www.python.org"
 arch="all"
@@ -16,10 +16,15 @@ subpackages="$pkgname-dbg $pkgname-dev $pkgname-doc $pkgname-tests::noarch
 makedepends="expat-dev openssl-dev zlib-dev ncurses-dev bzip2-dev xz-dev
 	sqlite-dev libffi-dev tcl-dev linux-headers gdbm-dev readline-dev"
 source="https://www.python.org/ftp/python/$pkgver/Python-$pkgver.tar.xz
+	CVE-2019-5010.patch
 	fix-xattrs-glibc.patch
 	musl-find_library.patch
 	"
 builddir="$srcdir/Python-$pkgver"
+
+# secfixes:
+#   3.6.8-r1:
+#   - CVE-2019-5010
 
 prepare() {
 	default_prepare
@@ -150,5 +155,6 @@ wininst() {
 }
 
 sha512sums="b17867e451ebe662f50df83ed112d3656c089e7d750651ea640052b01b713b58e66aac9e082f71fd16f5b5510bc9b797f5ccd30f5399581e9aa406197f02938a  Python-3.6.8.tar.xz
+7859fe12e393995f66f42e38f01ff29abef5f64301747a02d8e49a990ce4e7f529cf2a3420c76bd5f9df09905e64a4e0451a2103c061dde5f99166e7fc370715  CVE-2019-5010.patch
 37b6ee5d0d5de43799316aa111423ba5a666c17dc7f81b04c330f59c1d1565540eac4c585abe2199bbed52ebe7426001edb1c53bd0a17486a2a8e052d0f494ad  fix-xattrs-glibc.patch
 ab8eaa2858d5109049b1f9f553198d40e0ef8d78211ad6455f7b491af525bffb16738fed60fc84e960c4889568d25753b9e4a1494834fea48291b33f07000ec2  musl-find_library.patch"

--- a/main/python3/APKBUILD
+++ b/main/python3/APKBUILD
@@ -3,11 +3,11 @@
 
 pkgname=python3
 # the python2-tkinter's pkgver needs to be synchronized with this.
-pkgver=3.6.7
+pkgver=3.6.8
 _basever="${pkgver%.*}"
 pkgrel=0
 pkgdesc="A high-level scripting language"
-url="http://www.python.org"
+url="https://www.python.org"
 arch="all"
 license="custom"
 provides="py3-pip"
@@ -149,6 +149,6 @@ wininst() {
 		"$subpkgdir"/usr/lib/python$_basever/distutils/command
 }
 
-sha512sums="7be753046db8d12fc00f90d9c1b2edcc5ae80ac39e9d0d8d07553081a26f59a60c0d0cf6986006f0729f425d5751273110db3aa2d413d9405fafa9bd6c052fdf  Python-3.6.7.tar.xz
+sha512sums="b17867e451ebe662f50df83ed112d3656c089e7d750651ea640052b01b713b58e66aac9e082f71fd16f5b5510bc9b797f5ccd30f5399581e9aa406197f02938a  Python-3.6.8.tar.xz
 37b6ee5d0d5de43799316aa111423ba5a666c17dc7f81b04c330f59c1d1565540eac4c585abe2199bbed52ebe7426001edb1c53bd0a17486a2a8e052d0f494ad  fix-xattrs-glibc.patch
 ab8eaa2858d5109049b1f9f553198d40e0ef8d78211ad6455f7b491af525bffb16738fed60fc84e960c4889568d25753b9e4a1494834fea48291b33f07000ec2  musl-find_library.patch"

--- a/main/python3/CVE-2019-5010.patch
+++ b/main/python3/CVE-2019-5010.patch
@@ -1,0 +1,116 @@
+From bc947d7cd67c96cbfbc55dd53bce52392bd6f80d Mon Sep 17 00:00:00 2001
+From: Christian Heimes <christian@python.org>
+Date: Tue, 15 Jan 2019 23:47:42 +0100
+Subject: [PATCH] bpo-35746: Fix segfault in ssl's cert parser (GH-11569)
+
+Fix a NULL pointer deref in ssl module. The cert parser did not handle CRL
+distribution points with empty DP or URI correctly. A malicious or buggy
+certificate can result into segfault.
+
+Signed-off-by: Christian Heimes <christian@python.org>
+
+https://bugs.python.org/issue35746
+(cherry picked from commit a37f52436f9aa4b9292878b72f3ff1480e2606c3)
+
+Co-authored-by: Christian Heimes <christian@python.org>
+---
+ Lib/test/talos-2019-0758.pem                  | 22 +++++++++++++++++++
+ Lib/test/test_ssl.py                          | 22 +++++++++++++++++++
+ .../2019-01-15-18-16-05.bpo-35746.nMSd0j.rst  |  3 +++
+ Modules/_ssl.c                                |  4 ++++
+ 4 files changed, 51 insertions(+)
+ create mode 100644 Lib/test/talos-2019-0758.pem
+ create mode 100644 Misc/NEWS.d/next/Security/2019-01-15-18-16-05.bpo-35746.nMSd0j.rst
+
+diff --git a/Lib/test/talos-2019-0758.pem b/Lib/test/talos-2019-0758.pem
+new file mode 100644
+index 000000000000..13b95a77fd8a
+--- /dev/null
++++ b/Lib/test/talos-2019-0758.pem
+@@ -0,0 +1,22 @@
++-----BEGIN CERTIFICATE-----
++MIIDqDCCApKgAwIBAgIBAjALBgkqhkiG9w0BAQswHzELMAkGA1UEBhMCVUsxEDAO
++BgNVBAMTB2NvZHktY2EwHhcNMTgwNjE4MTgwMDU4WhcNMjgwNjE0MTgwMDU4WjA7
++MQswCQYDVQQGEwJVSzEsMCoGA1UEAxMjY29kZW5vbWljb24tdm0tMi50ZXN0Lmxh
++bC5jaXNjby5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC63fGB
++J80A9Av1GB0bptslKRIUtJm8EeEu34HkDWbL6AJY0P8WfDtlXjlPaLqFa6sqH6ES
++V48prSm1ZUbDSVL8R6BYVYpOlK8/48xk4pGTgRzv69gf5SGtQLwHy8UPBKgjSZoD
++5a5k5wJXGswhKFFNqyyxqCvWmMnJWxXTt2XDCiWc4g4YAWi4O4+6SeeHVAV9rV7C
++1wxqjzKovVe2uZOHjKEzJbbIU6JBPb6TRfMdRdYOw98n1VXDcKVgdX2DuuqjCzHP
++WhU4Tw050M9NaK3eXp4Mh69VuiKoBGOLSOcS8reqHIU46Reg0hqeL8LIL6OhFHIF
++j7HR6V1X6F+BfRS/AgMBAAGjgdYwgdMwCQYDVR0TBAIwADAdBgNVHQ4EFgQUOktp
++HQjxDXXUg8prleY9jeLKeQ4wTwYDVR0jBEgwRoAUx6zgPygZ0ZErF9sPC4+5e2Io
++UU+hI6QhMB8xCzAJBgNVBAYTAlVLMRAwDgYDVQQDEwdjb2R5LWNhggkA1QEAuwb7
++2s0wCQYDVR0SBAIwADAuBgNVHREEJzAlgiNjb2Rlbm9taWNvbi12bS0yLnRlc3Qu
++bGFsLmNpc2NvLmNvbTAOBgNVHQ8BAf8EBAMCBaAwCwYDVR0fBAQwAjAAMAsGCSqG
++SIb3DQEBCwOCAQEAvqantx2yBlM11RoFiCfi+AfSblXPdrIrHvccepV4pYc/yO6p
++t1f2dxHQb8rWH3i6cWag/EgIZx+HJQvo0rgPY1BFJsX1WnYf1/znZpkUBGbVmlJr
++t/dW1gSkNS6sPsM0Q+7HPgEv8CPDNK5eo7vU2seE0iWOkxSyVUuiCEY9ZVGaLVit
++p0C78nZ35Pdv4I+1cosmHl28+es1WI22rrnmdBpH8J1eY6WvUw2xuZHLeNVN0TzV
++Q3qq53AaCWuLOD1AjESWuUCxMZTK9DPS4JKXTK8RLyDeqOvJGjsSWp3kL0y3GaQ+
++10T1rfkKJub2+m9A9duin1fn6tHc2wSvB7m3DA==
++-----END CERTIFICATE-----
+diff --git a/Lib/test/test_ssl.py b/Lib/test/test_ssl.py
+index 705f1d3245b6..0aeabc10f2a9 100644
+--- a/Lib/test/test_ssl.py
++++ b/Lib/test/test_ssl.py
+@@ -79,6 +79,7 @@ def data_file(*name):
+ BADKEY = data_file("badkey.pem")
+ NOKIACERT = data_file("nokia.pem")
+ NULLBYTECERT = data_file("nullbytecert.pem")
++TALOS_INVALID_CRLDP = data_file("talos-2019-0758.pem")
+ 
+ DHFILE = data_file("ffdh3072.pem")
+ BYTES_DHFILE = os.fsencode(DHFILE)
+@@ -293,6 +294,27 @@ def test_parse_cert(self):
+         self.assertEqual(p['crlDistributionPoints'],
+                          ('http://SVRIntl-G3-crl.verisign.com/SVRIntlG3.crl',))
+ 
++    def test_parse_cert_CVE_2019_5010(self):
++        p = ssl._ssl._test_decode_cert(TALOS_INVALID_CRLDP)
++        if support.verbose:
++            sys.stdout.write("\n" + pprint.pformat(p) + "\n")
++        self.assertEqual(
++            p,
++            {
++                'issuer': (
++                    (('countryName', 'UK'),), (('commonName', 'cody-ca'),)),
++                'notAfter': 'Jun 14 18:00:58 2028 GMT',
++                'notBefore': 'Jun 18 18:00:58 2018 GMT',
++                'serialNumber': '02',
++                'subject': ((('countryName', 'UK'),),
++                            (('commonName',
++                              'codenomicon-vm-2.test.lal.cisco.com'),)),
++                'subjectAltName': (
++                    ('DNS', 'codenomicon-vm-2.test.lal.cisco.com'),),
++                'version': 3
++            }
++        )
++
+     def test_parse_cert_CVE_2013_4238(self):
+         p = ssl._ssl._test_decode_cert(NULLBYTECERT)
+         if support.verbose:
+diff --git a/Misc/NEWS.d/next/Security/2019-01-15-18-16-05.bpo-35746.nMSd0j.rst b/Misc/NEWS.d/next/Security/2019-01-15-18-16-05.bpo-35746.nMSd0j.rst
+new file mode 100644
+index 000000000000..dffe347eec84
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2019-01-15-18-16-05.bpo-35746.nMSd0j.rst
+@@ -0,0 +1,3 @@
++[CVE-2019-5010] Fix a NULL pointer deref in ssl module. The cert parser did
++not handle CRL distribution points with empty DP or URI correctly. A
++malicious or buggy certificate can result into segfault.
+diff --git a/Modules/_ssl.c b/Modules/_ssl.c
+index a188d6a7291a..7365630a5eaf 100644
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -1338,6 +1338,10 @@ _get_crl_dp(X509 *certificate) {
+         STACK_OF(GENERAL_NAME) *gns;
+ 
+         dp = sk_DIST_POINT_value(dps, i);
++        if (dp->distpoint == NULL) {
++            /* Ignore empty DP value, CVE-2019-5010 */
++            continue;
++        }
+         gns = dp->distpoint->name.fullname;
+ 
+         for (j=0; j < sk_GENERAL_NAME_num(gns); j++) {


### PR DESCRIPTION
Security fixes without CVE:
https://bugs.python.org/issue34791
https://bugs.python.org/issue34812
https://python-security.readthedocs.io/vuln/ssl-crl-dps-dos.html