### PR TITLE
testing/gdal: gdal should enable geos

### DIFF
--- a/testing/gdal/APKBUILD
+++ b/testing/gdal/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Trevor R.H. Clarke <trevor@notcows.com>
 pkgname=gdal
 pkgver=2.4.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A translator library for raster and vector geospatial data formats"
 url="http://gdal.org"
 arch="all"
@@ -11,6 +11,7 @@ depends=""
 depends_dev="gdal"
 makedepends="
 	curl-dev
+	geos-dev
 	giflib-dev
 	jpeg-dev
 	libjpeg-turbo-dev


### PR DESCRIPTION
`geos`, `proj4` and `gdal` is used together frequently.
`proj4` could be added `proj4-dev`. but `geos` have to be enabled when compiling.