### PR TITLE
community/memtester: new aport 4.3.0

### DIFF
--- a/testing/memtester/APKBUILD
+++ b/testing/memtester/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Olliver Schinagl <oliver@schinagl.nl>
+# Maintainer: Olliver Schinagl <oliver@schinagl.nl>
+pkgname=memtester
+pkgver=4.3.0
+pkgrel=0
+pkgdesc="A userspace utility for testing the memory subsystem for faults."
+url="http://pyropus.ca/software/memtester/"
+arch="all"
+license="GPL-2.0-or-later"
+depends=""
+options="!check" # No checks available
+subpackages="${pkgname}-doc"
+source="http://pyropus.ca/software/memtester/old-versions/memtester-4.3.0.tar.gz"
+
+build()
+{
+	make
+}
+
+package()
+{
+	install -D -m 755 "memtester" "${pkgdir}/usr/bin/memtester"
+	gzip -c "memtester.8" > "memtester.8.gz" && \
+		install -D -m 644 "memtester.8.gz" "${pkgdir}/usr/share/man/man8/memtester.8.gz"
+	install -D -m 644 "COPYING" "${pkgdir}/usr/share/doc/${pkgname}/copying"
+	gzip -c "README" > "README.gz" && \
+		install -D -m 644 "README.gz" "${pkgdir}/usr/share/doc/${pkgname}/README.gz"
+	gzip -c "README.tests" > "README.tests.gz" && \
+		install -D -m 644 "README.tests.gz" "${pkgdir}/usr/share/doc/${pkgname}/README.tests.gz"
+}
+
+sha512sums="045bcc73855706ff03e8ca65297a0d6e5b5ac02f99dae0f17cef1310b403efcb78d9a7295eca6d2de703b0a7b2f71b58a37f5a42040f01fc77a321a8d2205888  memtester-4.3.0.tar.gz"


### PR DESCRIPTION
While memtester hasn't been updated in quite a while, it is a very common tool to do memory testing from Linux.