### PR TITLE
testing/mame: fix ppc64le build break for float handling

### DIFF
--- a/testing/mame/APKBUILD
+++ b/testing/mame/APKBUILD
@@ -3,10 +3,10 @@
 pkgname=mame
 pkgver=0.205
 _pkgver=${pkgver/.}
-pkgrel=0
+pkgrel=1
 pkgdesc="Multi Arcade Machine Emulator with GroovyMAME/Switchres/No-nag patchset."
 url="https://mamedev.org"
-arch="all !ppc64le"
+arch="all"
 license="GPL-2.0-or-later"
 depends="$pkgname-common"
 makedepends="
@@ -54,6 +54,7 @@ source="
 	fix-musl.patch
 	m68000_archopts.patch
 	nonag.patch
+	fix-ppc64le-float.patch
 	SubtargetArcade_0200u0.diff
 	"
 options="!check" # No test suite
@@ -222,4 +223,5 @@ dc008245cbea0b94f58d83e09bf5fd3fff04ac0e2f3a36b910a8b7633c5377419fc67a1fd366ef26
 75bba366aebb37de7758368fbf7418194a18d535e61c1768e6c2c5cf4b3b7a2f625ef687cb8278c03daa9e308951df4c0bdcc944dfcc4ce5305f5ac83e5e049b  fix-musl.patch
 a4d628d4648d28b9ae95f27ecba4a70b999ef11ffde31b31ca3ce2ed2fd4cfcab82ec78e2602309952518fac8c549d0b8b4294f6aa34c1acaa77f012ea13de9e  m68000_archopts.patch
 864816a55f35f9d485ccd143a1e0acd76d47239a6d5344be2a76b50fd4efbdfb4f3e45318d7dfda67faa63c0a52022f2e8313f058965a1eba60e6ca4677a519b  nonag.patch
+daa915d08b61e3828b28144f1934fd1fa9fe04da00b3536f86b984035f1a1bc81da498e1bc8632bc5f9c8b86533b70814a91318627fcafc3f05ebda59e303cc4  fix-ppc64le-float.patch
 3796c725efb886f953c372b947a84dd6e09d59d0be9abc3c3c73625beeb7f3bdcc6e8c8057c3f59e297ed92fd5077b52a69a2de6dacb005b21cf552e4e641a4a  SubtargetArcade_0200u0.diff"

