### PR TITLE
community/firejail: upgrade to 0.9.56 LTS release

### DIFF
--- a/community/firejail/APKBUILD
+++ b/community/firejail/APKBUILD
@@ -2,7 +2,8 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=firejail
 pkgver=0.9.56
-pkgrel=0
+_extraver=LTS-release
+pkgrel=1
 pkgdesc="Linux namespaces and seccomp-bpf sandbox"
 url="https://firejail.wordpress.com/"
 arch="all"
@@ -12,8 +13,8 @@ makedepends="linux-headers"
 checkdepends="expect"
 options="suid"
 subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch"
-source="$pkgname-$pkgver.tar.gz::https://github.com/netblue30/$pkgname/archive/$pkgver.tar.gz"
-builddir="$srcdir/$pkgname-$pkgver"
+source="$pkgname-$pkgver.tar.gz::https://github.com/netblue30/$pkgname/archive/$pkgver-$_extraver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver-$_extraver"
 
 prepare() {
 	default_prepare
@@ -55,4 +56,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="bff0ec4d3a5834e9aacb2e06a7b53333f58d2da4b594f214397ef93384a9f1da496ea805ee79567c2e6546a475af817e2c93a653dc5e5e5cdc5a68ca49fce86a  firejail-0.9.56.tar.gz"
+sha512sums="50824780bbf3ebe86606c4f901224b42d8e427b3ddaf6818848a1259b84c8a0d619b561cfaab9018e24eecae6c0ffff98698efbf37e5934221e9b6c822c9298a  firejail-0.9.56.tar.gz"


### PR DESCRIPTION
  * code based on Firejail version `0.9.56`
  * much smaller code base for SUID executable
  * command line options removed:
```
     --audit, --build, --cgroup, --chroot, --get, --ls, --output,
     --output-stderr, --overlay, --overlay-named, --overlay-tmpfs,
     --overlay-clean, --private-home, --private-bin, --private-etc,
     --private-opt, --private-srv, --put, --rlimit*, --trace, --tracelog,
     --x11*, --xephyr*
```