### PR TITLE
main/tinyproxy: Fix wrong path in openrc-startscript

### DIFF
--- a/main/tinyproxy/APKBUILD
+++ b/main/tinyproxy/APKBUILD
@@ -2,28 +2,24 @@
 # Maintainer: Michael Mason <ms13sp@gmail.com>
 pkgname=tinyproxy
 pkgver=1.10.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Lightweight HTTP proxy"
 pkgusers="tinyproxy"
 pkggroups="tinyproxy"
 url="https://www.banu.com/tinyproxy/"
 arch="all"
 license="GPL-2.0-or-later"
-depends=
 makedepends="asciidoc"
 install="tinyproxy.pre-install"
-subpackages="$pkgname-doc"
+subpackages="$pkgname-doc $pkgname-openrc"
 source="https://github.com/$pkgname/$pkgname/releases/download/$pkgver/$pkgname-$pkgver.tar.gz
 	tinyproxy.initd"
 
 _builddir="$srcdir/$pkgname-$pkgver"
+
 prepare() {
 	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
+	default_prepare
 
 	# set default user to tinyproxy:tinyproxy and correct pidfile
 	sed -i -e 's:^User.*:User tinyproxy:' \
@@ -41,18 +37,17 @@ build() {
 		--localstatedir=/var \
 		--sysconfdir=/etc/tinyproxy \
 		--disable-dependency-tracking \
-		--enable-reverse \
-		|| return 1
-	make || return 1
+		--enable-reverse
+	make
 }
 
 package() {
 	cd "$_builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 	install -d -D -o tinyproxy -g tinyproxy "$pkgdir"/var/run/tinyproxy
 	install -d -D -o tinyproxy -g tinyproxy "$pkgdir"/var/log/tinyproxy
 	install -Dm755 "$srcdir"/tinyproxy.initd "$pkgdir"/etc/init.d/tinyproxy
 }
 
 sha512sums="53187adef865672a6c29f126189cf896bd02f8b0789ee2ee00b82d93b952c70dacdd2c82b0845392e518560e75e6ee107ce7662d1ec71108f293ba1d7de6aa2a  tinyproxy-1.10.0.tar.gz
-78ed4e80cce82a3d08685c67ae2d0e7e5d238b394fb4a58c3f30ff3de2fb96db0afdfd7ff474effae6215172ffcbad193fbbcc483dba8cdc8aa08eb893fc0717  tinyproxy.initd"
+7ef08d290acec161d0c2257885c10bc5c827a72bcc67d842c4a0396d114d1f6acabd40643e051f4c233798b449046e8c8a449ebe404f9ac4c93238adbff7909b  tinyproxy.initd"

--- a/main/tinyproxy/tinyproxy.initd
+++ b/main/tinyproxy/tinyproxy.initd
@@ -26,9 +26,9 @@ start() {
 	checkpath --directory --owner tinyproxy:tinyproxy /var/run/tinyproxy
 	ebegin "Starting tinyproxy"
 	if [ -n "${PIDFILE}" ]; then
-		start-stop-daemon --start --pidfile "${PIDFILE}" --startas /usr/sbin/tinyproxy -- -c "${CONFFILE}"
+		start-stop-daemon --start --pidfile "${PIDFILE}" --startas /usr/bin/tinyproxy -- -c "${CONFFILE}"
 	else
-		start-stop-daemon --start --exec /usr/sbin/tinyproxy -- -c "${CONFFILE}"
+		start-stop-daemon --start --exec /usr/bin/tinyproxy -- -c "${CONFFILE}"
 	fi
 	eend $?
 }
@@ -40,7 +40,7 @@ stop() {
 	if [ -n "${PIDFILE}" ]; then
 		start-stop-daemon --stop --pidfile "${PIDFILE}"
 	else
-		start-stop-daemon --stop --exec /usr/sbin/tinyproxy
+		start-stop-daemon --stop --exec /usr/bin/tinyproxy
 	fi
 	eend $?
 }


### PR DESCRIPTION
The openrc initscript used /usr/sbin/tinyproxy, whereas it should be
/usr/bin/tinyproxy.

Other changes:
* Modernized APKBUILD
* Add -openrc subpackage

Fixes https://bugs.alpinelinux.org/issues/9973
Should be backported to 3.9