### PR TITLE
[3.9] community/tor: security upgrade to 0.3.4.11

### DIFF
--- a/community/tor/APKBUILD
+++ b/community/tor/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Christine Dodrill <me@christine.website>
 # Maintainer: Christine Dodrill <me@christine.website>
 pkgname=tor
-pkgver=0.3.4.9
-pkgrel=1
+pkgver=0.3.4.11
+pkgrel=0
 pkgdesc="Anonymous network connectivity"
 url="https://www.torproject.org"
 arch="all"
@@ -19,6 +19,8 @@ source="https://www.torproject.org/dist/$pkgname-$pkgver.tar.gz
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   0.3.4.11-r0:
+#   - CVE-2019-8955
 #   0.3.0.8-r0:
 #   - CVE-2017-0376
 #   0.3.2.10-r0:
@@ -61,7 +63,7 @@ package() {
 		"$pkgdir"/etc/conf.d/$pkgname
 }
 
-sha512sums="cc254a2cc2f21b4511e9cb215ba5f05fefc4dceffcf46a402efa2d3540872a4ed8e0095245df0802ea12c1367451bc16ca60c0aea6a77e2139580f3c5ba8c02f  tor-0.3.4.9.tar.gz
+sha512sums="cde57dd0b4ccb65068d18d81f8d75b471ebc3f0e484b7f7be8bd6e0041d4447f18639b0d71aa110559e76bdf40828f7343a87c9ecb17239ee56b2c10bea19216  tor-0.3.4.11.tar.gz
 6de4ada16ba58264a247da70343eabd763e992d6b6683977fc1c67b7b4a9731748a7ec9751e869ad4b4ae9c72cf71b2e12dc289bb6e2aee499917f7663f4a735  tor.initd
 2b0de119bfdf9eb57e13317b7392190b1b8272c8f96023c71d3fc29215d887e9a3d0ffcef37cdb50b18d34e4b2251f75a739e258e0bb72aabd3339418b22fd67  tor.confd
 da386ff7e387312e647f04d360517a1f4cb1efbee36f4a3a6feb89a979bb12fa350fe6dfed49af0cb076ae30bb0c527b5d54127683eaa5aa45d6940dddd89dfb  torrc.sample.patch"


### PR DESCRIPTION
https://blog.torproject.org/new-releases-tor-0402-alpha-0358-03411-and-03312