### PR TITLE
community/containerd: update to 1.2.2

### DIFF
--- a/community/containerd/APKBUILD
+++ b/community/containerd/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=containerd
 
 # NOTE: containerd's Makefile tries to get REVISION from git, but we're building from a tarball.
-_commit=9b32062dc1
-pkgver=1.2.1
+_commit=9754871865f7fe2f4e74d43e2fc7ccd237edcbce
+pkgver=1.2.2
 pkgrel=0
 pkgdesc="An open and reliable container runtime"
 url="https://containerd.io"
@@ -42,4 +42,4 @@ package() {
 	install -Dm644 "$builddir"/man/*.5 "$pkgdir"/usr/share/man/man5/
 }
 
-sha512sums="0949299afe17e269a6c551e865e500afeeaba700cf78bb12fef4af8e6d48a2f699976e81dad44d797bb13079361f5d5e05e9abe903a3b158af93f2aaa95712e5  containerd-1.2.1.tar.gz"
+sha512sums="0fdd8799c5afb75074b6f00d5191e983ff570b323242665055c73b2e7a6bdd74a745e287f4f7b675dde26e8bf083c144104151e794ad24d2a8f6f39ae2ee6fff  containerd-1.2.2.tar.gz"


### PR DESCRIPTION
* Update to v1.2.2 - see https://github.com/containerd/containerd/releases/tag/v1.2.2 for release notes
* Use the whole commit hash in `containerd --version`

@ncopa 