### PR TITLE
[3.8] community/pdns-recursor: security upgrade to 4.1.9

### DIFF
--- a/community/pdns-recursor/APKBUILD
+++ b/community/pdns-recursor/APKBUILD
@@ -1,6 +1,6 @@
 # Contributor: Olivier Mauras <olivier@mauras.ch>
 pkgname=pdns-recursor
-pkgver=4.1.8
+pkgver=4.1.9
 pkgrel=0
 pkgdesc="PowerDNS Recursive Server"
 url="https://www.powerdns.com/"
@@ -13,7 +13,7 @@ install="$pkgname.pre-install"
 subpackages="$pkgname-doc $pkgname-openrc"
 pkgusers="recursor"
 pkggroups="recursor"
-source="http://downloads.powerdns.com/releases/$pkgname-$pkgver.tar.bz2
+source="https://downloads.powerdns.com/releases/$pkgname-$pkgver.tar.bz2
 	libressl-2.7.patch
 	pdns-recursor.initd
 	recursor.conf
@@ -23,6 +23,9 @@ options="!check"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   4.1.9-r0:
+#     - CVE-2019-3806
+#     - CVE-2019-3807
 #   4.1.8-r0:
 #     - CVE-2018-10851
 #     - CVE-2018-14626
@@ -66,7 +69,7 @@ package() {
 		"$pkgdir"/etc/pdns/recursor.conf
 }
 
-sha512sums="5c09b8ce3f2f3ed6bb350cbd20e6cad4b66f9db85677605d57eca67187c05ddde5071af246a7398e2821c9ed2e5ff101d2b4928366b3ddf12013020fa9b74e61  pdns-recursor-4.1.8.tar.bz2
+sha512sums="2deaf1cdc8c32087f744efe0d142421cfd2d89dc9b31edcdea55c1efc2637987e8557891716498e3703c4b1af4b0d301e2a53316c5a97c7a18ec85016ccfa8f1  pdns-recursor-4.1.9.tar.bz2
 2846854b74bcc1149e18aa5ff17d1c0548790a5eaf87a7194b89a1063c6783708bfa109e8edf9c2b430fbd90445bee7f80137601babab8766be106bcad700cf3  libressl-2.7.patch
 f23cb30d943e0b0aea09371dc57aa43e55b8f91062a3caa3fac17e3565a8e36dfd304f45eba588f625ca2337cd2ade450ea5ae1776872c006204cdaf912f6651  pdns-recursor.initd
 954df537693a202fc195e751011bbfaa605b3f3df42ac386fa82eb809b73c2b987f5e418b5c96bb3b0669497426ce0daa39a719844701e06990b82843a4cf0d4  recursor.conf"


### PR DESCRIPTION
https://docs.powerdns.com/recursor/security-advisories/powerdns-advisory-2019-01.html
https://docs.powerdns.com/recursor/security-advisories/powerdns-advisory-2019-02.html