### PR TITLE
[3.9] community/gitea: security upgrade to 1.6.4

### DIFF
--- a/community/gitea/APKBUILD
+++ b/community/gitea/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=gitea
-pkgver=1.6.3
+pkgver=1.6.4
 pkgrel=0
 pkgdesc="A self-hosted Git service written in Go"
 url="https://gitea.io"
@@ -68,7 +68,7 @@ check() {
 	"$builddir"/$pkgname help > /dev/null
 }
 
-sha512sums="367df2f85918e613fcf360afd3857cb4df9697222f064a8e60e3ae15b0ee3fa5018a28f221d906fa7f8045f3249ecf777f08180dbb3c898cbdcc09eaf5c2c5be  gitea-1.6.3.tar.gz
+sha512sums="7dd3bb585eeab46bb3e48c3dd1d0b28ddb714939d179a88c3c78a99befbd3cd7ebc08db74fc1958a37d7700780de3522b4518b33dd9fec5df5acb48fc8eeabfe  gitea-1.6.4.tar.gz
 a7c70a144dc0582d6230e59ff717023fddcac001a6a9c895b46a0df1fbd9639453b2f5027d47dad21f442869c145dbc801eda61b6c50a2dd8103f562b8569009  gitea.initd
 27a202006d6e8d4146659f6356eaa99437f9f596dd369e9430d64b859bc6a1ad16091eef09232aa385fe1bf8ca94bbdf31b94975068220ad10338cded384f726  gitea.ini
 05272f3733dffeb75881579ff6553d32515e4de32113ff9395e521e93946a45101d04d4e435d7d8e7bfe49a512e5e4ac300576d2e79d7bcf314fc0ce526a07f9  allow-to-set-version.patch"


### PR DESCRIPTION
https://github.com/go-gitea/gitea/releases/tag/v1.6.4