### PR TITLE
community/erlang: Fix compilation against musl >=1.1.21

### DIFF
--- a/community/erlang/APKBUILD
+++ b/community/erlang/APKBUILD
@@ -5,68 +5,64 @@
 pkgname=erlang
 pkgver=21.2.1
 _srcver=$pkgver
-pkgrel=0
+pkgrel=1
 pkgdesc="General-purpose programming language and runtime environment"
 url="http://www.erlang.org/"
 license="Apache-2.0"
 arch="all"
 depends="$pkgname-kernel $pkgname-stdlib $pkgname-compiler"
+options="!check" # TODO: multiple test failures on my machine, analyze this
 makedepends="perl-dev zlib-dev ncurses-dev openssl-dev openjdk8 unixodbc-dev
 	autoconf wxgtk-dev glu-dev"
 subpackages="$pkgname-dev
              $pkgname-asn1:asn
-	     $pkgname-common-test:common_test
-	     $pkgname-compiler:compiler
+	     $pkgname-common-test:common_test:noarch
+	     $pkgname-compiler:compiler:noarch
 	     $pkgname-crypto:crypto
-	     $pkgname-debugger:debugger
-	     $pkgname-dialyzer:dialyzer
-	     $pkgname-diameter:diameter
-	     $pkgname-edoc:edoc
-	     $pkgname-eldap:eldap
-	     $pkgname-erl-docgen:erl_docgen
+	     $pkgname-debugger:debugger:noarch
+	     $pkgname-dialyzer:dialyzer:noarch
+	     $pkgname-diameter:diameter:noarch
+	     $pkgname-edoc:edoc:noarch
+	     $pkgname-eldap:eldap:noarch
+	     $pkgname-erl-docgen:erl_docgen:noarch
 	     $pkgname-erl-interface:erl_interface
-	     $pkgname-erts:erts
-	     $pkgname-et:et
-	     $pkgname-eunit:eunit
-	     $pkgname-hipe:hipe
-	     $pkgname-inets:inets
-	     $pkgname-jinterface:jinterface
-	     $pkgname-kernel:kernel
-	     $pkgname-megaco:megaco
-	     $pkgname-mnesia:mnesia
-	     $pkgname-observer:observer
+	     $pkgname-erts:erts:noarch
+	     $pkgname-et:et:noarch
+	     $pkgname-eunit:eunit:noarch
+	     $pkgname-hipe:hipe:noarch
+	     $pkgname-inets:inets:noarch
+	     $pkgname-jinterface:jinterface:noarch
+	     $pkgname-kernel:kernel:noarch
+	     $pkgname-megaco:megaco:noarch
+	     $pkgname-mnesia:mnesia:noarch
+	     $pkgname-observer:observer:noarch
 	     $pkgname-odbc:odbc
 	     $pkgname-os-mon:os_mon
-	     $pkgname-otp-mibs:otp_mibs
-	     $pkgname-parsetools:parsetools
-	     $pkgname-public-key:public_key
-	     $pkgname-reltool:reltool
+	     $pkgname-otp-mibs:otp_mibs:noarch
+	     $pkgname-parsetools:parsetools:noarch
+	     $pkgname-public-key:public_key:noarch
+	     $pkgname-reltool:reltool:noarch
 	     $pkgname-runtime-tools:runtime_tools
-	     $pkgname-sasl:sasl
-	     $pkgname-snmp:snmp
-	     $pkgname-ssh:ssh
-	     $pkgname-ssl:ssl
-	     $pkgname-stdlib:stdlib
-	     $pkgname-syntax-tools:syntax_tools
+	     $pkgname-sasl:sasl:noarch
+	     $pkgname-snmp:snmp:noarch
+	     $pkgname-ssh:ssh:noarch
+	     $pkgname-ssl:ssl:noarch
+	     $pkgname-stdlib:stdlib:noarch
+	     $pkgname-syntax-tools:syntax_tools:noarch
 	     $pkgname-tools:tools
-	     $pkgname-xmerl:xmerl
+	     $pkgname-xmerl:xmerl:noarch
 	     $pkgname-wx:wx"
-options="!check"
 source="https://github.com/erlang/otp/archive/OTP-$_srcver.tar.gz
         0005-Do-not-install-nteventlog-and-related-doc-files-on-n.patch
         0010-fix-nteventlog-remove.patch
