### PR TITLE
testing/nginx-mod-http-modsecurity: new aport

### DIFF
--- a/testing/modsecurity/APKBUILD
+++ b/testing/modsecurity/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: AdamRushad <adamrushad@adamrushad.com>
+# Maintainer: AdamRushad <adamrushad@adamrushad.com>
+pkgname=modsecurity
+pkgver=3.0.3
+pkgrel=0
+pkgdesc="ModSecurity WAF engine"
+url="https://modsecurity.org"
+arch="all"
+license="Apache-2.0"
+depends=""
+makedepends="libxml2-dev pcre-dev linux-headers flex-dev yajl-dev geoip-dev curl-dev valgrind"
+install=""
+# ModSecurity does not build documentation automatically. Seems to be a bug upstream. Both perl and doxygen
+#  will be required for generating documentation once it is fixed/implemented.
+subpackages="$pkgname-dev"
+source="$pkgname-$pkgver.tar.gz::https://github.com/SpiderLabs/ModSecurity/releases/download/v$pkgver/$pkgname-v$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-v$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure --prefix=/usr --enable-valgrind
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="c75f70cee27c90b7a18d13c80ce7172c3eee1a68a2e07806cccc92dd20bdb27cd61f2b98629e6231a9d860a751bd3e8a72a013b0061738c05e06b4b234190592  modsecurity-3.0.3.tar.gz"

