### PR TITLE
non-free/unifi: upgrade to 5.9.29

### DIFF
--- a/non-free/unifi/APKBUILD
+++ b/non-free/unifi/APKBUILD
@@ -1,8 +1,9 @@
 # Maintainer: TBK <alpine@jjtc.eu>
 # Contributor: Leonardo Arena <rnalrd@alpinelinux.org>
+# Contributor: AdamRushad <2429990+adamrushad@users.noreply.github.com>
 pkgname=unifi
 _pkgname=UniFi
-pkgver=5.8.30
+pkgver=5.9.29
 pkgrel=0
 pkgdesc="The Ubiquiti UniFi SDN controller"
 url="http://wiki.ubnt.com/UniFi_FAQ"
@@ -86,7 +87,7 @@ package() {
 	install -Dm755 "$srcdir"/unifi_db_prune.cron "$pkgdir"/etc/periodic/weekly/unifi_db_prune
 }
 
-sha512sums="0d4a714ba875e17ce359b28e2a0a967366125971f021eb95f598c7e4860c03016afadcef0a4bb6e64f30b99afb790b65aaa166ccc31bb31f268412c1a1f1bffd  unifi-5.8.30.zip
+sha512sums="f00ba9470d78fa5922e81a5ff2e53927d2a2ec7d08ab543abf4b236ff9fb8761b060083025fc410f72c0ff48c75c915dd3561a3869dc4a2de0f8900e19af0976  unifi-5.9.29.zip
 b19a7d684ef2ec7c4159417c21185ccd8ce498da25405b69014fdb32e346a0077f7edc5dfc994481d12936aa8dbf22e6baf29571fd0003aaad19609d24c549f4  unifi.initd
 d339555a91de7488badbedf8a4c85cff878e7d0720a8cf6a8340f51f3666dcf4878b47a1fff4c9c2846d7af140d11e48e898f8c4dba1f81c1004b76a81f0821e  unifi.confd
 9e54d9e1c720b8e50c9af9363105f6ea9ff2cffff7dc67477a7701aacf21ba977424fe9fbaba6a00d5f64310a2e2517e9328a7acb91a4bc06ed237139a8e0d9b  unifi.logrotated


### PR DESCRIPTION
Upgrade UniFi SDN Controller to the latest stable, 5.9.29.