### PR TITLE
main/tar: backport "Remove erroneous abort() call"

### DIFF
--- a/main/tar/APKBUILD
+++ b/main/tar/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=tar
 pkgver=1.31
-pkgrel=0
+pkgrel=1
 pkgdesc="Utility used to store, backup, and transport files"
 url="https://www.gnu.org"
 arch="all"
@@ -11,7 +11,8 @@ install=""
 makedepends=""
 subpackages="$pkgname-doc"
 source="https://ftp.gnu.org/gnu/tar/$pkgname-$pkgver.tar.xz
-	ignore-apk-tools-checksums.patch"
+	ignore-apk-tools-checksums.patch
+	remove-erroneous-abort-call.patch"
 
 # secfixes:
 #   1.29-r1:
@@ -53,4 +54,5 @@ package() {
 }
 
 sha512sums="2185fbbe53d4fe3eb688ebc8c2fa800db2599a282c07007358d0a011394aafcf27a80600d044bb4fc299a172d3d95f953106be651db33eb6e5555bd24cad02aa  tar-1.31.tar.xz
-9cde0f1509328bc5fe2cb46642b53c7681c548cf28a2fb83eda7e9374c9c0ad27a0cd55b9c0cc93951def58dafa55ee71cace5493ddcb7966ee94dc5f1099739  ignore-apk-tools-checksums.patch"
+9cde0f1509328bc5fe2cb46642b53c7681c548cf28a2fb83eda7e9374c9c0ad27a0cd55b9c0cc93951def58dafa55ee71cace5493ddcb7966ee94dc5f1099739  ignore-apk-tools-checksums.patch
+c4d317b9968c0638287e6dff77a7660d36e8ad4af56039146992d519d05a0f73b6a459cc88de7a4afd9909efd1bdbd3567d8b3aa67b48d89867600c1023400aa  remove-erroneous-abort-call.patch"

--- a/main/tar/remove-erroneous-abort-call.patch
+++ b/main/tar/remove-erroneous-abort-call.patch
@@ -1,0 +1,33 @@
+From 85c005ee1345c342f707f3c55317daf6cb050603 Mon Sep 17 00:00:00 2001
+From: Sergey Poznyakoff <gray@gnu.org.ua>
+Date: Thu, 10 Jan 2019 18:18:49 +0200
+Subject: Remove erroneous abort() call
+
+The call was introduced by commit ccef8581. It caused tar to abort
+on perfectly normal operations, like untarring archives containing
+./ with the -U option,
+
+See http://lists.gnu.org/archive/html/bug-tar/2019-01/msg00019.html
+for details.
+
+* src/extract.c (maybe_recoverable): Remove misplaced call to abort().
+---
+ src/extract.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/extract.c b/src/extract.c
+index 090b866..8276f8f 100644
+--- a/src/extract.c
++++ b/src/extract.c
+@@ -787,7 +787,7 @@ maybe_recoverable (char *file_name, bool regular, bool *interdir_made)
+ 	case UNLINK_FIRST_OLD_FILES:
+ 	  break;
+ 	}
+-      abort (); /* notreached */
++      FALLTHROUGH;
+ 
+     case ENOENT:
+       /* Attempt creating missing intermediate directories.  */
+-- 
+cgit v1.0-41-gc330
+


### PR DESCRIPTION
Fix https://bugs.alpinelinux.org/issues/10027
Backports in:
#6450
#6451
#6452
#6453