### PR TITLE
WiP main/libmicrohttpd: upgrade to 0.9.63

### DIFF
--- a/main/libmicrohttpd/APKBUILD
+++ b/main/libmicrohttpd/APKBUILD
@@ -2,15 +2,15 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libmicrohttpd
-pkgver=0.9.62
+pkgver=0.9.63
 pkgrel=0
 pkgdesc="A small C library that is supposed to make it easy to run an HTTP server as part of another application."
 url="https://www.gnu.org/software/libmicrohttpd/"
 arch="all"
-license="GPL"
-makedepends="curl-dev libgcrypt-dev gnutls-dev"
+license="LGPL-2.1-or-later"
+makedepends="curl-dev gnutls-dev libgcrypt-dev"
 subpackages="$pkgname-dev $pkgname-doc"
-source="ftp://ftp.gnu.org/gnu/libmicrohttpd/$pkgname-$pkgver.tar.gz"
+source="https://ftp.gnu.org/gnu/libmicrohttpd/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
@@ -41,4 +41,4 @@ package() {
 		"$pkgdir"/usr/include/platform.h
 }
 
-sha512sums="337f29dbc5e8c30132c17aad6142f21ea1c794b0ce80a3fc4c5e1e14b3dabb300aa410bf9413ef9e65d5d486fcfedbc3716725763a1fa28b4687c9f2aa3158e4  libmicrohttpd-0.9.62.tar.gz"
+sha512sums="cb99e7af84fb6d7c0fd3894a9dc0fbff14959b35347506bd3211a65bbfad36455007b9e67493e97c9d8394834408df10eeabdc7758573e6aae0ba6f5f87afe17  libmicrohttpd-0.9.63.tar.gz"


### PR DESCRIPTION
https://mirrors.kernel.org/gnu/libmicrohttpd/ 0.9.63