### PR TITLE
community/go: security upgrade to 1.11.5 - CVE-2019-6486

### DIFF
--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=go
-pkgver=1.11.4
+pkgver=1.11.5
 pkgrel=0
 pkgdesc="Go programming language compiler"
 url="http://www.golang.org/"
@@ -22,6 +22,8 @@ x86) options="!check" ;; # FIXME
 esac
 
 # secfixes:
+#   1.11.5-r0:
+#     - CVE-2019-6486
 #   1.9.4-r0:
 #     - CVE-2018-6574
 
@@ -124,6 +126,6 @@ package() {
 		-exec rm -rf \{\} \+
 }
 
-sha512sums="9aa2e1800807841ec0432289b672c1607bdcb295f29c02d38adfaf1e3bf043040c9f916e4cb170875d92fe168c5ba6baef2b3d1f824a56ff9138ca2cdcc646e0  go1.11.4.src.tar.gz
+sha512sums="63500238e8d73e4b29279ee3eb9242960de93ccd3b52bacc4009f45cf123cb8edfe5f519d38c5b07bdf2a810925758511ff3255310a056113d0169f78be1d2f6  go1.11.5.src.tar.gz
 a8f3afd97992f03ccf2680cde214eefccac47daeb9eeb689b5e0b206ea3c19cfb23d448a4eb532894d830d4b91cd97b249e88f04c17feba02d9e243b40243bd0  default-buildmode-pie.patch
 faf8de430df185842902322f064254f3e9ecee0884b3075b5550c85da15ff61ea6c2bb8d0fb7cf3887abc0e40974bd73ee8f8c14da7f914dde7e9220177c4e2a  set-external-linker.patch"


### PR DESCRIPTION
Ref https://github.com/golang/go/issues/29903