### PR TITLE
community/mmc-utils: new aport

### DIFF
--- a/testing/mmc-utils/APKBUILD
+++ b/testing/mmc-utils/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Olliver Schinagl <oliver@schinagl.nl>
+# Maintainer: Olliver Schinagl <oliver@schinagl.nl>
+pkgname=mmc-utils
+pkgver="0_git$(date +%Y%m%d)"
+pkgrel=0
+pkgdesc="Configure MMC storage devices from userspace."
+url="http://pyropus.ca/software/memtester/"
+arch="all"
+license="GPL-2.0"
+depends=""
+makedepends="linux-headers"
+options="!check" # No checks available
+subpackages="${pkgname}-doc"
+_githash="aef913e31b659462fe6b9320d241676cba97f67b"
+source="https://git.kernel.org/pub/scm/linux/kernel/git/cjb/mmc-utils.git/snapshot/mmc-utils-${_githash}.tar.gz"
+
+build()
+{
+	cd "${srcdir}/mmc-utils-${_githash}"
+	make
+}
+
+package()
+{
+	cd "${srcdir}/mmc-utils-${_githash}"
+	make DESTDIR="${pkgdir}" prefix="/usr" install install-man
+	gzip -c "man/mmc.1" > "mmc.1.gz" && \
+		install -D -m 644 "mmc.1.gz" "${pkgdir}/usr/share/man/man1/mmc.1.gz"
+}
+sha512sums="afadc665f1c181d4ae2fd5e1e1fc0b05f79a0de039d04ee8db333254aafd7b90edc49accb54d8d7e29a2e541fce34037f83449f91a7b2ebbd2f28e415d9904fd  mmc-utils-aef913e31b659462fe6b9320d241676cba97f67b.tar.gz"


### PR DESCRIPTION
mmc-utils sadly has no tags or releases, there is only the git version.

MMC Utils are useful when working with /dev/mmcblk devices, so mostly useful (embedded) arm