### PR TITLE
testing/freeimage: fix link errors to freeimage.so on ppc64le

### DIFF
--- a/testing/freeimage/APKBUILD
+++ b/testing/freeimage/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=freeimage
 _pkgname="FreeImage"
 pkgver=3.18.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Open Source library project for developers who would like to support popular graphics image formats."
 url="http://freeimage.sourceforge.net/"
 arch="all"
@@ -27,6 +27,7 @@ build() {
 	cd "$builddir"
 	case "$CARCH" in
 		aarch64) export CFLAGS="$CFLAGS -DPNG_ARM_NEON_OPT=0";;
+		ppc64le) export CFLAGS="$CFLAGS -U__ALTIVEC__";;
 	esac
 	make
 }


### PR DESCRIPTION
In libfreeimage.so dynamic symbol table it has a reference to png_init_filter_functions_vsx
~ $ objdump -T /usr/lib/libfreeimage.so | grep png_init
0000000000000000      D  *UND*  0000000000000000              png_init_filter_functions_vsx

libpng.so source includes the png_init_filter_functions_vsx but it is not built for ppc64le with ALTIVEC disabled (current alpine config). So anything that dynamically links with freeimage.so will get an error like:
	Fails with error: /usr/lib/gcc/powerpc64le-alpine-linux-musl/8.2.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: /usr/lib/libfreeimage.so: undefined reference to `png_init_filter_functions_vsx'

To fix this the freeimage config should be consistent so should also be built with ALTIVEC disabled on ppc64le.
