### PR TITLE
testing/java-jtreg: New aport

### DIFF
--- a/testing/java-asmtools/APKBUILD
+++ b/testing/java-asmtools/APKBUILD
@@ -1,0 +1,49 @@
+# Contributor: Simon Frankenberger <simon-alpine@fraho.eu>
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
+pkgname=java-asmtools
+_pkgver=7.0-b06
+pkgver=${_pkgver/-b/.}
+pkgrel=0
+pkgdesc="The AsmTools open source project is used to develop tools for the production of proper and improper Java '.class' files"
+url="http://hg.openjdk.java.net/code-tools/asmtools"
+arch="noarch"
+license="GPL-2.0"
+makedepends="openjdk8"
+options="!check" # this package has no tests
+subpackages="$pkgname-doc:_doc"
+source="asmtools-$_pkgver.tar.bz2::http://hg.openjdk.java.net/code-tools/asmtools/archive/$_pkgver.tar.bz2
+http://ftp-stud.hs-esslingen.de/pub/Mirrors//ftp.apache.org/dist/ant/binaries/apache-ant-1.9.13-bin.zip
+"
+builddir="$srcdir/asmtools-$_pkgver"
+
+_ant_home="$srcdir"/apache-ant-1.9.13/
+
+build() {
+	cd "$builddir/build"
+
+	# fix the build target directory
+	sed -i "s@^BUILD_DIR.\+@BUILD_DIR = $builddir/target@" build.properties
+
+	$_ant_home/bin/ant
+}
+
+package() {
+	_destdir="$pkgdir/usr/share/java/asmtools"
+	mkdir -p "$_destdir"
+	cp -r \
+		$builddir/target/binaries/lib \
+		$builddir/target/binaries/LICENSE \
+		"$_destdir"
+}
+
+_doc() {
+	_destdir="$subpkgdir/usr/share/java/asmtools"
+	mkdir -p "$_destdir"
+	cp -r \
+		$builddir/target/binaries/doc \
+		$builddir/target/binaries/README.html \
+		"$_destdir"
+}
+
+sha512sums="c910cd36a93de648b1dde613b856cdde124a4b46469ff2cff62ebd17c83fc35573b212e50e38a396fb1e43fe6427aa60cb4eb6bfe4c0d641e4c057b6e28f114e  asmtools-7.0-b06.tar.bz2
+873062cf789e1572ec4ef3cdbb15c0d3a57e5a0794068591565367d4cec15b9f9a24f59734a85170d61b23eb9288d6bafd35a9ae2b015b09c7a175e344cb4e1c  apache-ant-1.9.13-bin.zip"

--- a/testing/java-asmtools/source-target.patch
+++ b/testing/java-asmtools/source-target.patch
@@ -1,0 +1,26 @@
+--- a/build/build.xml
++++ b/build/build.xml
+@@ -290,6 +290,7 @@
+         <delete dir="${build.classes}" quiet="true"/>
+         <mkdir dir="${build.classes}"/>
+         <javac encoding="iso-8859-1" debug="true" target="1.7"
++               source="1.7"
+                srcdir="${src.dir}"
+                sourcepath=""
+                destdir="${build.classes}"
+@@ -307,6 +308,7 @@
+     <target name="compile.test.copyright.classes">
+         <mkdir dir="${build.classes}"/>
+         <javac encoding="iso-8859-1" debug="true" target="1.7"
++               source="1.7"
+                srcdir="${test.dir}"
+                destdir="${build.classes}"
+                classpath="${jdk14.classpath}">
+@@ -320,6 +322,7 @@
+ 
+         <mkdir dir="${build.junit.classes}"/>
+         <javac encoding="iso-8859-1" debug="true" target="1.7"
++               source="1.7"
+                srcdir="${src.dir}"
+                destdir="${build.junit.classes}"
+                classpath="${jdk14.classpath}:${build.classes}:${bytecodelib}:${junitlib}">

