### PR TITLE
testing/traefik: don't break sshd

### DIFF
--- a/testing/traefik/APKBUILD
+++ b/testing/traefik/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Joe Holden <jwh@zorins.us>
 pkgname=traefik
 pkgver=1.7.7
-pkgrel=1
+pkgrel=2
 pkgdesc="The Cloud Native Edge Router"
 url="https://traefik.io"
 arch="all !x86 !s390x !armhf !armv7" # tests fails on x86 and armhf

--- a/testing/traefik/traefik.pre-install
+++ b/testing/traefik/traefik.pre-install
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 addgroup -S traefik 2>/dev/null
-adduser -S -D -h /var/empty -s /sbin/nologin -G traefik -g traefik traefik 2>/dev/null
+adduser -S -H -D -h /var/empty -s /sbin/nologin -G traefik -g traefik traefik 2>/dev/null
 
 exit 0


### PR DESCRIPTION
Add -H to adduser in .pre-install so adduser doesn't change the ownership of /var/empty