### PR TITLE
[3.8] main/subversion: security upgrade to 1.10.4

### DIFF
--- a/main/subversion/APKBUILD
+++ b/main/subversion/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=subversion
-pkgver=1.10.0
+pkgver=1.10.4
 pkgrel=0
 pkgdesc="Replacement for CVS, another versioning system (svn)"
-url="http://subversion.apache.org"
+url="https://subversion.apache.org"
 arch="all"
 license="Apache-2.0 BSD"
 depends=
@@ -21,6 +21,8 @@ source="https://archive.apache.org/dist/subversion/$pkgname-$pkgver.tar.bz2
 	svnserve.initd"
 
 # secfixes:
+#   1.10.4-r0:
+#     - CVE-2018-11803
 #   1.9.7-r0:
 #     - CVE-2017-9800
 
@@ -105,7 +107,7 @@ py() {
 	mv "$pkgdir"/usr/lib/*py* "${subpkgdir}${pypath}"
 }
 
-sha512sums="26e49c961d54c4e78067caa202f384c36544e0ce7506abbffe73e59186ac34559a70cbd6c0934ed47dcc5c3580fce0f0cc2ef14b77695c26e8dbbc6358d1ec6a  subversion-1.10.0.tar.bz2
+sha512sums="c44a4a4a9533cd4f4cb6ddbc3ce98585a96da6c8e75497d087034b52f899797bb0972dfc0e79db99e81149e59e7fa765398c6ad35eba64f11f4ae9c3b3537434  subversion-1.10.4.tar.bz2
 fb219c45b80602d919176cc191394df09f90d0f5c7d24e6a36b166bd92777ecae67eeac1e49c0ffbb0e724396b3d2094dbb0bef17d01dc87d418b1cd554bd7c4  subversion-1.7.0-deplibs.patch
 fd6e5f45cff4d3cf0d885a34c822b32141b13b199d99ad8e1b04d641c9c1ee27e73f5c556a4ad54a900b6d39cc14afad17b6738d8af44c76758f1a27b4d49f9a  subversion-perl-deplibs.patch
 7fe993443d4d3ef5e1e75f60e85036ee0b2bb2636c2c830210e64f525f95ae4c10ca1dc4504fc36915ec9391815becbe7cbf5f589c28609386d8d079ed02c630  svnserve.confd


### PR DESCRIPTION
https://subversion.apache.org/security/CVE-2018-11803-advisory.txt

See also #6000