### PR TITLE
main/subversion: security upgrade to 1.11.1

### DIFF
--- a/main/subversion/APKBUILD
+++ b/main/subversion/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=subversion
-pkgver=1.10.2
+pkgver=1.11.0
 pkgrel=0
 pkgdesc="Replacement for CVS, another versioning system (svn)"
-url="http://subversion.apache.org"
+url="https://subversion.apache.org"
 arch="all"
 license="Apache-2.0 BSD"
 depends=
@@ -61,6 +61,11 @@ build() {
 	make swig-py
 }
 
+check() {
+	cd "$builddir"
+	make test
+}
+
 package() {
 	cd "$builddir"
 	make -j1 DESTDIR="$pkgdir" install install-swig-pl-lib install-swig-py
@@ -105,7 +110,7 @@ py() {
 	mv "$pkgdir"/usr/lib/*py* "${subpkgdir}${pypath}"
 }
 
-sha512sums="ccbe860ec93a198745e40620cb7e005a85797e344a99ddbc0e24c32ad846976eae35cf5b3d62ba5751b998f0d40bbebbba72f484d92c92693bbb2112c989b129  subversion-1.10.2.tar.bz2
+sha512sums="d73cc800080529b1716a027fd3001d9c963a3cb69619d059498c99426cccc21a2985d1eeb5e1bff8d421fff477a9dff6f9be1c092470152452cf5e7175414e92  subversion-1.11.0.tar.bz2
 fb219c45b80602d919176cc191394df09f90d0f5c7d24e6a36b166bd92777ecae67eeac1e49c0ffbb0e724396b3d2094dbb0bef17d01dc87d418b1cd554bd7c4  subversion-1.7.0-deplibs.patch
 fd6e5f45cff4d3cf0d885a34c822b32141b13b199d99ad8e1b04d641c9c1ee27e73f5c556a4ad54a900b6d39cc14afad17b6738d8af44c76758f1a27b4d49f9a  subversion-perl-deplibs.patch
 7fe993443d4d3ef5e1e75f60e85036ee0b2bb2636c2c830210e64f525f95ae4c10ca1dc4504fc36915ec9391815becbe7cbf5f589c28609386d8d079ed02c630  svnserve.confd

--- a/main/subversion/APKBUILD
+++ b/main/subversion/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=subversion
-pkgver=1.11.0
+pkgver=1.11.1
 pkgrel=0
 pkgdesc="Replacement for CVS, another versioning system (svn)"
 url="https://subversion.apache.org"
@@ -21,6 +21,8 @@ source="https://archive.apache.org/dist/subversion/$pkgname-$pkgver.tar.bz2
 	svnserve.initd"
 
 # secfixes:
+#   1.11.1-r0:
+#     - CVE-2018-11803
 #   1.9.7-r0:
 #     - CVE-2017-9800
 
@@ -110,7 +112,7 @@ py() {
 	mv "$pkgdir"/usr/lib/*py* "${subpkgdir}${pypath}"
 }
 
-sha512sums="d73cc800080529b1716a027fd3001d9c963a3cb69619d059498c99426cccc21a2985d1eeb5e1bff8d421fff477a9dff6f9be1c092470152452cf5e7175414e92  subversion-1.11.0.tar.bz2
+sha512sums="2d082f715bf592ffc6a19311a9320dbae2ff0ee126b0472ce1c3f10e9aee670f43d894889430e6d093620f7b69c611e9a26773bc7a2f8b599ec37540ecd84a8d  subversion-1.11.1.tar.bz2
 fb219c45b80602d919176cc191394df09f90d0f5c7d24e6a36b166bd92777ecae67eeac1e49c0ffbb0e724396b3d2094dbb0bef17d01dc87d418b1cd554bd7c4  subversion-1.7.0-deplibs.patch
 fd6e5f45cff4d3cf0d885a34c822b32141b13b199d99ad8e1b04d641c9c1ee27e73f5c556a4ad54a900b6d39cc14afad17b6738d8af44c76758f1a27b4d49f9a  subversion-perl-deplibs.patch
 7fe993443d4d3ef5e1e75f60e85036ee0b2bb2636c2c830210e64f525f95ae4c10ca1dc4504fc36915ec9391815becbe7cbf5f589c28609386d8d079ed02c630  svnserve.confd


### PR DESCRIPTION
https://subversion.apache.org/security/CVE-2018-11803-advisory.txt