### PR TITLE
testing/capnproto: new aport

### DIFF
--- a/testing/capnproto/APKBUILD
+++ b/testing/capnproto/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 pkgname=capnproto
 pkgver=0.7.0
-pkgrel=1
+pkgrel=0
 pkgdesc="Tools for working with the Cap'n Proto format"
 url="https://capnproto.org/"
 arch="all"

--- a/testing/capnproto/APKBUILD
+++ b/testing/capnproto/APKBUILD
@@ -1,0 +1,40 @@
+# Contributor: Nick Black <dankamongmen@gmail.com>
+# Maintainer:
+pkgname=capnproto
+pkgver=0.7.0
+pkgrel=1
+pkgdesc="Tools for working with the Cap'n Proto format"
+url="https://capnproto.org/"
+arch="all"
+license="MIT"
+depends=
+makedepends="linux-headers"
+subpackages="$pkgname-dev"
+source="https://capnproto.org/$pkgname-c++-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-c++-$pkgver"
+
+build() {
+	cd "$builddir"
+	./configure --prefix=/usr/ --without-openssl
+	make
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make install DESTDIR="$pkgdir"
+}
+
+# We want to move the schema compilers into the dev package.
+# See https://wiki.alpinelinux.org/wiki/APKBUILD_Reference#dev.28.29
+dev() {
+	default_dev
+  mkdir -p "$subpkgdir"/usr/bin
+	mv "$pkgdir"/usr/bin/* "$subpkgdir"/usr/bin
+}
+
+sha512sums="9f8fb5753155798fcf9377a87f984a54d9fc5157c41aa11cd94108a773ca22d6e6952657e2d8079c9806f7de06f316c94957329fa52dbab6207aaa3b52348f04  capnproto-c++-0.7.0.tar.gz"

--- a/testing/capnproto/APKBUILD
+++ b/testing/capnproto/APKBUILD
@@ -33,7 +33,7 @@ package() {
 # See https://wiki.alpinelinux.org/wiki/APKBUILD_Reference#dev.28.29
 dev() {
 	default_dev
-  mkdir -p "$subpkgdir"/usr/bin
+	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/* "$subpkgdir"/usr/bin
 }
 


### PR DESCRIPTION
Cap'n Proto serialization and RPC library and tools v0.7.0.
Generates two packages: capnproto and capnproto-dev. The latter
includes schema compilers, along with headers and linkables.
The upstream test suite is run via check(). Built against Edge.
Alpha-level TLS RPC support is not built, following Debian's lead.