### PR TITLE
community/runc: upgrade for CVE-2019-5736

### DIFF
--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -3,13 +3,14 @@
 
 pkgname=runc
 
-# NOTE: using explicit post-1.0.0_rc6 commit, for containerd-1.2.1,
-# see https://github.com/containerd/containerd/blob/v1.2.1/RUNC.md
-# and https://github.com/containerd/containerd/blob/v1.2.1/vendor.conf
-_commit=96ec2177ae841256168fcf76954f7177af9446eb
+# NOTE: using explicit post-1.0.0_rc6 commit, for CVE-2019-5736
+# (https://nvd.nist.gov/vuln/detail/CVE-2019-5736).  This commit is more recent
+# than the one specified by containerd
+# (https://github.com/containerd/containerd/blob/v1.2.3/vendor.conf)
+_commit=6635b4f0c6af3810594d2770f662f34ddc15b40d
 
 pkgver=1.0.0_rc6
-pkgrel=0
+pkgrel=1
 pkgdesc="CLI tool for spawning and running containers according to the OCI specification"
 url="https://www.opencontainers.org"
 arch="all"
@@ -41,4 +42,4 @@ package() {
 	install -Dm644 "$builddir"/man/man8/* "$pkgdir"/usr/share/man/man8/
 }
 
-sha512sums="ec3d3fec773f2f9df714b0813efb110e21e328634e0b4ae77f323a892d0327aea5d4b6f9ae2a549aa06fda5b27431f4514fd663c7033dc170ca1a03627931f9d  runc-96ec2177ae841256168fcf76954f7177af9446eb.tar.gz"
+sha512sums="37bb09463df4742b0ea5b1f079f609642ab5621707674844ffef06f733703ec1d09b52a180ccb2d66c284c56ba242f7a1b70ba4c4c45722bf85fd2fd924bb9df  runc-6635b4f0c6af3810594d2770f662f34ddc15b40d.tar.gz"


### PR DESCRIPTION
build from the commit that addresses https://nvd.nist.gov/vuln/detail/CVE-2019-5736

will need to backport this to [3.9] branch, and maybe other older Alpine versions?

@ncopa @andypost 