### PR TITLE
community/caddy: upgrade to 0.11.4

### DIFF
--- a/community/caddy/APKBUILD
+++ b/community/caddy/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=caddy
-pkgver=0.11.1
+pkgver=0.11.4
 pkgrel=0
 pkgdesc="Fast, cross-platform HTTP/2 web server with automatic HTTPS"
 url="https://caddyserver.com/"
@@ -66,7 +66,7 @@ package() {
 		"$pkgdir"/etc/$pkgname/$pkgname.conf
 }
 
-sha512sums="a87b3926f22ef942fe341171aeda4967991d22475b6c38556de14301072798e2de78d12fca814044f94d0c5447b8dc9d60d6c412b8e6d6c059c3353431740571  caddy-0.11.1.tar.gz
+sha512sums="463c1e570292c042ffc959c2bf0c20df55477843deeef2f782030fe681ab8c5317505fdb00659662d52ffc8a56b5b1a7b7e6fc72b7f737d4950331ac781f239a  caddy-0.11.4.tar.gz
 00fe095efd8d801f0c2c69832c7240858080407ea3696ca07f6b53d3304f7e2784566d8a6b447cb83d7dc4542db551f1b4fa48ff031da7e4a1d4a26e59fc05c5  caddy.initd
 7808688e92ab9950403a9b8ad29777f5bd0f75aa8cccc1d49958bb1e5af1b972dfba0c6d31931354f702a3a13933d0a1b8f28b82eed263773d71b79ec95cc15c  caddy.confd
 c24805d17234e6cf40fe1dd102c03f05cf6129d43f58f5567d540a0e4400ce89994820bb0e317f611c65459ae26bcf7110e23a8fecaae11ca78a561892b45d75  caddy.conf"


### PR DESCRIPTION
https://github.com/mholt/caddy/releases/tag/v0.11.4