### PR TITLE
main/mosquitto: Fix for CVE-2018-12546, CVE-2018-12550, CVE-2018-12551

### DIFF
--- a/main/mosquitto/APKBUILD
+++ b/main/mosquitto/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Pedro Filipe <xpecex@outlook.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mosquitto
-pkgver=1.5.5
-pkgrel=1
+pkgver=1.5.6
+pkgrel=0
 pkgdesc="An Open Source MQTT v3.1 Broker"
-url="http://mosquitto.org/"
+url="https://mosquitto.org/"
 arch="all"
 license="BSD"
 replaces="mosquitto-utils"
@@ -22,6 +22,10 @@ source="http://mosquitto.org/files/source/$pkgname-$pkgver.tar.gz
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   1.5.6-r0:
+#     - CVE-2018-12546
+#     - CVE-2018-12550
+#     - CVE-2018-12551
 #   1.5.3-r0:
 #     - CVE-2018-12543
 #   1.4.15-r0:
@@ -87,6 +91,6 @@ clients() {
 	mv "$pkgdir"/usr/bin/mosquitto_[ps]ub "$subpkgdir"/usr/bin/
 }
 
-sha512sums="4984a8c3a48450ae87dfca9ea825433332c22a5c1b214b7c6d134789675431ba1bcebaceea2fe32c5d32c91ec47b9ded7b61c0c2caf6551f10e4f8dc455a5351  mosquitto-1.5.5.tar.gz
+sha512sums="99bd935f93ae25f0c7992870780cce4748b35ffd58fd0d39e20ee69f34c28d3eac289cf0c7dec078dbdced3bda12da4569d4b5e84ebdaa5514640f331ca3238b  mosquitto-1.5.6.tar.gz
 fb000f9fa1ef94cbf3811a23b5692c0c8f9e2df945959cef6005462715e99d6f75cf6b31bd496271ffc17634024aed986771a73962fef865c0d386f6c194fb33  config.patch
 16f96d8f7f3a8b06e2b2e04d42d7e0d89a931b52277fc017e4802f7a3bc85aff4dd290b1a0c40382ea8f5568d0ceb7319c031d9be916f346d805231a002b0433  mosquitto.initd"


### PR DESCRIPTION
This PR fixes multiple vulnerabilities in mosquitto. Details can be found at https://mosquitto.org/blog/2019/02/version-1-5-6-released/