### PR TITLE
testing/splix: new aport

### DIFF
--- a/testing/splix/APKBUILD
+++ b/testing/splix/APKBUILD
@@ -1,0 +1,57 @@
+# Contributor: Taner Tas <taner76@gmail.com>
+# Maintainer: Taner Tas <taner76@gmail.com>
+pkgname=splix
+_pkgver=2.0.0
+reporev=315
+pkgver=${_pkgver}_svn$reporev
+pkgrel=0
+pkgdesc="CUPS drivers for SPL (Samsung Printer Language) printers."
+url="http://splix.ap2c.org/"
+arch="all"
+license="GPL-2.0-only"
+makedepends="
+	cups-dev
+	jbigkit-dev
+	subversion
+	rsync
+	"
+install="$pkgname.post-install"
+source="
+	https://dev.alpinelinux.org/archive/$pkgname/$pkgname-$pkgver.tar.gz
+	splix-deviceID.patch
+	"
+svnurl="svn://svn.code.sf.net/p/splix/code/splix"
+disturl="dev.alpinelinux.org:/archive/$pkgname/"
+builddir="$srcdir/$pkgname"
+options="!check" # No test suite
+
+snapshot() {
+	clean
+	deps
+	mkdir -p "$srcdir"
+	cd "$srcdir"
+	svn co -r $reporev "$svnurl" $pkgname
+	rm -rf $pkgname/.svn
+	tar czvf $SRCDEST/$pkgname-$pkgver.tar.gz $pkgname
+	rsync --progress -La $SRCDEST/$pkgname-$pkgver.tar.gz $disturl
+}
+
+build() {
+	cd "$builddir"
+	export CXXFLAGS="$CXXFLAGS -fno-strict-aliasing"
+	make drv
+	make all DRV_ONLY=1
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install DRV_ONLY=1
+}
+
+sha512sums="34e9cd193e30b30d3d4bff2a2b2d78b022f41a0642e4a71db9150d9222284f731b64ea9903911e271b65ef18dc501848e945852774aa790ce8331dede8bcb088  splix-2.0.0_svn315.tar.gz
+6d869435a7e3faf9cb7f18b008b9ec1a3884efc6e2bb11a6c51bc54b08b283b04de9cc41c96e1c7c693e1fb6cbd79c1eb16de8ea896458034c72224dd3758fd4  splix-deviceID.patch"

