### PR TITLE
testing/vips: add check() and fix dependencies

### DIFF
--- a/testing/vips/APKBUILD
+++ b/testing/vips/APKBUILD
@@ -2,14 +2,15 @@
 # Maintainer: Will Jordan <will.jordan@gmail.com>
 pkgname=vips
 pkgver=8.7.4
-pkgrel=0
+pkgrel=1
 pkgdesc="A fast image processing library with low memory needs"
 url="http://www.vips.ecs.soton.ac.uk/"
 arch="all !s390x"
 license="LGPL-2.1-or-later"
-depends_dev="libjpeg-turbo-dev libexif-dev lcms2-dev"
-makedepends="$depends_dev fftw-dev giflib-dev glib-dev libpng-dev libwebp-dev
-	expat-dev orc-dev tiff-dev"
+makedepends="expat-dev fftw-dev giflib-dev glib-dev lcms2-dev
+	libexif-dev libjpeg-turbo-dev libpng-dev libwebp-dev
+	orc-dev tiff-dev"
+checkdepends="bc"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang $pkgname-tools"
 source="https://github.com/libvips/libvips/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz"
 
@@ -21,13 +22,16 @@ build() {
 		--host=$CHOST \
 		--prefix=/usr \
 		--enable-debug=no \
-		--without-python \
 		--without-gsf \
 		--disable-static \
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--docdir=/usr/share/doc
 	make
+}
+
+check() {
+	make check
 }
 
 package() {


### PR DESCRIPTION
Follow-up to https://github.com/alpinelinux/aports/pull/6074

```
  --enable-pyvips8        install vips8 Python overrides (default: no)
  --enable-pyvips7        build vips7 Python binding (default: no)
```