### PR TITLE
main/busybox: use /sbin/nologin as default shell for system accounts

### DIFF
--- a/main/busybox/0001-adduser-default-to-sbin-nologin-as-shell-for-system-.patch
+++ b/main/busybox/0001-adduser-default-to-sbin-nologin-as-shell-for-system-.patch
@@ -1,0 +1,23 @@
+From eceebc4fbf064ca04d0f0a639c8a7c600190170f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6ren=20Tempel?= <soeren+git@soeren-tempel.net>
+Date: Sun, 13 Jan 2019 19:07:16 +0100
+Subject: [PATCH] adduser: default to /sbin/nologin as shell for system
+ accounts
+
+---
+ loginutils/adduser.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/loginutils/adduser.c b/loginutils/adduser.c
+index b2b5be5b3..9326a9795 100644
+--- a/loginutils/adduser.c
++++ b/loginutils/adduser.c
+@@ -235,7 +235,7 @@ int adduser_main(int argc UNUSED_PARAM, char **argv)
+ 			usegroup = "nogroup";
+ 		}
+ 		if (!(opts & OPT_SHELL)) {
+-			pw.pw_shell = (char *) "/bin/false";
++			pw.pw_shell = (char *) "/sbin/nologin";
+ 		}
+ 	}
+ 	pw.pw_gid = usegroup ? xgroup2gid(usegroup) : -1; /* exits on failure */

--- a/main/busybox/APKBUILD
+++ b/main/busybox/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=busybox
 pkgver=1.29.3
-pkgrel=7
+pkgrel=8
 pkgdesc="Size optimized toolbox of many common UNIX utilities"
 url=http://busybox.net
 arch="all"
@@ -36,6 +36,7 @@ source="https://busybox.net/downloads/$pkgname-$pkgver.tar.bz2
 	0015-ip-print-dadfailed-flag.patch
 	0001-cp-optional-reflink-support.patch
 	0001-adduser-prevent-creation-from-invalid-entry-without-.patch
+	0001-adduser-default-to-sbin-nologin-as-shell-for-system-.patch
 
 	acpid.logrotate
 	busyboxconfig
@@ -214,6 +215,7 @@ d8926f0e4ed7d2fe5af89ff2a944d781b45b109c9edf1ef2591e7bce2a8bbadd7c8ca814cb3c928a
 2fdf01e4bb26a3b6fd7ff73649f15eff599d38db1bc61a699576ec9caae2fb37c49d689baca8b1a3a7b2999fbe04751da897518c2fb42d6f21756b468aa7599d  0015-ip-print-dadfailed-flag.patch
 c26e846dc4576a94c376132644ea26755f8cc531fa03b975f2f7e874e2fcbaaca3804ba46849c29b69061b1f411aebedef451418063ec457f88636198dae3be9  0001-cp-optional-reflink-support.patch
 06a341de7b34bbe5d7981366772c2ce46599af3e9640d114aa28f7ba4936489fc00c58d4b09c546409e383ef70ca51da179223a9ef53ed51f3575e652506e08e  0001-adduser-prevent-creation-from-invalid-entry-without-.patch
+a2787a3ecaf6746dadef62166e8ee6ecaa166147e5ad8b917c5838536057c875bab5f9cf40c3e05eba74d575484ac662929ac3799d58432d3a99ac46f364f302  0001-adduser-default-to-sbin-nologin-as-shell-for-system-.patch
 aa93095e20de88730f526c6f463cef711b290b9582cdbd8c1ba2bd290019150cbeaa7007c2e15f0362d5b9315dd63f60511878f0ea05e893f4fdfb4a54af3fb1  acpid.logrotate
 924ff0dac14b4f7213618bd1503ae1b251fea9c3ce11dd87a6ad23ac4fca9b3f765afefdc50f39613579f56b200547320977ec815f87f2c69e20b5aeb484116c  busyboxconfig
 1dc5c94708fc4d4129015c0cdd64fbe0edd2794bb10422ac2686db8a4ef06182d306ec89560d0310190c1ed86b8422c13594d2cc2b9281c8895145d5a233cc0c  busyboxconfig-extras


### PR DESCRIPTION
While working on #6033 I noticed that our custom `nologin` applet is currently not the default shell for system accounts created with `-S`.

The applet description states that:

```
nologin is a tool that is supposed to be the shell for user accounts that are not supposed to login.
```

Which makes we wonder why we use `/bin/false` as the default shell for the same purpose then. Assigning ncopa since he added the applet and maintains `main/busybox`.