--- a/testing/splix/splix-deviceID.patch
+++ b/testing/splix/splix-deviceID.patch
@@ -1,0 +1,105 @@
+diff -up splix/ppd/samsung.drv.in.deviceID splix/ppd/samsung.drv.in
+--- splix/ppd/samsung.drv.in.deviceID	2013-08-26 21:45:31.000000000 +0200
++++ splix/ppd/samsung.drv.in	2013-09-02 13:56:57.002669362 +0200
+@@ -39,6 +39,7 @@ Manufacturer "Samsung"
+             Resolution k 1 0 0 0 "300dpi/300 DPI"
+  
+             ModelName "SCX-4200"
++            Attribute "1284DeviceID" "" "MFG:Samsung;MDL:SCX-4200 Series;CMD:GDI;"
+             PCFileName "scx4200.ppd"
+         } {
+             Resolution k 1 0 0 0 "300dpi/300 DPI"
+@@ -83,6 +84,7 @@ Manufacturer "Samsung"
+                     PCFileName "ml1520.ppd"
+                 } {
+                     ModelName "ML-1610"
++                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-1610;CMD:GDI;"
+                     PCFileName "ml1610.ppd"
+                 } {
+                     ModelName "ML-1710"
+@@ -121,6 +123,7 @@ Manufacturer "Samsung"
+                     Throughput 22
+     		{
+                     	ModelName "ML-2250"
++                        Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-2250;"
+     	                PCFileName "ml2250.ppd"
+     		} {
+                     	ModelName "ML-2251"
+@@ -166,6 +169,7 @@ Manufacturer "Samsung"
+                     PCFileName "ml1640.ppd"
+                 } {
+                     ModelName "ML-2010"
++                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-2010;CMD:GDI;"
+                     PCFileName "ml2010.ppd"
+                 } {
+                     ModelName "ML-2015"
+@@ -177,6 +181,7 @@ Manufacturer "Samsung"
+                     #import "srtmode.defs"
+     
+                     ModelName "ML-2510"
++                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-2510 Series;CMD:GDI;"
+                     PCFileName "ml2510.ppd"
+                 }
+             }
+@@ -193,15 +198,18 @@ Manufacturer "Samsung"
+     
+                 {
+                     ModelName "ML-1660"
++                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-1660 Series;CMD:GDI,FWV,EXT;"
+                     PCFileName "ml1660.ppd"
+                 } {
+                     ModelName "ML-1910"
+                     PCFileName "ml1910.ppd"
+                 } {
+                     ModelName "ML-2525"
++                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-2525 Series;CMD:GDI,FWV,EXT;"
+                     PCFileName "ml2525.ppd"
+                 } {
+                     ModelName "ML-2525W"
++                    Attribute "1284DeviceID" "" "MFG:Samsung;MDL:ML-2525W Series;CMD:GDI,FWV,EXT;"
+                     PCFileName "ml2525w.ppd"
+                 }
+             } {
+@@ -465,6 +473,7 @@ Manufacturer "Samsung"
+         Attribute General CMSFile "CLP-310"
+ 
+         ModelName "CLP-310"
++        Attribute "1284DeviceID" "" "MFG:Samsung;MDL:CLP-310 Series;CMD:SPLC,FWV;"
+         PCFileName "clp310.ppd"
+     }{
+         Attribute General CMSFile "CLP-315"
+diff -up splix/ppd/xerox.drv.in.deviceID splix/ppd/xerox.drv.in
+--- splix/ppd/xerox.drv.in.deviceID	2013-08-26 17:22:00.000000000 +0200
++++ splix/ppd/xerox.drv.in	2013-09-02 13:55:22.634957854 +0200
+@@ -66,6 +66,7 @@ Manufacturer "Xerox"
+                 } {
+                     #import "manualduplex.defs"
+                     ModelName "Phaser 3120"
++                    Attribute "1284DeviceID" "" "MFG:Xerox;MDL:Phaser 3120;CMD:GDI;"
+                     PCFileName "ph3120.ppd"
+                 } {
+                     #import "manualduplex.defs"
+@@ -74,6 +75,7 @@ Manufacturer "Xerox"
+                 } {
+                     #import "manualduplex.defs"
+                     ModelName "Phaser 3130"
++                    Attribute "1284DeviceID" "" "MFG:Xerox;MDL:Phaser 3130;CMD:PCL5E,PCL6;"
+                     PCFileName "ph3130.ppd"
+                 } {
+                     // Multi-tray
+@@ -118,6 +120,7 @@ Manufacturer "Xerox"
+ 
+             {
+                 ModelName "Phaser 3117"
++                Attribute "1284DeviceID" "" "MFG:Xerox;MDL:Phaser 3117;CMD:GDI;"
+                 PCFileName "ph3117.ppd"
+             } {
+                 Resolution k 1 0 0 0 "1200x600dpi/1200x600 DPI"
+@@ -131,6 +134,7 @@ Manufacturer "Xerox"
+ 
+                 {
+                     ModelName "Phaser 3124"
++                    Attribute "1284DeviceID" "" "MFG:Xerox;MDL:Phaser 3124;CMD:GDI;"
+                     PCFileName "ph3124.ppd"
+                 }
+             }

--- a/testing/splix/splix.post-install
+++ b/testing/splix/splix.post-install
@@ -1,0 +1,14 @@
+#!/bin/sh
+  cat <<EOF
+Installation of the color profile for color printers:
+-----------------------------------------------------
+
+	Color printers need color profile files to get better results. These
+files are provided by your printer manufacturer and you have to install them
+manually. To do that, download the official linux drivers and locate the "cms"
+directory. Install the contents to "/usr/share/cups/profiles/\$MANUFACTURER".
+
+	Samsung color profile files are available at:
+		(Then use MANUFACTURER=samsung)
+		http://splix.ap2c.org/samsung_cms.tar.bz2
+EOF


### PR DESCRIPTION
http://splix.ap2c.org/
CUPS drivers for SPL (Samsung Printer Language) printers.

Based on Arch Linux aur.