### PR TITLE
main/dovecot: upgrade to 2.3.4

### DIFF
--- a/main/dovecot/APKBUILD
+++ b/main/dovecot/APKBUILD
@@ -4,7 +4,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dovecot
-pkgver=2.3.3
+pkgver=2.3.4
 _pkgvermajor=2.3
 pkgrel=0
 _pigeonholever=0.5.3
@@ -290,7 +290,7 @@ _submv() {
 	done
 }
 
-sha512sums="8666c4f92f7df883067540f85be9d03dbe6815b58a7f5de55b4292e986e9a2a1ef52c7e0c72dde2bc781fe40d57488b78a99b6b813745b8e4683f1a2fdc1f2ff  dovecot-2.3.3.tar.gz
+sha512sums="9e97eb08c319c417e8abcb430b3e6c87ed5aa820d6288656fdfd958ff34664f67202a66e4846763bfc85b309b116cea8012e49dab98b478c57974cc178a37a5a  dovecot-2.3.4.tar.gz
 8403b1976a915836ba875b96825446d46e0d8c7ff245ed1f2b014347fdc78a81f9ed6dbd05bd3b4f1f7072edc5e9a302201cdb375de44436adcbb83919f203f5  dovecot-2.3-pigeonhole-0.5.3.tar.gz
 fe4fbeaedb377d809f105d9dbaf7c1b961aa99f246b77189a73b491dc1ae0aa9c68678dde90420ec53ec877c08f735b42d23edb13117d7268420e001aa30967a  skip-iconv-check.patch
 794875dbf0ded1e82c5c3823660cf6996a7920079149cd8eed54231a53580d931b966dfb17185ab65e565e108545ecf6591bae82f935ab1b6ff65bb8ee93d7d5  split-protocols.patch


### PR DESCRIPTION
Ref https://www.dovecot.org/list/dovecot-news/2018-November/000391.html
