### PR TITLE
testing/hexer: fix build error by adding sqlite-libs makedepends

### DIFF
--- a/testing/hexer/APKBUILD
+++ b/testing/hexer/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Bradley J Chambers <brad.chambers@gmail.com>
 pkgname=hexer
 pkgver=1.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="LAS and OGR hexagonal density and boundary surface generation"
 url="https://github.com/hobu/hexer"
 arch="all"
 license="LGPL-2.0-or-later"
 options="!check"
 depends="gdal"
-makedepends="cmake gdal-dev"
+makedepends="sqlite-libs cmake gdal-dev"
 install=""
 subpackages="$pkgname-dev"
 source="$pkgname-$pkgver.tar.gz::https://github.com/hobu/$pkgname/archive/$pkgver.tar.gz


### PR DESCRIPTION
Build failing with error: /usr/lib/gcc/i586-alpine-linux-musl/8.2.0/../../../../i586-alpine-linux-musl/bin/ld: warning: libsqlite3.so.0, needed by /usr/lib/gcc/i586-alpine-linux-musl/8.2.0/../../../libgdal.so, not found (try using -rpath or -rpath-link)

fix by explicitly adding sqlite-libs to make dependancies