### PR TITLE
[3.7] community/wireshark: security upgrade to 2.4.12

### DIFF
--- a/community/wireshark/APKBUILD
+++ b/community/wireshark/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Jeremy Thomerson <jeremy@thomersonfamily.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=wireshark
-pkgver=2.4.8
+pkgver=2.4.9
 pkgrel=0
 pkgdesc="A network protocol analyzer - GTK version"
 url="http://www.wireshark.org"
@@ -20,6 +20,10 @@ source="http://www.wireshark.org/download/src/$pkgname-$pkgver.tar.xz
 builddir="$srcdir"/$pkgname-$pkgver
 
 # secfixes:
+#   2.4.9-r0:
+#     - CVE-2018-16056
+#     - CVE-2018-16057
+#     - CVE-2018-16058
 #   2.4.8-r0:
 #     - CVE-2018-14339
 #     - CVE-2018-14340
@@ -199,5 +203,5 @@ gtk() {
 	mv "$pkgdir"/usr/bin/wireshark-gtk "$subpkgdir"/usr/bin/
 }
 
-sha512sums="98a0ac3f2fba48a76e426621c9ae5d42f673b9181ea635cace2a491b1cba500eee0abd839fa3bb63c25b3e8c8786bea830df01a921a542a1b9806c848e2cdf07  wireshark-2.4.8.tar.xz
+sha512sums="c6c30c8cde4256f308e0553dea20b64812781c2c7ae5a26eac9c3cbfc18de6b4c2fd19a3d742807d3d310f163d912db52f8fe2cc6a4061d6c67ec56ecca76da2  wireshark-2.4.9.tar.xz
 951677dd125b1e36b351cc87a98e8b8d0391d184c7695594dd4270334d86ada1dff5f14cd960da9c5d5d26fc801c42f0219b2db6269f3c526c841c7940d2f369  fix-udpdump.patch"

--- a/community/wireshark/APKBUILD
+++ b/community/wireshark/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Jeremy Thomerson <jeremy@thomersonfamily.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=wireshark
-pkgver=2.4.9
+pkgver=2.4.10
 pkgrel=0
 pkgdesc="A network protocol analyzer - GTK version"
 url="http://www.wireshark.org"
@@ -20,6 +20,11 @@ source="http://www.wireshark.org/download/src/$pkgname-$pkgver.tar.xz
 builddir="$srcdir"/$pkgname-$pkgver
 
 # secfixes:
+#   2.4.10-r0:
+#     - CVE-2018-12086
+#     - CVE-2018-18225
+#     - CVE-2018-18226
+#     - CVE-2018-18227
 #   2.4.9-r0:
 #     - CVE-2018-16056
 #     - CVE-2018-16057
@@ -203,5 +208,5 @@ gtk() {
 	mv "$pkgdir"/usr/bin/wireshark-gtk "$subpkgdir"/usr/bin/
 }
 
-sha512sums="c6c30c8cde4256f308e0553dea20b64812781c2c7ae5a26eac9c3cbfc18de6b4c2fd19a3d742807d3d310f163d912db52f8fe2cc6a4061d6c67ec56ecca76da2  wireshark-2.4.9.tar.xz
+sha512sums="fc98e9b791fd99a7c0a0a7b0f0f0ec7e90c51b2a413bceacdacaafdbb325a66b3ad6263ca3bb8f97f808771b826f0219e374cf4458695b52f5ce0df65693e033  wireshark-2.4.10.tar.xz
 951677dd125b1e36b351cc87a98e8b8d0391d184c7695594dd4270334d86ada1dff5f14cd960da9c5d5d26fc801c42f0219b2db6269f3c526c841c7940d2f369  fix-udpdump.patch"

--- a/community/wireshark/APKBUILD
+++ b/community/wireshark/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Jeremy Thomerson <jeremy@thomersonfamily.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=wireshark
-pkgver=2.4.7
+pkgver=2.4.8
 pkgrel=0
 pkgdesc="A network protocol analyzer - GTK version"
 url="http://www.wireshark.org"
@@ -20,6 +20,17 @@ source="http://www.wireshark.org/download/src/$pkgname-$pkgver.tar.xz
 builddir="$srcdir"/$pkgname-$pkgver
 
 # secfixes:
+#   2.4.8-r0:
+#     - CVE-2018-14339
+#     - CVE-2018-14340
+#     - CVE-2018-14341
+#     - CVE-2018-14342
+#     - CVE-2018-14343
+#     - CVE-2018-14344
+#     - CVE-2018-14367
+#     - CVE-2018-14368
+#     - CVE-2018-14369
+#     - CVE-2018-14370
 #   2.4.7-r0:
 #     - CVE-2018-11356
 #     - CVE-2018-11357
@@ -188,5 +199,5 @@ gtk() {
 	mv "$pkgdir"/usr/bin/wireshark-gtk "$subpkgdir"/usr/bin/
 }
 
