### PR TITLE
testing/advancemame: Upgrade to 3.9

### DIFF
--- a/testing/advancemame/APKBUILD
+++ b/testing/advancemame/APKBUILD
@@ -1,13 +1,21 @@
 # Maintainer: Taner Tas <taner76@gmail.com>
 pkgname=advancemame
-pkgver=3.8
-pkgrel=1
+pkgver=3.9
+pkgrel=0
 pkgdesc="A port of the MAME emulator for Arcade Monitors and TVs but also for LCDs and PC monitors"
 url="http://www.advancemame.it"
-arch="all !armhf" # fails with clang 5 https://github.com/alpinelinux/aports/pull/6042#issuecomment-455065598
-license="GPL"
-makedepends="clang-dev sdl2-dev alsa-lib-dev freetype-dev zlib-dev expat-dev
-	slang-dev linux-headers"
+arch="all"
+license="GPL-2.0-only"
+makedepends="
+	alsa-lib-dev
+	clang-dev
+	expat-dev
+	freetype-dev
+	linux-headers
+	sdl2-dev
+	slang-dev
+	zlib-dev
+	"
 subpackages="$pkgname-doc $pkgname-data::noarch $pkgname-mess $pkgname-menu"
 source="https://github.com/amadvance/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.gz
 	fix-ppc64le-float128.patch"
@@ -20,9 +28,16 @@ prepare() {
 build() {
 	cd "$builddir"
 
-export CC=clang
-export CXX=clang++
-export LD="g++ -fuse-ld=gold"
+case "$CARCH" in
+	armhf)
+		true
+	;;
+	*)
+		export CC=clang
+		export CXX=clang++
+	;;
+esac
+
 
 	./configure \
 		--build=$CBUILD \
@@ -64,5 +79,5 @@ menu() {
 	mv "$pkgdir"/usr/bin/advmenu "$subpkgdir"/usr/bin/
 
 }
-sha512sums="82a2366add559cdb1bcb681e7e45c5a383ab6a6364881a2d63f8239c2fcb6a0e6f7e17e58929e85ee1f55516e8a0df8d492214574127567958af22145f5c6f59  advancemame-3.8.tar.gz
+sha512sums="43f9ba746f222b17ade2d213d6af7cc8fe6b3ee6008633f02b8877f4c7f75628bdf1cc9718db09f5f9a482d194c8ba94f9047334e8012d23c598454e5dab2eb3  advancemame-3.9.tar.gz
 d42a9b3c65c2d96be5287c7541eb1e911562b3f2aaf07c55c1849725592857716ce496405e3da2243edcbd4b7307226306533ddf66ef2e081b4c492412930d1b  fix-ppc64le-float128.patch"


### PR DESCRIPTION
* Use default compiler for armhf.
* Obey spdx license name.
* Cosmetic changes.