### PR TITLE
testing/imv: fix and reenable ppc64le build failures for bool decls

### DIFF
--- a/testing/imv/APKBUILD
+++ b/testing/imv/APKBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Drew DeVault <sir@cmpwn.com>
 pkgname=imv
 pkgver=3.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Image viewer for X11/Wayland"
 url="https://github.com/eXeC64/imv"
-arch="all !ppc64le"
+arch="all"
 license="MIT"
 makedepends="
 	asciidoc
@@ -27,6 +27,9 @@ prepare() {
 
 build() {
 	cd "$builddir"
+	case "$CARCH" in
+		ppc64le) export CFLAGS="$CFLAGS -U__ALTIVEC__";;
+	esac
 	make
 }
 


### PR DESCRIPTION
Building on ppc64le resulted in errors of type:
rc/viewport.h:26:58: error: unknown type name 'bool'; did you mean '_Bool'?

This occurs when building (by default) with ALTIVEC since it undefines bool in SDL_cpuinfo.h bool:
#ifdef __ALTIVEC__
#if defined(HAVE_ALTIVEC_H) && !defined(__APPLE_ALTIVEC__) && !defined(SDL_DISABLE_ALTIVEC_H)
#include <altivec.h>
#undef pixel
#undef bool
#endif           

Additionally since imv links with freeimage which is built without ALTIVEC enabled building imv with ALTIVEC enabled would also be required.                                           