### PR TITLE
testing/redo: fix check failing due to missing /dev/tty

### DIFF
--- a/testing/redo/APKBUILD
+++ b/testing/redo/APKBUILD
@@ -2,16 +2,16 @@
 # Maintainer: Kevin Daudt <kdaudt@alpinelinux.org>
 pkgname=redo
 pkgver=0.41
-pkgrel=1
+pkgrel=2
 pkgdesc="Smaller, easier, more powerful, and more reliable than make"
 url="https://redo.readthedocs.io/en/latest/"
-# arch="noarch"
+arch="noarch"
 license="Apache-2.0"
 depends="python2"
 makedepends="python2 perl"
 subpackages="$pkgname-doc"
-options="!check" # FIXME fails
-source="https://github.com/apenwarr/redo/archive/redo-${pkgver}.tar.gz"
+source="https://github.com/apenwarr/redo/archive/redo-${pkgver}.tar.gz
+        skip-when-tty-missing.patch"
 builddir="$srcdir/redo-redo-${pkgver}"
 
 build() {
@@ -36,4 +36,5 @@ package() {
         DESTDIR="$pkgdir" PREFIX="/usr" ./do install
 }
 
-sha512sums="94e4414a2f8120e5d4a949461734ed69dc2f39edfb7929d2efff83041ac0b941e037359ccfafcb4eff760608274e32c579df56d58fdb67b13b8a26eb1945b0d0  redo-0.41.tar.gz"
+sha512sums="94e4414a2f8120e5d4a949461734ed69dc2f39edfb7929d2efff83041ac0b941e037359ccfafcb4eff760608274e32c579df56d58fdb67b13b8a26eb1945b0d0  redo-0.41.tar.gz
+bc622d6a4b2c270f4f7791bb545d9f0a34a3c993f4a03dd901c4419c4f82ffeb43d210972f29abada14ba9eae812040c2c5a76ffdcfc744bb01fd5c32fa0ca89  skip-when-tty-missing.patch"

--- a/testing/redo/skip-when-tty-missing.patch
+++ b/testing/redo/skip-when-tty-missing.patch
@@ -1,0 +1,20 @@
+diff --git a/redo/builder.py b/redo/builder.py.new
+index e55955f7f9..160cba8dfe 100644
+--- a/redo/builder.py
++++ b/redo/builder.py.new
+@@ -1,5 +1,5 @@
+ """Code for parallel-building a set of targets, if needed."""
+-import errno, os, stat, signal, sys, tempfile, time
++import errno, os, os.path, stat, signal, sys, tempfile, time
+ from . import cycles, env, jobserver, logs, state, paths
+ from .helpers import unlink, close_on_exec
+ from .logs import debug2, err, warn, meta
+@@ -99,6 +99,8 @@ def await_log_reader():
+     if not env.v.LOG:
+         return
+     if log_reader_pid > 0:
++        if not os.path.exists('/dev/tty'):
++            return
+         # never actually close fd#1 or fd#2; insanity awaits.
+         # replace it with something else instead.
+         # Since our stdout/stderr are attached to redo-log's stdin,


### PR DESCRIPTION
On the builders, the checks failed because they tried to open /dev/tty,
which does not exists.

Add a patch that continues when /dev/tty is missing.

Re-enable redo