### PR TITLE
main/busybox: add program to get hw-provided clocksource on s390x

### DIFF
--- a/main/busybox/APKBUILD
+++ b/main/busybox/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=busybox
 pkgver=1.29.3
-pkgrel=10
+pkgrel=11
 pkgdesc="Size optimized toolbox of many common UNIX utilities"
 url=http://busybox.net
 arch="all"
@@ -47,6 +47,7 @@ source="https://busybox.net/downloads/$pkgname-$pkgver.tar.bz2
 	dad.if-up
 	nologin.c
 	ssl_client.c
+	tod_s390x.c
 	"
 
 # secfixes:
@@ -93,6 +94,7 @@ build() {
 		.config
 	make -C "$builddir" O="$PWD" silentoldconfig
 	make
+	[ "$CARCH" = "s390x" ] && gcc -o tod_s390x "$srcdir"/tod_s390x.c
 
 	# build dynamic (extras)
 	cd "$_dyndir_extras"
@@ -137,6 +139,7 @@ package() {
 	install -m755 busybox "$pkgdir"/bin/busybox || return 1
 	# we need /bin/sh to be able to execute post-install
 	ln -s /bin/busybox "$pkgdir"/bin/sh
+	[ "$CARCH" = "s390x" ] && install -Dm755 tod_s390x "$pkgdir"/bin/tod_s390x
 
 	#ifupdown needs those dirs to be present
 	mkdir -p \
@@ -229,4 +232,5 @@ aa93095e20de88730f526c6f463cef711b290b9582cdbd8c1ba2bd290019150cbeaa7007c2e15f03
 0becc2186d6c32fb0c401cf7bc0e46268b38ce8892db33be1daf40273024c1c02d518283f44086a313a2ccef34230a1d945ec148cc173f26e6aa9d88a7426e54  bbsuid.c
 b993ce589685d5d1f806153d0b7f71657f2d37556654ec60884130a40f09acc4944a13e0a4d02914000bedd779e5a35da08c760fed5f7ca5b601243aff7ba2c9  dad.if-up
 061f7417c1cbf0424a5fab77e2f5912aa1593f39b33ea294af4c03518ca712d793a77ea82ff1f36e9cb98751d9faacb9d0240cdf0894efd8f26c13c28a692404  nologin.c
-646ad9aefe3596d0170d92c8506ca1846e43b5b83cbef97ae565f15ffa7b14665a8c7061bc69c608c043f834c134c5d63f042509f8999031e89163508a868e46  ssl_client.c"
+646ad9aefe3596d0170d92c8506ca1846e43b5b83cbef97ae565f15ffa7b14665a8c7061bc69c608c043f834c134c5d63f042509f8999031e89163508a868e46  ssl_client.c
+c6d503aa43d73647e04656c611454afe0c638a7598486579ffa9de53248b6d48d95789054c37fdd6d580e217419f6078edaf1c2a5f25b0ad0e3fdee78f33a24c  tod_s390x.c"

--- a/main/busybox/tod_s390x.c
+++ b/main/busybox/tod_s390x.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+void main(){
+	unsigned long val;
+	asm volatile("stck 0(%1)" : "=m" (val) : "a" (&val) : "cc");
+	val = ((val >> 9) * 125) + (((val & 0x1ff) * 125) >> 9);
+	printf("%lu", val / 1000000000UL - 2208988800);
+}


### PR DESCRIPTION
References:
qemu/include/qemu/timer.h
qemu/include/hw/s390x/tod.h

Thanks to David Hildenbrand.