### PR TITLE
community/s-nail: Move from testing

### DIFF
--- a/community/s-nail/APKBUILD
+++ b/community/s-nail/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Steffen Nurpmeso <steffen@sdaoden.eu>
 pkgname=s-nail
 pkgver=14.9.11
-pkgrel=3
+pkgrel=4
 pkgdesc="SysV mail/BSD Mail/POSIX mailx: send and receive Internet mail"
 url="https://www.sdaoden.eu/code.html#s-mailx"
 arch="all"
@@ -27,7 +27,7 @@ build() {
 		VAL_IDNA=idn \
 		VAL_RANDOM="libgetrandom sysgetrandom urandom builtin" \
 		\
-		config &&
+		config
 	make build # XXX unite with config in v14.9.12
 }
 


### PR DESCRIPTION
This PR moves the s-nail aport from testing to community. I think this
aport is stable enough to provide stable releases.

Closes https://bugs.alpinelinux.org/issues/9919

Please also backport this change to 3.9