### PR TITLE
testing/hiawatha: upgrade to 10.9 / clarify licence

### DIFF
--- a/testing/hiawatha/APKBUILD
+++ b/testing/hiawatha/APKBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Kurt Marasco <celilo@lavabit.com>
 # Contributor: Pascal Ernster <aur at hardfalcon dot net>
 pkgname=hiawatha
-pkgver=10.8.4
+pkgver=10.9
 pkgrel=0
 pkgdesc='Secure and advanced webserver'
 url='https://www.hiawatha-webserver.org/'
 arch=all
-license='GPL'
+license='GPL-2.0-only'
 options="suid !check"
 subpackages="$pkgname-doc $pkgname-openrc"
 makedepends="cmake libxml2-dev libxslt-dev mbedtls-dev"
@@ -48,6 +48,6 @@ package() {
     "$pkgdir"/usr/share/doc/hiawatha/hiawatha.conf.sample
 }
 
-sha512sums="45eaf9fadfdc66911dcf334d2b9a6426e2949e8e834ed4405b6731fdac5626baaf949562a96c012573f96deb113db69fbdc9467f99ec1146e63cb44384ba7ec7  hiawatha-10.8.4.tar.gz
+sha512sums="ccd59d6c302d797a88d88206c770e794b9a2a374040bd08da67530c13a36d0232bf759df1f8d54790dcf1ae3dc25cadbd7d3af542f559b845a5cf346020eb74a  hiawatha-10.9.tar.gz
 4e1201110396e13b979948caae9c2dfb34f55398225d924164d2f0818b6778500ef3426b0ad358210ef7780289fbd752f7e006220941437fbcdd378746bf5a3d  hiawatha.initd
 b2aad6d02e03a3e25dc6dc30deab4637a7de5448255b6b707363e8c71ae1029e669bacdb6b88889ec1aa804fe717560e872dc44d049127af9aa155a8895c8a60  hiawatha.conf.sample"


### PR DESCRIPTION
https://www.hiawatha-webserver.org/changelog