### PR TITLE
community/knot: upgrade to 2.7.6

### DIFF
--- a/community/knot/APKBUILD
+++ b/community/knot/APKBUILD
@@ -4,8 +4,8 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=knot
-pkgver=2.7.4
-pkgrel=1
+pkgver=2.7.6
+pkgrel=0
 pkgdesc="An high-performance authoritative-only DNS server"
 url="https://www.knot-dns.cz"
 arch="all"
@@ -90,7 +90,7 @@ utils() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="e5f60a23817503468b18eaea517c5936945b901f568c56cb1ca67a208cc6206ff103e9ca03f1bf05018d13a688f54580ae816a5d70510f28a98ae31116a3f674  knot-2.7.4.tar.xz
+sha512sums="6b6a727d57337da01e2d44abec7fde4504d112604769b118fe6254b0317f149ed4e9fab321a04517eccedb08e409818d1817fc1136c27d1fd351538e6816022a  knot-2.7.6.tar.xz
 39503d16603eaff04cb34de97bff987952818d229ccb5b190567198505ece8077efdf230d5402e69ca4ab8acb282c53bfaaf495360dc11191c985a48fbb61318  test_net.patch
 471d3c639a8235ba09491c99d36c0a4f1074d6055ccfd3807be02a30d3ed5bbe69a84f0414ea7810db6bbc1e38f5837108e5744fc59f949ed78a262a7de4597e  knotd.confd
 979f06a83dd4326920a682f8190319577faf904e0e379b3c55e0420eb43dcb55d86c6727015634fa0c2dff1dddac43bbd5a216ff04f217ad91d670eb899dbefa  knotd.initd"

--- a/community/knot/APKBUILD
+++ b/community/knot/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Dennis Przytarski <dennis@przytarski.com>
 # Contributor: Francesco Zanini <francesco@zanini.me>
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
-# Maintainer: Francesco Colista <fcolista@alpinelinux.org>
+# Maintainer: tcely <knot+aports@tcely.33mail.com>
 pkgname=knot
 pkgver=2.7.6
 pkgrel=0


### PR DESCRIPTION
**Release notes:**
- https://www.knot-dns.cz/2019-01-23-version-276.html
- https://www.knot-dns.cz/2019-01-07-version-275.html

See also: https://github.com/alpinelinux/aports/pull/5106