### PR TITLE
testing/hiawatha: upgrade to 10.8.0.4

### DIFF
--- a/testing/hiawatha/APKBUILD
+++ b/testing/hiawatha/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Kurt Marasco <celilo@lavabit.com>
 # Contributor: Pascal Ernster <aur at hardfalcon dot net>
 pkgname=hiawatha
-pkgver=10.8.3
+pkgver=10.8.4
 pkgrel=0
 pkgdesc='Secure and advanced webserver'
 url='https://www.hiawatha-webserver.org/'
@@ -48,6 +48,6 @@ package() {
     "$pkgdir"/usr/share/doc/hiawatha/hiawatha.conf.sample
 }
 
-sha512sums="6c584062424512d85e3a7ef5bdea549df8aac413d211f641fed8593f6dcd95fdaf7bd9f30e1279a17bdca6eec30201aa736b02dfb0ce597eed4ed668b79c5418  hiawatha-10.8.3.tar.gz
+sha512sums="45eaf9fadfdc66911dcf334d2b9a6426e2949e8e834ed4405b6731fdac5626baaf949562a96c012573f96deb113db69fbdc9467f99ec1146e63cb44384ba7ec7  hiawatha-10.8.4.tar.gz
 4e1201110396e13b979948caae9c2dfb34f55398225d924164d2f0818b6778500ef3426b0ad358210ef7780289fbd752f7e006220941437fbcdd378746bf5a3d  hiawatha.initd
 b2aad6d02e03a3e25dc6dc30deab4637a7de5448255b6b707363e8c71ae1029e669bacdb6b88889ec1aa804fe717560e872dc44d049127af9aa155a8895c8a60  hiawatha.conf.sample"


### PR DESCRIPTION
https://www.hiawatha-webserver.org/changelog

--------------------------------------------

hiawatha (10.8.4) stable; urgency=high

    Bugfix: Directory traversal when AllowDotFiles is enabled.

-- Hugo Leisink <hugo at leisink.net> Tue, 12 Feb 2018 21:37:04 +0100