--- a/testing/java-jtharness/APKBUILD
+++ b/testing/java-jtharness/APKBUILD
@@ -1,0 +1,75 @@
+# Contributor: Simon Frankenberger <simon-alpine@fraho.eu>
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
+pkgname=java-jtharness
+pkgver=5.0
+pkgrel=0
+pkgdesc="The JT harness is a general purpose, fully-featured, flexible, and configurable test harness"
+url="http://hg.openjdk.java.net/code-tools/jtharness"
+arch="noarch"
+license="GPL-2.0"
+makedepends="openjdk8"
+options="!check" # this package has no tests
+subpackages="$pkgname-doc:_doc $pkgname-examples:_examples"
+source="jtharness-$pkgver.tar.bz2::http://hg.openjdk.java.net/code-tools/jtharness/archive/jt$pkgver.tar.bz2
+http://ftp-stud.hs-esslingen.de/pub/Mirrors//ftp.apache.org/dist/ant/binaries/apache-ant-1.9.13-bin.zip
+http://central.maven.org/maven2/asm/asm-all/3.1/asm-all-3.1.jar
+http://central.maven.org/maven2/junit/junit/4.4/junit-4.4.jar
+http://central.maven.org/maven2/javax/servlet/javax.servlet-api/3.0.1/javax.servlet-api-3.0.1.jar
+
+source-target.patch
+"
+builddir="$srcdir/jtharness-jt$pkgver"
+
+_ant_home="$srcdir"/apache-ant-1.9.13/
+_servletjar="$srcdir"/javax.servlet-api-3.0.1.jar
+_bytecodelib="$srcdir"/asm-all-3.1.jar
+_junitlib="$srcdir"/junit-4.4.jar
+
+prepare() {
+	default_prepare
+
+	cd "$builddir/build"
+	# configure the libraries
+	sed -i \
+		-e "s@^servletjar.\+@servletjar = $_servletjar@" \
+		-e "s@^bytecodelib.\+@bytecodelib = $_bytecodelib@" \
+		-e "s@^junitlib.\+@junitlib = $_junitlib@" \
+		-e "s@^BUILD_DIR.\+@BUILD_DIR = $builddir/target@" \
+		local.properties
+}
+
+build() {
+	cd "$builddir/build"
+	$_ant_home/bin/ant
+}
+
+package() {
+	_destdir="$pkgdir/usr/share/java/jtharness"
+	mkdir -p "$_destdir"
+	cp -r \
+		$builddir/target/binaries/legal \
+		$builddir/target/binaries/lib \
+		"$_destdir"
+}
+
+_examples() {
+	_destdir="$subpkgdir/usr/share/java/jtharness"
+	mkdir -p "$_destdir"
+	cp -r $builddir/target/binaries/examples "$_destdir"
+}
+
+_doc() {
+	_destdir="$subpkgdir/usr/share/java/jtharness"
+	mkdir -p "$_destdir"
+	cp -r \
+		$builddir/target/binaries/doc \
+		$builddir/target/binaries/ReleaseNotes-jtharness.html \
+		"$_destdir"
+}
+
+sha512sums="f4cbf815e90c5fadd7af8f68fd0cc9ee9ebf67fefd7cb8c0dff845b1954d0126dc55a593c3d6e3b46c7865dac3f4821e97f1bed542c374b2ee54347e00063acf  jtharness-5.0.tar.bz2
+873062cf789e1572ec4ef3cdbb15c0d3a57e5a0794068591565367d4cec15b9f9a24f59734a85170d61b23eb9288d6bafd35a9ae2b015b09c7a175e344cb4e1c  apache-ant-1.9.13-bin.zip
+00990aa9d39fe874f6799dc8d9d1b208b61e6358a949df86014edeacbea63dcdc4ac7870948a54270e1db4b8ec134313b200fe7cdede7aa6746c812c36f0ac13  asm-all-3.1.jar
+4ae9fb09ebd9800ba1c9f0bfc43f07f7bc499e41894dea74b50f01fd69690b5d4e8f7949e2afce10fa0da719e8a2df223430e3aef7e2529662c7b70a12c80ab9  junit-4.4.jar
+1e087f1e4632048f1c6ea12e3820a30c7a6e66b13277ec8e784d8c5aba99335cd90cdb08e23756e815324cc9c8dc22d0937c7ccf4b89ee00222cd5e4a1d2a0de  javax.servlet-api-3.0.1.jar
+ea27ff0a469df11179b3f2d6b0a78f94cc76959d42cde22a7043ffb557f93a3b8f905b50df41f40c7b82b5c77348875d32a93bd268e758d9ef0496b904ca9ec3  source-target.patch"

