### PR TITLE
main/apache2: Create /run folder for apache2 on install

### DIFF
--- a/main/apache2/APKBUILD
+++ b/main/apache2/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=apache2
 _pkgreal=httpd
 pkgver=2.4.38
-pkgrel=1
+pkgrel=2
 pkgdesc="A high performance Unix-based HTTP server"
 url="https://httpd.apache.org/"
 arch="all"
@@ -172,6 +172,10 @@ package() {
 			error "$i MPM was not built"
 		fi
 	done
+
+	# create the run directory
+	# ref #9982
+	mkdir -p "$pkgdir"/run/apache2
 }
 
 _make_conf_dir() {


### PR DESCRIPTION
The directory /run/apache2 is only created when running in openrc (see
apache2.initd). When installing on a non-openrc system (e.g. docker),
this folder is missing and apache2 refuses to start.

Closes https://bugs.alpinelinux.org/issues/9982