### PR TITLE
community/wxgtk: Rebuild due to incompatibilities

### DIFF
--- a/community/wxgtk/APKBUILD
+++ b/community/wxgtk/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: ScrumpyJack <scrumpyjack@st.ilet.to>
 pkgname=wxgtk
 pkgver=3.0.4
-pkgrel=0
+pkgrel=1
 pkgdesc="GTK2 port of wxWidgets GUI library"
 url="http://www.wxwidgets.org/"
 arch="all"


### PR DESCRIPTION
The wx-libraries had some incompabitilies regarding C++ ABI, as seen in
filezilla.

Just rebuild it and everything is fine.
This closes https://bugs.alpinelinux.org/issues/9970