### PR TITLE
[3.8] community/tor: security upgrade to 0.3.3.12

### DIFF
--- a/community/tor/APKBUILD
+++ b/community/tor/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Christine Dodrill <me@christine.website>
 # Maintainer: Christine Dodrill <me@christine.website>
 pkgname=tor
-pkgver=0.3.3.7
+pkgver=0.3.3.12
 pkgrel=0
 pkgdesc="Anonymous network connectivity"
 url="https://www.torproject.org"
@@ -19,6 +19,8 @@ source="https://www.torproject.org/dist/$pkgname-$pkgver.tar.gz
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   0.3.3.12-r0:
+#   - CVE-2019-8955
 #   0.3.0.8-r0:
 #   - CVE-2017-0376
 #   0.3.2.10-r0:
@@ -61,7 +63,7 @@ package() {
 		"$pkgdir"/etc/conf.d/$pkgname
 }
 
-sha512sums="70c7d089fecde7d5c4ccf4fc0c774aa3da2121f297012065292f9e5efda54206365ef1fa830116ee143b027f5023a5eadcd6fd4629c4d2d930c12fa9fa7abf9d  tor-0.3.3.7.tar.gz
+sha512sums="d292971748d3b62d538877114e3cea68a5e942100d9a1a2a6a247dbeb1ac8b9033ec0604a0f8193d9c9ffd20f98670af982a4f4ffa6947d0aed226bd4f949a15  tor-0.3.3.12.tar.gz
 6de4ada16ba58264a247da70343eabd763e992d6b6683977fc1c67b7b4a9731748a7ec9751e869ad4b4ae9c72cf71b2e12dc289bb6e2aee499917f7663f4a735  tor.initd
 2b0de119bfdf9eb57e13317b7392190b1b8272c8f96023c71d3fc29215d887e9a3d0ffcef37cdb50b18d34e4b2251f75a739e258e0bb72aabd3339418b22fd67  tor.confd
 da386ff7e387312e647f04d360517a1f4cb1efbee36f4a3a6feb89a979bb12fa350fe6dfed49af0cb076ae30bb0c527b5d54127683eaa5aa45d6940dddd89dfb  torrc.sample.patch"


### PR DESCRIPTION
https://blog.torproject.org/new-releases-tor-0402-alpha-0358-03411-and-03312