### PR TITLE
testing/multibootusb: New aport

### DIFF
--- a/testing/multibootusb/APKBUILD
+++ b/testing/multibootusb/APKBUILD
@@ -1,0 +1,52 @@
+# Contributor: Simon Frankenberger <simon-alpine@fraho.eu>
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
+pkgname=multibootusb
+pkgver=9.2.0
+pkgrel=0
+pkgdesc="Create multi boot live Linux on a USB disk"
+url="http://multibootusb.org/"
+arch="noarch"
+license="GPL-2.0"
+depends="python3 p7zip parted util-linux py3-udev mtools py3-dbus py3-six $pkgname-data"
+makedepends="py-setuptools"
+options="!check" # this package has no tests
+subpackages="$pkgname-gui:_gui $pkgname-data:_data"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/mbusb/${pkgname}/archive/v${pkgver}.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	python3 setup.py build
+}
+
+package() {
+	cd "$builddir"
+	python3 setup.py install --root="$pkgdir" --prefix="/usr"
+
+	# remove windows executables
+	rm -rf "$pkgdir"/usr/share/multibootusb/data/tools/dd \
+		"$pkgdir"/usr/share/multibootusb/data/tools/mkfs \
+		"$pkgdir"/usr/share/multibootusb/data/tools/syslinux/syslinux_windows.zip
+}
+
+_data() {
+	description="$description (Data files)"
+	options="!archcheck"
+	mkdir -p "$subpkgdir"/usr/share
+	mv "$pkgdir"/usr/share/multibootusb \
+		"$subpkgdir"/usr/share
+}
+
+_gui() {
+	description="$description (GUI)"
+	depends="py3-qt5 $pkgname"
+	mkdir -p "$subpkgdir"
+
+	mkdir -p "$subpkgdir"/usr/share
+	mv "$pkgdir"/usr/share/pixmaps \
+		"$pkgdir"/usr/share/applications \
+		"$subpkgdir"/usr/share
+
+
+}
+sha512sums="461ce6edd835b2a017d96c3987338cd9004894949ac0b121fc289d100b7945dd89970f966e48310b97f312221a2f5a047190c55802d3a07a9eec0bf6ec22356d  multibootusb-9.2.0.tar.gz"


### PR DESCRIPTION
Adds multibootusb, a python utility to create bootable medias with
multiple linux distributions.

Homepage: http://multibootusb.org/
Source: https://github.com/mbusb/multibootusb

Closes https://bugs.alpinelinux.org/issues/9874