### PR TITLE
testing/gdal: Added missing dependancy for `ogr2ogr`

### DIFF
--- a/testing/gdal/APKBUILD
+++ b/testing/gdal/APKBUILD
@@ -19,6 +19,7 @@ makedepends="
 	postgresql-dev
 	python2-dev
 	sqlite-dev
+	sqlite-libs
 	swig
 	tiff-dev
 	zlib-dev


### PR DESCRIPTION
`ogr2ogr` throws a missing shared library when run on alpine 3.8. Added
sqlite-lib to address issue.

Error Message
```
Error loading shared library libsqlite3.so.0: No such file or directory
(needed by /usr/lib/libgdal.so.20)
Error relocating /usr/lib/libgdal.so.20: sqlite3_bind_int: symbol not
found
Error relocating /usr/lib/libgdal.so.20: sqlite3_column_blob: symbol not
found
Error relocating /usr/lib/libgdal.so.20: sqlite3_column_int: symbol not
found
Error relocating /usr/lib/libgdal.so.20: sqlite3_column_int64: symbol
not found
Error relocating /usr/lib/libgdal.so.20: sqlite3_create_module_v2:
symbol not found
Error relocating /usr/lib/libgdal.so.20: sqlite3_bind_double: symbol not
found
Error relocating /usr/lib/libgdal.so.20: sqlite3_user_data: symbol not
found
...
```