### PR TITLE
[3.6] main/dovecot: security upgrade to 2.2.36.1

### DIFF
--- a/main/dovecot/APKBUILD
+++ b/main/dovecot/APKBUILD
@@ -3,14 +3,14 @@
 # Contributor: Michael Mason <ms13sp@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dovecot
-pkgver=2.2.27
-pkgrel=2
+pkgver=2.2.36.1
+_pkgvermajor=2.2
+pkgrel=0
 _pigeonholever=0.4.16
 _pluginextdataver=39
-_pkgvermajor=${pkgver%.*}
 _pigeonholevermajor=${_pigeonholever%.*}
 pkgdesc="IMAP and POP3 server"
-url="http://www.dovecot.org/"
+url="https://www.dovecot.org/"
 arch="all"
 license="LGPL2+"
 depends="libressl"
@@ -25,8 +25,8 @@ subpackages="$pkgname-doc $pkgname-dev
 	$pkgname-gssapi $pkgname-ldap $pkgname-pigeonhole-plugin:pigeonhole
 	$pkgname-pigeonhole-plugin-extdata:pigeonhole_extdata
 	"
-source="http://www.dovecot.org/releases/$_pkgvermajor/$pkgname-$pkgver.tar.gz
-	http://pigeonhole.dovecot.org/releases/$_pkgvermajor/$pkgname-$_pkgvermajor-pigeonhole-$_pigeonholever.tar.gz
+source="https://www.dovecot.org/releases/$_pkgvermajor/$pkgname-$pkgver.tar.gz
+	https://pigeonhole.dovecot.org/releases/$_pkgvermajor/$pkgname-$_pkgvermajor-pigeonhole-$_pigeonholever.tar.gz
 	http://hg.rename-it.nl/pigeonhole-${_pigeonholevermajor}-sieve-extdata/archive/$_pluginextdataver.tar.gz
 	dovecot.logrotate
 	dovecot.initd
@@ -37,6 +37,10 @@ options="libtool"
 builddir="$srcdir"/$pkgname-$pkgver
 _builddirpigeonhole="$srcdir"/$pkgname-${_pkgvermajor}-pigeonhole-$_pigeonholever
 _builddirpluginextdata="$srcdir"/pigeonhole-${_pigeonholevermajor/./-}-sieve-extdata-$_pluginextdataver
+
+# secfixes:
+#   2.2.36.1-r0:
+#     - CVE-2019-3814
 
 build() {
 	cd "$builddir"
@@ -202,21 +206,7 @@ sql() {
 	_mv $(cd "$pkgdir" && find usr -name '*-sql.*')
 	_mv $(cd "$pkgdir" && find etc/dovecot -name '*-sql.conf*')
 }
-md5sums="20133518f5bc0e64dd07ce55b83df2fb  dovecot-2.2.27.tar.gz
-e03eed707b39cffc4b2a82867de45d9c  dovecot-2.2-pigeonhole-0.4.16.tar.gz
-5d26d326856d00ce04c620b549d58f79  39.tar.gz
-df6d43508a82903a97e3a2a5b8436d3d  dovecot.logrotate
-f0c227ab4e2593f6d410440b82103de1  dovecot.initd
-e085d2bafae8c9d657c4a85a91eb35f6  extdata.conf
-ca86aa10f8f963c7f08c50c12c2dbe45  libressl.patch"
-sha256sums="897f92a87cda4b27b243f8149ce0ba7b7e71a2be8fb7994eb0a025e54cde18e9  dovecot-2.2.27.tar.gz
-8f0b98f18062d6e241eef74ebe16cc167cd246361cbe6657d94f0ecc5d7d3234  dovecot-2.2-pigeonhole-0.4.16.tar.gz
-da70fb0ce0424e9cad2c03834bd826a3685deb5a986ec5b87ae7c525055256d5  39.tar.gz
-d0fef8cd8200549877d7594cf458d6b33f05b31f95f1fd9a8368e8471c082735  dovecot.logrotate
-1a3c845c216bb6f9633d27a8c1c0d01b591942c463bddb5ae835f162bd7fb4bf  dovecot.initd
-1e7b6a42f07add59af8a031d24525bdda28a6d904acefa6e4f48b005d07213e6  extdata.conf
-27ce75e878fbea1038417b2629626cb6c96e078e8af97cb76641489448c0e88f  libressl.patch"
-sha512sums="faab441bb2afa1e6de3e6ec6207c92a333773941bbc10c4761483ef6ccc193d3a4983de1acc73325122c22b197ea25c1e54886cccfb6b060ede90936a69b71f2  dovecot-2.2.27.tar.gz
+sha512sums="b085ad919e3a45b209a52920d3462270822bba6f5de93f1a65c4d8522339ce8eff06059fe42f38442c2ffe178f91e4f66b43b2457ab47af379091da40dd860d8  dovecot-2.2.36.1.tar.gz
 5f59fb35dbe638f8ddd19c0fd0f3fbd6fec1fa238f3781b94c50a8f7ce72a53ac1381a6f8ad9bcc90df1edfa2b263a6dfba88521578e55ce4b3d840bed022b79  dovecot-2.2-pigeonhole-0.4.16.tar.gz
 832a80264fb9bd3021c4e192eb7594c203100783df547aff35acf4dc4d8de5eddfd676fcc5a07a0691d9bb6eb884c9497a692b72a2af5bf9e9bb7a2d3f38923e  39.tar.gz
 9f19698ab45969f1f94dc4bddf6de59317daee93c9421c81f2dbf8a7efe6acf89689f1d30f60f536737bb9526c315215d2bce694db27e7b8d7896036a59c31f0  dovecot.logrotate


### PR DESCRIPTION
https://www.dovecot.org/list/dovecot-news/2019-February/000393.html