### PR TITLE
community/borgbackup: backport patch to make borg work again

### DIFF
--- a/community/borgbackup/APKBUILD
+++ b/community/borgbackup/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=borgbackup
 pkgver=1.1.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Deduplicating backup program"
 url="https://borgbackup.readthedocs.io/"
 arch="all"
@@ -10,7 +10,8 @@ license="BSD-3-Clause"
 depends="python3 py3-msgpack py3-zmq"
 makedepends="python3-dev lz4-dev acl-dev attr-dev openssl-dev linux-headers
 	py3-setuptools"
-source="https://github.com/$pkgname/borg/releases/download/$pkgver/$pkgname-$pkgver.tar.gz"
+source="https://github.com/$pkgname/borg/releases/download/$pkgver/$pkgname-$pkgver.tar.gz
+        msgpack-fix.patch"
 
 build() {
 	cd "$builddir"
@@ -26,4 +27,5 @@ package() {
 	find . -name '*.h' -delete -o -name '*.c' -delete -o -name '*.pyx' -delete
 }
 
-sha512sums="586420b9cad7e731f2f1b8b05f3cd3dc606691c5a5ec307e887035d941ac5ac6d4c988783660969960a1221e4d9f2b865ee5558d4007ea7524632d0a50a8a402  borgbackup-1.1.7.tar.gz"
+sha512sums="586420b9cad7e731f2f1b8b05f3cd3dc606691c5a5ec307e887035d941ac5ac6d4c988783660969960a1221e4d9f2b865ee5558d4007ea7524632d0a50a8a402  borgbackup-1.1.7.tar.gz
+0b30850df11124c7d699867a88852dc2c49c7e3b4025f1d75a3b4404ca5801d73ab21260f86a7725bb3b19650c8c0ddea05569f5696cb68b3e45c8faf54a97b6  msgpack-fix.patch"

--- a/community/borgbackup/msgpack-fix.patch
+++ b/community/borgbackup/msgpack-fix.patch
@@ -1,0 +1,13 @@
+--- borgbackup-1.1.7/setup.py.original
++++ borgbackup-1.1.7/setup.py
+@@ -39,7 +39,9 @@
+     # we are rather picky about msgpack versions, because a good working msgpack is
+     # very important for borg, see https://github.com/borgbackup/borg/issues/3753
+     # best versions seem to be 0.4.6, 0.4.7, 0.4.8 and 0.5.6:
+-    'msgpack-python >=0.4.6, <=0.5.6, !=0.5.0, !=0.5.1, !=0.5.2, !=0.5.3, !=0.5.4, !=0.5.5',
++    'msgpack-python >=0.4.6, <=0.5.6, !=0.5.0, !=0.5.1, !=0.5.2, !=0.5.3, !=0.5.4, !=0.5.5;python_version <"3.4"',
++    'msgpack-python >=0.4.6, <0.5;python_version=="3.4"',
++    'msgpack >=0.5.6;python_version >="3.5"',
+     # if you can't satisfy the above requirement, these are versions that might
+     # also work ok, IF you make sure to use the COMPILED version of msgpack-python,
+     # NOT the PURE PYTHON fallback implementation: ==0.5.1, ==0.5.4


### PR DESCRIPTION
Backported from patch[1] from Arch made by Eli Schwartz, kudos to them. For me the patch didn't work verbatim, had to make slight adjustment

[1] - https://git.archlinux.org/svntogit/community.git/tree/trunk/0001-Fix-msgpack-version-constraints-using-proper-setupto.patch?h=packages/borg