### PR TITLE
testing/mame: upgrade to 0.205

### DIFF
--- a/testing/mame/APKBUILD
+++ b/testing/mame/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Taner Tas <taner76@gmail.com>
 # Maintainer: Taner Tas <taner76@gmail.com>
 pkgname=mame
-pkgver=0.201
+pkgver=0.205
 _pkgver=${pkgver/.}
 pkgrel=0
 pkgdesc="Multi Arcade Machine Emulator with GroovyMAME/Switchres/No-nag patchset."
@@ -48,7 +48,7 @@ subpackages="
 _groovymame_patch=groovymame-$pkgver.diff
 source="
 	https://github.com/mamedev/mame/archive/$pkgname$_pkgver.tar.gz
-	$_groovymame_patch::https://drive.google.com/uc?export=download&id=1ruDLYXbD8Y1lSUZ4ZNZlzbWWqw0-Zi1O
+	$_groovymame_patch::https://drive.google.com/uc?export=download&id=1jROC9Otq7OcjbtERWAA40ewKYxIT4cdX
 	mame.ini
 	midi.conf
 	fix-musl.patch
@@ -215,8 +215,8 @@ lang() {
 	mkdir -p "$subpkgdir"/usr/share/$pkgname
 	cp -r language "$subpkgdir"/usr/share/$pkgname/
 }
-sha512sums="e82ce0f3b52db88a2efc5a93f6da3174304b6549f19ffb5dd293d97b5630c8f89bb3def7e62cbebf2f75ecab8b5d4c21242775ed094a765207081cbe52636b2d  mame0201.tar.gz
-a9900699c3c28930d6bb7f8f72b79b25456907e5a59abef4daab87ffd0bbae0e611fe3ed9f414516daf4e9773b15b459d00056860fe21f908dab9bc79da3ad65  groovymame-0.201.diff
+sha512sums="fa0831eed3e6ef5a42b7e2efc8ed96b120c7e089139a4237771e8f3abd17d18369a1c1e865376ccbc828b6685070b3f0365b5132d48faa22c523d193d46ff3b6  mame0205.tar.gz
+89d7d5b35d5d1eb025259c9dda3b8a9cc8dfcee3f5055d6c676fcf4329cb8d0e1e498e580af933fafe35a5f257a94020a89c04f5b9d733bd0595dceae9588787  groovymame-0.205.diff
 dc008245cbea0b94f58d83e09bf5fd3fff04ac0e2f3a36b910a8b7633c5377419fc67a1fd366ef268e283f744d9a8d29928cfacf456b3edaa2d0b1a11d46a701  mame.ini
 8f83ff5a916f4ff8e86c5afbdfe4475f7780bb36c20c78d6d029d0eb0dafd77b3471faa538aca384001d2049dc94c4df3429c67d743adde9fd6329c91e6d19a2  midi.conf
 75bba366aebb37de7758368fbf7418194a18d535e61c1768e6c2c5cf4b3b7a2f625ef687cb8278c03daa9e308951df4c0bdcc944dfcc4ce5305f5ac83e5e049b  fix-musl.patch


### PR DESCRIPTION
Ref https://github.com/mamedev/mame/releases

Version change because right now it fails to build
```
>>> mame: Building testing/mame 0.201-r0 (using abuild 3.3.0_pre2-r0) started Sat, 12 Jan 2019 21:33:05 +0000
>>> mame: Checking sanity of /home/buildozer/aports/testing/mame/APKBUILD...
>>> ERROR: mame: uc?export=download&id=1ruDLYXbD8Y1lSUZ4ZNZlzbWWqw0-Zi1O is missing in checksums
```