### PR TITLE
testing/nlohmann-json: new aport

### DIFF
--- a/testing/nlohmann-json/APKBUILD
+++ b/testing/nlohmann-json/APKBUILD
@@ -1,0 +1,39 @@
+# Contributor: Nick Black <dankamongmen@gmail.com>
+# This is a headers-only implementaiton; there are no libraries.
+pkgname=nlohmann-json-dev
+pkgver=3.5.0
+pkgrel=0
+pkgdesc="JSON for Modern C++"
+url="https://github.com/nlohmann/json"
+arch="noarch"
+license="MIT"
+depends=""
+makedepends="doxygen"
+install=""
+subpackages="nlohmann-json-doc"
+source="nlohmann-json-$pkgver.tar.gz::https://github.com/nlohmann/json/archive/v$pkgver.tar.gz"
+builddir="$srcdir/json-$pkgver"
+
+build() {
+	cd "$builddir"
+	make -C doc
+}
+
+check() {
+	cd "$builddir"
+	make check-fast
+}
+
+package() {
+	cd "$builddir"
+	mkdir -p "$pkgdir/usr/include"
+	mv include/nlohmann "$pkgdir/usr/include"
+}
+
+doc() {
+	cd "$builddir"
+	mkdir -p "$subpkgdir/usr/share/doc/nlohmann-json"
+	mv README.md doc/html "$subpkgdir/usr/share/doc/nlohmann-json"
+}
+
+sha512sums="e2874e10e12070e8e1b9c01f41ce24002a3859c4aca8bf46083ea08e68f44ed6725bdcdf8e592b1e50d69975d506836c62a8e10fc6da00f0844c149dd6676996  nlohmann-json-3.5.0.tar.gz"


### PR DESCRIPTION
JSON for Modern C++. This is a headers-only implementation, so
only -dev and -doc packages are being produced. Unit tests are
run, but only the "check-fast" subset (longer tests take upwards
of a quarter-hour).