--- a/testing/java-jtharness/source-target.patch
+++ b/testing/java-jtharness/source-target.patch
@@ -1,0 +1,26 @@
+--- a/build/build.xml
++++ b/build/build.xml
+@@ -290,6 +290,7 @@
+         <delete dir="${build.classes}" quiet="true"/>
+         <mkdir dir="${build.classes}"/>
+         <javac encoding="iso-8859-1" debug="true" target="1.7"
++               source="1.7"
+                srcdir="${src.dir}"
+                sourcepath=""
+                destdir="${build.classes}"
+@@ -307,6 +308,7 @@
+     <target name="compile.test.copyright.classes">
+         <mkdir dir="${build.classes}"/>
+         <javac encoding="iso-8859-1" debug="true" target="1.7"
++               source="1.7"
+                srcdir="${test.dir}"
+                destdir="${build.classes}"
+                classpath="${jdk14.classpath}">
+@@ -320,6 +322,7 @@
+ 
+         <mkdir dir="${build.junit.classes}"/>
+         <javac encoding="iso-8859-1" debug="true" target="1.7"
++               source="1.7"
+                srcdir="${src.dir}"
+                destdir="${build.junit.classes}"
+                classpath="${jdk14.classpath}:${build.classes}:${bytecodelib}:${junitlib}">

