### PR TITLE
main/nettle: disable neon for arch armv7

### DIFF
--- a/main/nettle/APKBUILD
+++ b/main/nettle/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=nettle
 pkgver=3.4.1
-pkgrel=0
+pkgrel=1
 pkgdesc="A low-level cryptographic library"
 url="http://www.lysator.liu.se/~nisse/nettle/"
 arch="all"
@@ -17,7 +17,13 @@ source="https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-	[ "$CARCH" = "armhf" ] && local _ARM_NEON="--disable-arm-neon"
+	local _arch_opts=
+
+	case "$CARCH" in
+	armhf|armv7)
+		_arch_opts="--disable-arm-neon"
+	esac
+
 	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
@@ -30,7 +36,7 @@ build() {
 		--localstatedir=/var \
 		--enable-shared \
 		--disable-openssl \
-		$_ARM_NEON
+		$_arch_opts
 	make
 	# strip comments in fields from .pc as it confuses pkgconf
 	sed -i -e 's/ \#.*//' *.pc


### PR DESCRIPTION
A previous commit ensures arm neon is disabled for armhf:
36a1b9b653eb45ae33735f906d3e7ff6e4d61365

Extend this to armv7 as well. It uses vfpv3-d16 fpu which doesn't include
neon instruction set.