### PR TITLE
main/newsboat: upgrade to 2.14.1 (blocked on cargo)

### DIFF
--- a/main/newsboat/APKBUILD
+++ b/main/newsboat/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Mike Crute <mike@crute.us>
 pkgname=newsboat
-pkgver=2.13
+pkgver=2.14.1
 pkgrel=0
 pkgdesc="RSS/Atom feed reader for text terminals"
 url="https://newsboat.org"
@@ -8,8 +8,8 @@ arch="all"
 license="MIT"
 replaces="newsbeuter"
 provides="newsbeuter=$pkgver-r$pkgrel"
-makedepends="asciidoc curl-dev gettext-dev json-c-dev libxml2-dev
-	ncurses-dev perl sqlite-dev stfl-dev"
+makedepends="asciidoc cargo curl-dev gettext-dev json-c-dev
+	libxml2-dev ncurses-dev perl sqlite-dev stfl-dev"
 subpackages="$pkgname-doc $pkgname-lang"
 source="https://github.com/newsboat/newsboat/archive/r$pkgver.tar.gz"
 
@@ -32,4 +32,4 @@ package() {
 	make DESTDIR="$pkgdir" prefix=/usr install
 }
 
-sha512sums="f6d9d7547db4fddaaef35dac5e9a8cf6f37d17b010c032b1efdfcb0eb3ccde4c3199526ade9bdefe28a877d61cebfc70a8b051596ffef3b65bc912240ecc0099  r2.13.tar.gz"
+sha512sums="b2aad9ed1e358ade1417d57ac1caff7eea2c69a497c971591e700679edf8164ac0ecf557bf0e746cc2a0b263d09110fa8433769c69eda3a81ae97a9029425e2e  r2.14.1.tar.gz"


### PR DESCRIPTION
`newsboat` introduced a hard dependency on `cargo` which is still in community and not main. Looks like this will need to wait till that moves to main. Verified that this builds if community is in the repos file.