### PR TITLE
community/i3lock: upgrade to 2.11.1

### DIFF
--- a/community/i3lock/APKBUILD
+++ b/community/i3lock/APKBUILD
@@ -1,29 +1,37 @@
 # Contributor: Johannes Matheis <jomat+alpinebuild@jmt.gr>
 # Maintainer: Johannes Matheis <jomat+alpinebuild@jmt.gr>
 pkgname=i3lock
-pkgver=2.10
+pkgver=2.11.1
 pkgrel=0
 pkgdesc="An improved screenlocker based upon XCB and PAM"
 url="https://i3wm.org/i3lock/"
 arch="all"
 license="MIT"
 depends="xkeyboard-config"
-makedepends="libev-dev cairo-dev linux-pam-dev libxkbcommon-dev xcb-util-image-dev"
+makedepends="libev-dev cairo-dev linux-pam-dev libxkbcommon-dev
+	xcb-util-image-dev xcb-util-xrm-dev"
 subpackages="$pkgname-doc"
-source="$url/$pkgname-$pkgver.tar.bz2"
+source="https://i3wm.org/i3lock/i3lock-$pkgver.tar.bz2"
 builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
 	default_prepare
 
 	cd "$builddir"
-
 	# Fix ticket FS#31544, sed line taken from gentoo
-	sed -i -e 's:login:base-auth:g' i3lock.pam
+	sed -i -e 's:login:base-auth:g' pam/i3lock
 }
 
 build() {
 	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var \
+		--disable-builddir
 	make
 }
 
@@ -35,8 +43,6 @@ check() {
 package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install
-	install -m755 -d "$pkgdir/usr/share/man/man1/"
-	install -m644 $pkgname.1 "$pkgdir/usr/share/man/man1/"
 }
 
-sha512sums="ea865b202668212b58d0b97d0263171847e1bd0c529e2fd3d26c15ef253861b9a8357ff2efaa6a4f342c4d0d1ab03bc00f95f4d4008760ec8e0767ac29195517  i3lock-2.10.tar.bz2"
+sha512sums="8b779aa0a560884adc1a508e1f07f712bdf043f72c377c24d5e7e186a6b97f34a5bda7aa67de41f5e15a1a541f4a2c2d28bc284057926a5833d70b67437d073c  i3lock-2.11.1.tar.bz2"


### PR DESCRIPTION
As of v2.11 upstream is using autotools. Also add xcb-util-xrm-dev
make dependency to satisfy XCB_UTIL_XRM module requirement.