### PR TITLE
community/php7-pecl-timezonedb: upgrade to 2018.9

### DIFF
--- a/community/php7-pecl-timezonedb/APKBUILD
+++ b/community/php7-pecl-timezonedb/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
 pkgname=php7-pecl-timezonedb
 _pkgreal=timezonedb
-pkgver=2018.7
+pkgver=2018.9
 pkgrel=0
 pkgdesc="Timezone Database to be used with PHP's date and time functions."
 url="https://pecl.php.net/package/timezonedb"
@@ -30,4 +30,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/40_$_pkgreal.ini
 }
 
-sha512sums="fb8f79a53f5b10a6c01a3a43b33bdefe371ca8c6f5725b28f9efbbe009d2dd089a1747ef20ba1b8694e240ef4133dea8d6d09e8c483127f5d6932a9468106654  timezonedb-2018.7.tgz"
+sha512sums="77fabe3aa0283900ea2d3d20caaf7c4b9bac1859249c9df4f0225c203fc92310dfe9b4144640af034a4ba86ba78a748a39980ff796affc67edc99ec874867e06  timezonedb-2018.9.tgz"


### PR DESCRIPTION
Ref https://pecl.php.net/package-changelog.php?package=timezonedb&release=2018.9