### PR TITLE
testing/geos: upgrade to 3.7.1 and enable all arch

### DIFF
--- a/testing/geos/APKBUILD
+++ b/testing/geos/APKBUILD
@@ -1,12 +1,12 @@
 # Contributor: Eric Kidd <git@randomhacks.net>
 # Maintainer:
 pkgname=geos
-pkgver=3.7.0
-pkgrel=1
+pkgver=3.7.1
+pkgrel=0
 pkgdesc="GEOS is a library providing OpenGIS and JTS spatial operations in C++."
 url="https://trac.osgeo.org/geos/"
 # test fails on other archs
-arch="x86 x86_64"
+arch="all"
 license="LGPL-2.1"
 makedepends="swig python2-dev"
 subpackages="py-$pkgname:py $pkgname-dev"
@@ -52,4 +52,4 @@ py() {
 	mv "$pkgdir"/usr/lib/python* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="fcca5e503efa32bb388376b2a06b9ca5c74fbcddba750cce6b3b4109eb2eb122058aead12b9462cdd881f425cd75d7241645ab344f25ce022bc0659954560742  geos-3.7.0.tar.bz2"
+sha512sums="01e8087bcd3cb8f873adb7b56910e1575ccb3336badfdd3f13bc6792095b7010e5ab109ea0d0cd3d1459e2e526e83bcf64d6ee3f7eb47be75639becdaacd2a87  geos-3.7.1.tar.bz2"


### PR DESCRIPTION
Ref https://trac.osgeo.org/geos/browser/git/NEWS?rev=3.7.1
And follow-up to https://github.com/alpinelinux/aports/pull/6024