### PR TITLE
community/you-get: add dependencies

### DIFF
--- a/community/you-get/APKBUILD
+++ b/community/you-get/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Ivan Tham <pickfire@riseup.net>
 pkgname=you-get
 pkgver=0.4.1205
-pkgrel=0
+pkgrel=1
 pkgdesc="Tiny command line utility to download media contents"
 url="https://you-get.org"
 arch="noarch"
 license="MIT"
-depends="python3"
+depends="ca-certificates ffmpeg python3"
 makedepends="python3-dev"
 source="https://files.pythonhosted.org/packages/source/${pkgname:0:1}/$pkgname/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
- ffmpeg is used when combining video parts
- ca-certificates is used when making HTTPS connections