### PR TITLE
testing/openscap: fix ppc64le build break defining PATH_MAX

### DIFF
--- a/testing/openscap/APKBUILD
+++ b/testing/openscap/APKBUILD
@@ -2,10 +2,10 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=openscap
 pkgver=1.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="NIST Certified SCAP 1.2 toolkit "
 url="https://www.open-scap.org/tools/openscap-base/"
-arch="all !ppc64le"
+arch="all"
 license="LGPLv2+"
 makedepends="cmake python3-dev dbus-dev dbus-glib-dev bash libselinux-dev
 curl-dev openssl-dev libgcrypt-dev acl-dev libblkid libcap-dev libxml2-dev 
@@ -18,6 +18,7 @@ source="https://github.com/OpenSCAP/openscap/releases/download/$pkgver/$pkgname-
 openscap.patch
 sysctl_unittest.patch
 xinetd_probe.patch
+fix-ppc64le-path_max.patch
 path_mounted.patch"
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -58,4 +59,5 @@ sha512sums="9405d0f17b60ab4a52ddd0f49d0e2395eb2540f0d07d68dfd142e2b8b2988e88cf12
 6122baecee2ed3340e5f67d345bd75cfdb8450be26ef5d92d350ae1f13f799bbfd787171539ace4e5ec3e38d093e210aac99745c0fb122ceb7e9ac2e676894ae  openscap.patch
 346cc61dd2bfb270bd33bbfc09dd25a28e99eafd7ea9ec5a687eeb92ac2cce3015b2628fd110f2a7d912f9359ca78658ed9eb2782dc2f49d31e119ed8e25fd5b  sysctl_unittest.patch
 166015c7823ec5a9dd9695ec919aea9fb0843df87c4613ff8b98362c8cccc55a8201c0de18c09901c61406ef27e84c23d569dbf0cff7c5717b72a00d1bbe2746  xinetd_probe.patch
+70bcc718e473862ecac22752ad553c5a520e42207688960403e3d7b9caefc7868fc4d81379a07d3c50fdd9373caab5ac91f758f306d1e3d2bbf355618674b611  fix-ppc64le-path_max.patch
 f2157d6b1d31affe16edb184a287b69d28808123f1cc26a5a4238040d935517b307772b1f2d66271b8ee99b59a4d204930f9147b78478c83c36c7fc8718ec1d9  path_mounted.patch"

--- a/testing/openscap/fix-ppc64le-path_max.patch
+++ b/testing/openscap/fix-ppc64le-path_max.patch
@@ -1,0 +1,10 @@
+--- a/src/OVAL/probes/unix/linux/iflisteners_probe.c
++++ b/src/OVAL/probes/unix/linux/iflisteners_probe.c
+@@ -53,6 +53,7 @@
+ #include <netdb.h>
+ #include <arpa/inet.h>
+ #include <regex.h>
++#include <limits.h>
+ 
+ #include "_seap.h"
+ #include "probe-api.h"


### PR DESCRIPTION
add limits.h definition to allow PATH_MAX to be defined on ppc64le. Re-enable building for ppc64le.