### PR TITLE
community/gegl: upgrade to 0.4.12

### DIFF
--- a/community/gegl/APKBUILD
+++ b/community/gegl/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gegl
-pkgver=0.4.8
+pkgver=0.4.12
 pkgrel=0
 pkgdesc="Graph based image processing framework"
 url="http://www.gegl.org/"
@@ -8,6 +8,7 @@ arch="all"
 license="GPL-3.0 LGPL-3.0"
 makedepends="babl-dev libpng-dev libjpeg-turbo-dev gtk+-dev librsvg-dev
 	lua5.1-dev jasper-dev exiv2-dev json-glib-dev"
+checkdepends="diffutils"
 subpackages="$pkgname-dev $pkgname-lang"
 source="https://ftp.gimp.org/pub/$pkgname/${pkgver%.*}/$pkgname-$pkgver.tar.bz2"
 builddir="$srcdir"/$pkgname-$pkgver
@@ -24,8 +25,14 @@ build() {
 	make
 }
 
+check() {
+	cd "$builddir"
+	make check
+}
+
 package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
-sha512sums="20d2700cc74bce02e3e1b477f5e4dbd6546bb74625de235baaaa31e24f506930927af53de3d0880c0b16f93a10cec993c58a12adba59dec7dda0e389261799aa  gegl-0.4.8.tar.bz2"
+
+sha512sums="cacf9f5c34357b3939162d0d4712ee2b47298a3e806b55e275cdf5e23f186d436ea1a840b91b1b72b76d450d94674cca217b7c253cd6b52a7d9505b4ad73fde2  gegl-0.4.12.tar.bz2"


### PR DESCRIPTION
Required for GIMP 2.10.8