### PR TITLE
testing/botan: security upgrade to 2.9.0 - CVE-2018-20187

### DIFF
--- a/testing/botan/APKBUILD
+++ b/testing/botan/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 pkgname=botan
 _pkgname=Botan
-pkgver=2.8.0
+pkgver=2.9.0
 pkgrel=0
 pkgdesc="Crypto and TLS for C++11"
 url="https://botan.randombit.net/"
@@ -17,6 +17,8 @@ builddir="$srcdir/$_pkgname-$pkgver"
 install=""
 
 # secfixes:
+#   2.9.0-r0:
+#   - CVE-2018-20187
 #   2.7.0-r0:
 #   - CVE-2018-12435
 #   2.6.0-r0:
@@ -53,4 +55,4 @@ package() {
 	rm -rf "$pkgdir"/usr/lib/python*
 }
 
-sha512sums="12f734eea3e60a956f75a5b58e9bd83fac7b0dbcd71fb9577b025d171702d87a9a11e2e73162320bdefb2d25f3900757d89dd7fe13089321c88d948efc2ba214  Botan-2.8.0.tgz"
+sha512sums="b88f3894a4a5b7b2fbff9be6eb0b774bf679a014bd2364811b7e63d4f323e22ca9ef916491afbc2cdf9db68727c1449fbeb6fd417e591560add0955517db3f65  Botan-2.9.0.tgz"


### PR DESCRIPTION
https://botan.randombit.net/news.html#version-2-9-0-2019-01-04

```
-usr/lib/libbotan-2.so.8
-usr/lib/libbotan-2.so.8.8.0
+usr/lib/libbotan-2.so.9
+usr/lib/libbotan-2.so.9.9.0
```