### PR TITLE
testing/traefik: bump to 1.7.9

### DIFF
--- a/testing/traefik/APKBUILD
+++ b/testing/traefik/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Joe Holden <jwh@zorins.us>
 # Maintainer: Joe Holden <jwh@zorins.us>
 pkgname=traefik
-pkgver=1.7.8
+pkgver=1.7.9
 pkgrel=0
 pkgdesc="The Cloud Native Edge Router"
 url="https://traefik.io"
@@ -62,7 +62,7 @@ package() {
 		"$pkgdir"/etc/$pkgname/$pkgname.toml
 
 }
-sha512sums="6306e5531e51aa2204e76fa57aa69a83dc3b0ca7a02e94a832f272b9e3d5499521d2fd49a7fd07e889fabf2a5fd5e4f4b49da0a96750b2a390efceeae86deac3  traefik-1.7.8.tar.gz
+sha512sums="ce49b4f3925c5b69062c21e489080c059ab78112636ccd682d3f05ec9da03e410d863937527711c29e42e5e498a7be5fde33d2034867f3500afc1db789ef075f  traefik-1.7.9.tar.gz
 2fe42052cdb035b202c7c0a1acd5cfe9ed1800ca067f2f5588d54e6ffbdd672d7c46cfd57fcfc219cadaa24d64a0e038a20d092eb1e4c04b67b8eb83c0af74fd  traefik.initd
 1519c2f446c4bc3af8407eb367a05e5ec0491f28d56d5385b12a550c84606d84e2424aadd5d72e56e628fd1da3f0f194ab3c077e6da85ead75a256f8e8069751  traefik.confd
 140904e2358bc6dadbfb0f2c3cd83cd7aabeae1a54cd7424bbb50f941bde3273046c402352a2b888425ba74dda27d0a6e2197c2855b4fd6ad522eb9c4eaebd61  traefik.toml"


### PR DESCRIPTION
https://github.com/containous/traefik/releases/tag/v1.7.9