### PR TITLE
main/mariadb: switch default charset to utf8mb4

### DIFF
--- a/main/mariadb/APKBUILD
+++ b/main/mariadb/APKBUILD
@@ -7,7 +7,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mariadb
 pkgver=10.3.13
-pkgrel=3
+pkgrel=4
 pkgdesc="A fast SQL database server"
 url="https://www.mariadb.org"
 pkgusers="mysql"
@@ -109,8 +109,8 @@ build() {
 		-DSYSCONF2DIR=/etc/my.cnf.d \
 		-DMYSQL_DATADIR=/var/lib/mysql \
 		-DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock \
-		-DDEFAULT_CHARSET=utf8 \
-		-DDEFAULT_COLLATION=utf8_general_ci \
+		-DDEFAULT_CHARSET=utf8mb4 \
+		-DDEFAULT_COLLATION=utf8mb4_general_ci \
 		-DENABLED_LOCAL_INFILE=ON \
 		-DINSTALL_INFODIR=share/info \
 		-DINSTALL_MANDIR=share/man \


### PR DESCRIPTION
Fix for https://bugs.alpinelinux.org/issues/9965