### PR TITLE
main/mc: upgrade to 4.8.22

### DIFF
--- a/main/mc/APKBUILD
+++ b/main/mc/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mc
-pkgver=4.8.21
+pkgver=4.8.22
 pkgrel=0
 pkgdesc="Filemanager/shell that emulates Norton Commander"
 url="https://www.midnight-commander.org"
@@ -68,5 +68,5 @@ lang() {
 		"$subpkgdir"/usr/share/mc/hints/
 }
 
-sha512sums="db1a252744b47ebf5339ad204d8b69cb914f25ade7fe5aae2650c4abb57478715d3b7b3a24f4460adfb9fbdc928e8728b369b4f1709215e5e9af3d430fce6acf  mc-4.8.21.tar.xz
+sha512sums="834d467a4561fe4361bbde61be2c9ded95ade2a89855d953f58b7bfeb21297a3d6ebf674e72ac665b1794e0cbc8da752bc14fb37b129ff870856b339091f6bed  mc-4.8.22.tar.xz
 47aa001e8c20a24631617d665fd0d81b269ebad96696c4bd70c7040bbca713868e02fe53dfaee9a775a57f35a0e7c9e44ce299037379e249ad27354a78d905c3  alpine_syntax.patch"


### PR DESCRIPTION
Ref https://mail.gnome.org/archives/mc-devel/2019-January/msg00000.html