### PR TITLE
testing/howard-bc: upgrade to 1.1.4

### DIFF
--- a/testing/howard-bc/APKBUILD
+++ b/testing/howard-bc/APKBUILD
@@ -2,28 +2,42 @@
 # Maintainer: Gavin D. Howard <yzena.tech@gmail.com>
 pkgname=howard-bc
 _pkgname=bc
-pkgver=0.5
-pkgrel=1
+subpackages="$pkgname-doc"
+pkgver=1.1.4
+pkgrel=0
 pkgdesc="POSIX bc with GNU extensions"
 url="https://github.com/gavinhoward/bc"
 arch="all"
-license="0BSD"
-depends="!bc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/gavinhoward/$_pkgname/archive/$pkgver.tar.gz"
+license="BSD-2-Clause"
+source="$pkgname-$pkgver.tar.xz::https://github.com/gavinhoward/$_pkgname/releases/download/$pkgver/$_pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$_pkgname-$pkgver"
-# The test suite uses a previously installed version of bc,
-# so it would not make much sense to run it.
-options="!check"
 
 build() {
 	cd "$builddir"
-	CFLAGS="-flto" make release
+	PREFIX=/usr DESTDIR="$pkgdir" EXECSUFFIX=-howard ./configure.sh -G
+	make
+}
+
+check() {
+	cd "$builddir"
+	make test
+}
+
+doc() {
+	# Man pages
+	mkdir -p "$subpkgdir"/usr/share/man || return 1
+	mv "$pkgdir"/usr/share/man/man* "$subpkgdir"/usr/share/man/ \
+		|| return 1
+	gzip "$subpkgdir"/usr/share/man/man*/* || return 1
+
+	# Doc files
+	install -Dm644 "$builddir"/LICENSE.md \
+			"$subpkgdir"/usr/share/doc/$pkgname/LICENSE.md || return 1
 }
 
 package() {
 	cd "$builddir"
-	mkdir -p "$pkgdir"/usr/bin
-	PREFIX="$pkgdir"/usr make install
+	make install
 }
 
-sha512sums="110a8a6b09a4ebd053c0bcdf4621c5aa6344d4591f51f6b2d323330c0a817374dc635fbe058db8f721668fd47832bde73d50cb1031bdaeec4668aa12edf733ab  howard-bc-0.5.tar.gz"
+sha512sums="fa67325cc3cb5df7513e6d0ae74d3476d7d9e87722db2f24d0cf0781622f02ec99e6ab27d3e2d57866830dd18dc43eb3c52d460be6c6ec0260ce2bad7765d7aa  howard-bc-1.1.4.tar.xz"


### PR DESCRIPTION
My `bc` has had a new release, including one for Alpine specifically (to make its test suite able to run in parallel).