### PR TITLE
main/open-iscsid: use "modprobe" to detect available modules

### DIFF
--- a/main/open-iscsi/iscsid.initd
+++ b/main/open-iscsi/iscsid.initd
@@ -34,18 +34,12 @@ do_modules() {
 	modopts="$@"
 	for m in ${modules}
 	do
-		if [ -n "$(find /lib/modules/`uname -r` | grep ${m})" ]
-		then
-			ebegin "${msg} ${m}"
-			modprobe ${modopts} ${m}
-			ret=$?
-			eend ${ret}
-			if [ ${ret} -ne 0 ]; then
-				return ${ret}
-			fi
-		else
-			ebegin "${msg} ${m}: not found"
-			return 1
+		ebegin "${msg} ${m}"
+		modprobe ${modopts} ${m}
+		ret=$?
+		eend ${ret}
+		if [ ${ret} -ne 0 ]; then
+			return ${ret}
 		fi
 	done
 	return 0


### PR DESCRIPTION
I was trying to use `iscsid` on my Raspberry Pi to connect to a target from another machine and the init script failed because it couldn't find `scsi_transport_iscsi.ko` in `/lib/modules` -- I think in the Raspberry Pi kernel, it's built-in (not compiled as a module).

If we ditch the check in `/lib/modules` and just use `modprobe` itself, it can resolve with an appropriate zero exit code for built-in modules and still be non-zero for both missing and failing-to-load modules. :+1:

(I've successfully verified that this change allows me to start `iscsid` on my Raspberry Pi too. :heart:)