### PR TITLE
main/nodejs: upgrade to 10.15.1

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -33,7 +33,7 @@
 pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
-pkgver=10.14.2
+pkgver=10.15.1
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="https://nodejs.org/"
@@ -126,6 +126,6 @@ npm() {
 	mv "$pkgdir"/usr/lib/node_modules/npm "$subpkgdir"/usr/lib/node_modules/
 }
 
-sha512sums="72e78f8839543826025549022df9f23a71be3507261a387f82142d71d24065a23f9b905d7fd95a0940ac68355bfe0d81ee50c320eb46493e10e417cd975d3c8e  node-v10.14.2.tar.gz
+sha512sums="5570ff74924235f406186af26e7c5774cad9004f0c417345eb6d3e47d34b8284df004f64ee0c3dc14a84bf152d33f9e7e766aef099fd0172677759fc3309b1de  node-v10.15.1.tar.gz
 9d09a88074bf0093f35c5b610e73ebf4c5381df2a2b29feb69da1af0b18776a683b13f1276375bbcfc60936cc27769539e1f01b4ba94b22cad2d5f4daae14c46  dont-run-gyp-files-for-bundled-deps.patch
 4fd3f10bd82d1e851ed000169c2635c001a4a051283edf96f1efb2260e2d395199dd5843f79f1cff8f2c0c65462c44241c508ea67835dfbd9880d9196fae290a  link-with-libatomic-on-mips32.patch"


### PR DESCRIPTION
Bugfix release after security release https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#nodejs-10-changelog