### PR TITLE
main/postfix: Modify postfix-files so set-permissions works now

### DIFF
--- a/main/postfix/APKBUILD
+++ b/main/postfix/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=postfix
 pkgver=3.3.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Secure and fast drop-in replacement for Sendmail (MTA)"
 url="http://www.postfix.org/"
 arch="all"
@@ -164,6 +164,16 @@ package() {
 		_mvline "^\s*$map" "$map" dynamicmaps.cf
 	done
 	rm makedefs.out
+
+	# fix /etc/postfix/postfix-files so that "postfix set-permissions" can run
+	sed -i \
+		-e '/shlib_directory\/postfix-/d' \
+		-e '/meta_directory\/makedefs.out/d' \
+		-e '/manpage_directory/d' \
+		-e '/config_directory\/LICENSE/d' \
+		-e '/config_directory\/TLS_LICENSE/d' \
+		-e '/config_directory\/[^/]\+\.cf\.default/d' \
+		"$pkgdir"/etc/postfix/postfix-files
 }
 
 _mv_dict() {


### PR DESCRIPTION
This PR fixes /etc/postfix/postfix-files, a file containing a list of all files and permissions of the postfix package. This list is used to create/fix permission issues in the spool-directory or to setup a chrooted postfix installation.
Sadly this file contained non existant files (e.g. the postfix-ldap.so) when not all postfix packages were installed. This file also contained some entries about files which where moved to /usr/share/doc (LICENSE).

The "postfix set-permissions" aborts on the first missing file and refuses to continue. After removing the moved / not needed / missing files from the "postfix-files", the command now finishes without error.