### PR TITLE
testing/mpdecimal: new aport

### DIFF
--- a/testing/mpdecimal/APKBUILD
+++ b/testing/mpdecimal/APKBUILD
@@ -1,0 +1,28 @@
+# Contributor: Stefan Stutz <stutz@pm.me>
+# Maintainer: Stefan Stutz <stutz@pm.me>
+pkgname=mpdecimal
+pkgver=2.4.2
+pkgrel=0
+pkgdesc="libmpdec is a complete implementation of the General Decimal Arithmetic Specification"
+url="http://www.bytereef.org/mpdecimal/index.html"
+arch="all"
+license="BSD"
+subpackages="$pkgname-doc"
+source="http://www.bytereef.org/software/mpdecimal/releases/$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+        cd "$builddir"
+        ./configure --prefix=/usr
+}
+
+check() {
+        cd "$builddir"
+        make check
+}
+
+package() {
+    cd "$builddir"
+    make install DESTDIR="$pkgdir"
+}
+sha512sums="eb18ad53b81b93c469db4d915bbb3fae21b36ad82a88e01fef3a6946ac5f50b54376e259a5ecbe23836f1efd59d226b942ecdee87eaba7f9e75cdcaaa9499ef7  mpdecimal-2.4.2.tar.gz"


### PR DESCRIPTION
libmpdec is the basis for Python’s decimal module (since 3.3) as well as PHP's decimal extension.