### PR TITLE
main/openssl: Fix openssl secfix version number

### DIFF
--- a/main/openssl/APKBUILD
+++ b/main/openssl/APKBUILD
@@ -20,7 +20,7 @@ esac
 builddir="$srcdir/openssl-$pkgver"
 
 # secfixes:
-#   1.1.a-r0:
+#   1.1.1a-r0:
 #     - CVE-2018-0734
 #     - CVE-2018-0735
 


### PR DESCRIPTION
I have raised the PR against master, but this change also needs to be ported to the https://github.com/alpinelinux/aports/tree/3.9-stable branch (and potentially others?).  If I should raise separate PRs for those, please let me know.