### PR TITLE
community/elixir: upgrade to 1.8.1

### DIFF
--- a/community/elixir/APKBUILD
+++ b/community/elixir/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Marlus Saraiva <marlus.saraiva@gmail.com>
 pkgname=elixir
-pkgver=1.7.4
+pkgver=1.8.1
 pkgrel=0
 pkgdesc="Elixir is a dynamic, functional language designed for building scalable and maintainable applications"
 url="http://elixir-lang.org"
@@ -33,4 +33,4 @@ package() {
 	make DESTDIR="$pkgdir" PREFIX=/usr install
 }
 
-sha512sums="594e76601e0d6f7eeddfcaa9b76a2e5c66f702a497599fffc5e9255790c18ac5e00b986fc45fd3b90335522f51272bcd4bcf2b9f8951b94eebfb1d56ac7cebc2  elixir-1.7.4.tar.gz"
+sha512sums="114970707505cbf89f8fa55d5c54989dded7feb39cb3674e88f64e19f1a0680086ae49c856fb76fb7eaf0142fa0a0b81b1d5b9570825e05f083a9c580b0ca017  elixir-1.8.1.tar.gz"


### PR DESCRIPTION
https://elixir-lang.org/blog/2019/01/14/elixir-v1-8-0-released/