### PR TITLE
testing/mpdecimal: fix ppc64le bld break by adding update_config_guess

### DIFF
--- a/testing/mpdecimal/APKBUILD
+++ b/testing/mpdecimal/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stefan Stutz <stutz@pm.me>
 pkgname=mpdecimal
 pkgver=2.4.2
-pkgrel=0
+pkgrel=1
 pkgdesc="A complete implementation of the General Decimal Arithmetic Specification"
 url="http://www.bytereef.org/mpdecimal/index.html"
 arch="all"
@@ -12,6 +12,7 @@ source="http://www.bytereef.org/software/mpdecimal/releases/$pkgname-$pkgver.tar
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
+	update_config_guess || return 1
         cd "$builddir"
         ./configure --prefix=/usr
 }


### PR DESCRIPTION
On ppc64le build failing with:
configure: error: cannot guess build type; you must specify one

Adding update_config_guess will fix this