### PR TITLE
community/pdns: use guardian mode

### DIFF
--- a/community/pdns/APKBUILD
+++ b/community/pdns/APKBUILD
@@ -6,7 +6,7 @@
 # Maintainer:  Matt Smith <mcs@darkregion.net>
 pkgname=pdns
 pkgver=4.1.5
-pkgrel=0
+pkgrel=1
 pkgdesc="PowerDNS Authoritative Server"
 url="https://www.powerdns.com/"
 arch="all"
@@ -134,5 +134,5 @@ backend_sqlite3()       { _mv_backend gsqlite3 sqlite; }
 #backend_tinydns()       { _mv_backend tinydns; }
 
 sha512sums="c5c42975e6402f17b3cdf947a26c944a462d39c23bef44b6f6e823b8c9459be9e8bd750aa0481f9f707eec8b124c4edc4769a6241c75836583ee0bbe111e33e5  pdns-4.1.5.tar.bz2
-3f5b202c56408168ddbf81b47f5c48ca65de91ada88751213a06a1096334b89176c5a6a58f3c6a893a2d15b51ece9f2a64d7d2ea836220a3e45fe362969c6cfa  pdns.initd
+3a55547e1b6407e7d2faa6e02982ed903c2364381af1b7eeb626ae3a8b0e32558dd79bf31c982b134414e5636d4868c1f3660ac523f25d2440ed6f7b436843bf  pdns.initd
 3f809f3257680c3e496fa6a4c86c8a636db5d9d5b92aef96fe54c29b8266ee590deb792d13205cc171e27307fa73295dd3b101b09102fd66a2393a7cdbf9dd27  pdns.conf"

--- a/community/pdns/pdns.initd
+++ b/community/pdns/pdns.initd
@@ -13,7 +13,7 @@ fi
 name="PowerDNS ($instance_name)"
 
 command="/usr/sbin/pdns_server"
-command_args="${command_args:-} --guardian=no --daemon=no --write-pid=no $pdns_config"
+command_args="${command_args:-} --guardian=yes --daemon=no --write-pid=no $pdns_config"
 command_background="yes"
 pidfile="/run/$RC_SVCNAME.pid"
 


### PR DESCRIPTION
This fixes the reload command which relies on the guardian
to cycle the running instance.

https://bugs.alpinelinux.org/issues/7885