### PR TITLE
community/composer: add missing dependencies

### DIFF
--- a/community/composer/APKBUILD
+++ b/community/composer/APKBUILD
@@ -7,7 +7,7 @@ pkgdesc="Dependency manager for PHP"
 url="https://getcomposer.org/"
 arch="noarch"
 license="MIT"
-depends="php7 php7-phar php7-json php7-openssl"
+depends="php7 php7-phar php7-json php7-openssl php7-mbstring php7-iconv"
 source="$pkgname-$pkgver.phar::https://getcomposer.org/download/$pkgver/$pkgname.phar"
 
 package() {


### PR DESCRIPTION
Composer does not run properly without iconv and mbstring.

Fixes [#9855](https://bugs.alpinelinux.org/issues/9855)