### PR TITLE
howard-bc: update to 1.1.1

### DIFF
--- a/testing/howard-bc/APKBUILD
+++ b/testing/howard-bc/APKBUILD
@@ -2,28 +2,29 @@
 # Maintainer: Gavin D. Howard <yzena.tech@gmail.com>
 pkgname=howard-bc
 _pkgname=bc
-pkgver=0.5
-pkgrel=1
+pkgver=1.1.1
+pkgrel=0
 pkgdesc="POSIX bc with GNU extensions"
 url="https://github.com/gavinhoward/bc"
 arch="all"
-license="0BSD"
-depends="!bc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/gavinhoward/$_pkgname/archive/$pkgver.tar.gz"
+license="BSD-2-Clause"
+source="$pkgname-$pkgver.tar.gz::https://github.com/gavinhoward/$_pkgname/releases/download/$pkgver/$_pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$_pkgname-$pkgver"
-# The test suite uses a previously installed version of bc,
-# so it would not make much sense to run it.
-options="!check"
 
 build() {
 	cd "$builddir"
-	CFLAGS="-flto" make release
+	PREFIX=/usr DESTDIR="$pkgdir" EXECSUFFIX=-howard ./configure.sh -GO3
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
 }
 
 package() {
 	cd "$builddir"
-	mkdir -p "$pkgdir"/usr/bin
-	PREFIX="$pkgdir"/usr make install
+	make install
 }
 
-sha512sums="110a8a6b09a4ebd053c0bcdf4621c5aa6344d4591f51f6b2d323330c0a817374dc635fbe058db8f721668fd47832bde73d50cb1031bdaeec4668aa12edf733ab  howard-bc-0.5.tar.gz"
+sha512sums="b1e683f7dc3c73cb5d7a0561489806a2d80e9b4c2d84b5cb5fe03a2ebfd7422641cce8318c5bc47bf9397c3127632636dd4e1ff801331a3b7e55f57075679973  $_pkgname-$pkgver.tar.xz"

--- a/testing/howard-bc/APKBUILD
+++ b/testing/howard-bc/APKBUILD
@@ -17,7 +17,7 @@ build() {
 	make
 }
 
-check() {
+test() {
 	cd "$builddir"
 	make test
 }

--- a/testing/howard-bc/APKBUILD
+++ b/testing/howard-bc/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Gavin D. Howard <yzena.tech@gmail.com>
 pkgname=howard-bc
 _pkgname=bc
-pkgver=1.1.1
+pkgver=1.1.2
 pkgrel=0
 pkgdesc="POSIX bc with GNU extensions"
 url="https://github.com/gavinhoward/bc"
@@ -27,4 +27,4 @@ package() {
 	make install
 }
 
-sha512sums="b1e683f7dc3c73cb5d7a0561489806a2d80e9b4c2d84b5cb5fe03a2ebfd7422641cce8318c5bc47bf9397c3127632636dd4e1ff801331a3b7e55f57075679973  $_pkgname-$pkgver.tar.xz"
+sha512sums="0e48f518a43d5a86aaca489a72fb9c1c5423e21c0e167306424f13fdc5da32f91cca20d1a07e97638366ae8f2798c867b63cada6554955e6b8402a3bbcacdd4d  $_pkgname-$pkgver.tar.xz"

--- a/testing/howard-bc/APKBUILD
+++ b/testing/howard-bc/APKBUILD
@@ -8,7 +8,7 @@ pkgdesc="POSIX bc with GNU extensions"
 url="https://github.com/gavinhoward/bc"
 arch="all"
 license="BSD-2-Clause"
-source="$pkgname-$pkgver.tar.gz::https://github.com/gavinhoward/$_pkgname/releases/download/$pkgver/$_pkgname-$pkgver.tar.xz"
+source="$pkgname-$pkgver.tar.xz::https://github.com/gavinhoward/$_pkgname/releases/download/$pkgver/$_pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {


### PR DESCRIPTION
I have released a new version with history support and much more.

There are two releases in this update: [1.1.0][1] and [1.1.1][2].

The biggest changes to the package are updates to the build system and allowing the test suite to run. (I added a mode to ignore tests that needed to be generated by an existing `bc`.)

[1]: https://github.com/gavinhoward/bc/releases/tag/1.1.0
[2]: https://github.com/gavinhoward/bc/releases/tag/1.1.1