### PR TITLE
community/nodejs-current: upgrade to 11.9.0

### DIFF
--- a/community/nodejs-current/APKBUILD
+++ b/community/nodejs-current/APKBUILD
@@ -18,7 +18,7 @@
 #
 pkgname=nodejs-current
 # The current stable version, i.e. non-LTS.
-pkgver=11.6.0
+pkgver=11.9.0
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - current stable version"
 url="https://nodejs.org/"
@@ -91,6 +91,6 @@ package() {
 	rm "$pkgdir"/usr/bin/npm "$pkgdir"/usr/bin/npx
 }
 
-sha512sums="d25f0fe9f12a3d23c09fa3a5794de42755661b82153f5216739690979588290f438f3f3e95566d6ec0b7021e7212afec42c8e08ecb98106f5cc4844a7d46df33  node-v11.6.0.tar.gz
+sha512sums="3f64a984e4aec7f2a283dc1610175e780ee108a0fc96b13d03f3c1fda4a69c2b867c32d3dba04c5149c44d9669ebc889c0279eb942e99e23a4136b33e4dc1ce7  node-v11.9.0.tar.gz
 3697009ae7bf90e7a83da33eac915de9cb32680cafc8003e727540f98942312699e0ee2ebf3014dea15b1f4bcf93f983eec521ad86d75073664c64f5fdeea84d  dont-run-gyp-files-for-bundled-deps.patch
 adba24239eb8ccb1d27664e9a8b2af0992e2b7b59d03d67bd18598bf0a266f1b572e312980face891f93fad0330488e2af1ab8f524c1798746adb64bed994831  link-with-libatomic-on-mips32.patch"


### PR DESCRIPTION
Ref https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V11.md#2019-01-17-version-1170-current-bridgear

PS related upgrade of `main/nodejs` https://github.com/alpinelinux/aports/pull/6139