### PR TITLE
community/tomcat-native: Remove dependency to java

### DIFF
--- a/community/tomcat-native/APKBUILD
+++ b/community/tomcat-native/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=tomcat-native
 pkgver=1.2.21
-pkgrel=0
+pkgrel=1
 pkgdesc="Native resources optional component for Apache Tomcat"
 url="https://tomcat.apache.org/native-doc/"
 arch="all"
 license="Apache-2.0"
-depends="openjdk8-jre-base"
+options="!check" # package has no tests
 makedepends="apr-dev chrpath openjdk8 openssl-dev"
 subpackages="$pkgname-dev"
 source="https://www-eu.apache.org/dist/tomcat/tomcat-connectors/native/$pkgver/source/$pkgname-$pkgver-src.tar.gz"


### PR DESCRIPTION
The library itself doesn't depend on java, it's only used to compile this aport.

Fixes https://bugs.alpinelinux.org/issues/9740