### PR TITLE
testing/wireguard: upgrade to 0.0.20190123

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -3,7 +3,7 @@
 
 # NOTE: pkgrel must match _toolsrel in wireguard-vanilla
 pkgname=wireguard-tools
-pkgver=0.0.20181218
+pkgver=0.0.20190123
 pkgrel=2
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
@@ -62,5 +62,5 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="73c8e9b37d857349b75df776607c15ea2082814952acdba3ad6379c4ce631601db2767603e46ecadf1bce9348a0c26d07f4f6b5857ddd72bb4f4411d1d13d88c  WireGuard-0.0.20181218.tar.xz
+sha512sums="8be40cebabca2a40f98ee10d6fa93708b12b17c6b0eab9aa8b7fab353d78fbd5b280b7b90cb2973cf74a1b9d47c3d250bf3ede6d1318129a45d57e21329b7f59  WireGuard-0.0.20190123.tar.xz"
 4577574333f023217ae6e0945807e1ccd2dec7caa87e329b1d5b44569f6b5969663ad74f8154b85d3dc7063dd762649e3fa87c7667e238ffb77c0e5df9245a5e  alpine-compat.patch"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20181218
-_rel=0
+_ver=0.0.20190123
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="73c8e9b37d857349b75df776607c15ea2082814952acdba3ad6379c4ce631601db2767603e46ecadf1bce9348a0c26d07f4f6b5857ddd72bb4f4411d1d13d88c  WireGuard-0.0.20181218.tar.xz"
+sha512sums="8be40cebabca2a40f98ee10d6fa93708b12b17c6b0eab9aa8b7fab353d78fbd5b280b7b90cb2973cf74a1b9d47c3d250bf3ede6d1318129a45d57e21329b7f59  WireGuard-0.0.20190123.tar.xz"


### PR DESCRIPTION
* tools: curve25519: handle unaligned loads/stores safely

This should fix sporadic crashes with `wg pubkey` on certain architectures.

* netlink: auth socket changes against namespace of socket

In WireGuard, the underlying UDP socket lives in the namespace where the
interface was created and doesn't move if the interface is moved. This
allows one to create the interface in some privileged place that has
Internet access, and then move it into a container namespace that only
has the WireGuard interface for egress. Consider the following
situation:

1. Interface created in namespace A. Socket therefore lives in namespace A.
2. Interface moved to namespace B. Socket remains in namespace A.
3. Namespace B now has access to the interface and changes the listen
port and/or fwmark of socket. Change is reflected in namespace A.

This behavior is arguably _fine_ and perhaps even expected or
acceptable. But there's also an argument to be made that B should have
A's cred to do so. So, this patch adds a simple ns_capable check.

* ratelimiter: build tests with !IPV6

Should reenable building in debug mode for systems without IPv6.

* noise: replace getnstimeofday64 with ktime_get_real_ts64
* ratelimiter: totalram_pages is now a function
* qemu: enable FP on MIPS

Linux 5.0 support.

* keygen-html: bring back pure javascript implementation

Benoît Viguier has proofs that values will stay well within 2^53. We
also have an improved carry function that's much simpler. Probably more
constant time than emscripten's 64-bit integers.

* contrib: introduce simple highlighter library

This is the highlighter library being used in:
- https://twitter.com/EdgeSecurity/status/1085294681003454465
- https://twitter.com/EdgeSecurity/status/1081953278248796165

It's included here as a contrib example, so that others can paste it into
their own GUI clients for having the same strictly validating highlighting.

* netlink: use __kernel_timespec for handshake time

This readies us for Y2038. See https://lwn.net/Articles/776435/ for more info.