### PR TITLE
testing/wireguard-virt: upgrade to 0.0.20190123

### DIFF
--- a/testing/wireguard-virt/APKBUILD
+++ b/testing/wireguard-virt/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20181218
-_rel=0
+_ver=0.0.20190123
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-virt}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="73c8e9b37d857349b75df776607c15ea2082814952acdba3ad6379c4ce631601db2767603e46ecadf1bce9348a0c26d07f4f6b5857ddd72bb4f4411d1d13d88c  WireGuard-0.0.20181218.tar.xz"
+sha512sums="8be40cebabca2a40f98ee10d6fa93708b12b17c6b0eab9aa8b7fab353d78fbd5b280b7b90cb2973cf74a1b9d47c3d250bf3ede6d1318129a45d57e21329b7f59  WireGuard-0.0.20190123.tar.xz"


### PR DESCRIPTION
This amends ee1955b85cff0d912c7c3c96d58b807541e48082 as
it bumped wireguard-vanilla and -tools only.