### PR TITLE
main/readline: upgrade to 8.0

### DIFF
--- a/main/readline/APKBUILD
+++ b/main/readline/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=readline
-pkgver=7.0.003
-pkgrel=1
+pkgver=8.0.0
+pkgrel=0
 _myver=${pkgver%.*}
 pkgdesc="GNU readline library"
 url="https://tiswww.cwru.edu/php/chet/readline/rltop.html"
@@ -32,7 +32,6 @@ prepare() {
 		esac
 	done
 	default_prepare
-	update_config_sub
 }
 
 build() {
@@ -66,9 +65,6 @@ libhistory() {
 	mv "$pkgdir"/usr/lib/$subpkgname.* "$subpkgdir"/usr/lib
 }
 
-sha512sums="18243189d39bf0d4c8a76cddcce75243c1bae8824c686e9b6ba352667607e5b10c5feb79372a1093c1c388d821841670702e940df12eae94bcebdeed90047870  readline-7.0.tar.gz
+sha512sums="41759d27bc3a258fefd7f4ff3277fa6ab9c21abb7b160e1a75aa8eba547bd90b288514e76264bd94fb0172da8a4faa54aab2c07b68a0356918ecf7f1969e866f  readline-8.0.tar.gz
 325dcf74e9f463a74fb116cb6f3ff8d9708dbec24b423a778eeda3a5ac4fe6df131e0e99d034053ad356b01502894ecc8facc09160d4c29b2291bd95cff6b635  fix-ncurses-underlinking.patch
-5dbe872e94166aaed7ca2edec5a34ef9b13b254381e252cc6d851877b461579903cbb5b5dc588eabececcf1ebe636f6cb4da406cd01b64757f8c7e7f62e9a276  inputrc
-4402186905af8cd42c609d640c2e13b9ad61c7778e5a3fd2c2d9da301f0deab05b04d7836f31527262f44f406517823dbb18cb07f2c73931186c806b494699ec  readline70-001.diff
-13d1489578508d4d2c3a1618024198a709dbce74a6bbf0f6d7ec67d2419c55bfec9f0ca9de0ed93f129d21d5c3a94307ccdc49408455bbb301c5e3a772b03185  readline70-002.diff
-eaf962a1480eb3870519017b81ecc5cef171e4c41fcf8c17da61ccbfd0379ed6bca85c17b03e2207ae4d51509f33fd010294c75f4bd0433a52118015d4160385  readline70-003.diff"
+5dbe872e94166aaed7ca2edec5a34ef9b13b254381e252cc6d851877b461579903cbb5b5dc588eabececcf1ebe636f6cb4da406cd01b64757f8c7e7f62e9a276  inputrc"


### PR DESCRIPTION
Ref http://lists.gnu.org/archive/html/bug-bash/2019-01/msg00064.html