### PR TITLE
main/curl: Security upgrade to 7.64.0

### DIFF
--- a/main/curl/APKBUILD
+++ b/main/curl/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=curl
-pkgver=7.63.0
+pkgver=7.64.0
 pkgrel=0
 pkgdesc="URL retrival utility and library"
 url="https://curl.haxx.se"
@@ -19,6 +19,10 @@ options="!check" # sftp tests failing
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   7.64.0-r0:
+#     - CVE-2018-16980
+#     - CVE-2018-3822
+#     - CVE-2018-3823
 #   7.62.0-r0:
 #     - CVE-2018-16839
 #     - CVE-2018-16840
@@ -111,4 +115,4 @@ libcurl() {
 	mv "$pkgdir"/usr/lib "$subpkgdir"/usr
 }
 
-sha512sums="c905eb157c6b0093f1b1a506e4782b83af423fd6de1ce0ab5372164a686ef292ffb10d7999d3dec2de602f63ee41b65e1a1008409dd8c959a597644c0ecb395b  curl-7.63.0.tar.xz"
+sha512sums="953f1f5336ce5dfd1b9f933624432d401552d91ee02d39ecde6f023c956f99ec6aae8d7746d7c34b6eb2d6452f114e67da4e64d9c8dd90b7644b7844e7b9b423  curl-7.64.0.tar.xz"


### PR DESCRIPTION
This PR update curl to the latest release and fixes some CVEs:
- CVE-2018-16980
- CVE-2018-3822
- CVE-2018-3823

Please also backport this update to the 3.9 stable branch.