### PR TITLE
community/tint2: fix download link, upgrade to 16.6.1

### DIFF
--- a/community/tint2/APKBUILD
+++ b/community/tint2/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=tint2
-pkgver=16.6
+pkgver=16.6.1
 pkgrel=0
 pkgdesc="tint2 is a simple unintrusive panel/taskbar"
 url="https://gitlab.com/o9000/tint2"
@@ -15,7 +15,7 @@ makedepends="cmake imlib2-dev glib-dev pango-dev cairo-dev
     libxcomposite-dev libxdamage-dev libxinerama-dev libxrandr-dev
     gtk+-dev librsvg-dev startup-notification-dev linux-headers"
 subpackages="$pkgname-doc $pkgname-lang"
-source="https://sources.voidlinux.eu/$pkgname-$pkgver/$pkgname-v$pkgver.tar.bz2"
+source="https://gitlab.com/o9000/$pkgname/-/archive/v$pkgver/$pkgname-v$pkgver.tar.bz2"
 builddir="$srcdir"/$pkgname-v${pkgver}
 
 prepare() {
@@ -41,4 +41,4 @@ package() {
 	make DESTDIR="${pkgdir}" install
 }
 
-sha512sums="0fbe6ddadd885f17f205496f79042d85b9b5f93e378119a9aef3b59ac8a256c37530850f7719b51ebeab88722d54822f923be8eac37e01fd65d857161b98eab2  tint2-v16.6.tar.bz2"
+sha512sums="d82e64883f40ae93daa67b4dc0aaa530456d28ee2d52c224d8eb1c91bc59bc43ba530843250274079e1567cd30eb9fd1eb79324aeec1af4bb3d748a046fd93aa  tint2-v16.6.1.tar.bz2"


### PR DESCRIPTION
https://gitlab.com/o9000/tint2/blob/master/ChangeLog#L6