### PR TITLE
testing/bees: fix ppc64le build break and reenable

### DIFF
--- a/testing/bees/APKBUILD
+++ b/testing/bees/APKBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Bradley Saulteaux <bradsoto@gmail.com>
 pkgname=bees
 pkgver=0.6.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Best-Effort Extent-Same, a btrfs dedup agent"
 url="https://github.com/Zygo/bees"
-arch="all !ppc64le"
+arch="all"
 license="GPL-3.0-or-later"
 depends="btrfs-progs"
 makedepends="btrfs-progs-dev util-linux-dev"
@@ -12,6 +12,7 @@ install=""
 subpackages="$pkgname-openrc"
 source="${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz
 	10-pthread_getname1.patch
+	ppc64le_fix_min_compare.patch
 	bees.initd"
 
 build() {
@@ -31,4 +32,5 @@ package() {
 
 sha512sums="cd44d21959d3ab4dda255f0a4a57bd3aeecfb9fee6ea26d68a1b5f84d407f75bd0b442ecf4fefc5ac856dcd9af035f44ceeff77a8926b164f97a15350efcee33  bees-0.6.1.tar.gz
 50c9cc16f094a0a69f31cf6e42601b9114344ea23a1455d6b5a3f18829ad03426ebdc37187af747bb74f51f75866c3a6da8805d0537af8e729a2f53819d52efb  10-pthread_getname1.patch
+2e13a670184d71b64e04450adb182d0a6e842e1a7d561882e0a07ae4ea7a9ed15a3fcce03f61c5412eabdb2fadf559f221e21ffd10440c4b8b700f3eab02aab4  ppc64le_fix_min_compare.patch
 093bc4c9604a0b28b39069e447d83800c91d0974fe4618ce5e5063e5c816b2d63c1b633710c592d76e8f6367d696283d6fa4a3a9561b09ce62fa28cabf8e55d0  bees.initd"

--- a/testing/bees/ppc64le_fix_min_compare.patch
+++ b/testing/bees/ppc64le_fix_min_compare.patch
@@ -1,0 +1,11 @@
+--- a/src/fiemap.cc
++++ b/src/fiemap.cc
+@@ -27,7 +27,7 @@
+ 		if (argc > 2) { fm.fm_start = stoull(argv[2], nullptr, 0); }
+ 		if (argc > 3) { fm.fm_length = stoull(argv[3], nullptr, 0); }
+ 		if (argc > 4) { fm.fm_flags = stoull(argv[4], nullptr, 0); }
+-		fm.fm_length = min(fm.fm_length, FIEMAP_MAX_OFFSET - fm.fm_start);
++		fm.fm_length = min(fm.fm_length, (uint64_t)FIEMAP_MAX_OFFSET - fm.fm_start);
+ 		uint64_t stop_at = fm.fm_start + fm.fm_length;
+ 		uint64_t last_byte = fm.fm_start;
+ 		do {


### PR DESCRIPTION
on ppc64le build fails with error:
fiemap.cc:30:67: error: no matching function for call to 'min(__u64&, long long unsigned int)'
   fm.fm_length = min(fm.fm_length, FIEMAP_MAX_OFFSET - fm.fm_start);

To fix add explicit casting to min function argument.
