### PR TITLE
community/mbedtls: Upgrade to 2.16.0 (LTS)

### DIFF
--- a/community/mbedtls/APKBUILD
+++ b/community/mbedtls/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mbedtls
-pkgver=2.14.1
+pkgver=2.16.0
 pkgrel=0
 pkgdesc="Light-weight cryptographic and SSL/TLS library"
 url="https://tls.mbed.org"
@@ -73,4 +73,4 @@ static() {
 	chmod -x "$subpkgdir"/usr/lib/*.a
 }
 
-sha512sums="f8a9371fcdca34f61db3676f14f83ba303194dc097fcf34b8088b2d2b1b88b2818c2ed54eef747d8dff7c799e11aee511eb179bb815ae46934b3426d09926dda  mbedtls-2.14.1-apache.tgz"
+sha512sums="765303bc0572b904e05990b254ed160eb18e300a1bbbb4aa5176e5cdbf5464a944d5ad06b712183e2396a48f0c7ae529e0c820303c3995f7d6b9c3f24535d004  mbedtls-2.16.0-apache.tgz"


### PR DESCRIPTION
This commit upgrades the mbedtls library to the recently released 2.16
LTS version.

https://tls.mbed.org/tech-updates/releases/mbedtls-2.16.0-2.7.9-and-2.1.18-released

The depending packages don't need to be rebuild as the soname
doesn't change (libmbedcrypto.so.3, libmbedtls.so.12 and
libmbedx509.so.0)