### PR TITLE
[3.8] community/wireshark: security upgrade to 2.4.12

### DIFF
--- a/community/wireshark/APKBUILD
+++ b/community/wireshark/APKBUILD
@@ -3,10 +3,10 @@
 # Contributor: Jeremy Thomerson <jeremy@thomersonfamily.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=wireshark
-pkgver=2.4.11
+pkgver=2.4.12
 pkgrel=0
 pkgdesc="A network protocol analyzer - GTK version"
-url="http://www.wireshark.org"
+url="https://www.wireshark.org"
 arch="all"
 license="GPL-2.0-or-later"
 depends=""
@@ -14,12 +14,17 @@ makedepends="bison flex perl-dev glib glib-dev libpcap-dev libcap-dev
 	gtk+3.0-dev c-ares-dev pcre-dev gnutls-dev libgcrypt-dev libressl-dev
 	libnl3-dev qt5-qtbase-dev qt5-qttools-dev lua5.2-dev bash portaudio-dev"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-gtk $pkgname-common tshark"
-source="http://www.wireshark.org/download/src/$pkgname-$pkgver.tar.xz
+source="https://www.wireshark.org/download/src/$pkgname-$pkgver.tar.xz
 	fix-udpdump.patch
         "
 builddir="$srcdir"/$pkgname-$pkgver
 
 # secfixes:
+#   2.4.12-r0:
+#     - CVE-2019-5717
+#     - CVE-2019-5718
+#     - CVE-2019-5719
+#     - CVE-2019-5721
 #   2.4.11-r0:
 #     - CVE-2018-19622
 #     - CVE-2018-19623
@@ -215,5 +220,5 @@ gtk() {
 	mv "$pkgdir"/usr/bin/wireshark-gtk "$subpkgdir"/usr/bin/
 }
 
-sha512sums="ad3afdeaf70257f5bb95772b4f14bf1207e5b0119065853e040d7e2ec17a431d5476b7afd113ecfa59de7586968a9130ed501bd85d3fd410b18f99f9d75676d9  wireshark-2.4.11.tar.xz
+sha512sums="444611ccf03d8b108a2f4f25b818e732db1c2e96fde30cfe4ac5852c78335b64df2631da66cc1c37cd683232980952a9d188dcbe722ea4a61749b64331f7e2ba  wireshark-2.4.12.tar.xz
 951677dd125b1e36b351cc87a98e8b8d0391d184c7695594dd4270334d86ada1dff5f14cd960da9c5d5d26fc801c42f0219b2db6269f3c526c841c7940d2f369  fix-udpdump.patch"


### PR DESCRIPTION
https://www.wireshark.org/docs/relnotes/wireshark-2.6.6.html
#6180