-sha512sums="bb6a75de86a578947b44c10e7b5f9348059856356872cc7bbb76f5edef797e29137c3a4f2528595eced4fecf7fccab8d4bbbc167da9c65c4ae31131d5a2fb5a4  wireshark-2.4.7.tar.xz
+sha512sums="98a0ac3f2fba48a76e426621c9ae5d42f673b9181ea635cace2a491b1cba500eee0abd839fa3bb63c25b3e8c8786bea830df01a921a542a1b9806c848e2cdf07  wireshark-2.4.8.tar.xz
 951677dd125b1e36b351cc87a98e8b8d0391d184c7695594dd4270334d86ada1dff5f14cd960da9c5d5d26fc801c42f0219b2db6269f3c526c841c7940d2f369  fix-udpdump.patch"

--- a/community/wireshark/APKBUILD
+++ b/community/wireshark/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Jeremy Thomerson <jeremy@thomersonfamily.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=wireshark
-pkgver=2.4.10
+pkgver=2.4.11
 pkgrel=0
 pkgdesc="A network protocol analyzer - GTK version"
 url="http://www.wireshark.org"
@@ -20,6 +20,13 @@ source="http://www.wireshark.org/download/src/$pkgname-$pkgver.tar.xz
 builddir="$srcdir"/$pkgname-$pkgver
 
 # secfixes:
+#   2.4.11-r0:
+#     - CVE-2018-19622
+#     - CVE-2018-19623
+#     - CVE-2018-19624
+#     - CVE-2018-19625
+#     - CVE-2018-19626
+#     - CVE-2018-19627
 #   2.4.10-r0:
 #     - CVE-2018-12086
 #     - CVE-2018-18225
@@ -208,5 +215,5 @@ gtk() {
 	mv "$pkgdir"/usr/bin/wireshark-gtk "$subpkgdir"/usr/bin/
 }
 
-sha512sums="fc98e9b791fd99a7c0a0a7b0f0f0ec7e90c51b2a413bceacdacaafdbb325a66b3ad6263ca3bb8f97f808771b826f0219e374cf4458695b52f5ce0df65693e033  wireshark-2.4.10.tar.xz
+sha512sums="ad3afdeaf70257f5bb95772b4f14bf1207e5b0119065853e040d7e2ec17a431d5476b7afd113ecfa59de7586968a9130ed501bd85d3fd410b18f99f9d75676d9  wireshark-2.4.11.tar.xz
 951677dd125b1e36b351cc87a98e8b8d0391d184c7695594dd4270334d86ada1dff5f14cd960da9c5d5d26fc801c42f0219b2db6269f3c526c841c7940d2f369  fix-udpdump.patch"

--- a/community/wireshark/APKBUILD
+++ b/community/wireshark/APKBUILD
@@ -3,10 +3,10 @@
 # Contributor: Jeremy Thomerson <jeremy@thomersonfamily.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=wireshark
-pkgver=2.4.11
+pkgver=2.4.12
 pkgrel=0
 pkgdesc="A network protocol analyzer - GTK version"
-url="http://www.wireshark.org"
+url="https://www.wireshark.org"
 arch="all"
 license="GPL2+"
 depends=""
@@ -14,12 +14,17 @@ makedepends="bison flex perl-dev glib glib-dev libpcap-dev libcap-dev
 	gtk+3.0-dev c-ares-dev pcre-dev gnutls-dev libgcrypt-dev libressl-dev
 	libnl3-dev qt5-qtbase-dev qt5-qttools-dev lua5.2-dev bash portaudio-dev"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-gtk $pkgname-common tshark"
-source="http://www.wireshark.org/download/src/$pkgname-$pkgver.tar.xz
+source="https://www.wireshark.org/download/src/$pkgname-$pkgver.tar.xz
 	fix-udpdump.patch
         "
 builddir="$srcdir"/$pkgname-$pkgver
 
 # secfixes:
+#   2.4.12-r0:
+#     - CVE-2019-5717
+#     - CVE-2019-5718
+#     - CVE-2019-5719
+#     - CVE-2019-5721
 #   2.4.11-r0:
 #     - CVE-2018-19622
 #     - CVE-2018-19623
@@ -215,5 +220,5 @@ gtk() {
 	mv "$pkgdir"/usr/bin/wireshark-gtk "$subpkgdir"/usr/bin/
 }
 
-sha512sums="ad3afdeaf70257f5bb95772b4f14bf1207e5b0119065853e040d7e2ec17a431d5476b7afd113ecfa59de7586968a9130ed501bd85d3fd410b18f99f9d75676d9  wireshark-2.4.11.tar.xz
+sha512sums="444611ccf03d8b108a2f4f25b818e732db1c2e96fde30cfe4ac5852c78335b64df2631da66cc1c37cd683232980952a9d188dcbe722ea4a61749b64331f7e2ba  wireshark-2.4.12.tar.xz
 951677dd125b1e36b351cc87a98e8b8d0391d184c7695594dd4270334d86ada1dff5f14cd960da9c5d5d26fc801c42f0219b2db6269f3c526c841c7940d2f369  fix-udpdump.patch"


### PR DESCRIPTION
https://www.wireshark.org/docs/relnotes/wireshark-2.6.6.html
#6180