### PR TITLE
main/tar: upgrade to 1.32

### DIFF
--- a/main/tar/APKBUILD
+++ b/main/tar/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=tar
-pkgver=1.31
+pkgver=1.32
 pkgrel=0
 pkgdesc="Utility used to store, backup, and transport files"
 url="https://www.gnu.org"
@@ -34,11 +34,10 @@ build() {
 	make
 }
 
-# some checks are failing in 1.31
-#check() {
-#	cd "$builddir"
-#	make check
-#}
+check() {
+	cd "$builddir"
+	make check
+}
 
 package() {
 	cd "$builddir"
@@ -52,5 +51,5 @@ package() {
 	ln -s /bin/tar "$pkgdir"/usr/bin/tar
 }
 
-sha512sums="2185fbbe53d4fe3eb688ebc8c2fa800db2599a282c07007358d0a011394aafcf27a80600d044bb4fc299a172d3d95f953106be651db33eb6e5555bd24cad02aa  tar-1.31.tar.xz
+sha512sums="1bd13854009b6ee08958481738e6bf661e40216a2befe461d06b4b350eb882e431b3a4eeea7ca1d35d37102df76194c9d933df2b18b3c5401350e9fc17017750  tar-1.32.tar.xz
 9cde0f1509328bc5fe2cb46642b53c7681c548cf28a2fb83eda7e9374c9c0ad27a0cd55b9c0cc93951def58dafa55ee71cace5493ddcb7966ee94dc5f1099739  ignore-apk-tools-checksums.patch"


### PR DESCRIPTION
This replaces https://github.com/alpinelinux/aports/pull/6449