### PR TITLE
community/containerd: update to 1.2.4

### DIFF
--- a/community/containerd/APKBUILD
+++ b/community/containerd/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=containerd
 
 # NOTE: containerd's Makefile tries to get REVISION from git, but we're building from a tarball.
-_commit=7f5f1176dd9fb3cc8d3ce5de91759ed3dc969fa2
-pkgver=1.2.3
+_commit=e6b3f5632f50dbc4e9cb6288d911bf4f5e95b18e
+pkgver=1.2.4
 pkgrel=0
 pkgdesc="An open and reliable container runtime"
 url="https://containerd.io"
@@ -42,4 +42,4 @@ package() {
 	install -Dm644 "$builddir"/man/*.5 "$pkgdir"/usr/share/man/man5/
 }
 
-sha512sums="01c6e196ddaebfffd069aca87c669acae3923bc9b25f3a59070a6fdbe28661afd4e548b9bb6a4faec3d3d3a937f36eacd7c179986d04f83428cff439e41b1e0d  containerd-1.2.3.tar.gz"
+sha512sums="8a4e5064b2c1e14d39d9943f445ae18e4653f73bd3bb90f7efe558b9ffd4345db4b308362103dbfbede716eae8b547c1cec3d93962acb0a2ff34d66e4fce0d80  containerd-1.2.4.tar.gz"


### PR DESCRIPTION
Although this was released to address the recent `runc` vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2019-5736) which we've addressed by updating our `runc` package, there are several other notable updates, per https://github.com/containerd/containerd/releases/tag/v1.2.4.

@ncopa @andypost