### PR TITLE
testing/hiawatha: update to 10.8.3

### DIFF
--- a/testing/hiawatha/APKBUILD
+++ b/testing/hiawatha/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Kurt Marasco <celilo@lavabit.com>
 # Contributor: Pascal Ernster <aur at hardfalcon dot net>
 pkgname=hiawatha
-pkgver=10.8.2
+pkgver=10.8.3
 pkgrel=0
 pkgdesc='Secure and advanced webserver'
 url='https://www.hiawatha-webserver.org/'
@@ -48,6 +48,6 @@ package() {
     "$pkgdir"/usr/share/doc/hiawatha/hiawatha.conf.sample
 }
 
-sha512sums="0faf4889f9433055c597c64dcb10bdb0f6f4c9f279168702c2bafb8a5e610ea304ea85d30b0d6eecc0809bebb8920786073470580d3c4589845d496783ded965  hiawatha-10.8.2.tar.gz
+sha512sums="6c584062424512d85e3a7ef5bdea549df8aac413d211f641fed8593f6dcd95fdaf7bd9f30e1279a17bdca6eec30201aa736b02dfb0ce597eed4ed668b79c5418  hiawatha-10.8.3.tar.gz
 4e1201110396e13b979948caae9c2dfb34f55398225d924164d2f0818b6778500ef3426b0ad358210ef7780289fbd752f7e006220941437fbcdd378746bf5a3d  hiawatha.initd
 b2aad6d02e03a3e25dc6dc30deab4637a7de5448255b6b707363e8c71ae1029e669bacdb6b88889ec1aa804fe717560e872dc44d049127af9aa155a8895c8a60  hiawatha.conf.sample"


### PR DESCRIPTION
This also fixes an issue with a recent mbedtls version bump

Signed-off-by: Leo Unglaub <leo@unglaub.at>