### PR TITLE
community/drupal7: security upgrade to 7.62

### DIFF
--- a/community/drupal7/APKBUILD
+++ b/community/drupal7/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
 pkgname=drupal7
-pkgver=7.61
+pkgver=7.62
 pkgrel=0
 pkgdesc="An open source content management platform"
 url="https://www.drupal.org/"
@@ -36,6 +36,8 @@ builddir="$srcdir/drupal-$pkgver"
 options="!check" # This package not have testsuite
 
 # secfixes:
+#   7.62-r0:
+#     - CVE-2018-1000888
 #   7.59-r0:
 #     - CVE-2018-7602
 #   7.58-r0:
@@ -76,4 +78,4 @@ package() {
 		"$pkgdir"/var/lib/$pkgname/sites/default/files
 }
 
-sha512sums="8f0bdd5b7ef33e62d09698b3889726fab1edb14df6263635bca65c9bbe0400df618dbf02ef298eeee169d48ab554d3b58d867bd4ce0d429b4b9167979917db51  drupal-7.61.tar.gz"
+sha512sums="9556d3d2a0ae8f908614ffd9b424268df6f2a81cbcd5a985745e8567b21ee37c574d1069ec7f796aab7db7c0026529aba2aa87b7b7d77f968bf29f7abda28464  drupal-7.62.tar.gz"


### PR DESCRIPTION
CVE-2018-1000888
- https://www.drupal.org/sa-core-2019-001
- https://www.drupal.org/sa-core-2019-002