### PR TITLE
main/curl: fix missing static library symbols

### DIFF
--- a/main/curl/APKBUILD
+++ b/main/curl/APKBUILD
@@ -13,7 +13,7 @@ depends="ca-certificates"
 depends_dev="openssl-dev libssh2-dev nghttp2-dev zlib-dev"
 checkdepends="python2"
 makedepends="$depends_dev autoconf automake groff libtool perl"
-subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev libcurl"
+subpackages="$pkgname-static $pkgname-dbg $pkgname-doc $pkgname-dev libcurl"
 source="https://curl.haxx.se/download/$pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -112,6 +112,12 @@ libcurl() {
 
 	mkdir -p "$subpkgdir"/usr
 	mv "$pkgdir"/usr/lib "$subpkgdir"/usr
+}
+
+static() {
+	pkgdesc="Curl static library"
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib/
 }
 
 sha512sums="1629ba154691bf9d936e0bce69ec8fb54991a40d34bc16ffdfb117f91e3faa93164154fc9ae9043e963955862e69515018673b7239f2fd625684a59cdd1db81c  curl-7.64.1.tar.xz"

--- a/main/curl/APKBUILD
+++ b/main/curl/APKBUILD
@@ -82,7 +82,7 @@ builddir="$srcdir/$pkgname-$pkgver"
 build() {
 	cd "$builddir"
 	autoreconf -vif
-	./configure \
+	./configure LDFLAGS=-static PKG_CONFIG='pkg-config --static' \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \


### PR DESCRIPTION
Linking to `libcurl.a` results of missing symbols.
There is the same problem with `libssh2.a`.