### PR TITLE
main/tzdata: upgrade to 2018i

### DIFF
--- a/main/tzdata/APKBUILD
+++ b/main/tzdata/APKBUILD
@@ -2,10 +2,10 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=tzdata
-pkgver=2018g
-_tzcodever=2018g
+pkgver=2018i
+_tzcodever=2018i
 _ptzver=0.5
-pkgrel=1
+pkgrel=0
 pkgdesc="Timezone data"
 url="https://www.iana.org/time-zones"
 arch="all"
@@ -57,8 +57,8 @@ package() {
 		"$pkgdir"/usr/bin/posixtz
 }
 
-sha512sums="58f89b7323bfe795c5f13039f7527d18b15c9e37fce6e9fa1a402ce2689bf5c772cf1ffb86f23309814a563f9f429da472df1229818b07b1e04f16bdedb21484  tzcode2018g.tar.gz
-92e9bbd61f51be8f2cf7ec9491691e5e2f97803914dbad77b7fb8b6600ed68fc3b98450fc808bb2d4c6c835df5f9eb7bf4529d059d9b1370f2ab4c12e7f1adfa  tzdata2018g.tar.gz
+sha512sums="1a3d53043f20b8252f7598f547d78e7294d9e0cf1fcdd2159354d9769f824c8c8a03cef9cbb7fa579345fdb41372335117d2ef782ecd9c107dd0526e59492d9d  tzcode2018i.tar.gz
+6afcacb377842190648ed26f01abcf3db37aa2e7c63d8c509c29b4bc0078b7ff2d4e5375291b9f53498215b9e2f04936bc6145e2f651ae0be6d8166d8d336f6a  tzdata2018i.tar.gz
 68dbaab9f4aef166ac2f2d40b49366527b840bebe17a47599fe38345835e4adb8a767910745ece9c384b57af815a871243c3e261a29f41d71f8054df3061b3fd  posixtz-0.5.tar.xz
 0f2a10ee2bb4007f57b59123d1a0b8ef6accf99e568f21537f0bb19f290fff46e24050f55f12569d7787be600e1b62aa790ea85a333153f3ea081a812c81b1b5  0001-posixtz-ensure-the-file-offset-we-pass-to-lseek-is-o.patch
 fb322ab7867517ba39265d56d3576cbcea107c205d524e87015c1819bbb7361f7322232ee3b86ea9b8df2886e7e06a6424e3ac83b2006be290a33856c7d40ac4  0002-fix-implicit-declaration-warnings-by-including-strin.patch"


### PR DESCRIPTION
Ref https://www.iana.org/time-zones

```
gcc -Os -fomit-frame-pointer -Wl,--as-needed -o posixtz main.c posixtz.c
>>> tzdata: Entering fakeroot...
warning: -y is obsolescent
warning: -y is obsolescent
warning: -y is obsolescent
>>> tzdata-doc*: Running split function doc...
```