### PR TITLE
testing/postgis: upgrade to 2.5.1

### DIFF
--- a/testing/postgis/APKBUILD
+++ b/testing/postgis/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Bjoern Schilberg <bjoern@intevation.de>
 # Maintainer: Bjoern Schilberg <bjoern@intevation.de>
 pkgname=postgis
-pkgver=2.5.0
-pkgrel=3
+pkgver=2.5.1
+pkgrel=0
 pkgdesc="PostGIS is a spatial database extender for PostgreSQL object-relational database."
 url="https://postgis.net/"
 # geos test fails on other archs
@@ -35,4 +35,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="1ba638dae9fb167e59fc5590b57277cf62b4ceb270a77026cfca3977f6727ef27acbc5505007335652480f5157e1d6c76f782553cc294ab1e5159347dd3c8934  postgis-2.5.0.tar.gz"
+sha512sums="c6c9c8c5befd945614e92d1062df1d753ca8b7fd69b70226065c2dac77a59783b14ece4da994187079b683ee090ba5a79389ba679f22fce8c20a5afc2c8dfca0  postgis-2.5.1.tar.gz"


### PR DESCRIPTION
Ref https://postgis.net/2018/11/18/postgis-2.5.1/

Follow-up https://github.com/alpinelinux/aports/pull/6024