### PR TITLE
main/py-bcrypt: upgrade to 3.1.6

### DIFF
--- a/main/py-bcrypt/APKBUILD
+++ b/main/py-bcrypt/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=py-bcrypt
 _pkgname=${pkgname/py-/}
-pkgver=3.1.4
+pkgver=3.1.6
 pkgrel=0
 pkgdesc="Modern password hashing for your software and your servers"
 url="https://github.com/pyca/bcrypt"
@@ -48,4 +48,4 @@ _py3() {
 }
 
 
-sha512sums="f4b18095ee1ea09a4a1ae4d970353d4743b84e8b2637132857339febc8fd25697359c8a3308578db623ee0c900a5711a693d9bfd21625bf93c1e6437bfb24f6c  py-bcrypt-3.1.4.tar.gz"
+sha512sums="ceb29bec656f56acea9e11112a46d8179c6c3be6d9295201ebdbf33692dd5503b353bd8206f3f4edc4b3b3027799d75915f498e4b7ac01124b90a0d70b1f60a8  py-bcrypt-3.1.6.tar.gz"


### PR DESCRIPTION
https://github.com/pyca/bcrypt#316