### PR TITLE
community/qt5-qtwebengine: Fix x86

### DIFF
--- a/community/qt5-qtwebengine/APKBUILD
+++ b/community/qt5-qtwebengine/APKBUILD
@@ -1,12 +1,11 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=qt5-qtwebengine
 pkgver=5.12.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Qt5 - QtWebEngine components"
 url="http://qt-project.org/"
 # ppc64le, s390x: not supported
-# x86: fails to build
-arch="all !ppc64le !x86 !s390x"
+arch="all !ppc64le !s390x"
 license="LGPL-2.0 with exceptions or GPL-3.0 with exceptions"
 depends=""
 depends_dev="qt5-qtdeclarative-dev qt5-qtwebchannel-dev gstreamer-dev gst-plugins-base-dev
@@ -80,6 +79,7 @@ source="http://download.qt-project.org/$_rel/qt/${pkgver%.*}/$_ver/submodules/qt
 	musl-sandbox.patch
 	yasm-nls.patch
 	arm-missing-files.patch
+	Fix-x86-32-builds-with-GCC-8.patch
 	"
 builddir="$srcdir"/qtwebengine-everywhere-src-$_V
 
@@ -115,4 +115,5 @@ b1f7823d0bdd14dbcb4dbd72ab2d16460d343722d2601921a50f8912ce580a632e0d7b01d7fea6f2
 b37fbc4df03c82123f94982039defa12d9bb8c885c9dcf8fff556b5f9cc58182fa471f970cc3a5e2d5dbe964855f591b474366b6a8926d94ae6a78e883811c1a  qt-musl-thread-stacksize.patch
 635d77109b5ce9bc9697d621f1bf98193903e2ac69fc4079fb92f175daa80147fed8ae15544d239ef680e120474d8f811002935ef1a078836ba01695f9ddfcb9  musl-sandbox.patch
 f6b1941e40f44b675ab554166e3cd8d3272b23f48571b4949b3af7b8e1c642ee84fe0ee26dd2457fc3bf20e9924cddb411e293b7a8a103029ee196587371a1e2  yasm-nls.patch
-2f99cb38352c34281508cbd1e676bffc4ed6835b68d59e871bb7f4a3898d5735c6455e9ea7fe00c22770a2e0238282eb98e0faddd597b63dfda5ab65acdf1d97  arm-missing-files.patch"
+2f99cb38352c34281508cbd1e676bffc4ed6835b68d59e871bb7f4a3898d5735c6455e9ea7fe00c22770a2e0238282eb98e0faddd597b63dfda5ab65acdf1d97  arm-missing-files.patch
+a884ea38a2244a5fa3cef8afd7d2c88b0429cab70bd091511c75906f436d9515260cebb84212b166552acbfb925ee5b612f141eb30f0dd73c84506ccab7ce2ce  Fix-x86-32-builds-with-GCC-8.patch"

--- a/community/qt5-qtwebengine/Fix-x86-32-builds-with-GCC-8.patch
+++ b/community/qt5-qtwebengine/Fix-x86-32-builds-with-GCC-8.patch
@@ -1,0 +1,36 @@
+From 0c72e11fee13749f697ab87d9f6b04c835696657 Mon Sep 17 00:00:00 2001
+From: Allan Sandfeld Jensen <allan.jensen@qt.io>
+Date: Mon, 10 Dec 2018 14:32:13 +0100
+Subject: [PATCH] Fix x86-32 builds with GCC 8
+
+The C++11 alignof() now returns minimum alignment and not
+prefered alignment which Chromium expects.
+
+Change-Id: I7aadb426e6e15b4f2317cafdde550ea74e4c1ccf
+Fixes: QTBUG-72391
+Reviewed-by: Michal Klocek <michal.klocek@qt.io>
+---
+ src/3rdparty/chromium/mojo/public/c/system/macros.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/3rdparty/chromium/mojo/public/c/system/macros.h b/src/3rdparty/chromium/mojo/public/c/system/macros.h
+index 6de4a913de..87016c431d 100644
+--- a/src/3rdparty/chromium/mojo/public/c/system/macros.h
++++ b/src/3rdparty/chromium/mojo/public/c/system/macros.h
+@@ -27,10 +27,10 @@
+   (sizeof(void*) == 4 ? 32 : 0)
+ 
+ // Like the C++11 |alignof| operator.
+-#if __cplusplus >= 201103L
+-#define MOJO_ALIGNOF(type) alignof(type)
+-#elif defined(__GNUC__)
++#if defined(__GNUC__)
+ #define MOJO_ALIGNOF(type) __alignof__(type)
++#elif __cplusplus >= 201103L
++#define MOJO_ALIGNOF(type) alignof(type)
+ #elif defined(_MSC_VER)
+ // The use of |sizeof| is to work around a bug in MSVC 2010 (see
+ // http://goo.gl/isH0C; supposedly fixed since then).
+-- 
+2.16.3
+


### PR DESCRIPTION
I took the patch from https://codereview.qt-project.org/#/c/247777/
and I changed the file paths from chromium to src/3rdparty/chromium
to match the structure of the source tarball.

I can confirm that qt5-qtwebengine now compiles for x86.