### PR TITLE
main/py-urllib3: upgrade to 1.24.1

### DIFF
--- a/main/py-urllib3/APKBUILD
+++ b/main/py-urllib3/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=py-urllib3
 _pkgname=${pkgname/py-/}
-pkgver=1.22
+pkgver=1.24.1
 pkgrel=0
 pkgdesc="HTTP library with thread-safe connection pooling, file post, and more"
 url="https://github.com/shazow/urllib3"
@@ -50,4 +50,4 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="1b45a4a64e71847a4fc62b9263235d5b05b62076698fa324454efeb7ad065abd702cc9eadb2d396d9270b07e91e9bad94c52a4b9b115aadccb27f81955e6feab  py-urllib3-1.22.tar.gz"
+sha512sums="2f5453cf0ec1b65de9a9fca0fdb45664f7481507c875b7115c063cb177628b4b611377e588508ab8433e0797fc78b60fd3ea5cc5ac0a3f105d36bfff9a56f1f4  py-urllib3-1.24.1.tar.gz"


### PR DESCRIPTION
A bit of changes, but most importantly the security patch for leak of Auth header during redirects.
Release notes - https://github.com/urllib3/urllib3/blob/master/CHANGES.rst#1241-2018-11-02
Related py-requests bump - https://github.com/alpinelinux/aports/pull/6023#issuecomment-454553238