--- a/testing/java-jtreg/APKBUILD
+++ b/testing/java-jtreg/APKBUILD
@@ -1,0 +1,84 @@
+# Contributor: Simon Frankenberger <simon-alpine@fraho.eu>
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
+pkgname=java-jtreg
+_pkgver=4.2-b13
+pkgver=${_pkgver/-/.}
+pkgrel=0
+pkgdesc="jtreg is the test harness used by the JDK test framework"
+url="http://hg.openjdk.java.net/code-tools/jtreg"
+arch="noarch"
+license="GPL-2.0"
+depends="java-jtharness java-asmtools"
+makedepends="openjdk8 zip"
+options="!check" # the tests require an X11 or VNC display
+#subpackages="$pkgname-doc:_doc $pkgname-examples:_examples"
+source="jtreg-$pkgver.tar.bz2::http://hg.openjdk.java.net/code-tools/jtreg/archive/jtreg$_pkgver.tar.bz2
+http://ftp-stud.hs-esslingen.de/pub/Mirrors//ftp.apache.org/dist/ant/binaries/apache-ant-1.9.13-bin.zip
+http://central.maven.org/maven2/junit/junit/4.10/junit-4.10.jar
+http://central.maven.org/maven2/org/testng/testng/6.9.5/testng-6.9.5.jar
+http://central.maven.org/maven2/com/beust/jcommander/1.72/jcommander-1.72.jar
+
+jtreg-symlink-patch.txt
+jtdiff-symlink-patch.txt
+"
+builddir="$srcdir/jtreg-jtreg$_pkgver"
+
+build() {
+	cd "$builddir"
+
+	mkdir -p "$builddir"/build
+	make JTHARNESS_HOME=/usr/share/java/jtharness \
+		ANTHOME="$srcdir"/apache-ant-1.9.13 \
+		ASMTOOLS_HOME=/usr/share/java/asmtools \
+		JDKHOME=/usr/lib/jvm/default-jvm \
+		JUNIT_HOME="$srcdir" \
+		TESTNG_HOME="$srcdir" \
+		JCOMMANDER_JAR="$srcdir"/jcommander-1.72.jar \
+		TOUCH=/bin/touch \
+		-C make
+}
+
+package() {
+	_destdir="$pkgdir/usr/share/java/jtreg"
+	mkdir -p "$_destdir"
+	cp -r \
+		$builddir/build/images/jtreg/bin\
+		$builddir/build/images/jtreg/legal \
+		$builddir/build/images/jtreg/lib \
+		$builddir/build/images/jtreg/COPYRIGHT \
+		$builddir/build/images/jtreg/LICENSE \
+		$builddir/build/images/jtreg/README \
+		$builddir/build/images/jtreg/release \
+		"$_destdir"
+
+	# link to jtharness and asmtools from depends
+	rm "$_destdir"/lib/asmtools.jar
+	rm "$_destdir"/lib/javatest.jar
+	ln -s /usr/share/java/asmtools/lib/asmtools.jar  "$_destdir"/lib/asmtools.jar
+	ln -s /usr/share/java/jtharness/lib/javatest.jar "$_destdir"/lib/javatest.jar
+
+	# patch the jtreg executable script to handle symlink from /usr/bin
+	cd "$pkgdir"
+	patch -p1 -i "$srcdir"/jtreg-symlink-patch.txt
+	patch -p1 -i "$srcdir"/jtdiff-symlink-patch.txt
+
+	mkdir -p "$pkgdir/usr/bin"
+	ln -s /usr/share/java/jtreg/bin/jtdiff "$pkgdir"/usr/bin/jtdiff
+	ln -s /usr/share/java/jtreg/bin/jtreg  "$pkgdir"/usr/bin/jtreg
+}
+
+_doc() {
+	_destdir="$subpkgdir/usr/share/java/jtreg"
+	mkdir -p "$_destdir"
+	cp -r \
+		$builddir/target/binaries/doc \
+		"$_destdir"
+}
+
+sha512sums="b0ecbf8a38e5913e3e26cc92435f82d2db7201ef931c756a6106c23fe9dc07b7b2a21651e92b01e3c89cc01a831bbd7be02f7e55c60733af9430f7641c419246  jtreg-4.2.b13.tar.bz2
+873062cf789e1572ec4ef3cdbb15c0d3a57e5a0794068591565367d4cec15b9f9a24f59734a85170d61b23eb9288d6bafd35a9ae2b015b09c7a175e344cb4e1c  apache-ant-1.9.13-bin.zip
+2c8b595c24a5ad2499a5bd5bb01204453cd09f51308fea5834922e042b8f39bd8ef0099848eb3a8576ddc4ce4ec907181ba0c20f1222a25b3064d1c3c5499cbd  junit-4.10.jar
+15a6d6a3c29e6212d18c299e905620ff743825029129ce44d70cadbff589873bfc983f79b9a50052b85b03c8dac25ef5cf9de1628e10db980a4ac94c66173475  testng-6.9.5.jar
+2da86589ff7ecbb53cfce845887155bca7400ecf2fdfdef7113ea03926a195a1cbcf0c071271df6bedc5cdfa185c6576f67810f6957cd9b60ab3600a4545420e  jcommander-1.72.jar
+c12bb37a378bf15a2d73b3bd4aadf122dfb60860dda640cb909d62517cb13e7471f76d849598aacb88ef73a119cb45eb1c52165b98faa3dca112ab9f528e2f55  jtreg-symlink-patch.txt
+67f63317a2aaedd17e822389065ff5d86d574f4cb2e2af375856a9c7356dd048c396517372788b889db376fe4aa73c66d530938b8975d11d7714ac84e3dcd00d  jtdiff-symlink-patch.txt"