--- a/testing/nginx-mod-http-modsecurity/APKBUILD
+++ b/testing/nginx-mod-http-modsecurity/APKBUILD
@@ -1,0 +1,217 @@
+# Maintainer: AdamRushad <adamrushad@adamrushad.com>
+# Contributor: Jeff Bilyk <jbilyk@gmail.com>
+# Contributor: Bartłomiej Piotrowski <nospam@bpiotrowski.pl>
+# Contributor: Jakub Jirutka <jakub@jirutka.cz>
+
+###
+### NOTE: This is separated due to needing a new untested package:
+### modsecurity. If/when this dependency gets moved to main, or
+### nginx and modsecurity are moved to community, the following
+### line can be added to the nginx APKBUILD, and this package
+### deleted from the tree:
+###    _add_module "http-modsecurity" "v1.0.0" "https://github.com/SpiderLabs/ModSecurity-nginx"
+### Plus the following makedepends entry: modsecurity-dev
+###
+### Until then, this is left separate to conform to the requirement
+### that all packages in main shall have no dependencies outside
+### of main.
+###
+### This package should be updated with to have pkgver match
+### main/nginx. If a new release of ModSecurity-nginx is made,
+### _pkgver should be bumped to compile it against the current
+### version of nginx. Additionally, if we need to change compile
+### options in nginx, this should be updated to match, as well.
+###
+#
+# secfixes:
+#   1.14.1-r0:
+#     - CVE-2018-16843
+#     - CVE-2018-16844
+#     - CVE-2018-16845
+#   1.12.1-r0:
+#     - CVE-2017-7529
+#
+pkgname=nginx-mod-http-modsecurity
+# NOTE: Upgrade only to even-numbered versions (e.g. 1.14.z, 1.16.z)!
+# Odd-numbered versions are mainline (development) versions.
+pkgver=1.14.2
+pkgrel=0
+# NOTE: This is the actual version of the modsecurity nginx module
+_pkgver=v1.0.0
+# Revision of nginx-tests to use for check().
+# Updated to resolve issue with ssl_sni_reneg.t failing with OpenSSL 1.1.1
+#_tests_hgrev=d6daf03478ad
+_tests_hgrev=4c43a0ebcd2d
+_njs_ver=0.2.0
+pkgdesc="ModSecurity v3 nginx connector"
+url="https://github.com/SpiderLabs/ModSecurity-nginx"
+arch="all"
+license="Apache-2.0"
+#depends="nginx"
+depends=""
+makedepends="linux-headers gd-dev geoip-dev libxml2-dev libxslt-dev
+	openssl-dev paxmark pcre-dev perl-dev pkgconf zlib-dev modsecurity-dev"
+checkdepends="gd perl perl-fcgi perl-io-socket-ssl perl-net-ssleay
+	perl-protocol-websocket tzdata uwsgi-python"
+install=""
+subpackages=""
+replaces=""
+source="https://nginx.org/download/nginx-$pkgver.tar.gz
+	nginx-tests-$_tests_hgrev.tar.gz::https://hg.nginx.org/nginx-tests/archive/$_tests_hgrev.tar.gz
+	nginx-njs-$_njs_ver.tar.gz::https://hg.nginx.org/njs/archive/$_njs_ver.tar.gz
+	njs~fix-test-exit-code.patch
+	ModSecurity-nginx.tar.gz::https://github.com/SpiderLabs/ModSecurity-nginx/archive/$_pkgver.tar.gz
+	ModSecurity-nginx~backport-test-fixes.patch
+	"
+builddir="$srcdir/nginx-$pkgver"
+
+_modules_dir="usr/lib/nginx/modules"
+
+# luajit is not available for s390x.
+case "$CARCH" in
+	s390x) makedepends="$makedepends lua5.1-dev";;
+	*) makedepends="$makedepends luajit-dev";;
+esac
+
+prepare() {
+	local file; for file in $source; do
+		case $file in
+		*~*.patch)
+			msg $file
+			cd "$srcdir"/${file%%~*}-*
+			patch -p 1 -i "$srcdir/$file"
+			;;
+		*.patch)
+			msg $file
+			cd "$builddir"
+			patch -p 1 -i "$srcdir/$file"
+			;;
+		esac
+	done
+
+	# This test requires superuser privileges and CAP_NET_ADMIN.
+	rm "$srcdir"/nginx-tests-*/proxy_bind_transparent.t
+	rm "$srcdir"/nginx-tests-*/proxy_bind_transparent_capability.t
+}
+
+build() {
+	cd "$builddir"
+
+	export LUAJIT_LIB="$(pkgconf --variable=libdir luajit)"
+	export LUAJIT_INC="$(pkgconf --variable=includedir luajit)"
+	./configure \
+		--prefix=/var/lib/nginx \
+		--sbin-path=/usr/sbin/nginx \
+		--modules-path=/$_modules_dir \
+		--conf-path=/etc/nginx/nginx.conf \
+		--pid-path=/run/nginx/nginx.pid \
+		--lock-path=/run/nginx/nginx.lock \
+		--http-client-body-temp-path=/var/tmp/nginx/client_body \
+		--http-proxy-temp-path=/var/tmp/nginx/proxy \
+		--http-fastcgi-temp-path=/var/tmp/nginx/fastcgi \
+		--http-uwsgi-temp-path=/var/tmp/nginx/uwsgi \
+		--http-scgi-temp-path=/var/tmp/nginx/scgi \
+		--with-perl_modules_path=/usr/lib/perl5/vendor_perl \
+		\
+		--user=$pkgusers \
+		--group=$_grp_ngx \
+		--with-threads \
+		--with-file-aio \
+		\
+		--with-http_ssl_module \
+		--with-http_v2_module \
+		--with-http_realip_module \
+		--with-http_addition_module \
+		--with-http_xslt_module=dynamic \
+		--with-http_image_filter_module=dynamic \
+		--with-http_geoip_module=dynamic \
+		--with-http_sub_module \
+		--with-http_dav_module \
+		--with-http_flv_module \
+		--with-http_mp4_module \
+		--with-http_gunzip_module \
+		--with-http_gzip_static_module \
+		--with-http_auth_request_module \
+		--with-http_random_index_module \
+		--with-http_secure_link_module \
+		--with-http_degradation_module \
+		--with-http_slice_module \
+		--with-http_stub_status_module \
+		--with-http_perl_module=dynamic \
+		--with-mail=dynamic \
+		--with-mail_ssl_module \
+		--with-stream=dynamic \
+		--with-stream_ssl_module \
+		--with-stream_realip_module \
+		--with-stream_geoip_module=dynamic \
+		--with-stream_ssl_preread_module \
+		\
+		--add-dynamic-module="$srcdir/njs-$_njs_ver/nginx" \
+		--add-dynamic-module="$srcdir/ModSecurity-nginx-${_pkgver#v}"
+
+	make
+}
+
+check() {
+	msg "Running nginx tests..."
+	cd "$srcdir"/nginx-tests-*
+	TEST_NGINX_BINARY="$builddir/objs/nginx" prove -I./lib .
+	local name="${pkgname#nginx-mod-}"
+	name="${name//-/_}"
+	TEST_NGINX_BINARY="$builddir/objs/nginx" TEST_NGINX_GLOBALS="load_module '$builddir/objs/ngx_${name}_module.so';" prove -I./lib "$srcdir"/ModSecurity-nginx-${_pkgver#v}/tests/
+
+	msg "Running njs tests..."
+	cd "$srcdir"/njs-*
+	make test
+}
+
+package() {
+	cd "$builddir"
+
+	make DESTDIR="$pkgdir" install
+
+	cd "$pkgdir"
+
+	install -dm755 ./etc/nginx/modules
+
+	rm -rf ./run ./etc/nginx/*.default
+	local name="${pkgname#nginx-mod-}"
+	name="${name//-/_}"
+	find ./ -not -name ngx_${name}_module.so -type f -exec rm \{\} \+
+	echo "load_module \"modules/ngx_${name}_module.so\";" > ./etc/nginx/modules/${name}.conf
+	find ./ -depth -type d -and -not -name . -exec rmdir --ignore-fail-on-non-empty \{\} \+
+}
+
+vim() {
+	pkgdesc="$pkgdesc (vim syntax)"
+	depends=
+
+	mkdir -p "$subpkgdir"/usr/share/vim
+	cp -r "$builddir"/contrib/vim "$subpkgdir"/usr/share/vim/vimfiles
+}
+
+_module() {
+	local name="${subpkgname#nginx-mod-}"
+	name="${name//-/_}"
+	local soname="$(eval "echo \$_${name}_so")";
+	soname="${soname:-"ngx_${name}_module.so"}"
+
+	pkgdesc="$pkgdesc (module $name)"
+	depends="nginx $(eval "echo \$_${name}_depends")"
+	provides="$(eval "echo \$_${name}_provides")"
+
+	mkdir -p "$subpkgdir"/$_modules_dir
+	cd "$subpkgdir"
+
+	mv "$pkgdir"/$_modules_dir/$soname ./$_modules_dir/$soname
+
+	mkdir -p "$subpkgdir"/etc/nginx/modules
+	echo "load_module \"modules/$soname\";" > ./etc/nginx/modules/$name.conf
+}
+
+sha512sums="d8362dbd86435657d6b13156bd6ad1b251d2ab10bc11cdda959b142dd6120b087e4b314f0025d9bbcc88529cb4b9407fb4df1cfae5d081b7ea1db51ccfc2dbe7  nginx-1.14.2.tar.gz
+9aa842816d74a0f6d2339bd9940971d70c8d74838a01b9924e841ca3f1506cde8d0dd5a1619e7cddcc5de807aac40ff8b0183e88f9f8182673fbeb041078ccfd  nginx-tests-4c43a0ebcd2d.tar.gz
+be07e635f5e0e50a28366b28180344568b5cca9d67c79bc80d0c6758d8d4097ff9428393fb6951ed239c6e9c9e3f84b46f9c92a6e2c313f1f35e677b3662512f  nginx-njs-0.2.0.tar.gz
+cd6983c164383100e0239be85dfeddc7879ab9c29589aecdd9bb4b6772d1f0a5d4cd70bf728d0fb5181765cbed77b7e4c99fd85c0ec59c55826c52e923510017  njs~fix-test-exit-code.patch
+e6f1019e7fd1472288de737722babe9291e1e59b45549ee5353c71d74460cf1a7c739ba2a737e53c33b664863ad4385f2c9e1b53d6a430bb1f7724a9c893280a  ModSecurity-nginx.tar.gz
+6285ec0e47ac3523609077a8482a769db044330a1c847f387e51490dc9f8579e53a2051e4553e7e5b8b7a97ddb6481ff5f6cec09fa77e499719fa674da768790  ModSecurity-nginx~backport-test-fixes.patch"

--- a/testing/nginx-mod-http-modsecurity/ModSecurity-nginx~backport-test-fixes.patch
+++ b/testing/nginx-mod-http-modsecurity/ModSecurity-nginx~backport-test-fixes.patch
@@ -1,0 +1,20 @@
+--- ./tests/modsecurity.t.orig
++++ ./tests/modsecurity.t
+@@ -97,6 +97,7 @@
+             modsecurity on;
+             modsecurity_rules '
+                 SecRuleEngine On
++                SecResponseBodyAccess On
+                 SecDefaultAction "phase:4,log,deny,status:403"
+                 SecRule ARGS "@streq redirect301" "id:1,phase:4,status:301,redirect:http://www.modsecurity.org"
+                 SecRule ARGS "@streq redirect302" "id:2,phase:4,status:302,redirect:http://www.modsecurity.org"
+--- ./tests/modsecurity-proxy.t.orig
++++ ./tests/modsecurity-proxy.t
+@@ -86,6 +86,7 @@
+             modsecurity on;
+             modsecurity_rules '
+                 SecRuleEngine On
++                SecResponseBodyAccess On
+                 SecDefaultAction "phase:4,log,deny,status:403"
+                 SecRule ARGS "@streq redirect301" "id:1,phase:4,status:301,redirect:http://www.modsecurity.org"
+                 SecRule ARGS "@streq redirect302" "id:2,phase:4,status:302,redirect:http://www.modsecurity.org"

--- a/testing/nginx-mod-http-modsecurity/nginx-tests~modsecurity-dynamic-modules.patch
+++ b/testing/nginx-mod-http-modsecurity/nginx-tests~modsecurity-dynamic-modules.patch
@@ -1,0 +1,12 @@
+--- ./lib/Test/Nginx.pm.orig
++++ ./lib/Test/Nginx.pm
+@@ -635,6 +635,9 @@
+ 	$s .= "load_module $modules/ngx_stream_geoip_module.so;\n"
+ 		if $self->has_module('stream_geoip\S+=dynamic');
+ 
++	$s .= "load_module $modules/ngx_http_modsecurity_module.so;\n"
++		if $self->has_module('ModSecurity-nginx');
++
+ 	return $s;
+ }
+ 

--- a/testing/nginx-mod-http-modsecurity/njs~fix-test-exit-code.patch
+++ b/testing/nginx-mod-http-modsecurity/njs~fix-test-exit-code.patch
@@ -1,0 +1,24 @@
+# HG changeset patch
+# User Dmitry Volyntsev <xeioex@nginx.com>
+# Date 1524763304 -10800
+# Node ID 4e647f0bf155f0e858a8838c216e3ba1559ff870
+# Parent  1305b1701099541bcb47579ce1719550662e0d1c
+Fixed unit tests exit code.
+
+Previously, 0 was returned regardless of failures.
+
+Patch-Source: http://hg.nginx.org/njs/rev/4e647f0bf155
+
+diff -r 1305b1701099 -r 4e647f0bf155 njs/test/njs_unit_test.c
+--- a/njs/test/njs_unit_test.c	Thu Apr 26 19:58:26 2018 +0300
++++ b/njs/test/njs_unit_test.c	Thu Apr 26 20:21:44 2018 +0300
+@@ -9878,7 +9878,7 @@
+         printf("njs unit tests passed\n");
+     }
+ 
+-    return NXT_OK;
++    return rc;
+ }
+ 
+ 
+


### PR DESCRIPTION
New aports for ModSecurity. The first is the ModSecurity nginx connector, testing/nginx-mod-http-modsecurity. The second is a dependency of that nginx module, the ModSecurity 3.x library. Both packages included in this PR to ensure automated builds work. Comments also present in the nginx-mod-http-modsecurity APKBUILD related to why it is separate and how to merge into main/nginx if/when that is appropriate.