### PR TITLE
testing/py-boto3: added missing py-s3transfer dependency

### DIFF
--- a/testing/py-boto3/APKBUILD
+++ b/testing/py-boto3/APKBUILD
@@ -3,13 +3,13 @@
 pkgname=py-boto3
 _pkgname=boto3
 pkgver=1.9.75
-pkgrel=1
+pkgrel=2
 pkgdesc="AWS SDK for Python (Boto3)"
 url="https://aws.amazon.com/sdk-for-python/"
 arch="noarch"
 license="Apache-2.0"
 options="!check"
-depends="py-botocore"
+depends="py-botocore py-s3transfer"
 makedepends="python2-dev py-setuptools python3-dev"
 subpackages="py3-$_pkgname:_py3 py2-$_pkgname:_py2"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"


### PR DESCRIPTION
I was going across requirements.txt in official boto3 repo and found out that we missed one of reqs.
This PR is just a fresh version of #3387 for latest boto3 lib.

S3 manager references - https://github.com/boto/boto3/blob/develop/boto3/s3/transfer.py
reqs file reference - https://github.com/boto/boto3/blob/develop/requirements.txt#L3