### PR TITLE
community/py-rpigpio: upgrade to 0.6.5

### DIFF
--- a/community/py-rpigpio/APKBUILD
+++ b/community/py-rpigpio/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: ScrumpyJack <scrumpyjack@st.ilet.to>
 pkgname=py-rpigpio
 _pkgname=RPi.GPIO
-pkgver=0.6.3
-pkgrel=1
+pkgver=0.6.5
+pkgrel=0
 pkgdesc="This package provides a class to control the GPIO on a Raspberry Pi."
 url="https://pypi.python.org/pypi/RPi.GPIO"
 arch="armhf armv7"
@@ -48,4 +48,4 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="b2fd08d9db1a2d58bdfed9d27c279d1f8c5cb6923ebd61253dae257b7271a7c5dec2271d6a426c9d1c67fc0444e18057e2e12ed8c3aa0f3d847291ba64beccf4  py-rpigpio-0.6.3.tar.gz"
+sha512sums="1393f49715b9c2d693743f962f75c4129ed229c83f49f31b913af8eaddb94280884127b8815d5c1e8451c3764c86962763a611b19ebc4afe72ac5fea3b61817b  py-rpigpio-0.6.5.tar.gz"


### PR DESCRIPTION
Please pull for v3.9

# 0.6.5
    Fix exception on re-export of /sys/class/gpio/gpioNN
# 0.6.4
    Event cleanup bug (issue 145)
    Raise exception for duplicate PWM objects (issue 54)
    Fix build warnings (Issue 146 - Dominik George)
    test.py runs unchanged for both python 2+3
    Soft PWM stops running fix (Issues 94, 111, 154)
    Soft PWM segfault fix (Luke Allen pull request)

