### PR TITLE
testing/py-filelock: new aport

### DIFF
--- a/testing/py-filelock/APKBUILD
+++ b/testing/py-filelock/APKBUILD
@@ -1,0 +1,52 @@
+# Contributor: Dmitry Romanenko <dmitry@romanenko.in>
+# Maintainer: Dmitry Romanenko <dmitry@romanenko.in>
+pkgname=py-filelock
+_pkgname=filelock
+pkgver=3.0.10
+pkgrel=0
+pkgdesc="A platform independent file lock for Python"
+url="https://github.com/benediktschmitt/py-filelock"
+arch="noarch"
+license="Unlicense"
+depends=""
+checkdepends="pytest"
+makedepends="python2-dev python3-dev py-setuptools"
+subpackages="py3-$_pkgname:_py3 py2-$_pkgname:_py2"
+source="$pkgname-$pkgver.tar.gz::https://github.com/benediktschmitt/$pkgname/archive/v$pkgver.tar.gz"
+builddir="$srcdir"/$pkgname-$pkgver
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python2 -m pytest -xvv test.py
+	python3 -m pytest -xvv test.py
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="1fa4594eaba6689ea61149a60a71e86007297614a1c22dc6c94b4774520d396ff8ad03076dfdbb2ce49d2b6e42c374af065a115c167d81cf6107918abfbe52ef  py-filelock-3.0.10.tar.gz"


### PR DESCRIPTION
tl;dr dependency for tests of #6090 
Currently pointing to github releases instead of Pypi releases because tests somehow not included in tarball on pypi (?)
https://github.com/benediktschmitt/py-filelock/issues/48