### PR TITLE
community/geth: upgrade to 1.8.21

### DIFF
--- a/community/geth/APKBUILD
+++ b/community/geth/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: André Klitzing <aklitzing@gmail.com>
 # Maintainer: André Klitzing <aklitzing@gmail.com>
 pkgname=geth
-pkgver=1.8.20
-pkgrel=1
+pkgver=1.8.21
+pkgrel=0
 pkgdesc="Official Go implementation of the Ethereum protocol"
 url="https://geth.ethereum.org/"
 arch="all"
@@ -30,5 +30,5 @@ package() {
 	install -m755 -t "${pkgdir}"/usr/bin build/bin/*
 }
 
-sha512sums="99a414991801f2deed6d40fe8fcd60f35c0bc1b0f54af4427d4e431de111d626855985ae929663dc5c7454a8d224663858d0f7236238d05c78775377b46510ba  geth-1.8.20.tar.gz
+sha512sums="807acab8a61fd2708c88a1ab69b2f0a961b9dd4fec55edbb7329d1c358619d4f3e4137319c5231a8cf07ecb10f29506d6e7a8120e0c67e760dedc46171bb31fb  geth-1.8.21.tar.gz
 7f1d4cf22e1d48baebd28725ee099cb878028980af336b6e92d1f580a24a7d11e8b302e2b1f8c14f5b18b1d01313abe43464d8bef631ca18e5b0d613fe0a10a0  fix-ppc64le-isatty.patch"


### PR DESCRIPTION
Geth 1.8.21 is an emergency hotfix release to postpone the mainnet Constantinople upgrade! The reason is a last minute reentrancy vulnerability dicovered by ChainSecurity.