### PR TITLE
community/gcompat: add missing glibc ldso paths

### DIFF
--- a/community/gcompat/APKBUILD
+++ b/community/gcompat/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: William Pitcock <nenolod@dereferenced.org>
 pkgname=gcompat
 pkgver=0.3.0
-pkgrel=0
+pkgrel=1
 pkgdesc="The GNU C Library compatibility layer for musl"
 url="https://code.foxkit.us/adelie/gcompat"
 arch="all !aarch64"
@@ -15,23 +15,30 @@ builddir="$srcdir/gcompat-$pkgver"
 options="!check"
 
 case "$CARCH" in
-armel) _ld="ld-linux.so.3" ;;
-armhf | armv7) _ld="ld-linux-armhf.so.3" ;;
-aarch64) _ld="ld-linux-aarch64.so.1" ;;
-x86) _ld="ld-linux.so.2" ;;
-x86_64) _ld="ld-linux-x86-64.so.2" ;;
-mips* | s390*) _ld="ld.so.1" ;;
-ppc64le) _ld="ld64.so.2" ;;
+aarch64)	_ld="lib/ld-linux-aarch64.so.1" ;;
+armel)		_ld="lib/ld-linux.so.3" ;;
+armhf)		_ld="lib/ld-linux-armhf.so.3" ;;
+armv7)		_ld="lib/ld-linux-armhf.so.3" ;;
+mips)		_ld="lib/ld.so.1" ;;
+mips64)		_ld="lib64/ld.so.1" ;;
+mipsel)		_ld="lib/ld.so.1" ;;
+mips64el)	_ld="lib64/ld.so.1" ;;
+ppc)		_ld="lib/ld.so.1" ;;
+ppc64)		_ld="lib64/ld64.so.1" ;;
+ppc64le)	_ld="lib64/ld64.so.2" ;;
+s390x)		_ld="lib/ld64.so.1" ;;
+x86)		_ld="lib/ld-linux.so.2" ;;
+x86_64)		_ld="lib64/ld-linux-x86-64.so.2";;
 esac
 
 build() {
 	cd "$builddir"
-	make LINKER_PATH="/lib/ld-musl-${CARCH}.so.1" LOADER_NAME="$_ld"
+	make LINKER_PATH="/lib/ld-musl-${CARCH}.so.1" LOADER_NAME="${_ld##*/}" LOADER_PATH="$_ld"
 }
 
 package() {
 	cd "$builddir"
-	make LINKER_PATH="/lib/ld-musl-${CARCH}.so.1" LOADER_NAME="$_ld" DESTDIR="$pkgdir" install
+	make LINKER_PATH="/lib/ld-musl-${CARCH}.so.1" LOADER_NAME="${_ld##*/}" LOADER_PATH="$_ld" DESTDIR="$pkgdir" install
 }
 
 sha512sums="1f7dd73efd556b7e0f7f1c80751185583de24daf4ab235b488ea1ab98cea2d3a94abed341b922be0bd43c8d539a00176b892c78acf09f2adacb279c09648b3be  gcompat-0.3.0.tar.xz"


### PR DESCRIPTION
This is like #5926, except for gcompat.

Edit: Fixed PR link