--- a/testing/mame/fix-ppc64le-float.patch
+++ b/testing/mame/fix-ppc64le-float.patch
@@ -1,0 +1,115 @@
+--- a/3rdparty/bx/include/bx/inline/endian.inl
++++ b/3rdparty/bx/include/bx/inline/endian.inl
+@@ -46,7 +46,7 @@
+ 	}
+ 
+ 	template <typename Ty>
+-	inline Ty toLittleEndian(const Ty _in)
++	inline Ty toLittleEndian(Ty _in)
+ 	{
+ #if BX_CPU_ENDIAN_BIG
+ 		return endianSwap(_in);
+@@ -56,7 +56,7 @@
+ 	}
+ 
+ 	template <typename Ty>
+-	inline Ty toBigEndian(const Ty _in)
++	inline Ty toBigEndian(Ty _in)
+ 	{
+ #if BX_CPU_ENDIAN_LITTLE
+ 		return endianSwap(_in);
+@@ -66,7 +66,7 @@
+ 	}
+ 
+ 	template <typename Ty>
+-	inline Ty toHostEndian(const Ty _in, bool _fromLittleEndian)
++	inline Ty toHostEndian(Ty _in, bool _fromLittleEndian)
+ 	{
+ #if BX_CPU_ENDIAN_LITTLE
+ 		return _fromLittleEndian ? _in : endianSwap(_in);
+--- a/3rdparty/bx/include/bx/inline/readerwriter.inl
++++ b/3rdparty/bx/include/bx/inline/readerwriter.inl
+@@ -273,7 +273,7 @@
+ 	}
+ 
+ 	template<typename Ty>
+-	int32_t read(ReaderI* _reader, Ty& _value, Error* _err)
++	inline int32_t read(ReaderI* _reader, Ty& _value, Error* _err)
+ 	{
+ 		BX_ERROR_SCOPE(_err);
+ 		BX_STATIC_ASSERT(isTriviallyCopyable<Ty>() );
+@@ -281,7 +281,7 @@
+ 	}
+ 
+ 	template<typename Ty>
+-	int32_t readHE(ReaderI* _reader, Ty& _value, bool _fromLittleEndian, Error* _err)
++	inline int32_t readHE(ReaderI* _reader, Ty& _value, bool _fromLittleEndian, Error* _err)
+ 	{
+ 		BX_ERROR_SCOPE(_err);
+ 		BX_STATIC_ASSERT(isTriviallyCopyable<Ty>() );
+@@ -329,7 +329,7 @@
+ 	}
+ 
+ 	template<typename Ty>
+-	int32_t write(WriterI* _writer, const Ty& _value, Error* _err)
++	inline int32_t write(WriterI* _writer, const Ty& _value, Error* _err)
+ 	{
+ 		BX_ERROR_SCOPE(_err);
+ 		BX_STATIC_ASSERT(isTriviallyCopyable<Ty>() );
+@@ -337,7 +337,7 @@
+ 	}
+ 
+ 	template<typename Ty>
+-	int32_t writeLE(WriterI* _writer, const Ty& _value, Error* _err)
++	inline int32_t writeLE(WriterI* _writer, const Ty& _value, Error* _err)
+ 	{
+ 		BX_ERROR_SCOPE(_err);
+ 		BX_STATIC_ASSERT(isTriviallyCopyable<Ty>() );
+@@ -346,8 +346,14 @@
+ 		return result;
+ 	}
+ 
++	template<>
++	inline int32_t writeLE(WriterI* _writer, const float& _value, Error* _err)
++	{
++		return writeLE(_writer, floatToBits(_value), _err);
++	}
++
+ 	template<typename Ty>
+-	int32_t writeBE(WriterI* _writer, const Ty& _value, Error* _err)
++	inline int32_t writeBE(WriterI* _writer, const Ty& _value, Error* _err)
+ 	{
+ 		BX_ERROR_SCOPE(_err);
+ 		BX_STATIC_ASSERT(isTriviallyCopyable<Ty>() );
+@@ -356,6 +362,12 @@
+ 		return result;
+ 	}
+ 
++	template<>
++	inline int32_t writeBE(WriterI* _writer, const float& _value, Error* _err)
++	{
++		return writeBE(_writer, floatToBits(_value), _err);
++	}
++
+ 	inline int64_t skip(SeekerI* _seeker, int64_t _offset)
+ 	{
+ 		return _seeker->seek(_offset, Whence::Current);
+@@ -392,7 +404,7 @@
+ 	}
+ 
+ 	template<typename Ty>
+-	int32_t peek(ReaderSeekerI* _reader, Ty& _value, Error* _err)
++	inline int32_t peek(ReaderSeekerI* _reader, Ty& _value, Error* _err)
+ 	{
+ 		BX_ERROR_SCOPE(_err);
+ 		BX_STATIC_ASSERT(isTriviallyCopyable<Ty>() );
+--- a/3rdparty/bx/include/bx/readerwriter.h
++++ b/3rdparty/bx/include/bx/readerwriter.h
+@@ -10,6 +10,7 @@
+ #include "endian.h"
+ #include "error.h"
+ #include "filepath.h"
++#include "math.h"
+ #include "string.h"
+ #include "uint32_t.h"
+ 


### PR DESCRIPTION
Submitting patches from https://github.com/bkaradzic/bx/commit/684f7ec5d6a8e0d9c396bdd2dfc1f19244800557?diff=unified

to fix ppc64le build issue described in https://github.com/alpinelinux/aports/commit/8b6964b6832e341d8c5514411c5f3e8af47ac6a4

with this integration ppc64le can be enabled again