### PR TITLE
testing/postgis: enable on x86 x86_64

### DIFF
--- a/testing/postgis/APKBUILD
+++ b/testing/postgis/APKBUILD
@@ -2,11 +2,11 @@
 # Maintainer: Bjoern Schilberg <bjoern@intevation.de>
 pkgname=postgis
 pkgver=2.5.0
-pkgrel=2
+pkgrel=3
 pkgdesc="PostGIS is a spatial database extender for PostgreSQL object-relational database."
 url="https://postgis.net/"
 # geos test fails on other archs
-# arch="x86 x86_64"
+arch="x86 x86_64"
 license="GPL-2.0-or-later"
 depends="postgresql perl"
 makedepends="postgresql-dev geos-dev gdal-dev libxml2-dev proj4-dev perl-dev


### PR DESCRIPTION
Just enable build as follow-up to https://github.com/alpinelinux/aports/pull/5958#issuecomment-452995673