### PR TITLE
community/glm workaround for upstreambug #832, to allow building kicad

### DIFF
--- a/community/glm/APKBUILD
+++ b/community/glm/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=glm
 pkgver=0.9.9.3
-pkgrel=1
+pkgrel=2
 pkgdesc="C++ mathematics library for graphics programming"
 url="http://glm.g-truc.net/"
 arch="noarch"
@@ -10,6 +10,7 @@ makedepends="cmake"
 subpackages="$pkgname-dev"
 source="https://github.com/g-truc/glm/releases/download/$pkgver/glm-$pkgver.zip
 	fix-endian-test.patch
+   constexpr.patch
 	"
 builddir="$srcdir/$pkgname"
 
@@ -36,4 +37,5 @@ package() {
 }
 
 sha512sums="eb7589345eb627d9fda84771bd2cf3eb0e4e9e48bf6bb7490bd8844b66558717de5dc96cde9d66e81f7ba4e54090f18dbe1bbccb2452ed0ed8c17cdf7b6e4aa2  glm-0.9.9.3.zip
-54fd8926e3e8271ea32ff25b433003e7eef5611ac7b3c397c0e3b5cd6b139071dba774964c8ae4f8859523a354fec45e38d4ad8fdd46f930f21ce529cc95a65e  fix-endian-test.patch"
+54fd8926e3e8271ea32ff25b433003e7eef5611ac7b3c397c0e3b5cd6b139071dba774964c8ae4f8859523a354fec45e38d4ad8fdd46f930f21ce529cc95a65e  fix-endian-test.patch
+325e71fa396584258eb8c6f7c3592b21bbc41843dd0a1a5a90544a2ec33356c1ec143388b8b2c18282b4e17d3c1ede12c0286c233c7a02c41ca6826b24a6a8d9  constexpr.patch"

--- a/community/glm/constexpr.patch
+++ b/community/glm/constexpr.patch
@@ -1,0 +1,11 @@
+diff -urw src/glm/glm/detail/setup.hpp glm/glm/detail/setup.hpp
+--- src/glm/glm/detail/setup.hpp	2019-02-20 16:32:28.020000000 +0000
++++ glm/glm/detail/setup.hpp	2019-02-20 16:32:22.200000000 +0000
+@@ -283,7 +283,6 @@
+ #else
+ #	define GLM_HAS_CONSTEXPR ((GLM_LANG & GLM_LANG_CXX0X_FLAG) && GLM_HAS_INITIALIZER_LISTS && (\
+ 		((GLM_COMPILER & GLM_COMPILER_INTEL) && (GLM_COMPILER >= GLM_COMPILER_INTEL17)) || \
+-		((GLM_COMPILER & GLM_COMPILER_GCC) && (GLM_COMPILER >= GLM_COMPILER_GCC6)) || \
+ 		((GLM_COMPILER & GLM_COMPILER_VC) && (GLM_COMPILER >= GLM_COMPILER_VC15))))
+ #endif
+ 


### PR DESCRIPTION
There is  a bug in glm(https://github.com/g-truc/glm/issues/832) that confuses gcc versions and C++11 support with C++14 support, which prohibits to compile kicad (https://bugs.launchpad.net/kicad/+bug/1804030). This patch reverts the change that introduces this problem.