### PR TITLE
community/runc: new aport

### DIFF
--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -26,7 +26,7 @@ build() {
 	mkdir -p $(dirname "$builddir")
 	ln -s "$PWD/$pkgname-$_commit" "$builddir"
 	cd "$builddir"
-	make
+	make COMMIT="$_commit"
 	make man
 }
 

--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -1,0 +1,40 @@
+# Contributor: Jake Buchholz <tomalok@gmail.com>
+# Maintainer: Jake Buchholz <tomalok@gmail.com>
+
+pkgname=runc
+pkgver=1.0.0_rc6
+_srcver=1.0.0-rc6
+pkgrel=0
+pkgdesc="CLI tool for spawning and running containers according to the OCI specification"
+url="https://www.opencontainers.org"
+arch="all"
+license="Apache-2.0"
+depends="libseccomp"
+makedepends="go go-md2man libseccomp-dev libtool"
+subpackages="$pkgname-doc"
+source="runc-$pkgver.tar.gz::https://github.com/opencontainers/runc/archive/v$_srcver.tar.gz"
+builddir="$srcdir/src/github.com/opencontainers/runc"
+
+build() {
+	cd "$srcdir"
+	export GOPATH="$PWD"
+	mkdir -p $(dirname "$builddir")
+	ln -s "$PWD/$pkgname-$_srcver" "$builddir"
+	cd "$builddir"
+	make
+	make man
+}
+
+check() {
+	cd "$builddir"
+	./runc --version
+}
+
+package() {
+	cd "$builddir"
+	install -Dsm755 "$builddir"/runc "$pkgdir"/usr/bin/runc
+	install -d "$pkgdir"/usr/share/man/man8/
+	install -Dm644 "$builddir"/man/man8/* "$pkgdir"/usr/share/man/man8/
+}
+
+sha512sums="a265525e4ede1841af0b7bffb6a0f2efe043fff6aacd26f54967ddc96240c4d3244e62f85544b10f1684244cc1f79360de1b6ac92a451738ca5fa42d2be37e54  runc-1.0.0_rc6.tar.gz"

--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -2,8 +2,13 @@
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 
 pkgname=runc
+
+# NOTE: using explicit post-1.0.0_rc6 commit, for containerd-1.2.1,
+# see https://github.com/containerd/containerd/blob/v1.2.1/RUNC.md
+# and https://github.com/containerd/containerd/blob/v1.2.1/vendor.conf
+_commit=96ec2177ae841256168fcf76954f7177af9446eb
+
 pkgver=1.0.0_rc6
-_srcver=1.0.0-rc6
 pkgrel=0
 pkgdesc="CLI tool for spawning and running containers according to the OCI specification"
 url="https://www.opencontainers.org"
@@ -12,14 +17,14 @@ license="Apache-2.0"
 depends="libseccomp"
 makedepends="go go-md2man libseccomp-dev libtool"
 subpackages="$pkgname-doc"
-source="runc-$pkgver.tar.gz::https://github.com/opencontainers/runc/archive/v$_srcver.tar.gz"
+source="runc-$_commit.tar.gz::https://github.com/opencontainers/runc/archive/$_commit.tar.gz"
 builddir="$srcdir/src/github.com/opencontainers/runc"
 
 build() {
 	cd "$srcdir"
 	export GOPATH="$PWD"
 	mkdir -p $(dirname "$builddir")
-	ln -s "$PWD/$pkgname-$_srcver" "$builddir"
+	ln -s "$PWD/$pkgname-$_commit" "$builddir"
 	cd "$builddir"
 	make
 	make man
@@ -37,4 +42,4 @@ package() {
 	install -Dm644 "$builddir"/man/man8/* "$pkgdir"/usr/share/man/man8/
 }
 
-sha512sums="a265525e4ede1841af0b7bffb6a0f2efe043fff6aacd26f54967ddc96240c4d3244e62f85544b10f1684244cc1f79360de1b6ac92a451738ca5fa42d2be37e54  runc-1.0.0_rc6.tar.gz"
+sha512sums="ec3d3fec773f2f9df714b0813efb110e21e328634e0b4ae77f323a892d0327aea5d4b6f9ae2a549aa06fda5b27431f4514fd663c7033dc170ca1a03627931f9d  runc-96ec2177ae841256168fcf76954f7177af9446eb.tar.gz"


### PR DESCRIPTION
Splitting `runc` out of community/docker, should be a little more straightforward and self-contained than PR #5713; also makes use of the new `go-md2man` package (PR #5973).

@ncopa 