### PR TITLE
main/libgit2: security upgrade to 0.28.1

### DIFF
--- a/main/libgit2/APKBUILD
+++ b/main/libgit2/APKBUILD
@@ -3,13 +3,13 @@
 # Contributor: Pierre-Gilas MILLON <pgmillon@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libgit2
-pkgver=0.27.7
+pkgver=0.28.1
 pkgrel=0
 pkgdesc="A linkable library for Git"
 url="https://libgit2.org/"
 arch="all"
 license="GPL-2.0-only-WITH-GCC-exception-2.0"
-depends_dev="curl-dev libssh2-dev"
+depends_dev="libssh2-dev"
 makedepends="$depends_dev python2 cmake zlib-dev openssl-dev"
 subpackages="$pkgname-dev $pkgname-tests::noarch"
 provides="$pkgname-libs"  # for backward compatibility with v3.4
@@ -21,6 +21,8 @@ options="!check" # FIXME some tests fails
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   0.28.1-r0:
+#   - CVE-2018-11235
 #   0.27.4-r0:
 #   - CVE-2018-15501
 #   0.27.3-r0:
@@ -62,5 +64,5 @@ tests() {
 	cp -a "$builddir"/tests "$subpkgdir"/usr/src/$pkgname/
 }
 
-sha512sums="de2e266939bd40bc580603539e1156906b97299523336ddc6a66c3bec26729495bef2daa2d240b83b7e011e93852381e95a4407132b0440a5aa1e1b7642c0011  libgit2-0.27.7.tar.gz
-268e24554282666900a2179a368dc2569cb3bce60ffea187fd53de1bc119a85abc02cddd8be2ab607d44db793c4807acdbb49fc5d1badfc08bf382fa511d7b3e  build-both-static-dynamic.patch"
+sha512sums="5a1bc5c6af6ad25cb8b2c446e75a774d2a615d4999ec3223d681c7b120d83e7cecd94f1ca549bac0802f5324e27e73cc5a6483ad410636c2f06f098b30b1b647  libgit2-0.28.1.tar.gz
+fc574046fd16b2b1e24b11598bf06da8e51de81b0677dcc736b080e4881287c9974a02120128b89ea02ed00fe9c59b03347ef4a2bafd2ddb4acf57770b6c580f  build-both-static-dynamic.patch"

--- a/main/libgit2/build-both-static-dynamic.patch
+++ b/main/libgit2/build-both-static-dynamic.patch
@@ -5,26 +5,26 @@ Subject: [PATCH] Build both static and dynamic library
 This is very hack-ish, it makes option BUILD_SHARED_LIBS unusable.
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -39,7 +39,6 @@
+@@ -43,7 +43,6 @@
  # Build options
  #
- OPTION( SONAME				"Set the (SO)VERSION of the target"		ON  )
--OPTION( BUILD_SHARED_LIBS	"Build Shared Library (OFF for Static)"	ON  )
- OPTION( THREADSAFE			"Build libgit2 as threadsafe"			ON )
- OPTION( BUILD_CLAR			"Build Tests using the Clar suite"		ON  )
- OPTION( BUILD_EXAMPLES		"Build library usage example apps"		OFF )
-@@ -58,6 +57,8 @@
- OPTION( DEBUG_POOL			"Enable debug pool allocator"			OFF )
- OPTION( ENABLE_WERROR			"Enable compilation with -Werror"		OFF )
- OPTION( USE_BUNDLED_ZLIB    "Use the bundled version of zlib"       OFF )
-+
-+SET( BUILD_SHARED_LIBS ON )
+ OPTION(SONAME				"Set the (SO)VERSION of the target"			 ON)
+-OPTION(BUILD_SHARED_LIBS		"Build Shared Library (OFF for Static)"			 ON)
+ OPTION(THREADSAFE			"Build libgit2 as threadsafe"				 ON)
+ OPTION(BUILD_CLAR			"Build Tests using the Clar suite"			 ON)
+ OPTION(BUILD_EXAMPLES			"Build library usage example apps"			OFF)
+@@ -65,6 +64,8 @@
+ OPTION(ENABLE_WERROR			"Enable compilation with -Werror"			OFF)
+ OPTION(USE_BUNDLED_ZLIB    		"Use the bundled version of zlib"			OFF)
  
++SET( BUILD_SHARED_LIBS ON )
++
  IF (UNIX AND NOT APPLE)
- 	OPTION( ENABLE_REPRODUCIBLE_BUILDS	"Enable reproducible builds" 			OFF )
+	OPTION(ENABLE_REPRODUCIBLE_BUILDS "Enable reproducible builds"				OFF)
+ ENDIF()
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -407,9 +407,12 @@
+@@ -476,9 +476,12 @@
  ENDIF()
  
  # Compile and link libgit2
@@ -35,10 +35,10 @@ This is very hack-ish, it makes option BUILD_SHARED_LIBS unusable.
 +ADD_LIBRARY(git2_static STATIC ${WIN_RC} ${LIBGIT2_OBJECTS})
 +SET_TARGET_PROPERTIES(git2_static PROPERTIES OUTPUT_NAME git2 CLEAN_DIRECT_OUTPUT 1)
 +
+ SET_TARGET_PROPERTIES(git2 PROPERTIES C_STANDARD 90)
  SET_TARGET_PROPERTIES(git2 PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${libgit2_BINARY_DIR})
  SET_TARGET_PROPERTIES(git2 PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${libgit2_BINARY_DIR})
- SET_TARGET_PROPERTIES(git2 PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${libgit2_BINARY_DIR})
-@@ -445,7 +448,7 @@
+@@ -515,7 +518,7 @@
  ENDIF ()
  
  # Install


### PR DESCRIPTION
Fixes CVE-2018-11235

Updating to 0.28.0 should also fix this issue (cargo segfault) : https://bugs.alpinelinux.org/issues/9825 cf. https://github.com/rust-lang/cargo/issues/6365 & https://github.com/libgit2/libgit2/pull/4880 / https://github.com/libgit2/libgit2/pull/4911
Probably a good idea to merge this before https://github.com/alpinelinux/aports/pull/6071 .

I didn't make any major change to `build-both-static-dynamic.patch`, just adapted it to the newer versions of the files it patches.