### PR TITLE
testing/fs-uae: on ppc64le fix build error float128 by restricting build options

### DIFF
--- a/testing/fs-uae/APKBUILD
+++ b/testing/fs-uae/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=fs-uae
 # Remember to upgrade fs-uae-launcher to same version of fs-uae
 pkgver=2.8.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Amiga emulator."
 url="https://fs-uae.net/"
 arch="all !armhf !armv7 !aarch64 !s390x"  # --enable-jit not supported for these arches
@@ -22,7 +22,7 @@ build() {
 		ppc64le)
 			_jitoptions="--disable-jit"
 			export CFLAGS="-g -O2 -U__ALTIVEC__"
-			export CXXFLAGS="-g -O2 -U__ALTIVEC__"
+			export CXXFLAGS="-D__STRICT_ANSI__ -g -O2 -U__ALTIVEC__"
 		;;
 	esac
 


### PR DESCRIPTION
Building with gcc 8.2.0 fs-uae package fails on ppc64le with:
error: __float128 is not supported on this   abs(__float128 __x)target

A recent commit in the master branch of gcc fixes this on ppc64le:
https://github.com/gcc-mirror/gcc/commit/9f91ba1728c38b535f88d295bf7e801f3b401bc3#diff-fc3e201bd64a529bc10033e3c236556f

Until new gcc release this build error can be worked around by building ppc64le with __STRICT_ANSI__