+        fix-musl-1.1.21.patch
 	"
 
 builddir="$srcdir/otp-OTP-$_srcver"
 
 prepare() {
-	default_prepare || return 1
+	default_prepare
 
-	cd "$builddir"
-	#rm lib/os_mon/ebin/*
-}
-
-build() {
 	cd "$builddir"
 	export CPPFLAGS="-D_BSD_SOURCE $CPPFLAGS"
 	export PATH="/usr/lib/jvm/java-1.8-openjdk/bin:$PATH"
@@ -79,14 +75,28 @@ build() {
 		--build="$CBUILD" \
 		--enable-threads \
 		--enable-shared-zlib \
-		--enable-ssl=dynamic-ssl-lib \
-		|| return 1
-	make -j1 || return 1
+		--enable-ssl=dynamic-ssl-lib
+}
+
+build() {
+	cd "$builddir"
+	make
+}
+
+check() {
+	cd "$builddir"
+
+	# build smoke tests
+	ERL_TOP="$builddir" make release_tests
+
+	# run the tests
+	cd "$builddir"/release/tests/test_server
+	"$builddir"/bin/erl -s ts install -s ts smoke_test batch -s init stop
 }
 
 package() {
 	cd "$builddir"
-	make -j1 DESTDIR="$pkgdir" install || return 1
+	make -j1 DESTDIR="$pkgdir" install
 }
 
 _mv_erlang_lib() {
@@ -142,7 +152,6 @@ xmerl() { _mv_erlang_lib xmerl; }
 wx() { _mv_erlang_lib wx; }
 
 dev() {
-	set -x
 	local i= j=
 	depends="$pkgname=$pkgver-r$pkgrel $depends_dev"
 	pkgdesc="$pkgdesc (development files)"
@@ -170,7 +179,7 @@ dev() {
 	for i in lib/*.so usr/lib/*.so; do
 		if [ -L "$i" ]; then
 			mkdir -p "$subpkgdir"/"${i%/*}"
-			mv "$i" "$subpkgdir/$i" || return 1
+			mv "$i" "$subpkgdir/$i"
 		fi
 	done
 	return 0
@@ -179,4 +188,5 @@ dev() {
 
 sha512sums="777ad11ba632dc43592618f514278fb137b44bcf8aaafe78173996f2fed31c84c105d839f70fafacab22ac94e1ad238ef17e5722e244bf7291029f911a146ff2  OTP-21.2.1.tar.gz
 5d377faccd73382bc86c5aa3182767bc5d1639220c78c2f624135f597f3c823a6871ff13f6f8a109baa8a9ae5d215233b40193e5cfe07af275aa53f327e956de  0005-Do-not-install-nteventlog-and-related-doc-files-on-n.patch
-bb4346dabe17115bc310837c5f0aeb367a745d8ba2159495084e599d0419fc57648d144c811306914ac48d0e087d6150a356f38640ba070642b4578acc5fe573  0010-fix-nteventlog-remove.patch"
+bb4346dabe17115bc310837c5f0aeb367a745d8ba2159495084e599d0419fc57648d144c811306914ac48d0e087d6150a356f38640ba070642b4578acc5fe573  0010-fix-nteventlog-remove.patch
+631e00d78f2db2c8cdb2972a49d65cd2eb673e886fdc64fb9fd8d1218e02ec55122fe0b425b0d7154bb53003f855614960ccec10184796ce06acdde09bd62422  fix-musl-1.1.21.patch"

--- a/community/erlang/fix-musl-1.1.21.patch
+++ b/community/erlang/fix-musl-1.1.21.patch
@@ -1,0 +1,33 @@
+The musl library until v1.1.20 provided the expected symbols by erlang.
+Starting with 1.1.21 the __sigaction and __libc_sigaction are no longer present,
+leading to strange errors like "dlsym: Resource temporarily unavailable" when erlang
+is trying to setup the signal handlers.
+
+musl 1.1.20-r3:
+/ # readelf -a /lib/ld-musl-x86_64.so.1 | grep sigaction
+   112: 0000000000046130   386 FUNC    GLOBAL DEFAULT    8 __libc_sigaction
+   114: 00000000000462b2    38 FUNC    GLOBAL DEFAULT    8 __sigaction
+   826: 00000000000462b2    38 FUNC    WEAK   DEFAULT    8 sigaction
+
+musl 1.1.21-r0:
+/ # readelf -a /lib/ld-musl-x86_64.so.1 | grep sigaction
+   725: 000000000004453c    38 FUNC    WEAK   DEFAULT    8 sigaction
+
+So this patch fixes the function to patch, from __libc_sigaction to sigaction.
+Cause of this issue is:
+https://git.musl-libc.org/cgit/musl/commit/src/signal/sigaction.c?id=9b14ad541068d4f7d0be9bcd1ff4c70090d868d3
+
+
+--- old/erts/emulator/hipe/hipe_x86_signal.c
++++ new/erts/emulator/hipe/hipe_x86_signal.c
+@@ -166,8 +166,8 @@
+  * There are libc-internal calls to __libc_sigaction which install handlers, so we must
+  * override __libc_sigaction rather than __sigaction.
+  */
+-#define NEXT_SIGACTION "__libc_sigaction"
+-#define LIBC_SIGACTION __libc_sigaction
++#define NEXT_SIGACTION "sigaction"
++#define LIBC_SIGACTION _sigaction
+ #define OVERRIDE_SIGACTION
+ #ifndef _NSIG
+ #define _NSIG NSIG


### PR DESCRIPTION
The latest update in musl removed some internal wrappers around
sigaction, which erlang needs. Erlang tries to patch them, so it can do
other fancy stuff before calling the real sigaction.

Without this PR all erlang applications failed to start with the following
message: "dlsym: Resource temporarily unavailable"

Other changes:
* APKBUILD modernized
* Made the build parallel (erlang supports this)
* Some subpackages (which only contain .beam files) are platfrom independant, so specify them as "noarch"
* check() function implemented, but disabled as the tests fail on my machine

Fixes https://bugs.alpinelinux.org/issues/9983 and all other packages requiring erlang.
Backporting **not** needed as alpine 3.9 is still on musl 1.1.20