### PR TITLE
main/cmake: upgrade to 3.13.4

### DIFF
--- a/main/cmake/APKBUILD
+++ b/main/cmake/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cmake
-pkgver=3.13.0
+pkgver=3.13.4
 pkgrel=0
 pkgdesc="Cross-platform, open-source make system"
 url="https://www.cmake.org"
@@ -69,4 +69,4 @@ bashcomp() {
                 "$subpkgdir"/usr/share/bash-completion/
 }
 
-sha512sums="c353d20afc657f84e71aa5d6e9aa93caaca4eba33e3d1d75d25a504e50a1a8651bce1a27989998629449f36b3ed5c3be4c0a11b7f490f22abec9e73c1aa9073e  cmake-3.13.0.tar.gz"
+sha512sums="5a2cc092109652ced5a3a6ae00fe0c7d134efa7d90d59f376368408bb684343db9e144ee53b184f3437f8a86cf9976a130a1e1676c993d56b278a6640a418c93  cmake-3.13.4.tar.gz"


### PR DESCRIPTION
https://blog.kitware.com/cmake-3-13-3-available-for-download/