### PR TITLE
testing/advancemame: on ppc64le fix build error with unsupported float128

### DIFF
--- a/testing/advancemame/APKBUILD
+++ b/testing/advancemame/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Taner Tas <taner76@gmail.com>
 pkgname=advancemame
 pkgver=3.8
-pkgrel=0
+pkgrel=1
 pkgdesc="A port of the MAME emulator for Arcade Monitors and TVs but also for LCDs and PC monitors"
 url="http://www.advancemame.it"
 arch="all"
@@ -9,7 +9,8 @@ license="GPL"
 makedepends="clang-dev sdl2-dev alsa-lib-dev freetype-dev zlib-dev expat-dev
 	slang-dev linux-headers"
 subpackages="$pkgname-doc $pkgname-data::noarch $pkgname-mess $pkgname-menu"
-source="https://github.com/amadvance/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.gz"
+source="https://github.com/amadvance/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.gz
+	fix-ppc64le-float128.patch"
 options="!check"
 
 prepare() {
@@ -63,4 +64,5 @@ menu() {
 	mv "$pkgdir"/usr/bin/advmenu "$subpkgdir"/usr/bin/
 
 }
-sha512sums="82a2366add559cdb1bcb681e7e45c5a383ab6a6364881a2d63f8239c2fcb6a0e6f7e17e58929e85ee1f55516e8a0df8d492214574127567958af22145f5c6f59  advancemame-3.8.tar.gz"
+sha512sums="82a2366add559cdb1bcb681e7e45c5a383ab6a6364881a2d63f8239c2fcb6a0e6f7e17e58929e85ee1f55516e8a0df8d492214574127567958af22145f5c6f59  advancemame-3.8.tar.gz
+d42a9b3c65c2d96be5287c7541eb1e911562b3f2aaf07c55c1849725592857716ce496405e3da2243edcbd4b7307226306533ddf66ef2e081b4c492412930d1b  fix-ppc64le-float128.patch"

--- a/testing/advancemame/fix-ppc64le-float128.patch
+++ b/testing/advancemame/fix-ppc64le-float128.patch
@@ -1,0 +1,24 @@
+--- a/advance/d2/d2.cc
++++ b/advance/d2/d2.cc
+@@ -21,6 +21,9 @@
+ #include <string>
+ #include <iostream>
+ #include <sstream>
++#if defined(__PPC64__)
++#define __STRICT_ANSI__
++#endif
+ #include <cstdlib>
+ #include <cstdio>
+ 
+--- a/advance/lib/portable.h
++++ b/advance/lib/portable.h
+@@ -67,6 +67,9 @@
+ 
+ /* Include some standard headers */
+ #include <stdio.h>
++#if defined(__PPC64__)
++#define __STRICT_ANSI__
++#endif
+ #include <stdlib.h> /* On many systems (e.g., Darwin), `stdio.h' is a prerequisite. */
+ #include <stdarg.h>
+ #include <string.h>


### PR DESCRIPTION
Building with gcc 8.2 package fails with:
error: __float128 is not supported on this target abs(__float128 __x)

A later commit in the master branch of gcc fixes this on ppc64le:
https://github.com/gcc-mirror/gcc/commit/9f91ba1728c38b535f88d295bf7e801f3b401bc3#diff-fc3e201bd64a529bc10033e3c236556f

At gcc version 8.2.0 this error can be worked around by building ppc64le with __STRICT_ANSI__