### PR TITLE
testing/mame: revert s390x to clang

### DIFF
--- a/testing/mame/APKBUILD
+++ b/testing/mame/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=mame
 pkgver=0.206
 _pkgver=${pkgver/.}
-pkgrel=1
+pkgrel=2
 pkgdesc="Multi Arcade Machine Emulator with GroovyMAME/Switchres/No-nag patchset."
 url="https://mamedev.org"
 arch="all"
@@ -85,8 +85,8 @@ build() {
 	esac
 
 	case "$CARCH" in
-		armhf|s390x)
-			# clang segfaults on armhf,s390x
+		armhf)
+			# clang segfaults on armhf
 			true
 		;;
 		*)


### PR DESCRIPTION
* s390x build seems fine according to build logs of 0.206-r0