### PR TITLE
main/dpkg: add changelog scripts

### DIFF
--- a/main/dpkg/APKBUILD
+++ b/main/dpkg/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dpkg
 pkgver=1.19.2
-pkgrel=0
+pkgrel=1
 pkgdesc="The Debian Package Manager"
 url="http://packages.debian.org/dpkg"
 arch="all"
@@ -58,7 +58,9 @@ dev() {
 		"$pkgdir"/usr/bin/dpkg-genchanges \
 		"$pkgdir"/usr/bin/dpkg-gencontrol \
 		"$pkgdir"/usr/bin/dpkg-gensymbols \
+		"$pkgdir"/usr/bin/dpkg-mergechangelogs \
 		"$pkgdir"/usr/bin/dpkg-name \
+		"$pkgdir"/usr/bin/dpkg-parsechangelog \
 		"$pkgdir"/usr/bin/dpkg-scanpackages \
 		"$pkgdir"/usr/bin/dpkg-scansources \
 		"$pkgdir"/usr/bin/dpkg-shlibdeps \


### PR DESCRIPTION
Add the dpkg-mergechangelogs and dpkg-parsechangelogs Perl scripts
to the dpkg-dev subpackage (derived from the dpkg source package).
Tested against Edge; both scripts appear to work as expected.
BTW, dpkg-dev 1.19.4 is now available, but I have not updated.