--- a/testing/java-jtreg/jtdiff-symlink-patch.txt
+++ b/testing/java-jtreg/jtdiff-symlink-patch.txt
@@ -1,0 +1,37 @@
+--- a/usr/share/java/jtreg/bin/jtdiff
++++ b/usr/share/java/jtreg/bin/jtdiff
+@@ -37,6 +37,10 @@
+ #
+ # jtdiff also provides an Ant task for direct invocation from Ant.
+ 
++_prog=$0
++_link=`readlink $_prog`
++[ -n "$_link" ] && _prog=$_link
++
+ # Determine jtdiff/JavaTest installation directory
+ if [ -n "$JT_HOME" ]; then
+     if [ ! -r $JT_HOME/lib/jtreg.jar ];then
+@@ -48,11 +52,11 @@
+     # - should work on most derivatives of Bourne shell, like ash, bash, ksh,
+     #   sh, zsh, etc, including on Windows, MKS (ksh) and Cygwin (ash or bash)
+     if type -p type 1>/dev/null 2>&1 && test -z "`type -p type`" ; then
+-        myname=`type -p "$0"`
++        myname=`type -p "$_prog"`
+     elif type type 1>/dev/null 2>&1 ; then
+-        myname=`type "$0" | sed -e 's/^.* is a tracked alias for //' -e 's/^.* is //'`
++        myname=`type "$_prog" | sed -e 's/^.* is a tracked alias for //' -e 's/^.* is //'`
+     elif whence whence 1>/dev/null 2>&1 ; then
+-        myname=`whence "$0"`
++        myname=`whence "$_prog"`
+     fi
+     mydir=`dirname "$myname"`
+     p=`cd "$mydir" ; pwd`
+@@ -117,7 +121,7 @@
+ 
+ "${JT_JAVA:-${JAVA_HOME:+$JAVA_HOME/bin/}java}" \
+     $javaOpts \
+-    -Dprogram=`basename "$0"` \
++    -Dprogram=`basename "$_prog"` \
+     -cp "${JT_HOME}/lib/jtreg.jar" \
+     com.sun.javatest.diff.Main \
+     $jtdiffOpts

--- a/testing/java-jtreg/jtreg-symlink-patch.txt
+++ b/testing/java-jtreg/jtreg-symlink-patch.txt
@@ -1,0 +1,36 @@
+--- a/usr/share/java/jtreg/bin/jtreg
++++ b/usr/share/java/jtreg/bin/jtreg
+@@ -47,6 +47,10 @@
+ #
+ # jtreg also provides Ant tasks; see the documentation for details.
+ 
++_prog=$0
++_link=`readlink $_prog`
++[ -n "$_link" ] && _prog=$_link
++
+ # Determine jtreg/JavaTest installation directory
+ if [ -n "$JT_HOME" ]; then
+     if [ ! -r $JT_HOME/lib/jtreg.jar ];then
+@@ -58,11 +62,11 @@
+     # - should work on most derivatives of Bourne shell, like ash, bash, ksh,
+     #   sh, zsh, etc, including on Windows, MKS (ksh) and Cygwin (ash or bash)
+     if type -p type 1>/dev/null 2>&1 && test -z "`type -p type`" ; then
+-        myname=`type -p "$0"`
++        myname=`type -p "$_prog"`
+     elif type type 1>/dev/null 2>&1 ; then
+-        myname=`type "$0" | sed -e 's/^.* is a tracked alias for //' -e 's/^.* is //'`
++        myname=`type "$_prog" | sed -e 's/^.* is a tracked alias for //' -e 's/^.* is //'`
+     elif whence whence 1>/dev/null 2>&1 ; then
+-        myname=`whence "$0"`
++        myname=`whence "$_prog"`
+     fi
+     mydir=`dirname "$myname"`
+     p=`cd "$mydir" ; pwd`
+@@ -132,6 +136,6 @@
+ 
+ "${JT_JAVA}" \
+     $javaOpts \
+-    -Dprogram=`basename "$0"` \
++    -Dprogram=`basename "$_prog"` \
+     -jar "${JT_HOME}/lib/jtreg.jar" \
+     $jtregOpts


### PR DESCRIPTION
This PR adds the java regression test harness with all dependencies.

This package can be used to test java applications, but I'll use this mainly for porting the OpenJDK to alpine (see #6179).