### PR TITLE
testing/openjdk9: new aport

### DIFF
--- a/testing/openjdk9/10-portola.patch
+++ b/testing/openjdk9/10-portola.patch
@@ -1,0 +1,813 @@
+Author: Portola Project <portola-dev@openjdk.java.net>
+URL: https://openjdk.java.net/projects/portola/
+Summary: Provide a port of the JDK to the musl C library
+----
+
+diff -upr a/common/autoconf/build-aux/config.guess b/common/autoconf/build-aux/config.guess
+--- a/common/autoconf/build-aux/config.guess
++++ b/common/autoconf/build-aux/config.guess
+@@ -30,6 +30,17 @@
+ DIR=`dirname $0`
+ OUT=`. $DIR/autoconf-config.guess`
+ 
++# config.guess doesn't identify systems running the musl C library, and will
++# instead return a string with a -gnu suffix. This block detects musl and
++# modifies the string to have a -musl suffix instead. 
++echo $OUT | grep -- -linux- > /dev/null 2> /dev/null
++if test $? = 0; then
++  ldd_version=`ldd --version 2>&1 | head -1 | cut -f1 -d' '`
++  if [ x"${ldd_version}" = x"musl" ]; then
++    OUT=`echo $OUT | sed 's/-gnu/-musl/'`
++  fi
++fi
++
+ # Test and fix solaris on x86_64
+ echo $OUT | grep i386-pc-solaris > /dev/null 2> /dev/null
+ if test $? = 0; then
+diff -upr a/common/autoconf/build-aux/config.sub b/common/autoconf/build-aux/config.sub
+--- a/common/autoconf/build-aux/config.sub
++++ b/common/autoconf/build-aux/config.sub
+@@ -29,6 +29,11 @@
+ 
+ DIR=`dirname $0`
+ 
++if [ "$1"x = "x86_64-unknown-linux-musl"x ]; then
++    echo $1
++    exit
++fi
++
+ # First, filter out everything that doesn't begin with "aarch64-"
+ if ! echo $* | grep '^aarch64-' >/dev/null ; then
+     . $DIR/autoconf-config.sub "$@"
+diff -upr a/common/autoconf/buildjdk-spec.gmk.in b/common/autoconf/buildjdk-spec.gmk.in
+--- a/common/autoconf/buildjdk-spec.gmk.in
++++ b/common/autoconf/buildjdk-spec.gmk.in
+@@ -50,17 +50,20 @@ IMAGES_OUTPUTDIR := $(patsubst $(BUILD_O
+ 
+ OPENJDK_BUILD_CPU_LEGACY := @OPENJDK_BUILD_CPU_LEGACY@
+ OPENJDK_BUILD_CPU_LEGACY_LIB := @OPENJDK_BUILD_CPU_LEGACY_LIB@
++OPENJDK_BUILD_LIBC := @OPENJDK_BUILD_LIBC@
+ OPENJDK_TARGET_CPU := @OPENJDK_BUILD_CPU@
+ OPENJDK_TARGET_CPU_ARCH := @OPENJDK_BUILD_CPU_ARCH@
+ OPENJDK_TARGET_CPU_BITS := @OPENJDK_BUILD_CPU_BITS@
+ OPENJDK_TARGET_CPU_ENDIAN := @OPENJDK_BUILD_CPU_ENDIAN@
+ OPENJDK_TARGET_CPU_LEGACY := @OPENJDK_BUILD_CPU_LEGACY@
++OPENJDK_TARGET_LIBC := @OPENJDK_BUILD_LIBC@
+ 
+ HOTSPOT_TARGET_OS := @HOTSPOT_BUILD_OS@
+ HOTSPOT_TARGET_OS_TYPE := @HOTSPOT_BUILD_OS_TYPE@
+ HOTSPOT_TARGET_CPU := @HOTSPOT_BUILD_CPU@
+ HOTSPOT_TARGET_CPU_ARCH := @HOTSPOT_BUILD_CPU_ARCH@
+ HOTSPOT_TARGET_CPU_DEFINE := @HOTSPOT_BUILD_CPU_DEFINE@
++HOTSPOT_TARGET_LIBC := @HOTSPOT_BUILD_LIBC@
+ 
+ CFLAGS_JDKLIB := @OPENJDK_BUILD_CFLAGS_JDKLIB@
+ CXXFLAGS_JDKLIB := @OPENJDK_BUILD_CXXFLAGS_JDKLIB@
+diff -upr a/common/autoconf/configure.ac b/common/autoconf/configure.ac
+--- a/common/autoconf/configure.ac
++++ b/common/autoconf/configure.ac
+@@ -205,6 +205,7 @@ JDKOPT_SETUP_CODE_COVERAGE
+ 
+ # Need toolchain to setup dtrace
+ HOTSPOT_SETUP_DTRACE
++HOTSPOT_SETUP_SA
+ HOTSPOT_ENABLE_DISABLE_AOT
+ HOTSPOT_ENABLE_DISABLE_GTEST
+ 
+diff -upr a/common/autoconf/generated-configure.sh b/common/autoconf/generated-configure.sh
+--- a/common/autoconf/generated-configure.sh
++++ b/common/autoconf/generated-configure.sh
+@@ -705,6 +705,7 @@ FIXPATH_DETACH_FLAG
+ FIXPATH
+ BUILD_GTEST
+ ENABLE_AOT
++INCLUDE_SA_ATTACH
+ GCOV_ENABLED
+ ZIP_EXTERNAL_DEBUG_SYMBOLS
+ COPY_DEBUG_SYMBOLS
+@@ -973,6 +974,7 @@ CANONICAL_TOPDIR
+ ORIGINAL_TOPDIR
+ TOPDIR
+ PATH_SEP
++HOTSPOT_BUILD_LIBC
+ HOTSPOT_BUILD_CPU_DEFINE
+ HOTSPOT_BUILD_CPU_ARCH
+ HOTSPOT_BUILD_CPU
+@@ -984,6 +986,7 @@ OPENJDK_BUILD_CPU_OSARCH
+ OPENJDK_BUILD_CPU_ISADIR
+ OPENJDK_BUILD_CPU_LEGACY_LIB
+ OPENJDK_BUILD_CPU_LEGACY
++HOTSPOT_TARGET_LIBC
+ HOTSPOT_TARGET_CPU_DEFINE
+ HOTSPOT_TARGET_CPU_ARCH
+ HOTSPOT_TARGET_CPU
+@@ -1000,6 +1003,7 @@ RELEASE_FILE_OS_ARCH
+ RELEASE_FILE_OS_NAME
+ OPENJDK_MODULE_TARGET_PLATFORM
+ COMPILE_TYPE
++OPENJDK_TARGET_LIBC
+ OPENJDK_TARGET_CPU_ENDIAN
+ OPENJDK_TARGET_CPU_BITS
+ OPENJDK_TARGET_CPU_ARCH
+@@ -1007,6 +1011,7 @@ OPENJDK_TARGET_CPU
+ OPENJDK_TARGET_OS_ENV
+ OPENJDK_TARGET_OS_TYPE
+ OPENJDK_TARGET_OS
++OPENJDK_BUILD_LIBC
+ OPENJDK_BUILD_CPU_ENDIAN
+ OPENJDK_BUILD_CPU_BITS
+ OPENJDK_BUILD_CPU_ARCH
+@@ -1100,6 +1105,7 @@ infodir
+ docdir
+ oldincludedir
+ includedir
++runstatedir
+ localstatedir
+ sharedstatedir
+ sysconfdir
+@@ -1187,6 +1193,7 @@ enable_debug_symbols
+ enable_zip_debug_info
+ enable_native_coverage
+ enable_dtrace
++enable_sa_attach
+ enable_aot
+ enable_hotspot_gtest
+ with_stdc__lib
+@@ -1391,6 +1398,7 @@ datadir='${datarootdir}'
+ sysconfdir='${prefix}/etc'
+ sharedstatedir='${prefix}/com'
+ localstatedir='${prefix}/var'
++runstatedir='${localstatedir}/run'
+ includedir='${prefix}/include'
+ oldincludedir='/usr/include'
+ docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
+@@ -1643,6 +1651,15 @@ do
+   | -silent | --silent | --silen | --sile | --sil)
+     silent=yes ;;
+ 
++  -runstatedir | --runstatedir | --runstatedi | --runstated \
++  | --runstate | --runstat | --runsta | --runst | --runs \
++  | --run | --ru | --r)
++    ac_prev=runstatedir ;;
++  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
++  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
++  | --run=* | --ru=* | --r=*)
++    runstatedir=$ac_optarg ;;
++
+   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
+     ac_prev=sbindir ;;
+   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
+@@ -1780,7 +1797,7 @@ fi
+ for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
+ 		datadir sysconfdir sharedstatedir localstatedir includedir \
+ 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
+-		libdir localedir mandir
++		libdir localedir mandir runstatedir
+ do
+   eval ac_val=\$$ac_var
+   # Remove trailing slashes.
+@@ -1933,6 +1950,7 @@ Fine tuning of the installation director
+   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
+   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
+   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
++  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
+   --libdir=DIR            object code libraries [EPREFIX/lib]
+   --includedir=DIR        C header files [PREFIX/include]
+   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
+@@ -1996,6 +2014,9 @@ Optional Features:
+   --enable-dtrace[=yes/no/auto]
+                           enable dtrace. Default is auto, where dtrace is
+                           enabled if all dependencies are present.
++  --enable-sa-attach[=yes/no/auto]
++                          enable serviceability agent attach. Default is auto,
++                          where it is enabled if all dependencies are present.
+   --enable-aot[=yes/no/auto]
+                           enable ahead of time compilation feature. Default is
+                           auto, where aot is enabled if all dependencies are
+@@ -4354,6 +4375,11 @@ VALID_JVM_VARIANTS="server client minima
+ 
+ 
+ ###############################################################################
++# Check if the serviceability agent attach functionality should be included.
++#
++
++
++###############################################################################
+ # Set up all JVM features for each JVM variant.
+ #
+ 
+@@ -15739,6 +15765,18 @@ test -n "$target_alias" &&
+       ;;
+   esac
+ 
++  case "$build_os" in
++    *linux*-musl)
++      VAR_LIBC=musl
++      ;;
++    *linux*-gnu)
++      VAR_LIBC=gnu
++      ;;
++    *)
++      VAR_LIBC=default
++      ;;
++  esac
++
+ 
+   # First argument is the cpu name from the trip/quad
+   case "$build_cpu" in
+@@ -15829,6 +15867,8 @@ test -n "$target_alias" &&
+   OPENJDK_BUILD_CPU_ARCH="$VAR_CPU_ARCH"
+   OPENJDK_BUILD_CPU_BITS="$VAR_CPU_BITS"
+   OPENJDK_BUILD_CPU_ENDIAN="$VAR_CPU_ENDIAN"
++  OPENJDK_BUILD_LIBC="$VAR_LIBC"
++
+ 
+ 
+ 
+@@ -15842,6 +15882,13 @@ $as_echo_n "checking openjdk-build os-cp
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OPENJDK_BUILD_OS-$OPENJDK_BUILD_CPU" >&5
+ $as_echo "$OPENJDK_BUILD_OS-$OPENJDK_BUILD_CPU" >&6; }
+ 
++  if test "x$OPENJDK_BUILD_OS" = "xlinux"; then
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking openjdk-build C library" >&5
++$as_echo_n "checking openjdk-build C library... " >&6; }
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OPENJDK_BUILD_LIBC" >&5
++$as_echo "$OPENJDK_BUILD_LIBC" >&6; }
++  fi
++
+   # Convert the autoconf OS/CPU value to our own data, into the VAR_OS/CPU variables.
+ 
+   case "$host_os" in
+@@ -15878,6 +15925,18 @@ $as_echo "$OPENJDK_BUILD_OS-$OPENJDK_BUI
+       ;;
+   esac
+ 
++  case "$host_os" in
++    *linux*-musl)
++      VAR_LIBC=musl
++      ;;
++    *linux*-gnu)
++      VAR_LIBC=gnu
++      ;;
++    *)
++      VAR_LIBC=default
++      ;;
++  esac
++
+ 
+   # First argument is the cpu name from the trip/quad
+   case "$host_cpu" in
+@@ -15968,6 +16027,8 @@ $as_echo "$OPENJDK_BUILD_OS-$OPENJDK_BUI
+   OPENJDK_TARGET_CPU_ARCH="$VAR_CPU_ARCH"
+   OPENJDK_TARGET_CPU_BITS="$VAR_CPU_BITS"
+   OPENJDK_TARGET_CPU_ENDIAN="$VAR_CPU_ENDIAN"
++  OPENJDK_TARGET_LIBC="$VAR_LIBC"
++
+ 
+ 
+ 
+@@ -15981,6 +16042,13 @@ $as_echo_n "checking openjdk-target os-c
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" >&5
+ $as_echo "$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" >&6; }
+ 
++  if test "x$OPENJDK_TARGET_OS" = "xlinux"; then
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking openjdk-target C library" >&5
++$as_echo_n "checking openjdk-target C library... " >&6; }
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OPENJDK_TARGET_LIBC" >&5
++$as_echo "$OPENJDK_TARGET_LIBC" >&6; }
++  fi
++
+ 
+ 
+ # Check whether --with-target-bits was given.
+@@ -16144,7 +16212,13 @@ $as_echo "$COMPILE_TYPE" >&6; }
+   else
+     OPENJDK_TARGET_CPU_BUNDLE="$OPENJDK_TARGET_CPU"
+   fi
+-  OPENJDK_TARGET_BUNDLE_PLATFORM="${OPENJDK_TARGET_OS_BUNDLE}-${OPENJDK_TARGET_CPU_BUNDLE}"
++
++  OPENJDK_TARGET_LIBC_BUNDLE=""
++  if test "x$OPENJDK_TARGET_LIBC" = "xmusl"; then
++    OPENJDK_TARGET_LIBC_BUNDLE="-$OPENJDK_TARGET_LIBC"
++  fi
++
++  OPENJDK_TARGET_BUNDLE_PLATFORM="${OPENJDK_TARGET_OS_BUNDLE}-${OPENJDK_TARGET_CPU_BUNDLE}${OPENJDK_TARGET_LIBC_BUNDLE}"
+ 
+ 
+   if test "x$OPENJDK_TARGET_CPU_BITS" = x64; then
+@@ -16222,6 +16296,12 @@ $as_echo "$COMPILE_TYPE" >&6; }
+   fi
+ 
+ 
++  if test "x$OPENJDK_TARGET_LIBC" = "xmusl"; then
++    HOTSPOT_TARGET_LIBC=$OPENJDK_TARGET_LIBC
++  else
++    HOTSPOT_TARGET_LIBC=""
++  fi
++
+ 
+ 
+   # Also store the legacy naming of the cpu.
+@@ -16296,7 +16376,13 @@ $as_echo "$COMPILE_TYPE" >&6; }
+   else
+     OPENJDK_BUILD_CPU_BUNDLE="$OPENJDK_BUILD_CPU"
+   fi
+-  OPENJDK_BUILD_BUNDLE_PLATFORM="${OPENJDK_BUILD_OS_BUNDLE}-${OPENJDK_BUILD_CPU_BUNDLE}"
++
++  OPENJDK_BUILD_LIBC_BUNDLE=""
++  if test "x$OPENJDK_BUILD_LIBC" = "xmusl"; then
++    OPENJDK_BUILD_LIBC_BUNDLE="-$OPENJDK_BUILD_LIBC"
++  fi
++
++  OPENJDK_BUILD_BUNDLE_PLATFORM="${OPENJDK_BUILD_OS_BUNDLE}-${OPENJDK_BUILD_CPU_BUNDLE}${OPENJDK_BUILD_LIBC_BUNDLE}"
+ 
+ 
+   if test "x$OPENJDK_BUILD_CPU_BITS" = x64; then
+@@ -16374,6 +16460,12 @@ $as_echo "$COMPILE_TYPE" >&6; }
+   fi
+ 
+ 
++  if test "x$OPENJDK_BUILD_LIBC" = "xmusl"; then
++    HOTSPOT_BUILD_LIBC=$OPENJDK_BUILD_LIBC
++  else
++    HOTSPOT_BUILD_LIBC=""
++  fi
++
+ 
+ 
+ 
+@@ -53672,6 +53764,97 @@ $as_echo "yes, dependencies present" >&6
+   fi
+ 
+ 
++  # Test for serviceability agent attach dependencies
++  # Check whether --enable-sa-attach was given.
++if test "${enable_sa_attach+set}" = set; then :
++  enableval=$enable_sa_attach;
++fi
++
++
++  SA_ATTACH_DEP_MISSING=false
++
++  for ac_header in thread_db.h
++do :
++  ac_fn_cxx_check_header_mongrel "$LINENO" "thread_db.h" "ac_cv_header_thread_db_h" "$ac_includes_default"
++if test "x$ac_cv_header_thread_db_h" = xyes; then :
++  cat >>confdefs.h <<_ACEOF
++#define HAVE_THREAD_DB_H 1
++_ACEOF
++ SA_ATTACH_HEADERS_OK=yes
++else
++  SA_ATTACH_HEADERS_OK=no
++fi
++
++done
++
++  if test "x$SA_ATTACH_HEADERS_OK" != "xyes"; then
++    SA_ATTACH_DEP_MISSING=true
++  fi
++
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if serviceability agent attach should be included" >&5
++$as_echo_n "checking if serviceability agent attach should be included... " >&6; }
++  if test "x$enable_sa_attach" = "xyes"; then
++    if test "x$SA_ATTACH_DEP_MISSING" = "xtrue"; then
++      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no, missing dependencies" >&5
++$as_echo "no, missing dependencies" >&6; }
++
++  # Print a helpful message on how to acquire the necessary build dependency.
++  # sa-attach is the help tag: freetype, cups, alsa etc
++  MISSING_DEPENDENCY=sa-attach
++
++  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
++    cygwin_help $MISSING_DEPENDENCY
++  elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.msys"; then
++    msys_help $MISSING_DEPENDENCY
++  else
++    PKGHANDLER_COMMAND=
++
++    case $PKGHANDLER in
++      apt-get)
++        apt_help     $MISSING_DEPENDENCY ;;
++      yum)
++        yum_help     $MISSING_DEPENDENCY ;;
++      brew)
++        brew_help    $MISSING_DEPENDENCY ;;
++      port)
++        port_help    $MISSING_DEPENDENCY ;;
++      pkgutil)
++        pkgutil_help $MISSING_DEPENDENCY ;;
++      pkgadd)
++        pkgadd_help  $MISSING_DEPENDENCY ;;
++    esac
++
++    if test "x$PKGHANDLER_COMMAND" != x; then
++      HELP_MSG="You might be able to fix this by running '$PKGHANDLER_COMMAND'."
++    fi
++  fi
++
++      as_fn_error $? "Cannot enable sa-attach with missing dependencies. See above. $HELP_MSG" "$LINENO" 5
++    else
++      INCLUDE_SA_ATTACH=true
++      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, forced" >&5
++$as_echo "yes, forced" >&6; }
++    fi
++  elif test "x$enable_sa_attach" = "xno"; then
++    INCLUDE_SA_ATTACH=false
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no, forced" >&5
++$as_echo "no, forced" >&6; }
++  elif test "x$enable_sa_attach" = "xauto" || test "x$enable_sa_attach" = "x"; then
++    if test "x$SA_ATTACH_DEP_MISSING" = "xtrue"; then
++      INCLUDE_SA_ATTACH=false
++      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no, missing dependencies" >&5
++$as_echo "no, missing dependencies" >&6; }
++    else
++      INCLUDE_SA_ATTACH=true
++      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, dependencies present" >&5
++$as_echo "yes, dependencies present" >&6; }
++    fi
++  else
++    as_fn_error $? "Invalid value for --enable-sa-attach: $enable_sa_attach" "$LINENO" 5
++  fi
++
++
++
+   # Check whether --enable-aot was given.
+ if test "${enable_aot+set}" = set; then :
+   enableval=$enable_aot;
+diff -upr a/common/autoconf/hotspot.m4 b/common/autoconf/hotspot.m4
+--- a/common/autoconf/hotspot.m4	2019-02-13 20:03:08.652337196 +0100
++++ b/common/autoconf/hotspot.m4	2019-02-13 20:03:53.435132939 +0100
+@@ -241,6 +241,50 @@ AC_DEFUN_ONCE([HOTSPOT_ENABLE_DISABLE_AO
+ ])
+ 
+ ###############################################################################
++# Check if the serviceability agent attach functionality should be included.
++#
++AC_DEFUN_ONCE([HOTSPOT_SETUP_SA],
++[
++  # Test for serviceability agent attach dependencies
++  AC_ARG_ENABLE([sa-attach], [AS_HELP_STRING([--enable-sa-attach@<:@=yes/no/auto@:>@],
++      [enable serviceability agent attach. Default is auto, where it is enabled if all dependencies
++      are present.])])
++
++  SA_ATTACH_DEP_MISSING=false
++
++  AC_CHECK_HEADERS([thread_db.h], [SA_ATTACH_HEADERS_OK=yes],[SA_ATTACH_HEADERS_OK=no])
++  if test "x$SA_ATTACH_HEADERS_OK" != "xyes"; then
++    SA_ATTACH_DEP_MISSING=true
++  fi
++
++  AC_MSG_CHECKING([if serviceability agent attach should be included])
++  if test "x$enable_sa_attach" = "xyes"; then
++    if test "x$SA_ATTACH_DEP_MISSING" = "xtrue"; then
++      AC_MSG_RESULT([no, missing dependencies])
++      HELP_MSG_MISSING_DEPENDENCY([sa-attach])
++      AC_MSG_ERROR([Cannot enable sa-attach with missing dependencies. See above. $HELP_MSG])
++    else
++      INCLUDE_SA_ATTACH=true
++      AC_MSG_RESULT([yes, forced])
++    fi
++  elif test "x$enable_sa_attach" = "xno"; then
++    INCLUDE_SA_ATTACH=false
++    AC_MSG_RESULT([no, forced])
++  elif test "x$enable_sa_attach" = "xauto" || test "x$enable_sa_attach" = "x"; then
++    if test "x$SA_ATTACH_DEP_MISSING" = "xtrue"; then
++      INCLUDE_SA_ATTACH=false
++      AC_MSG_RESULT([no, missing dependencies])
++    else
++      INCLUDE_SA_ATTACH=true
++      AC_MSG_RESULT([yes, dependencies present])
++    fi
++  else
++    AC_MSG_ERROR([Invalid value for --enable-sa-attach: $enable_sa_attach])
++  fi
++  AC_SUBST(INCLUDE_SA_ATTACH)
++])
++
++###############################################################################
+ # Set up all JVM features for each JVM variant.
+ #
+ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_FEATURES],
+diff -upr a/common/autoconf/platform.m4 b/common/autoconf/platform.m4
+--- a/common/autoconf/platform.m4	2019-02-13 20:03:08.652337196 +0100
++++ b/common/autoconf/platform.m4	2019-02-13 20:03:53.445132820 +0100
+@@ -140,6 +140,18 @@ AC_DEFUN([PLATFORM_EXTRACT_VARS_FROM_OS]
+       AC_MSG_ERROR([unsupported operating system $1])
+       ;;
+   esac
++
++  case "$1" in
++    *linux*-musl)
++      VAR_LIBC=musl
++      ;;
++    *linux*-gnu)
++      VAR_LIBC=gnu
++      ;;
++    *)
++      VAR_LIBC=default
++      ;;
++  esac
+ ])
+ 
+ # Expects $host_os $host_cpu $build_os and $build_cpu
+@@ -178,6 +190,7 @@ AC_DEFUN([PLATFORM_EXTRACT_TARGET_AND_BU
+   OPENJDK_BUILD_CPU_ARCH="$VAR_CPU_ARCH"
+   OPENJDK_BUILD_CPU_BITS="$VAR_CPU_BITS"
+   OPENJDK_BUILD_CPU_ENDIAN="$VAR_CPU_ENDIAN"
++  OPENJDK_BUILD_LIBC="$VAR_LIBC"
+   AC_SUBST(OPENJDK_BUILD_OS)
+   AC_SUBST(OPENJDK_BUILD_OS_TYPE)
+   AC_SUBST(OPENJDK_BUILD_OS_ENV)
+@@ -185,10 +198,16 @@ AC_DEFUN([PLATFORM_EXTRACT_TARGET_AND_BU
+   AC_SUBST(OPENJDK_BUILD_CPU_ARCH)
+   AC_SUBST(OPENJDK_BUILD_CPU_BITS)
+   AC_SUBST(OPENJDK_BUILD_CPU_ENDIAN)
++  AC_SUBST(OPENJDK_BUILD_LIBC)
+ 
+   AC_MSG_CHECKING([openjdk-build os-cpu])
+   AC_MSG_RESULT([$OPENJDK_BUILD_OS-$OPENJDK_BUILD_CPU])
+ 
++  if test "x$OPENJDK_BUILD_OS" = "xlinux"; then
++    AC_MSG_CHECKING([openjdk-build C library])
++    AC_MSG_RESULT([$OPENJDK_BUILD_LIBC])
++  fi
++
+   # Convert the autoconf OS/CPU value to our own data, into the VAR_OS/CPU variables.
+   PLATFORM_EXTRACT_VARS_FROM_OS($host_os)
+   PLATFORM_EXTRACT_VARS_FROM_CPU($host_cpu)
+@@ -208,6 +227,7 @@ AC_DEFUN([PLATFORM_EXTRACT_TARGET_AND_BU
+   OPENJDK_TARGET_CPU_ARCH="$VAR_CPU_ARCH"
+   OPENJDK_TARGET_CPU_BITS="$VAR_CPU_BITS"
+   OPENJDK_TARGET_CPU_ENDIAN="$VAR_CPU_ENDIAN"
++  OPENJDK_TARGET_LIBC="$VAR_LIBC"
+   AC_SUBST(OPENJDK_TARGET_OS)
+   AC_SUBST(OPENJDK_TARGET_OS_TYPE)
+   AC_SUBST(OPENJDK_TARGET_OS_ENV)
+@@ -215,9 +235,15 @@ AC_DEFUN([PLATFORM_EXTRACT_TARGET_AND_BU
+   AC_SUBST(OPENJDK_TARGET_CPU_ARCH)
+   AC_SUBST(OPENJDK_TARGET_CPU_BITS)
+   AC_SUBST(OPENJDK_TARGET_CPU_ENDIAN)
++  AC_SUBST(OPENJDK_TARGET_LIBC)
+ 
+   AC_MSG_CHECKING([openjdk-target os-cpu])
+   AC_MSG_RESULT([$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])
++
++  if test "x$OPENJDK_TARGET_OS" = "xlinux"; then
++    AC_MSG_CHECKING([openjdk-target C library])
++    AC_MSG_RESULT([$OPENJDK_TARGET_LIBC])
++  fi
+ ])
+ 
+ # Check if a reduced build (32-bit on 64-bit platforms) is requested, and modify behaviour
+@@ -353,7 +379,13 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS_HEL
+   else
+     OPENJDK_$1_CPU_BUNDLE="$OPENJDK_$1_CPU"
+   fi
+-  OPENJDK_$1_BUNDLE_PLATFORM="${OPENJDK_$1_OS_BUNDLE}-${OPENJDK_$1_CPU_BUNDLE}"
++
++  OPENJDK_$1_LIBC_BUNDLE=""
++  if test "x$OPENJDK_$1_LIBC" = "xmusl"; then  
++    OPENJDK_$1_LIBC_BUNDLE="-$OPENJDK_$1_LIBC"
++  fi
++
++  OPENJDK_$1_BUNDLE_PLATFORM="${OPENJDK_$1_OS_BUNDLE}-${OPENJDK_$1_CPU_BUNDLE}${OPENJDK_$1_LIBC_BUNDLE}"
+   AC_SUBST(OPENJDK_$1_BUNDLE_PLATFORM)
+ 
+   if test "x$OPENJDK_$1_CPU_BITS" = x64; then
+@@ -431,6 +463,12 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS_HEL
+   fi
+   AC_SUBST(HOTSPOT_$1_CPU_DEFINE)
+ 
++  if test "x$OPENJDK_$1_LIBC" = "xmusl"; then
++    HOTSPOT_$1_LIBC=$OPENJDK_$1_LIBC
++  else
++    HOTSPOT_$1_LIBC=""
++  fi
++  AC_SUBST(HOTSPOT_$1_LIBC)
+ ])
+ 
+ AC_DEFUN([PLATFORM_SET_RELEASE_FILE_OS_VALUES],
+diff -upr a/common/autoconf/spec.gmk.in b/common/autoconf/spec.gmk.in
+--- a/common/autoconf/spec.gmk.in	2019-02-13 20:59:33.647572189 +0100
++++ b/common/autoconf/spec.gmk.in	2019-02-13 20:03:53.515131983 +0100
+@@ -71,6 +71,8 @@ OPENJDK_TARGET_CPU_ARCH:=@OPENJDK_TARGET
+ OPENJDK_TARGET_CPU_BITS:=@OPENJDK_TARGET_CPU_BITS@
+ OPENJDK_TARGET_CPU_ENDIAN:=@OPENJDK_TARGET_CPU_ENDIAN@
+ 
++OPENJDK_TARGET_LIBC:=@OPENJDK_TARGET_LIBC@
++
+ COMPILE_TYPE:=@COMPILE_TYPE@
+ 
+ # Legacy support
+@@ -87,6 +89,8 @@ HOTSPOT_TARGET_CPU := @HOTSPOT_TARGET_CP
+ HOTSPOT_TARGET_CPU_ARCH := @HOTSPOT_TARGET_CPU_ARCH@
+ HOTSPOT_TARGET_CPU_DEFINE := @HOTSPOT_TARGET_CPU_DEFINE@
+ 
++HOTSPOT_TARGET_LIBC := @HOTSPOT_TARGET_LIBC@
++
+ OPENJDK_TARGET_BUNDLE_PLATFORM:=@OPENJDK_TARGET_BUNDLE_PLATFORM@
+ JDK_ARCH_ABI_PROP_NAME := @JDK_ARCH_ABI_PROP_NAME@
+ 
+@@ -101,6 +105,8 @@ OPENJDK_BUILD_CPU_ARCH:=@OPENJDK_BUILD_C
+ OPENJDK_BUILD_CPU_BITS:=@OPENJDK_BUILD_CPU_BITS@
+ OPENJDK_BUILD_CPU_ENDIAN:=@OPENJDK_BUILD_CPU_ENDIAN@
+ 
++OPENJDK_BUILD_LIBC:=@OPENJDK_BUILD_LIBC@
++
+ # Target platform value in ModuleTarget class file attribute.
+ OPENJDK_MODULE_TARGET_PLATFORM:=@OPENJDK_MODULE_TARGET_PLATFORM@
+ 
+@@ -780,6 +786,7 @@ ELF_LIBS:=@ELF_LIBS@
+ #
+ 
+ INCLUDE_SA=@INCLUDE_SA@
++INCLUDE_SA_ATTACH=@INCLUDE_SA_ATTACH@
+ INCLUDE_GRAAL=@INCLUDE_GRAAL@
+ 
+ OS_VERSION_MAJOR:=@OS_VERSION_MAJOR@
+diff -upr a/common/conf/jib-profiles.js b/common/conf/jib-profiles.js
+--- a/common/conf/jib-profiles.js
++++ b/common/conf/jib-profiles.js
+@@ -58,8 +58,10 @@
+  * input.build_id
+  * input.target_os
+  * input.target_cpu
++ * input.target_libc
+  * input.build_os
+  * input.build_cpu
++ * input.build_libc
+  * input.target_platform
+  * input.build_platform
+  * // The build_osenv_* variables describe the unix layer on Windows systems,
+@@ -99,13 +101,17 @@
+  *       target_os; <string>
+  *       // Name of cpu the profile is built to run on
+  *       target_cpu; <string>
+- *       // Combination of target_os and target_cpu for convenience
++ *       // Optional libc string if non standard
++ *       target_libc; <string>
++ *       // Optional combination of target_os and target_cpu for convenience
+  *       target_platform; <string>
+  *       // Name of os the profile is built on
+  *       build_os; <string>
+  *       // Name of cpu the profile is built on
+  *       build_cpu; <string>
+- *       // Combination of build_os and build_cpu for convenience
++ *       // Optional libc string if non standard
++ *       build_libc; <string>
++ *       // Optional combination of build_os and build_cpu for convenience
+  *       build_platform; <string>
+  *
+  *       // List of dependencies needed to build this profile
+@@ -230,7 +236,7 @@ var getJibProfilesCommon = function (inp
+ 
+     // List of the main profile names used for iteration
+     common.main_profile_names = [
+-        "linux-x64", "linux-x86", "macosx-x64", "solaris-x64",
++        "linux-x64", "linux-x64-musl", "linux-x86", "macosx-x64", "solaris-x64",
+         "solaris-sparcv9", "windows-x64", "windows-x86",
+         "linux-arm64", "linux-arm-vfp-hflt", "linux-arm-vfp-hflt-dyn"
+     ];
+@@ -391,7 +397,11 @@ var getJibProfilesCommon = function (inp
+            boot_jdk_revision = "8u20";
+            boot_jdk_subdirpart = "1.8.0_20";
+        }
++    } else if (input.build_libc == "musl") {
++       boot_jdk_revision="9-ea+167-2017-05-05-133034.duke.portolajdk9+1.0";
++       boot_jdk_subdirpart="-9";
+     }
++
+     common.boot_jdk_revision = boot_jdk_revision;
+     common.boot_jdk_subdirpart = boot_jdk_subdirpart;
+     common.boot_jdk_home = input.get("boot_jdk", "home_path") + "/jdk"
+@@ -423,6 +433,14 @@ var getJibProfilesProfiles = function (i
+             default_make_targets: ["docs-bundles"],
+         },
+ 
++        "linux-x64-musl": {
++            target_os: "linux",
++            target_cpu: "x64",
++            target_libc: "musl",
++            configure_args: concat(common.configure_args_64bit,
++                "--with-zlib=system"),
++        },
++
+         "linux-x86": {
+             target_os: "linux",
+             target_cpu: "x86",
+@@ -666,6 +684,10 @@ var getJibProfilesProfiles = function (i
+         "linux-x64": {
+             platform: "linux-x64",
+         },
++        "linux-x64-musl": {
++            platform: "linux-x64",
++            demo_ext: "tar.gz"
++        },
+         "linux-x86": {
+             platform: "linux-x86",
+         },
+@@ -903,8 +925,6 @@ var getJibProfilesProfiles = function (i
+     };
+     profiles = concatObjects(profiles, profilesRiFreetype);
+ 
+-    // Generate the missing platform attributes
+-    profiles = generatePlatformAttributes(profiles);
+     profiles = generateDefaultMakeTargetsConfigureArg(common, profiles);
+     return profiles;
+ };
+@@ -934,9 +954,21 @@ var getJibProfilesDependencies = functio
+         ? input.target_os + "_x64"
+         : input.target_platform);
+ 
+-    var dependencies = {
+-
+-        boot_jdk: {
++    // the musl version of the JDK is still in development
++    // so the binaries are not located in the same place as
++    // for other platforms
++    var boot_jdk_dep;
++    if (input.build_os == "linux" && input.build_libc == "musl") {
++        boot_jdk_dep = {
++            organization: common.organization,
++            ext: "tar.gz",
++            module: "jdk-" + input.build_platform,
++            revision: common.boot_jdk_revision,
++            configure_args: "--with-boot-jdk=" + common.boot_jdk_home,
++            environment_path: common.boot_jdk_home + "/bin"
++        };
++    } else {
++        boot_jdk_dep = {
+             server: "javare",
+             module: "jdk",
+             revision: common.boot_jdk_revision,
+@@ -945,7 +977,19 @@ var getJibProfilesDependencies = functio
+                 + "-" + common.boot_jdk_platform + ".tar.gz",
+             configure_args: "--with-boot-jdk=" + common.boot_jdk_home,
+             environment_path: common.boot_jdk_home + "/bin"
+-        },
++        };
++    }
++
++    var gnumake_module;
++    if (input.build_os == "windows") {
++        gnumake_module = "gnumake-" + input.build_osenv_platform;
++    } else {
++        gnumake_module = "gnumake-" + input.build_platform;
++    }
++
++    var dependencies = {
++
++        boot_jdk: boot_jdk_dep,
+ 
+         devkit: {
+             organization: common.organization,
+@@ -982,9 +1026,7 @@ var getJibProfilesDependencies = functio
+             ext: "tar.gz",
+             revision: "4.0+1.0",
+ 
+-            module: (input.build_os == "windows"
+-                ? "gnumake-" + input.build_osenv_platform
+-                : "gnumake-" + input.build_platform),
++            module: gnumake_module,
+ 
+             configure_args: (input.build_os == "windows"
+                 ? "MAKE=" + input.get("gnumake", "install_path") + "/cygwin/bin/make"
+@@ -1025,27 +1067,6 @@ var getJibProfilesDependencies = functio
+ };
+ 
+ /**
+- * Generate the missing platform attributes for profiles
+- *
+- * @param profiles Profiles map to generate attributes on
+- * @returns {{}} New profiles map with platform attributes fully filled in
+- */
+-var generatePlatformAttributes = function (profiles) {
+-    var ret = concatObjects(profiles, {});
+-    for (var profile in profiles) {
+-        if (ret[profile].build_os == null) {
+-            ret[profile].build_os = ret[profile].target_os;
+-        }
+-        if (ret[profile].build_cpu == null) {
+-            ret[profile].build_cpu = ret[profile].target_cpu;
+-        }
+-        ret[profile].target_platform = ret[profile].target_os + "_" + ret[profile].target_cpu;
+-        ret[profile].build_platform = ret[profile].build_os + "_" + ret[profile].build_cpu;
+-    }
+-    return ret;
+-};
+-
+-/**
+  * The default_make_targets attribute on a profile is not a real Jib attribute.
+  * This function rewrites that attribute into the corresponding configure arg.
+  * Calling this function multiple times on the same profiles object is safe.
+diff -upr a/make/ReleaseFile.gmk b/make/ReleaseFile.gmk
+--- a/make/ReleaseFile.gmk
++++ b/make/ReleaseFile.gmk
+@@ -50,6 +50,7 @@ define create-info-file
+   $(call info-file-item, "IMPLEMENTOR", "$(COMPANY_NAME)")
+   $(call info-file-item, "OS_NAME", "$(RELEASE_FILE_OS_NAME)")
+   $(call info-file-item, "OS_ARCH", "$(RELEASE_FILE_OS_ARCH)")
++  $(call info-file-item, "LIBC", "$(OPENJDK_TARGET_LIBC)")
+ endef
+ 
+ # Param 1 - The file containing the MODULES list

--- a/testing/openjdk9/20-portola-hotspot.patch
+++ b/testing/openjdk9/20-portola-hotspot.patch
@@ -1,0 +1,1427 @@
+Author: Portola Project <portola-dev@openjdk.java.net>
+URL: https://openjdk.java.net/projects/portola/
+Summary: Provide a port of the JDK to the musl C library
+----
+
+diff -upr a/hotspot/make/lib/CompileJvm.gmk b/hotspot/make/lib/CompileJvm.gmk
+--- a/hotspot/make/lib/CompileJvm.gmk
++++ b/hotspot/make/lib/CompileJvm.gmk
+@@ -128,6 +128,10 @@ else
+   OPENJDK_TARGET_CPU_VM_VERSION := $(OPENJDK_TARGET_CPU)
+ endif
+ 
++ifneq ($(HOTSPOT_TARGET_LIBC),)
++  LIBC_DEFINE := -DHOTSPOT_LIBC='"$(HOTSPOT_TARGET_LIBC)"'
++endif
++
+ CFLAGS_VM_VERSION := \
+     $(VERSION_CFLAGS) \
+     -DHOTSPOT_VERSION_STRING='"$(VERSION_STRING)"' \
+@@ -135,6 +139,7 @@ CFLAGS_VM_VERSION := \
+     -DHOTSPOT_BUILD_USER='"$(USERNAME)"' \
+     -DHOTSPOT_VM_DISTRO='"$(HOTSPOT_VM_DISTRO)"' \
+     -DCPU='"$(OPENJDK_TARGET_CPU_VM_VERSION)"' \
++    $(LIBC_DEFINE) \
+     #
+ 
+ # -DDONT_USE_PRECOMPILED_HEADER will exclude all includes in precompiled.hpp.
+diff -upr a/hotspot/make/lib/Lib-jdk.hotspot.agent.gmk b/hotspot/make/lib/Lib-jdk.hotspot.agent.gmk
+--- a/hotspot/make/lib/Lib-jdk.hotspot.agent.gmk
++++ b/hotspot/make/lib/Lib-jdk.hotspot.agent.gmk
+@@ -1,5 +1,5 @@
+ #
+-# Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
++# Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ #
+ # This code is free software; you can redistribute it and/or modify it
+@@ -57,7 +57,10 @@ ifeq ($(OPENJDK_TARGET_OS), linux)
+   SA_CFLAGS := $(CFLAGS_JDKLIB) -D_FILE_OFFSET_BITS=64 \
+       $(SA_MACHINE_FLAG_linux)
+   SA_LDFLAGS := $(LDFLAGS_JDKLIB) $(SA_MACHINE_FLAG_linux)
+-  SA_LIBS := -lthread_db $(LIBDL)
++  SA_LIBS := $(LIBDL)
++  ifeq ($(INCLUDE_SA_ATTACH), true)
++    SA_LIBS += -lthread_db
++  endif
+ 
+ else ifeq ($(OPENJDK_TARGET_OS), solaris)
+   SA_TOOLCHAIN := TOOLCHAIN_LINK_CXX
+@@ -95,6 +98,12 @@ else ifeq ($(OPENJDK_TARGET_OS), windows
+   endif
+ endif
+ 
++ifeq ($(INCLUDE_SA_ATTACH), true)
++  SA_CFLAGS += -DINCLUDE_SA_ATTACH
++endif
++
++SA_CFLAGS += -DLIBC=\"$(OPENJDK_TARGET_LIBC)\"
++
+ ################################################################################
+ 
+ $(eval $(call SetupNativeCompilation, BUILD_LIBSA, \
+diff -upr a/hotspot/src/cpu/aarch64/vm/bytes_aarch64.hpp b/hotspot/src/cpu/aarch64/vm/bytes_aarch64.hpp
+--- a/hotspot/src/cpu/aarch64/vm/bytes_aarch64.hpp
++++ b/hotspot/src/cpu/aarch64/vm/bytes_aarch64.hpp
+@@ -30,12 +30,6 @@
+ 
+ class Bytes: AllStatic {
+  public:
+-  // Returns true if the byte ordering used by Java is different from the native byte ordering
+-  // of the underlying machine. For example, this is true for Intel x86, but false for Solaris
+-  // on Sparc.
+-  static inline bool is_Java_byte_ordering_different(){ return true; }
+-
+-
+   // Efficient reading and writing of unaligned unsigned data in platform-specific byte ordering
+   // (no special code is needed since x86 CPUs can access unaligned data)
+   static inline u2   get_native_u2(address p)         { return *(u2*)p; }
+diff -upr a/hotspot/src/cpu/arm/vm/bytes_arm.hpp b/hotspot/src/cpu/arm/vm/bytes_arm.hpp
+--- a/hotspot/src/cpu/arm/vm/bytes_arm.hpp
++++ b/hotspot/src/cpu/arm/vm/bytes_arm.hpp
+@@ -35,12 +35,6 @@
+ class Bytes: AllStatic {
+ 
+  public:
+-  // Returns true if the byte ordering used by Java is different from the native byte ordering
+-  // of the underlying machine.
+-  static inline bool is_Java_byte_ordering_different() {
+-    return VM_LITTLE_ENDIAN != 0;
+-  }
+-
+   static inline u2 get_Java_u2(address p) {
+     return (u2(p[0]) << 8) | u2(p[1]);
+   }
+diff -upr a/hotspot/src/cpu/ppc/vm/bytes_ppc.hpp b/hotspot/src/cpu/ppc/vm/bytes_ppc.hpp
+--- a/hotspot/src/cpu/ppc/vm/bytes_ppc.hpp
++++ b/hotspot/src/cpu/ppc/vm/bytes_ppc.hpp
+@@ -37,10 +37,6 @@ class Bytes: AllStatic {
+ 
+ #if defined(VM_LITTLE_ENDIAN)
+ 
+-  // Returns true, if the byte ordering used by Java is different from the native byte ordering
+-  // of the underlying machine. For example, true for Intel x86, False, for Solaris on Sparc.
+-  static inline bool is_Java_byte_ordering_different() { return true; }
+-
+   // Forward declarations of the compiler-dependent implementation
+   static inline u2 swap_u2(u2 x);
+   static inline u4 swap_u4(u4 x);
+@@ -155,10 +151,6 @@ class Bytes: AllStatic {
+ 
+ #else // !defined(VM_LITTLE_ENDIAN)
+ 
+-  // Returns true, if the byte ordering used by Java is different from the nativ byte ordering
+-  // of the underlying machine. For example, true for Intel x86, False, for Solaris on Sparc.
+-  static inline bool is_Java_byte_ordering_different() { return false; }
+-
+   // Thus, a swap between native and Java ordering is always a no-op:
+   static inline u2   swap_u2(u2 x)  { return x; }
+   static inline u4   swap_u4(u4 x)  { return x; }
+diff -upr a/hotspot/src/cpu/s390/vm/bytes_s390.hpp b/hotspot/src/cpu/s390/vm/bytes_s390.hpp
+--- a/hotspot/src/cpu/s390/vm/bytes_s390.hpp
++++ b/hotspot/src/cpu/s390/vm/bytes_s390.hpp
+@@ -42,12 +42,6 @@ class Bytes: AllStatic {
+   //
+   // In short, it makes no sense on z/Architecture to piecemeal get or put unaligned data.
+ 
+-  // Returns true if the byte ordering used by Java is different from
+-  // the native byte ordering of the underlying machine.
+-  // z/Arch is big endian, thus, a swap between native and Java ordering
+-  // is always a no-op.
+-  static inline bool is_Java_byte_ordering_different() { return false; }
+-
+   // Only swap on little endian machines => suffix `_le'.
+   static inline u2   swap_u2_le(u2 x) { return x; }
+   static inline u4   swap_u4_le(u4 x) { return x; }
+diff -upr a/hotspot/src/cpu/sparc/vm/bytes_sparc.hpp b/hotspot/src/cpu/sparc/vm/bytes_sparc.hpp
+--- a/hotspot/src/cpu/sparc/vm/bytes_sparc.hpp
++++ b/hotspot/src/cpu/sparc/vm/bytes_sparc.hpp
+@@ -34,10 +34,6 @@ class Bytes: AllStatic {
+ 
+   // can I count on address always being a pointer to an unsigned char? Yes
+ 
+-  // Returns true, if the byte ordering used by Java is different from the nativ byte ordering
+-  // of the underlying machine. For example, true for Intel x86, False, for Solaris on Sparc.
+-  static inline bool is_Java_byte_ordering_different() { return false; }
+-
+   // Thus, a swap between native and Java ordering is always a no-op:
+   static inline u2   swap_u2(u2 x)  { return x; }
+   static inline u4   swap_u4(u4 x)  { return x; }
+diff -upr a/hotspot/src/cpu/x86/vm/bytes_x86.hpp b/hotspot/src/cpu/x86/vm/bytes_x86.hpp
+--- a/hotspot/src/cpu/x86/vm/bytes_x86.hpp
++++ b/hotspot/src/cpu/x86/vm/bytes_x86.hpp
+@@ -36,36 +36,85 @@ class Bytes: AllStatic {
+ #endif // AMD64
+ 
+  public:
+-  // Returns true if the byte ordering used by Java is different from the native byte ordering
+-  // of the underlying machine. For example, this is true for Intel x86, but false for Solaris
+-  // on Sparc.
+-  static inline bool is_Java_byte_ordering_different(){ return true; }
+-
+-
+   // Efficient reading and writing of unaligned unsigned data in platform-specific byte ordering
+-  // (no special code is needed since x86 CPUs can access unaligned data)
+-  static inline u2   get_native_u2(address p)         { return *(u2*)p; }
+-  static inline u4   get_native_u4(address p)         { return *(u4*)p; }
+-  static inline u8   get_native_u8(address p)         { return *(u8*)p; }
+-
+-  static inline void put_native_u2(address p, u2 x)   { *(u2*)p = x; }
+-  static inline void put_native_u4(address p, u4 x)   { *(u4*)p = x; }
+-  static inline void put_native_u8(address p, u8 x)   { *(u8*)p = x; }
+-
++  template <typename T>
++  static inline T get_native(const void* p) {
++    assert(p != NULL, "null pointer");
++
++    T x;
++
++    if (is_ptr_aligned(p, sizeof(T))) {
++      x = *(T*)p;
++    } else {
++      memcpy(&x, p, sizeof(T));
++    }
++
++    return x;
++  }
++
++  template <typename T>
++  static inline void put_native(void* p, T x) {
++    assert(p != NULL, "null pointer");
++
++    if (is_ptr_aligned(p, sizeof(T))) {
++      *(T*)p = x;
++    } else {
++      memcpy(p, &x, sizeof(T));
++    }
++  }
++
++  static inline u2   get_native_u2(address p)         { return get_native<u2>((void*)p); }
++  static inline u4   get_native_u4(address p)         { return get_native<u4>((void*)p); }
++  static inline u8   get_native_u8(address p)         { return get_native<u8>((void*)p); }
++  static inline void put_native_u2(address p, u2 x)   { put_native<u2>((void*)p, x); }
++  static inline void put_native_u4(address p, u4 x)   { put_native<u4>((void*)p, x); }
++  static inline void put_native_u8(address p, u8 x)   { put_native<u8>((void*)p, x); }
+ 
+   // Efficient reading and writing of unaligned unsigned data in Java
+   // byte ordering (i.e. big-endian ordering). Byte-order reversal is
+   // needed since x86 CPUs use little-endian format.
+-  static inline u2   get_Java_u2(address p)           { return swap_u2(get_native_u2(p)); }
+-  static inline u4   get_Java_u4(address p)           { return swap_u4(get_native_u4(p)); }
+-  static inline u8   get_Java_u8(address p)           { return swap_u8(get_native_u8(p)); }
+-
+-  static inline void put_Java_u2(address p, u2 x)     { put_native_u2(p, swap_u2(x)); }
+-  static inline void put_Java_u4(address p, u4 x)     { put_native_u4(p, swap_u4(x)); }
+-  static inline void put_Java_u8(address p, u8 x)     { put_native_u8(p, swap_u8(x)); }
+-
++  template <typename T>
++  static inline T get_Java(const address p) {
++    T x = get_native<T>(p);
++
++    if (Endian::is_Java_byte_ordering_different()) {
++      x = swap<T>(x);
++    }
++
++    return x;
++  }
++
++  template <typename T>
++  static inline void put_Java(address p, T x) {
++    if (Endian::is_Java_byte_ordering_different()) {
++      x = swap<T>(x);
++    }
++
++    put_native<T>(p, x);
++  }
++
++  static inline u2   get_Java_u2(address p)           { return get_Java<u2>(p); }
++  static inline u4   get_Java_u4(address p)           { return get_Java<u4>(p); }
++  static inline u8   get_Java_u8(address p)           { return get_Java<u8>(p); }
++
++  static inline void put_Java_u2(address p, u2 x)     { put_Java<u2>(p, x); }
++  static inline void put_Java_u4(address p, u4 x)     { put_Java<u4>(p, x); }
++  static inline void put_Java_u8(address p, u8 x)     { put_Java<u8>(p, x); }
+ 
+   // Efficient swapping of byte ordering
++  template <typename T>
++  static T swap(T x) {
++    switch (sizeof(T)) {
++    case sizeof(u1): return x;
++    case sizeof(u2): return swap_u2(x);
++    case sizeof(u4): return swap_u4(x);
++    case sizeof(u8): return swap_u8(x);
++    default:
++      guarantee(false, "invalid size: " SIZE_FORMAT "\n", sizeof(T));
++      return 0;
++    }
++  }
++
+   static inline u2   swap_u2(u2 x);                   // compiler-dependent implementation
+   static inline u4   swap_u4(u4 x);                   // compiler-dependent implementation
+   static inline u8   swap_u8(u8 x);
+diff -upr a/hotspot/src/cpu/zero/vm/bytes_zero.hpp b/hotspot/src/cpu/zero/vm/bytes_zero.hpp
+--- a/hotspot/src/cpu/zero/vm/bytes_zero.hpp
++++ b/hotspot/src/cpu/zero/vm/bytes_zero.hpp
+@@ -36,16 +36,6 @@ typedef union unaligned {
+ 
+ class Bytes: AllStatic {
+  public:
+-  // Returns true if the byte ordering used by Java is different
+-  // from the native byte ordering of the underlying machine.
+-  static inline bool is_Java_byte_ordering_different() {
+-#ifdef VM_LITTLE_ENDIAN
+-    return true;
+-#else
+-    return false;
+-#endif
+-  }
+-
+   // Efficient reading and writing of unaligned unsigned data in
+   // platform-specific byte ordering.
+   static inline u2 get_native_u2(address p){
+diff -upr a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
+--- a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
++++ b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
+@@ -26,7 +26,11 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <fcntl.h>
++#ifdef INCLUDE_SA_ATTACH
+ #include <thread_db.h>
++#else
++#include <dirent.h>
++#endif
+ #include "libproc_impl.h"
+ 
+ #define SA_ALTROOT "SA_ALTROOT"
+@@ -116,11 +120,13 @@ bool init_libproc(bool debug) {
+    // init debug mode
+    _libsaproc_debug = debug;
+ 
++#ifdef INCLUDE_SA_ATTACH
+    // initialize the thread_db library
+    if (td_init() != TD_OK) {
+      print_debug("libthread_db's td_init failed\n");
+      return false;
+    }
++#endif
+ 
+    return true;
+ }
+@@ -273,6 +279,7 @@ thread_info* add_thread_info(struct ps_p
+ }
+ 
+ 
++#ifdef INCLUDE_SA_ATTACH
+ // struct used for client data from thread_db callback
+ struct thread_db_client_data {
+    struct ps_prochandle* ph;
+@@ -299,9 +306,12 @@ static int thread_db_callback(const td_t
+ 
+   return TD_OK;
+ }
++#endif // INCLUDE_SA_ATTACH
+ 
+-// read thread_info using libthread_db
++// read thread_info using libthread_db or by iterating through the entries
++// in /proc/<pid>/task/
+ bool read_thread_info(struct ps_prochandle* ph, thread_info_callback cb) {
++#ifdef INCLUDE_SA_ATTACH
+   struct thread_db_client_data mydata;
+   td_thragent_t* thread_agent = NULL;
+   if (td_ta_new(ph, &thread_agent) != TD_OK) {
+@@ -322,10 +332,33 @@ bool read_thread_info(struct ps_prochand
+ 
+   // delete thread agent
+   td_ta_delete(thread_agent);
++#else
++  DIR *dir = NULL;
++  struct dirent *ent = NULL;
++  char taskpath[80];
++  pid_t pid = ph->pid;
++
++  // Find the lwpids to attach to by traversing the /proc/<pid>/task/ directory.
++  snprintf(taskpath, sizeof (taskpath), "/proc/%ld/task", (unsigned long)pid);
++  if ((dir = opendir(taskpath)) != NULL) {
++    while ((ent = readdir(dir)) != NULL) {
++      unsigned long lwp;
++
++      if ((lwp = strtoul(ent->d_name, NULL, 10)) != 0) {
++        // Create and add the thread info.
++        (*cb)(ph, 0, lwp);
++      }
++    }
++  } else {
++    print_debug("Could not open /proc/%ld/task.\n", (unsigned long)pid);
++    return false;
++  }
++
++  closedir(dir);
++#endif
+   return true;
+ }
+ 
+-
+ // get number of threads
+ int get_num_threads(struct ps_prochandle* ph) {
+    return ph->num_threads;
+diff -upr a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.h b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.h
+--- a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.h
++++ b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.h
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+@@ -27,6 +27,9 @@
+ 
+ #include <unistd.h>
+ #include <limits.h>
++
++struct ps_prochandle;
++
+ #include "libproc.h"
+ #include "symtab.h"
+ 
+@@ -126,4 +129,32 @@ thread_info* add_thread_info(struct ps_p
+ // a test for ELF signature without using libelf
+ bool is_elf_file(int fd);
+ 
++// ps_getpid() is only defined on Linux to return a thread's process ID
++pid_t ps_getpid(struct ps_prochandle *ph);
++
++// ps_pglobal_lookup() looks up the symbol sym_name in the symbol table
++// of the load object object_name in the target process identified by ph.
++// It returns the symbol's value as an address in the target process in
++// *sym_addr.
++
++ps_err_e ps_pglobal_lookup(struct ps_prochandle *ph, const char *object_name,
++                    const char *sym_name, psaddr_t *sym_addr);
++// read "size" bytes of data from debuggee at address "addr"
++ps_err_e ps_pdread(struct ps_prochandle *ph, psaddr_t  addr,
++                   void *buf, size_t size);
++
++// write "size" bytes of data to debuggee at address "addr"
++ps_err_e ps_pdwrite(struct ps_prochandle *ph, psaddr_t addr,
++                    const void *buf, size_t size);
++
++ps_err_e ps_lsetfpregs(struct ps_prochandle *ph, lwpid_t lid, const prfpregset_t *fpregs);
++
++ps_err_e ps_lsetregs(struct ps_prochandle *ph, lwpid_t lid, const prgregset_t gregset);
++
++ps_err_e  ps_lgetfpregs(struct  ps_prochandle  *ph,  lwpid_t lid, prfpregset_t *fpregs);
++
++ps_err_e ps_lgetregs(struct ps_prochandle *ph, lwpid_t lid, prgregset_t gregset);
++
++// new libthread_db of NPTL seem to require this symbol
++ps_err_e ps_get_thread_area();
+ #endif //_LIBPROC_IMPL_H_
+diff -upr a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.c b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.c
+--- a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.c
++++ b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2002, 2017, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+@@ -24,6 +24,7 @@
+ 
+ #include <jni.h>
+ #include "libproc.h"
++#include "libproc_impl.h"
+ 
+ #include <elf.h>
+ #include <sys/types.h>
+diff -upr a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/proc_service.h b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/proc_service.h
+--- a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/proc_service.h
++++ b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/proc_service.h
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+@@ -26,7 +26,10 @@
+ #define _PROC_SERVICE_H_
+ 
+ #include <stdio.h>
++#include <sys/procfs.h>
++#ifdef INCLUDE_SA_ATTACH
+ #include <thread_db.h>
++#endif
+ 
+ // Linux does not have the proc service library, though it does provide the
+ // thread_db library which can be used to manipulate threads without having
+@@ -42,35 +45,4 @@ typedef enum {
+         PS_NOSYM,       /* p_lookup() could not find given symbol */
+         PS_NOFREGS      /* FPU register set not available for given lwp */
+ } ps_err_e;
+-
+-// ps_getpid() is only defined on Linux to return a thread's process ID
+-pid_t ps_getpid(struct ps_prochandle *ph);
+-
+-// ps_pglobal_lookup() looks up the symbol sym_name in the symbol table
+-// of the load object object_name in the target process identified by ph.
+-// It returns the symbol's value as an address in the target process in
+-// *sym_addr.
+-
+-ps_err_e ps_pglobal_lookup(struct ps_prochandle *ph, const char *object_name,
+-                    const char *sym_name, psaddr_t *sym_addr);
+-
+-// read "size" bytes of data from debuggee at address "addr"
+-ps_err_e ps_pdread(struct ps_prochandle *ph, psaddr_t  addr,
+-                   void *buf, size_t size);
+-
+-// write "size" bytes of data to debuggee at address "addr"
+-ps_err_e ps_pdwrite(struct ps_prochandle *ph, psaddr_t addr,
+-                    const void *buf, size_t size);
+-
+-ps_err_e ps_lsetfpregs(struct ps_prochandle *ph, lwpid_t lid, const prfpregset_t *fpregs);
+-
+-ps_err_e ps_lsetregs(struct ps_prochandle *ph, lwpid_t lid, const prgregset_t gregset);
+-
+-ps_err_e  ps_lgetfpregs(struct  ps_prochandle  *ph,  lwpid_t lid, prfpregset_t *fpregs);
+-
+-ps_err_e ps_lgetregs(struct ps_prochandle *ph, lwpid_t lid, prgregset_t gregset);
+-
+-// new libthread_db of NPTL seem to require this symbol
+-ps_err_e ps_get_thread_area();
+-
+ #endif /* _PROC_SERVICE_H_ */
+diff -upr a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+--- a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
++++ b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+@@ -731,6 +731,10 @@ static bool read_lib_segments(struct ps_
+   ELF_PHDR* phbuf;
+   ELF_PHDR* lib_php = NULL;
+ 
++#ifndef LIBC
++#error "LIBC not set"
++#endif
++
+   int page_size = sysconf(_SC_PAGE_SIZE);
+ 
+   if ((phbuf = read_program_header_table(lib_fd, lib_ehdr)) == NULL) {
+@@ -755,7 +759,8 @@ static bool read_lib_segments(struct ps_
+         // Coredump stores value of p_memsz elf field
+         // rounded up to page boundary.
+ 
+-        if ((existing_map->memsz != page_size) &&
++        if ((strcmp(LIBC, "musl")) &&
++            (existing_map->memsz != page_size) &&
+             (existing_map->fd != lib_fd) &&
+             (ROUNDUP(existing_map->memsz, page_size) != ROUNDUP(lib_php->p_memsz, page_size))) {
+ 
+diff -upr a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+--- a/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
++++ b/hotspot/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+@@ -218,9 +218,11 @@ static bool ptrace_waitpid(pid_t pid) {
+ static bool ptrace_attach(pid_t pid, char* err_buf, size_t err_buf_len) {
+   if (ptrace(PTRACE_ATTACH, pid, NULL, NULL) < 0) {
+     char buf[200];
+-    char* msg = strerror_r(errno, buf, sizeof(buf));
+-    snprintf(err_buf, err_buf_len, "ptrace(PTRACE_ATTACH, ..) failed for %d: %s", pid, msg);
+-    print_debug("%s\n", err_buf);
++    if (strerror_r(errno, buf, sizeof(buf) == 0)) {
++      snprintf(err_buf, err_buf_len,
++               "ptrace(PTRACE_ATTACH, ..) failed for %d: %s", pid, buf);
++      print_debug("%s\n", err_buf);
++    }
+     return false;
+   } else {
+     return ptrace_waitpid(pid);
+@@ -406,7 +408,7 @@ struct ps_prochandle* Pgrab(pid_t pid, c
+   thr = ph->threads;
+   while (thr) {
+      // don't attach to the main thread again
+-    if (ph->pid != thr->lwp_id && ptrace_attach(thr->lwp_id, err_buf, err_buf_len) != true) {
++     if (pid != thr->lwp_id && ptrace_attach(thr->lwp_id, err_buf, err_buf_len) != true) {
+         // even if one attach fails, we get return NULL
+         Prelease(ph);
+         return NULL;
+diff -upr a/hotspot/src/os/aix/vm/os_aix.inline.hpp b/hotspot/src/os/aix/vm/os_aix.inline.hpp
+--- a/hotspot/src/os/aix/vm/os_aix.inline.hpp
++++ b/hotspot/src/os/aix/vm/os_aix.inline.hpp
+@@ -32,7 +32,7 @@
+ 
+ #include <unistd.h>
+ #include <sys/socket.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/ioctl.h>
+ #include <netdb.h>
+ 
+diff -upr a/hotspot/src/os/bsd/vm/os_bsd.inline.hpp b/hotspot/src/os/bsd/vm/os_bsd.inline.hpp
+--- a/hotspot/src/os/bsd/vm/os_bsd.inline.hpp
++++ b/hotspot/src/os/bsd/vm/os_bsd.inline.hpp
+@@ -31,7 +31,7 @@
+ 
+ #include <unistd.h>
+ #include <sys/socket.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <netdb.h>
+ 
+ // File names are case-sensitive on windows only
+diff -upr a/hotspot/src/os/linux/vm/os_linux.cpp b/hotspot/src/os/linux/vm/os_linux.cpp
+--- a/hotspot/src/os/linux/vm/os_linux.cpp
++++ b/hotspot/src/os/linux/vm/os_linux.cpp
+@@ -98,7 +98,6 @@
+ # include <string.h>
+ # include <syscall.h>
+ # include <sys/sysinfo.h>
+-# include <gnu/libc-version.h>
+ # include <sys/ipc.h>
+ # include <sys/shm.h>
+ # include <link.h>
+@@ -143,8 +142,8 @@ pthread_t os::Linux::_main_thread;
+ int os::Linux::_page_size = -1;
+ bool os::Linux::_supports_fast_thread_cpu_time = false;
+ uint32_t os::Linux::_os_version = 0;
+-const char * os::Linux::_glibc_version = NULL;
+-const char * os::Linux::_libpthread_version = NULL;
++const char * os::Linux::_glibc_version = "unknown";
++const char * os::Linux::_libpthread_version = "unknown";
+ pthread_condattr_t os::Linux::_condattr[1];
+ 
+ static jlong initial_time_count=0;
+@@ -502,17 +501,21 @@ void os::Linux::libpthread_init() {
+   #error "glibc too old (< 2.3.2)"
+ #endif
+ 
+-  size_t n = confstr(_CS_GNU_LIBC_VERSION, NULL, 0);
+-  assert(n > 0, "cannot retrieve glibc version");
+-  char *str = (char *)malloc(n, mtInternal);
+-  confstr(_CS_GNU_LIBC_VERSION, str, n);
+-  os::Linux::set_glibc_version(str);
++  size_t n;
++
++  n = confstr(_CS_GNU_LIBC_VERSION, NULL, 0);
++  if (n > 0) {
++    char* str = (char *)malloc(n, mtInternal);
++    confstr(_CS_GNU_LIBC_VERSION, str, n);
++    os::Linux::set_glibc_version(str);
++  }
+ 
+   n = confstr(_CS_GNU_LIBPTHREAD_VERSION, NULL, 0);
+-  assert(n > 0, "cannot retrieve pthread version");
+-  str = (char *)malloc(n, mtInternal);
+-  confstr(_CS_GNU_LIBPTHREAD_VERSION, str, n);
+-  os::Linux::set_libpthread_version(str);
++  if (n > 0) {
++    char* str = (char *)malloc(n, mtInternal);
++    confstr(_CS_GNU_LIBPTHREAD_VERSION, str, n);
++    os::Linux::set_libpthread_version(str);
++  }
+ }
+ 
+ /////////////////////////////////////////////////////////////////////////////
+@@ -2809,11 +2812,23 @@ extern "C" JNIEXPORT void numa_error(cha
+ // If we are running with earlier version, which did not have symbol versions,
+ // we should use the base version.
+ void* os::Linux::libnuma_dlsym(void* handle, const char *name) {
+-  void *f = dlvsym(handle, name, "libnuma_1.1");
+-  if (f == NULL) {
+-    f = dlsym(handle, name);
++  typedef void* (*dlvsym_func_type)(void* handle, const char* name, const char* version);
++  static dlvsym_func_type dlvsym_func;
++  static bool initialized = false;
++
++  if (!initialized) {
++    dlvsym_func = (dlvsym_func_type)dlsym(RTLD_NEXT, "dlvsym");
++    initialized = true;
+   }
+-  return f;
++
++  if (dlvsym_func != NULL) {
++    void *f = dlvsym_func(handle, name, "libnuma_1.1");
++    if (f != NULL) {
++      return f;
++    }
++  }
++
++  return dlsym(handle, name);
+ }
+ 
+ bool os::Linux::libnuma_init() {
+@@ -4713,6 +4728,63 @@ void os::Linux::check_signal_handler(int
+ extern void report_error(char* file_name, int line_no, char* title,
+                          char* format, ...);
+ 
++// Some linux distributions (notably: Alpine Linux) include the
++// grsecurity in the kernel by default. Of particular interest from a
++// JVM perspective is PaX (https://pax.grsecurity.net/), which adds
++// some security features related to page attributes. Specifically,
++// the MPROTECT PaX functionality
++// (https://pax.grsecurity.net/docs/mprotect.txt) prevents dynamic
++// code generation by disallowing a (previously) writable page to be
++// marked as executable. This is, of course, exactly what HotSpot does
++// for both JIT compiled method, as well as for stubs, adapters, etc.
++//
++// Instead of crashing "lazily" when trying to make a page executable,
++// this code probes for the presence of PaX and reports the failure
++// eagerly.
++static void check_pax(void) {
++  // Zero doesn't generate code dynamically, so no need to perform the PaX check
++#ifndef ZERO
++  size_t size = os::Linux::page_size();
++
++  void* p = ::mmap(NULL, size, PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
++  if (p == MAP_FAILED) {
++    vm_exit_out_of_memory(size, OOM_MMAP_ERROR, "failed to allocate memory for PaX check.");
++  }
++
++  int res = ::mprotect(p, size, PROT_WRITE|PROT_EXEC);
++  if (res == -1) {
++    vm_exit_during_initialization("Failed to mark memory page as executable",
++                                  "Please check if grsecurity/PaX is enabled in your kernel.\n"
++                                  "\n"
++                                  "For example, you can do this by running (note: you may need root privileges):\n"
++                                  "\n"
++                                  "    sysctl kernel.pax.softmode\n"
++                                  "\n"
++                                  "If PaX is included in the kernel you will see something like this:\n"
++                                  "\n"
++                                  "    kernel.pax.softmode = 0\n"
++                                  "\n"
++                                  "In particular, if the value is 0 (zero), then PaX is enabled.\n"
++                                  "\n"
++                                  "PaX includes security functionality which interferes with the dynamic code\n"
++                                  "generation the JVM relies on. Specifically, the MPROTECT functionality as\n"
++                                  "described on https://pax.grsecurity.net/docs/mprotect.txt is not compatible\n"
++                                  "with the JVM. If you want to allow the JVM to run you will have to disable PaX.\n"
++                                  "You can do this on a per-executable basis using the paxctl tool, for example:\n"
++                                  "\n"
++                                  "    paxctl -cm bin/java\n"
++                                  "\n"
++                                  "Please note that this modifies the executable binary in-place, so you may want\n"
++                                  "to make a backup of it first. Also note that you have to repeat this for other\n"
++                                  "executables like javac, jar, jcmd, etc.\n"
++                                  );
++
++  }
++
++  ::munmap(p, size);
++#endif
++}
++
+ // this is called _before_ the most of global arguments have been parsed
+ void os::init(void) {
+   char dummy;   // used to get a guess on initial stack address
+@@ -4764,6 +4836,7 @@ void os::init(void) {
+   Linux::_pthread_setname_np =
+     (int(*)(pthread_t, const char*))dlsym(RTLD_DEFAULT, "pthread_setname_np");
+ 
++  check_pax();
+ }
+ 
+ // To install functions for atexit system call
+diff -upr a/hotspot/src/os/linux/vm/os_linux.inline.hpp b/hotspot/src/os/linux/vm/os_linux.inline.hpp
+--- a/hotspot/src/os/linux/vm/os_linux.inline.hpp
++++ b/hotspot/src/os/linux/vm/os_linux.inline.hpp
+@@ -31,7 +31,7 @@
+ 
+ #include <unistd.h>
+ #include <sys/socket.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <netdb.h>
+ 
+ // File names are case-sensitive on windows only
+diff -upr a/hotspot/src/os/posix/vm/os_posix.cpp b/hotspot/src/os/posix/vm/os_posix.cpp
+--- a/hotspot/src/os/posix/vm/os_posix.cpp
++++ b/hotspot/src/os/posix/vm/os_posix.cpp
+@@ -207,30 +207,30 @@ void os::Posix::print_rlimit_info(output
+   st->print(" STACK ");
+   getrlimit(RLIMIT_STACK, &rlim);
+   if (rlim.rlim_cur == RLIM_INFINITY) st->print("infinity");
+-  else st->print("%luk", rlim.rlim_cur >> 10);
++  else st->print(UINT64_FORMAT "k", uint64_t(rlim.rlim_cur) >> 10);
+ 
+   st->print(", CORE ");
+   getrlimit(RLIMIT_CORE, &rlim);
+   if (rlim.rlim_cur == RLIM_INFINITY) st->print("infinity");
+-  else st->print("%luk", rlim.rlim_cur >> 10);
++  else st->print(UINT64_FORMAT "k", uint64_t(rlim.rlim_cur) >> 10);
+ 
+   // Isn't there on solaris
+ #if !defined(SOLARIS) && !defined(AIX)
+   st->print(", NPROC ");
+   getrlimit(RLIMIT_NPROC, &rlim);
+   if (rlim.rlim_cur == RLIM_INFINITY) st->print("infinity");
+-  else st->print("%lu", rlim.rlim_cur);
++  else st->print(UINT64_FORMAT, uint64_t(rlim.rlim_cur));
+ #endif
+ 
+   st->print(", NOFILE ");
+   getrlimit(RLIMIT_NOFILE, &rlim);
+   if (rlim.rlim_cur == RLIM_INFINITY) st->print("infinity");
+-  else st->print("%lu", rlim.rlim_cur);
++  else st->print(UINT64_FORMAT, uint64_t(rlim.rlim_cur));
+ 
+   st->print(", AS ");
+   getrlimit(RLIMIT_AS, &rlim);
+   if (rlim.rlim_cur == RLIM_INFINITY) st->print("infinity");
+-  else st->print("%luk", rlim.rlim_cur >> 10);
++  else st->print(UINT64_FORMAT "k", uint64_t(rlim.rlim_cur) >> 10);
+   st->cr();
+ }
+ 
+diff -upr a/hotspot/src/os/solaris/vm/os_solaris.inline.hpp b/hotspot/src/os/solaris/vm/os_solaris.inline.hpp
+--- a/hotspot/src/os/solaris/vm/os_solaris.inline.hpp
++++ b/hotspot/src/os/solaris/vm/os_solaris.inline.hpp
+@@ -31,7 +31,7 @@
+ #include <sys/param.h>
+ #include <dlfcn.h>
+ #include <sys/socket.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/filio.h>
+ #include <unistd.h>
+ #include <netdb.h>
+diff -upr a/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp b/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
+--- a/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
++++ b/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
+@@ -73,7 +73,9 @@
+ # include <pwd.h>
+ # include <poll.h>
+ # include <ucontext.h>
++#ifndef AMD64
+ # include <fpu_control.h>
++#endif
+ 
+ #ifdef AMD64
+ #define REG_SP REG_RSP
+diff -upr a/hotspot/src/share/vm/classfile/classFileParser.cpp b/hotspot/src/share/vm/classfile/classFileParser.cpp
+--- a/hotspot/src/share/vm/classfile/classFileParser.cpp
++++ b/hotspot/src/share/vm/classfile/classFileParser.cpp
+@@ -1674,19 +1674,13 @@ void ClassFileParser::parse_fields(const
+ }
+ 
+ 
+-static void copy_u2_with_conversion(u2* dest, const u2* src, int length) {
+-  while (length-- > 0) {
+-    *dest++ = Bytes::get_Java_u2((u1*) (src++));
+-  }
+-}
+-
+-const u2* ClassFileParser::parse_exception_table(const ClassFileStream* const cfs,
+-                                                 u4 code_length,
+-                                                 u4 exception_table_length,
+-                                                 TRAPS) {
++const void* ClassFileParser::parse_exception_table(const ClassFileStream* const cfs,
++                                                   u4 code_length,
++                                                   u4 exception_table_length,
++                                                   TRAPS) {
+   assert(cfs != NULL, "invariant");
+ 
+-  const u2* const exception_table_start = cfs->get_u2_buffer();
++  const void* const exception_table_start = cfs->get_u1_buffer();
+   assert(exception_table_start != NULL, "null exception table");
+ 
+   cfs->guarantee_more(8 * exception_table_length, CHECK_NULL); // start_pc,
+@@ -1804,13 +1798,13 @@ static void copy_lvt_element(const Class
+ 
+ // Function is used to parse both attributes:
+ // LocalVariableTable (LVT) and LocalVariableTypeTable (LVTT)
+-const u2* ClassFileParser::parse_localvariable_table(const ClassFileStream* cfs,
+-                                                     u4 code_length,
+-                                                     u2 max_locals,
+-                                                     u4 code_attribute_length,
+-                                                     u2* const localvariable_table_length,
+-                                                     bool isLVTT,
+-                                                     TRAPS) {
++const void* ClassFileParser::parse_localvariable_table(const ClassFileStream* cfs,
++                                                       u4 code_length,
++                                                       u2 max_locals,
++                                                       u4 code_attribute_length,
++                                                       u2* const localvariable_table_length,
++                                                       bool isLVTT,
++                                                       TRAPS) {
+   const char* const tbl_name = (isLVTT) ? "LocalVariableTypeTable" : "LocalVariableTable";
+   *localvariable_table_length = cfs->get_u2(CHECK_NULL);
+   const unsigned int size =
+@@ -1824,7 +1818,7 @@ const u2* ClassFileParser::parse_localva
+                        "%s has wrong length in class file %s", tbl_name, CHECK_NULL);
+   }
+ 
+-  const u2* const localvariable_table_start = cfs->get_u2_buffer();
++  const u1* const localvariable_table_start = cfs->get_u1_buffer();
+   assert(localvariable_table_start != NULL, "null local variable table");
+   if (!_need_verify) {
+     cfs->skip_u2_fast(size);
+@@ -1940,10 +1934,10 @@ static const u1* parse_stackmap_table(co
+   return stackmap_table_start;
+ }
+ 
+-const u2* ClassFileParser::parse_checked_exceptions(const ClassFileStream* const cfs,
+-                                                    u2* const checked_exceptions_length,
+-                                                    u4 method_attribute_length,
+-                                                    TRAPS) {
++const void* ClassFileParser::parse_checked_exceptions(const ClassFileStream* const cfs,
++                                                      u2* const checked_exceptions_length,
++                                                      u4 method_attribute_length,
++                                                      TRAPS) {
+   assert(cfs != NULL, "invariant");
+   assert(checked_exceptions_length != NULL, "invariant");
+ 
+@@ -1951,7 +1945,7 @@ const u2* ClassFileParser::parse_checked
+   *checked_exceptions_length = cfs->get_u2_fast();
+   const unsigned int size =
+     (*checked_exceptions_length) * sizeof(CheckedExceptionElement) / sizeof(u2);
+-  const u2* const checked_exceptions_start = cfs->get_u2_buffer();
++  const void* const checked_exceptions_start = cfs->get_u1_buffer();
+   assert(checked_exceptions_start != NULL, "null checked exceptions");
+   if (!_need_verify) {
+     cfs->skip_u2_fast(size);
+@@ -2118,10 +2112,10 @@ void ClassFileParser::ClassAnnotationCol
+ void ClassFileParser::copy_localvariable_table(const ConstMethod* cm,
+                                                int lvt_cnt,
+                                                u2* const localvariable_table_length,
+-                                               const u2**const localvariable_table_start,
++                                               const void** const localvariable_table_start,
+                                                int lvtt_cnt,
+                                                u2* const localvariable_type_table_length,
+-                                               const u2**const localvariable_type_table_start,
++                                               const void** const localvariable_type_table_start,
+                                                TRAPS) {
+ 
+   ResourceMark rm(THREAD);
+@@ -2316,10 +2310,10 @@ Method* ClassFileParser::parse_method(co
+   u4 code_length = 0;
+   const u1* code_start = 0;
+   u2 exception_table_length = 0;
+-  const u2* exception_table_start = NULL;
++  const void* exception_table_start = NULL; // (potentially unaligned) pointer to array of u2 elements
+   Array<int>* exception_handlers = Universe::the_empty_int_array();
+   u2 checked_exceptions_length = 0;
+-  const u2* checked_exceptions_start = NULL;
++  const void* checked_exceptions_start = NULL; // (potentially unaligned) pointer to array of u2 elements
+   CompressedLineNumberWriteStream* linenumber_table = NULL;
+   int linenumber_table_length = 0;
+   int total_lvt_length = 0;
+@@ -2329,9 +2323,9 @@ Method* ClassFileParser::parse_method(co
+   u2 max_lvt_cnt = INITIAL_MAX_LVT_NUMBER;
+   u2 max_lvtt_cnt = INITIAL_MAX_LVT_NUMBER;
+   u2* localvariable_table_length = NULL;
+-  const u2** localvariable_table_start = NULL;
++  const void** localvariable_table_start = NULL; // (potentially unaligned) pointer to array of LVT attributes
+   u2* localvariable_type_table_length = NULL;
+-  const u2** localvariable_type_table_start = NULL;
++  const void** localvariable_type_table_start = NULL; // (potentially unaligned) pointer to LVTT attributes
+   int method_parameters_length = -1;
+   const u1* method_parameters_data = NULL;
+   bool method_parameters_seen = false;
+@@ -2472,17 +2466,17 @@ Method* ClassFileParser::parse_method(co
+             localvariable_table_length = NEW_RESOURCE_ARRAY_IN_THREAD(
+               THREAD, u2,  INITIAL_MAX_LVT_NUMBER);
+             localvariable_table_start = NEW_RESOURCE_ARRAY_IN_THREAD(
+-              THREAD, const u2*, INITIAL_MAX_LVT_NUMBER);
++              THREAD, const void*, INITIAL_MAX_LVT_NUMBER);
+             localvariable_type_table_length = NEW_RESOURCE_ARRAY_IN_THREAD(
+               THREAD, u2,  INITIAL_MAX_LVT_NUMBER);
+             localvariable_type_table_start = NEW_RESOURCE_ARRAY_IN_THREAD(
+-              THREAD, const u2*, INITIAL_MAX_LVT_NUMBER);
++              THREAD, const void*, INITIAL_MAX_LVT_NUMBER);
+             lvt_allocated = true;
+           }
+           if (lvt_cnt == max_lvt_cnt) {
+             max_lvt_cnt <<= 1;
+             localvariable_table_length = REALLOC_RESOURCE_ARRAY(u2, localvariable_table_length, lvt_cnt, max_lvt_cnt);
+-            localvariable_table_start  = REALLOC_RESOURCE_ARRAY(const u2*, localvariable_table_start, lvt_cnt, max_lvt_cnt);
++            localvariable_table_start  = REALLOC_RESOURCE_ARRAY(const void*, localvariable_table_start, lvt_cnt, max_lvt_cnt);
+           }
+           localvariable_table_start[lvt_cnt] =
+             parse_localvariable_table(cfs,
+@@ -2501,18 +2495,18 @@ Method* ClassFileParser::parse_method(co
+             localvariable_table_length = NEW_RESOURCE_ARRAY_IN_THREAD(
+               THREAD, u2,  INITIAL_MAX_LVT_NUMBER);
+             localvariable_table_start = NEW_RESOURCE_ARRAY_IN_THREAD(
+-              THREAD, const u2*, INITIAL_MAX_LVT_NUMBER);
++              THREAD, const void*, INITIAL_MAX_LVT_NUMBER);
+             localvariable_type_table_length = NEW_RESOURCE_ARRAY_IN_THREAD(
+               THREAD, u2,  INITIAL_MAX_LVT_NUMBER);
+             localvariable_type_table_start = NEW_RESOURCE_ARRAY_IN_THREAD(
+-              THREAD, const u2*, INITIAL_MAX_LVT_NUMBER);
++              THREAD, const void*, INITIAL_MAX_LVT_NUMBER);
+             lvt_allocated = true;
+           }
+           // Parse local variable type table
+           if (lvtt_cnt == max_lvtt_cnt) {
+             max_lvtt_cnt <<= 1;
+             localvariable_type_table_length = REALLOC_RESOURCE_ARRAY(u2, localvariable_type_table_length, lvtt_cnt, max_lvtt_cnt);
+-            localvariable_type_table_start  = REALLOC_RESOURCE_ARRAY(const u2*, localvariable_type_table_start, lvtt_cnt, max_lvtt_cnt);
++            localvariable_type_table_start  = REALLOC_RESOURCE_ARRAY(const void*, localvariable_type_table_start, lvtt_cnt, max_lvtt_cnt);
+           }
+           localvariable_type_table_start[lvtt_cnt] =
+             parse_localvariable_table(cfs,
+@@ -2783,10 +2777,10 @@ Method* ClassFileParser::parse_method(co
+ 
+   // Copy exception table
+   if (exception_table_length > 0) {
+-    int size =
+-      exception_table_length * sizeof(ExceptionTableElement) / sizeof(u2);
+-    copy_u2_with_conversion((u2*) m->exception_table_start(),
+-                            exception_table_start, size);
++    Copy::conjoint_swap_if_needed<Endian::JAVA>(exception_table_start,
++                                                m->exception_table_start(),
++                                                exception_table_length * sizeof(ExceptionTableElement),
++                                                sizeof(u2));
+   }
+ 
+   // Copy method parameters
+@@ -2802,11 +2796,10 @@ Method* ClassFileParser::parse_method(co
+ 
+   // Copy checked exceptions
+   if (checked_exceptions_length > 0) {
+-    const int size =
+-      checked_exceptions_length * sizeof(CheckedExceptionElement) / sizeof(u2);
+-    copy_u2_with_conversion((u2*) m->checked_exceptions_start(),
+-                            checked_exceptions_start,
+-                            size);
++    Copy::conjoint_swap_if_needed<Endian::JAVA>(checked_exceptions_start,
++                                                m->checked_exceptions_start(),
++                                                checked_exceptions_length * sizeof(CheckedExceptionElement),
++                                                sizeof(u2));
+   }
+ 
+   // Copy class file LVT's/LVTT's into the HotSpot internal LVT.
+diff -upr a/hotspot/src/share/vm/classfile/classFileParser.hpp b/hotspot/src/share/vm/classfile/classFileParser.hpp
+--- a/hotspot/src/share/vm/classfile/classFileParser.hpp
++++ b/hotspot/src/share/vm/classfile/classFileParser.hpp
+@@ -238,28 +238,28 @@ class ClassFileParser VALUE_OBJ_CLASS_SP
+                      bool* const declares_nonstatic_concrete_methods,
+                      TRAPS);
+ 
+-  const u2* parse_exception_table(const ClassFileStream* const stream,
+-                                  u4 code_length,
+-                                  u4 exception_table_length,
+-                                  TRAPS);
++  const void* parse_exception_table(const ClassFileStream* const stream,
++                                    u4 code_length,
++                                    u4 exception_table_length,
++                                    TRAPS);
+ 
+   void parse_linenumber_table(u4 code_attribute_length,
+                               u4 code_length,
+                               CompressedLineNumberWriteStream**const write_stream,
+                               TRAPS);
+ 
+-  const u2* parse_localvariable_table(const ClassFileStream* const cfs,
+-                                      u4 code_length,
+-                                      u2 max_locals,
+-                                      u4 code_attribute_length,
+-                                      u2* const localvariable_table_length,
+-                                      bool isLVTT,
+-                                      TRAPS);
+-
+-  const u2* parse_checked_exceptions(const ClassFileStream* const cfs,
+-                                     u2* const checked_exceptions_length,
+-                                     u4 method_attribute_length,
+-                                     TRAPS);
++  const void* parse_localvariable_table(const ClassFileStream* const cfs,
++                                        u4 code_length,
++                                        u2 max_locals,
++                                        u4 code_attribute_length,
++                                        u2* const localvariable_table_length,
++                                        bool isLVTT,
++                                        TRAPS);
++
++  const void* parse_checked_exceptions(const ClassFileStream* const cfs,
++                                       u2* const checked_exceptions_length,
++                                       u4 method_attribute_length,
++                                       TRAPS);
+ 
+   void parse_type_array(u2 array_length,
+                         u4 code_length,
+@@ -453,10 +453,10 @@ class ClassFileParser VALUE_OBJ_CLASS_SP
+   void copy_localvariable_table(const ConstMethod* cm,
+                                 int lvt_cnt,
+                                 u2* const localvariable_table_length,
+-                                const u2**const localvariable_table_start,
++                                const void** const localvariable_table_start,
+                                 int lvtt_cnt,
+                                 u2* const localvariable_type_table_length,
+-                                const u2** const localvariable_type_table_start,
++                                const void** const localvariable_type_table_start,
+                                 TRAPS);
+ 
+   void copy_method_annotations(ConstMethod* cm,
+diff -upr a/hotspot/src/share/vm/classfile/classFileStream.hpp b/hotspot/src/share/vm/classfile/classFileStream.hpp
+--- a/hotspot/src/share/vm/classfile/classFileStream.hpp
++++ b/hotspot/src/share/vm/classfile/classFileStream.hpp
+@@ -128,10 +128,6 @@ class ClassFileStream: public ResourceOb
+     return _current;
+   }
+ 
+-  const u2* get_u2_buffer() const {
+-    return (const u2*) _current;
+-  }
+-
+   // Skip length u1 or u2 elements from stream
+   void skip_u1(int length, TRAPS) const;
+   void skip_u1_fast(int length) const {
+diff -upr a/hotspot/src/share/vm/interpreter/abstractInterpreter.hpp b/hotspot/src/share/vm/interpreter/abstractInterpreter.hpp
+--- a/hotspot/src/share/vm/interpreter/abstractInterpreter.hpp
++++ b/hotspot/src/share/vm/interpreter/abstractInterpreter.hpp
+@@ -249,7 +249,7 @@ class AbstractInterpreter: AllStatic {
+     return (oop*) slot_addr;
+   }
+   static jint* int_addr_in_slot(intptr_t* slot_addr) {
+-    if ((int) sizeof(jint) < wordSize && !Bytes::is_Java_byte_ordering_different())
++    if ((int) sizeof(jint) < wordSize && !Endian::is_Java_byte_ordering_different())
+       // big-endian LP64
+       return (jint*)(slot_addr + 1) - 1;
+     else
+diff -upr a/hotspot/src/share/vm/interpreter/bytecode.hpp b/hotspot/src/share/vm/interpreter/bytecode.hpp
+--- a/hotspot/src/share/vm/interpreter/bytecode.hpp
++++ b/hotspot/src/share/vm/interpreter/bytecode.hpp
+@@ -122,7 +122,7 @@ class Bytecode: public StackObj {
+   static void assert_constant_size(int required_size, int where, Bytecodes::Code bc, bool is_wide = false) NOT_DEBUG_RETURN;
+   static void assert_native_index(Bytecodes::Code bc, bool is_wide = false) NOT_DEBUG_RETURN;
+   static bool can_use_native_byte_order(Bytecodes::Code bc, bool is_wide = false) {
+-    return (!Bytes::is_Java_byte_ordering_different() || Bytecodes::native_byte_order(bc /*, is_wide*/));
++    return (!Endian::is_Java_byte_ordering_different() || Bytecodes::native_byte_order(bc /*, is_wide*/));
+   }
+ };
+ 
+diff -upr a/hotspot/src/share/vm/runtime/vm_version.cpp b/hotspot/src/share/vm/runtime/vm_version.cpp
+--- a/hotspot/src/share/vm/runtime/vm_version.cpp
++++ b/hotspot/src/share/vm/runtime/vm_version.cpp
+@@ -262,8 +262,14 @@ const char* Abstract_VM_Version::interna
+     #define FLOAT_ARCH_STR XSTR(FLOAT_ARCH)
+   #endif
+ 
++  #ifdef HOTSPOT_LIBC
++    #define LIBC_STR "-" HOTSPOT_LIBC
++  #else
++    #define LIBC_STR ""
++  #endif
++
+   #define INTERNAL_VERSION_SUFFIX VM_RELEASE ")" \
+-         " for " OS "-" CPU FLOAT_ARCH_STR \
++         " for " OS "-" CPU FLOAT_ARCH_STR LIBC_STR \
+          " JRE (" VERSION_STRING "), built on " __DATE__ " " __TIME__ \
+          " by " XSTR(HOTSPOT_BUILD_USER) " with " HOTSPOT_BUILD_COMPILER
+ 
+diff -upr a/hotspot/src/share/vm/services/heapDumper.cpp b/hotspot/src/share/vm/services/heapDumper.cpp
+--- a/hotspot/src/share/vm/services/heapDumper.cpp
++++ b/hotspot/src/share/vm/services/heapDumper.cpp
+@@ -1134,7 +1134,7 @@ void DumperSupport::dump_prim_array(Dump
+ 
+   switch (type) {
+     case T_INT : {
+-      if (Bytes::is_Java_byte_ordering_different()) {
++      if (Endian::is_Java_byte_ordering_different()) {
+         WRITE_ARRAY(array, int, u4, length);
+       } else {
+         writer->write_raw((void*)(array->int_at_addr(0)), length_in_bytes);
+@@ -1146,7 +1146,7 @@ void DumperSupport::dump_prim_array(Dump
+       break;
+     }
+     case T_CHAR : {
+-      if (Bytes::is_Java_byte_ordering_different()) {
++      if (Endian::is_Java_byte_ordering_different()) {
+         WRITE_ARRAY(array, char, u2, length);
+       } else {
+         writer->write_raw((void*)(array->char_at_addr(0)), length_in_bytes);
+@@ -1154,7 +1154,7 @@ void DumperSupport::dump_prim_array(Dump
+       break;
+     }
+     case T_SHORT : {
+-      if (Bytes::is_Java_byte_ordering_different()) {
++      if (Endian::is_Java_byte_ordering_different()) {
+         WRITE_ARRAY(array, short, u2, length);
+       } else {
+         writer->write_raw((void*)(array->short_at_addr(0)), length_in_bytes);
+@@ -1162,7 +1162,7 @@ void DumperSupport::dump_prim_array(Dump
+       break;
+     }
+     case T_BOOLEAN : {
+-      if (Bytes::is_Java_byte_ordering_different()) {
++      if (Endian::is_Java_byte_ordering_different()) {
+         WRITE_ARRAY(array, bool, u1, length);
+       } else {
+         writer->write_raw((void*)(array->bool_at_addr(0)), length_in_bytes);
+@@ -1170,7 +1170,7 @@ void DumperSupport::dump_prim_array(Dump
+       break;
+     }
+     case T_LONG : {
+-      if (Bytes::is_Java_byte_ordering_different()) {
++      if (Endian::is_Java_byte_ordering_different()) {
+         WRITE_ARRAY(array, long, u8, length);
+       } else {
+         writer->write_raw((void*)(array->long_at_addr(0)), length_in_bytes);
+diff -upr a/hotspot/src/share/vm/utilities/bytes.hpp b/hotspot/src/share/vm/utilities/bytes.hpp
+--- a/hotspot/src/share/vm/utilities/bytes.hpp
++++ b/hotspot/src/share/vm/utilities/bytes.hpp
+@@ -27,6 +27,27 @@
+ 
+ #include "utilities/macros.hpp"
+ 
++class Endian : AllStatic {
++public:
++  enum Order {
++    LITTLE,
++    BIG,
++    JAVA = BIG,
++    NATIVE =
++#ifdef VM_LITTLE_ENDIAN
++    LITTLE
++#else
++    BIG
++#endif
++  };
++
++  // Returns true, if the byte ordering used by Java is different from
++  // the native byte ordering of the underlying machine.
++  static inline bool is_Java_byte_ordering_different() {
++    return NATIVE != JAVA;
++  }
++};
++
+ #include CPU_HEADER(bytes)
+ 
+ #endif // SHARE_VM_UTILITIES_BYTES_HPP
+diff -upr a/hotspot/src/share/vm/utilities/copy.cpp b/hotspot/src/share/vm/utilities/copy.cpp
+--- a/hotspot/src/share/vm/utilities/copy.cpp
++++ b/hotspot/src/share/vm/utilities/copy.cpp
+@@ -56,14 +56,17 @@ void Copy::conjoint_memory_atomic(void*
+ class CopySwap : AllStatic {
+ public:
+   /**
+-   * Copy and byte swap elements
++   * Copy and optionally byte swap elements
++   *
++   * <swap> - true if elements should be byte swapped
+    *
+    * @param src address of source
+    * @param dst address of destination
+    * @param byte_count number of bytes to copy
+    * @param elem_size size of the elements to copy-swap
+    */
+-  static void conjoint_swap(address src, address dst, size_t byte_count, size_t elem_size) {
++  template<bool swap>
++  static void conjoint_swap_if_needed(const void* src, void* dst, size_t byte_count, size_t elem_size) {
+     assert(src != NULL, "address must not be NULL");
+     assert(dst != NULL, "address must not be NULL");
+     assert(elem_size == 2 || elem_size == 4 || elem_size == 8,
+@@ -71,12 +74,12 @@ public:
+     assert(is_size_aligned(byte_count, elem_size),
+            "byte_count " SIZE_FORMAT " must be multiple of element size " SIZE_FORMAT, byte_count, elem_size);
+ 
+-    address src_end = src + byte_count;
++    address src_end = (address)src + byte_count;
+ 
+     if (dst <= src || dst >= src_end) {
+-      do_conjoint_swap<RIGHT>(src, dst, byte_count, elem_size);
++      do_conjoint_swap<RIGHT,swap>(src, dst, byte_count, elem_size);
+     } else {
+-      do_conjoint_swap<LEFT>(src, dst, byte_count, elem_size);
++      do_conjoint_swap<LEFT,swap>(src, dst, byte_count, elem_size);
+     }
+   }
+ 
+@@ -125,18 +128,19 @@ private:
+    * @param dst address of destination
+    * @param byte_count number of bytes to copy
+    */
+-  template <typename T, CopyDirection D, bool is_src_aligned, bool is_dst_aligned>
+-  static void do_conjoint_swap(address src, address dst, size_t byte_count) {
+-    address cur_src, cur_dst;
++  template <typename T, CopyDirection D, bool swap, bool is_src_aligned, bool is_dst_aligned>
++  static void do_conjoint_swap(const void* src, void* dst, size_t byte_count) {
++    const char* cur_src;
++    char* cur_dst;
+ 
+     switch (D) {
+     case RIGHT:
+-      cur_src = src;
+-      cur_dst = dst;
++      cur_src = (const char*)src;
++      cur_dst = (char*)dst;
+       break;
+     case LEFT:
+-      cur_src = src + byte_count - sizeof(T);
+-      cur_dst = dst + byte_count - sizeof(T);
++      cur_src = (const char*)src + byte_count - sizeof(T);
++      cur_dst = (char*)dst + byte_count - sizeof(T);
+       break;
+     }
+ 
+@@ -149,7 +153,9 @@ private:
+         memcpy(&tmp, cur_src, sizeof(T));
+       }
+ 
+-      tmp = byte_swap(tmp);
++      if (swap) {
++        tmp = byte_swap(tmp);
++      }
+ 
+       if (is_dst_aligned) {
+         *(T*)cur_dst = tmp;
+@@ -173,26 +179,27 @@ private:
+   /**
+    * Copy and byte swap elements
+    *
+-   * <T> - type of element to copy
+-   * <D> - copy direction
++   * <T>    - type of element to copy
++   * <D>    - copy direction
++   * <swap> - true if elements should be byte swapped
+    *
+    * @param src address of source
+    * @param dst address of destination
+    * @param byte_count number of bytes to copy
+    */
+-  template <typename T, CopyDirection direction>
+-  static void do_conjoint_swap(address src, address dst, size_t byte_count) {
++  template <typename T, CopyDirection direction, bool swap>
++  static void do_conjoint_swap(const void* src, void* dst, size_t byte_count) {
+     if (is_ptr_aligned(src, sizeof(T))) {
+       if (is_ptr_aligned(dst, sizeof(T))) {
+-        do_conjoint_swap<T,direction,true,true>(src, dst, byte_count);
++        do_conjoint_swap<T,direction,swap,true,true>(src, dst, byte_count);
+       } else {
+-        do_conjoint_swap<T,direction,true,false>(src, dst, byte_count);
++        do_conjoint_swap<T,direction,swap,true,false>(src, dst, byte_count);
+       }
+     } else {
+       if (is_ptr_aligned(dst, sizeof(T))) {
+-        do_conjoint_swap<T,direction,false,true>(src, dst, byte_count);
++        do_conjoint_swap<T,direction,swap,false,true>(src, dst, byte_count);
+       } else {
+-        do_conjoint_swap<T,direction,false,false>(src, dst, byte_count);
++        do_conjoint_swap<T,direction,swap,false,false>(src, dst, byte_count);
+       }
+     }
+   }
+@@ -201,26 +208,31 @@ private:
+   /**
+    * Copy and byte swap elements
+    *
+-   * <D> - copy direction
++   * <D>    - copy direction
++   * <swap> - true if elements should be byte swapped
+    *
+    * @param src address of source
+    * @param dst address of destination
+    * @param byte_count number of bytes to copy
+    * @param elem_size size of the elements to copy-swap
+    */
+-  template <CopyDirection D>
+-  static void do_conjoint_swap(address src, address dst, size_t byte_count, size_t elem_size) {
++  template <CopyDirection D, bool swap>
++  static void do_conjoint_swap(const void* src, void* dst, size_t byte_count, size_t elem_size) {
+     switch (elem_size) {
+-    case 2: do_conjoint_swap<uint16_t,D>(src, dst, byte_count); break;
+-    case 4: do_conjoint_swap<uint32_t,D>(src, dst, byte_count); break;
+-    case 8: do_conjoint_swap<uint64_t,D>(src, dst, byte_count); break;
++    case 2: do_conjoint_swap<uint16_t,D,swap>(src, dst, byte_count); break;
++    case 4: do_conjoint_swap<uint32_t,D,swap>(src, dst, byte_count); break;
++    case 8: do_conjoint_swap<uint64_t,D,swap>(src, dst, byte_count); break;
+     default: guarantee(false, "do_conjoint_swap: Invalid elem_size " SIZE_FORMAT "\n", elem_size);
+     }
+   }
+ };
+ 
+-void Copy::conjoint_swap(address src, address dst, size_t byte_count, size_t elem_size) {
+-  CopySwap::conjoint_swap(src, dst, byte_count, elem_size);
++void Copy::conjoint_copy(const void* src, void* dst, size_t byte_count, size_t elem_size) {
++  CopySwap::conjoint_swap_if_needed<false>(src, dst, byte_count, elem_size);
++}
++
++void Copy::conjoint_swap(const void* src, void* dst, size_t byte_count, size_t elem_size) {
++  CopySwap::conjoint_swap_if_needed<true>(src, dst, byte_count, elem_size);
+ }
+ 
+ // Fill bytes; larger units are filled atomically if everything is aligned.
+diff -upr a/hotspot/src/share/vm/utilities/copy.hpp b/hotspot/src/share/vm/utilities/copy.hpp
+--- a/hotspot/src/share/vm/utilities/copy.hpp
++++ b/hotspot/src/share/vm/utilities/copy.hpp
+@@ -229,6 +229,16 @@ class Copy : AllStatic {
+   }
+ 
+   /**
++   * Copy elements
++   *
++   * @param src address of source
++   * @param dst address of destination
++   * @param byte_count number of bytes to copy
++   * @param elem_size size of the elements to copy-swap
++   */
++  static void conjoint_copy(const void* src, void* dst, size_t byte_count, size_t elem_size);
++
++  /**
+    * Copy and *unconditionally* byte swap elements
+    *
+    * @param src address of source
+@@ -236,7 +246,24 @@ class Copy : AllStatic {
+    * @param byte_count number of bytes to copy
+    * @param elem_size size of the elements to copy-swap
+    */
+-  static void conjoint_swap(address src, address dst, size_t byte_count, size_t elem_size);
++  static void conjoint_swap(const void* src, void* dst, size_t byte_count, size_t elem_size);
++
++  /**
++   * Copy and byte swap elements from the specified endian to the native (cpu) endian if needed (if they differ)
++   *
++   * @param src address of source
++   * @param dst address of destination
++   * @param byte_count number of bytes to copy
++   * @param elem_size size of the elements to copy-swap
++   */
++  template <Endian::Order endian>
++  static void conjoint_swap_if_needed(const void* src, void* dst, size_t byte_count, size_t elem_size) {
++    if (Endian::NATIVE != endian) {
++      conjoint_swap(src, dst, byte_count, elem_size);
++    } else {
++      conjoint_copy(src, dst, byte_count, elem_size);
++    }
++  }
+ 
+   // Fill methods
+ 
+diff -upr a/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp b/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
+--- a/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
++++ b/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
+@@ -216,7 +216,7 @@ inline int g_isnan(double f) { return is
+ #elif defined(__APPLE__)
+ inline int g_isnan(double f) { return isnan(f); }
+ #elif defined(LINUX) || defined(_ALLBSD_SOURCE)
+-inline int g_isnan(float  f) { return isnanf(f); }
++inline int g_isnan(float  f) { return isnan(f); }
+ inline int g_isnan(double f) { return isnan(f); }
+ #else
+ #error "missing platform-specific definition here"
+diff -upr a/hotspot/src/share/vm/utilities/globalDefinitions.hpp b/hotspot/src/share/vm/utilities/globalDefinitions.hpp
+--- a/hotspot/src/share/vm/utilities/globalDefinitions.hpp
++++ b/hotspot/src/share/vm/utilities/globalDefinitions.hpp
+@@ -487,7 +487,7 @@ inline bool is_size_aligned(size_t size,
+   return align_size_up_(size, alignment) == size;
+ }
+ 
+-inline bool is_ptr_aligned(void* ptr, size_t alignment) {
++inline bool is_ptr_aligned(const void* ptr, size_t alignment) {
+   return align_size_up_((intptr_t)ptr, (intptr_t)alignment) == (intptr_t)ptr;
+ }
+ 

--- a/testing/openjdk9/30-portola-jdk.patch
+++ b/testing/openjdk9/30-portola-jdk.patch
@@ -1,0 +1,316 @@
+Author: Portola Project <portola-dev@openjdk.java.net>
+URL: https://openjdk.java.net/projects/portola/
+Summary: Provide a port of the JDK to the musl C library
+----
+
+diff -upr a/jdk/make/lib/CoreLibraries.gmk b/jdk/make/lib/CoreLibraries.gmk
+--- a/jdk/make/lib/CoreLibraries.gmk
++++ b/jdk/make/lib/CoreLibraries.gmk
+@@ -338,6 +338,9 @@ else
+   LIBJLI_OUTPUT_DIR := $(INSTALL_LIBRARIES_HERE)/jli
+ endif
+ 
++
++LIBJLI_CFLAGS += -DLIBC=\"$(OPENJDK_TARGET_LIBC)\"
++
+ LIBJLI_CFLAGS += $(addprefix -I, $(LIBJLI_SRC_DIRS))
+ 
+ ifneq ($(USE_EXTERNAL_LIBZ), true)
+diff -upr a/jdk/src/java.base/aix/native/libnet/aix_close.c b/jdk/src/java.base/aix/native/libnet/aix_close.c
+--- a/jdk/src/java.base/aix/native/libnet/aix_close.c
++++ b/jdk/src/java.base/aix/native/libnet/aix_close.c
+@@ -64,7 +64,7 @@
+ #include <sys/uio.h>
+ #include <unistd.h>
+ #include <errno.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ /*
+  * Stack allocated by thread when doing blocking operation
+diff -upr a/jdk/src/java.base/aix/native/libnio/ch/AixPollPort.c b/jdk/src/java.base/aix/native/libnio/ch/AixPollPort.c
+--- a/jdk/src/java.base/aix/native/libnio/ch/AixPollPort.c
++++ b/jdk/src/java.base/aix/native/libnio/ch/AixPollPort.c
+@@ -34,7 +34,7 @@
+ #include <unistd.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/pollset.h>
+ #include <fcntl.h>
+ #include <stddef.h>
+diff -upr a/jdk/src/java.base/linux/native/libnet/linux_close.c b/jdk/src/java.base/linux/native/libnet/linux_close.c
+--- a/jdk/src/java.base/linux/native/libnet/linux_close.c
++++ b/jdk/src/java.base/linux/native/libnet/linux_close.c
+@@ -36,7 +36,7 @@
+ #include <sys/uio.h>
+ #include <unistd.h>
+ #include <errno.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ /*
+  * Stack allocated by thread when doing blocking operation
+@@ -58,7 +58,7 @@ typedef struct {
+ /*
+  * Signal to unblock thread
+  */
+-static int sigWakeup = (__SIGRTMAX - 2);
++static int sigWakeup;
+ 
+ /*
+  * fdTable holds one entry per file descriptor, up to a certain
+@@ -147,6 +147,7 @@ static void __attribute((constructor)) i
+     /*
+      * Setup the signal handler
+      */
++    sigWakeup = SIGRTMAX - 2;
+     sa.sa_handler = sig_wakeup;
+     sa.sa_flags   = 0;
+     sigemptyset(&sa.sa_mask);
+diff -upr a/jdk/src/java.base/linux/native/libnio/fs/LinuxWatchService.c b/jdk/src/java.base/linux/native/libnio/fs/LinuxWatchService.c
+--- a/jdk/src/java.base/linux/native/libnio/fs/LinuxWatchService.c
++++ b/jdk/src/java.base/linux/native/libnio/fs/LinuxWatchService.c
+@@ -32,7 +32,7 @@
+ #include <dlfcn.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/inotify.h>
+ 
+ #include "sun_nio_fs_LinuxWatchService.h"
+diff -upr a/jdk/src/java.base/macosx/native/include/jvm_md.h b/jdk/src/java.base/macosx/native/include/jvm_md.h
+--- a/jdk/src/java.base/macosx/native/include/jvm_md.h
++++ b/jdk/src/java.base/macosx/native/include/jvm_md.h
+@@ -60,7 +60,7 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <errno.h>
+-#include <sys/signal.h>
++#include <signal.h>
+ 
+ /* O Flags */
+ 
+diff -upr a/jdk/src/java.base/macosx/native/libnet/bsd_close.c b/jdk/src/java.base/macosx/native/libnet/bsd_close.c
+--- a/jdk/src/java.base/macosx/native/libnet/bsd_close.c
++++ b/jdk/src/java.base/macosx/native/libnet/bsd_close.c
+@@ -38,7 +38,7 @@
+ #include <sys/uio.h>
+ #include <unistd.h>
+ #include <errno.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ /*
+  * Stack allocated by thread when doing blocking operation
+diff -upr a/jdk/src/java.base/solaris/native/libnio/ch/DevPollArrayWrapper.c b/jdk/src/java.base/solaris/native/libnio/ch/DevPollArrayWrapper.c
+--- a/jdk/src/java.base/solaris/native/libnio/ch/DevPollArrayWrapper.c
++++ b/jdk/src/java.base/solaris/native/libnio/ch/DevPollArrayWrapper.c
+@@ -28,7 +28,7 @@
+ #include "jvm.h"
+ #include "jlong.h"
+ #include "sun_nio_ch_DevPollArrayWrapper.h"
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <unistd.h>
+ #include <sys/time.h>
+ 
+diff -upr a/jdk/src/java.base/unix/native/include/jvm_md.h b/jdk/src/java.base/unix/native/include/jvm_md.h
+--- a/jdk/src/java.base/unix/native/include/jvm_md.h
++++ b/jdk/src/java.base/unix/native/include/jvm_md.h
+@@ -65,7 +65,7 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <errno.h>
+-#include <sys/signal.h>
++#include <signal.h>
+ 
+ /* O Flags */
+ 
+diff -upr a/jdk/src/java.base/unix/native/libjava/jdk_util_md.h b/jdk/src/java.base/unix/native/libjava/jdk_util_md.h
+--- a/jdk/src/java.base/unix/native/libjava/jdk_util_md.h
++++ b/jdk/src/java.base/unix/native/libjava/jdk_util_md.h
+@@ -37,7 +37,7 @@
+ #define ISNAND(d) isnan(d)
+ #elif defined(__linux__) || defined(_ALLBSD_SOURCE)
+ #include <math.h>
+-#define ISNANF(f) isnanf(f)
++#define ISNANF(f) isnan(f)
+ #define ISNAND(d) isnan(d)
+ #elif defined(_AIX)
+ #include <math.h>
+diff -upr a/jdk/src/java.base/unix/native/libjli/java_md_solinux.c b/jdk/src/java.base/unix/native/libjli/java_md_solinux.c
+--- a/jdk/src/java.base/unix/native/libjli/java_md_solinux.c
++++ b/jdk/src/java.base/unix/native/libjli/java_md_solinux.c
+@@ -241,6 +241,39 @@ RequiresSetenv(const char *jvmpath) {
+     char *dmllp = NULL;
+     char *p; /* a utility pointer */
+ 
++#ifdef __linux
++#ifndef LIBC
++#error "LIBC not set"
++#endif
++
++    if (strcmp(LIBC, "musl") == 0) {
++      /*
++       * The musl library loader requires LD_LIBRARY_PATH to be set in
++       * order to correctly resolve the dependency libjava.so has on libjvm.so.
++       *
++       * Specifically, it differs from glibc in the sense that even if
++       * libjvm.so has already been loaded it will not be considered a
++       * candidate for resolving the dependency unless the *full* path
++       * of the already loaded library matches the dependency being loaded.
++       *
++       * libjvm.so is being loaded by the launcher using a long path to
++       * dlopen, not just the basename of the library. Typically this
++       * is something like "../lib/server/libjvm.so". However, if/when
++       * libjvm.so later tries to dlopen libjava.so (which it does in
++       * order to get access to a few functions implemented in
++       * libjava.so) the musl loader will, as part of loading
++       * dependent libraries, try to load libjvm.so using only its
++       * basename "libjvm.so". Since this does not match the longer
++       * path path it was first loaded with, the already loaded
++       * library is not considered a candidate, and the loader will
++       * instead look for libjvm.so elsewhere. If it's not in
++       * LD_LIBRARY_PATH the dependency load will fail, and libjava.so
++       * will therefore fail as well.
++       */
++      return JNI_TRUE;
++    }
++#endif
++
+ #ifdef AIX
+     /* We always have to set the LIBPATH on AIX because ld doesn't support $ORIGIN. */
+     return JNI_TRUE;
+diff -upr a/jdk/src/java.base/unix/native/libnet/net_util_md.h b/jdk/src/java.base/unix/native/libnet/net_util_md.h
+--- a/jdk/src/java.base/unix/native/libnet/net_util_md.h
++++ b/jdk/src/java.base/unix/native/libnet/net_util_md.h
+@@ -27,7 +27,7 @@
+ #define NET_UTILS_MD_H
+ 
+ #include <netdb.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/socket.h>
+ 
+ /************************************************************************
+diff -upr a/jdk/src/java.base/unix/native/libnio/ch/NativeThread.c b/jdk/src/java.base/unix/native/libnio/ch/NativeThread.c
+--- a/jdk/src/java.base/unix/native/libnio/ch/NativeThread.c
++++ b/jdk/src/java.base/unix/native/libnio/ch/NativeThread.c
+@@ -31,24 +31,21 @@
+ #include "jlong.h"
+ #include "sun_nio_ch_NativeThread.h"
+ #include "nio_util.h"
++#include <signal.h>
+ 
+ #ifdef __linux__
+   #include <pthread.h>
+-  #include <sys/signal.h>
+   /* Also defined in net/linux_close.c */
+-  #define INTERRUPT_SIGNAL (__SIGRTMAX - 2)
++  #define INTERRUPT_SIGNAL (SIGRTMAX - 2)
+ #elif _AIX
+   #include <pthread.h>
+-  #include <sys/signal.h>
+   /* Also defined in net/aix_close.c */
+   #define INTERRUPT_SIGNAL (SIGRTMAX - 1)
+ #elif __solaris__
+   #include <thread.h>
+-  #include <signal.h>
+   #define INTERRUPT_SIGNAL (SIGRTMAX - 2)
+ #elif _ALLBSD_SOURCE
+   #include <pthread.h>
+-  #include <signal.h>
+   /* Also defined in net/bsd_close.c */
+   #define INTERRUPT_SIGNAL SIGIO
+ #else
+diff -upr a/jdk/src/java.base/unix/native/libnio/ch/Net.c b/jdk/src/java.base/unix/native/libnio/ch/Net.c
+--- a/jdk/src/java.base/unix/native/libnio/ch/Net.c
++++ b/jdk/src/java.base/unix/native/libnio/ch/Net.c
+@@ -23,7 +23,7 @@
+  * questions.
+  */
+ 
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <string.h>
+diff -upr a/jdk/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c b/jdk/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
+--- a/jdk/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
++++ b/jdk/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
+@@ -27,9 +27,6 @@
+ #include <X11/Xutil.h>
+ #include <X11/Xos.h>
+ #include <X11/Xatom.h>
+-#ifdef __linux__
+-#include <execinfo.h>
+-#endif
+ 
+ #include <jvm.h>
+ #include <jni.h>
+@@ -787,26 +784,6 @@ JNIEXPORT jstring JNICALL Java_sun_awt_X
+     return ret;
+ }
+ 
+-#ifdef __linux__
+-void print_stack(void)
+-{
+-  void *array[10];
+-  size_t size;
+-  char **strings;
+-  size_t i;
+-
+-  size = backtrace (array, 10);
+-  strings = backtrace_symbols (array, size);
+-
+-  fprintf (stderr, "Obtained %zd stack frames.\n", size);
+-
+-  for (i = 0; i < size; i++)
+-     fprintf (stderr, "%s\n", strings[i]);
+-
+-  free (strings);
+-}
+-#endif
+-
+ Window get_xawt_root_shell(JNIEnv *env) {
+   static jclass classXRootWindow = NULL;
+   static jmethodID methodGetXRootWindow = NULL;
+diff -upr a/jdk/src/jdk.jdwp.agent/share/native/libjdwp/util.h b/jdk/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+--- a/jdk/src/jdk.jdwp.agent/share/native/libjdwp/util.h
++++ b/jdk/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+@@ -35,15 +35,15 @@
+ #ifdef DEBUG
+     /* Just to make sure these interfaces are not used here. */
+     #undef free
+-    #define free(p) Do not use this interface.
++    #define free do_not_use_this_interface_free
+     #undef malloc
+-    #define malloc(p) Do not use this interface.
++    #define malloc do_not_use_this_interface_malloc
+     #undef calloc
+-    #define calloc(p) Do not use this interface.
++    #define calloc do_not_use_this_interface_calloc
+     #undef realloc
+-    #define realloc(p) Do not use this interface.
++    #define realloc do_not_use_this_interface_realloc
+     #undef strdup
+-    #define strdup(p) Do not use this interface.
++    #define strdup do_not_use_this_interface_strdup
+ #endif
+ 
+ #include "log_messages.h"
+diff -upr a/jdk/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c b/jdk/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c
+--- a/jdk/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c
++++ b/jdk/src/jdk.jdwp.agent/unix/native/libdt_socket/socket_md.c
+@@ -37,7 +37,7 @@
+ #include <thread.h>
+ #else
+ #include <pthread.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #endif
+ 
+ #include "socket_md.h"

--- a/testing/openjdk9/APKBUILD
+++ b/testing/openjdk9/APKBUILD
@@ -1,0 +1,351 @@
+# Contributor: Holger Jaekel <holger.jaekel@gmx.de>
+# Maintainer: Holger Jaekel <holger.jaekel@gmx.de>
+pkgname=openjdk9
+_majorver=9
+_minorver=0
+_securityver=4
+_updatever=12
+pkgver=${_majorver}.${_minorver}.${_securityver}.u${_updatever}
+_hg_version_tag=${_majorver}.${_minorver}.${_securityver}+${_updatever}
+_hg_tag=jdk-${_hg_version_tag}
+pkgrel=0
+pkgdesc="OpenJDK Java ${_majorver} environment"
+url="http://openjdk.java.net/"
+arch="all"
+license="GPLv2+CE"
+depends="$pkgname-headless"
+depends_dev=""
+makedepends="
+	$depends_dev
+	alsa-lib-dev
+	autoconf
+	bash
+	cups-dev
+	fontconfig-dev
+	giflib-dev
+	graphviz
+	grep
+	lcms2-dev
+	libelf-dev
+	libexecinfo-dev
+	libjpeg-turbo-dev
+	libpng-dev
+	libx11-dev
+	libxext-dev
+	libxrender-dev
+	libxt-dev
+	libxtst-dev
+	linux-headers
+	openjdk8
+	unzip
+	zip
+	zlib-dev
+	"
+
+case $CARCH in
+x86)	_jarch=i386;;
+x86_64)	_jarch=amd64;;
+arm*)	_jarch=aarch32;;
+*)		_jarch="$CARCH";;
+esac
+
+_java_home="/usr/lib/jvm/java-9-openjdk"
+_jrelib="$_java_home/jre/lib/$_jarch"
+
+install=""
+subpackages="
+	$pkgname-jmods
+	$pkgname-headless
+	$pkgname-dev
+	$pkgname-examples:examples:noarch
+	$pkgname-doc
+	$pkgname-src:src:noarch
+	"
+source="
+	http://hg.openjdk.java.net/jdk-updates/jdk${_majorver}u/archive/${_hg_tag}.tar.bz2
+	corba-${_hg_version_tag}.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk${_majorver}u/corba/archive/${_hg_tag}.tar.bz2
+	hotspot-${_hg_version_tag}.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk${_majorver}u/hotspot/archive/${_hg_tag}.tar.bz2
+	jaxp-${_hg_version_tag}.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk${_majorver}u/jaxp/archive/${_hg_tag}.tar.bz2
+	jaxws-${_hg_version_tag}.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk${_majorver}u/jaxws/archive/${_hg_tag}.tar.bz2
+	jdk-jdk-${_hg_version_tag}.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk${_majorver}u/jdk/archive/${_hg_tag}.tar.bz2
+	langtools-${_hg_version_tag}.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk${_majorver}u/langtools/archive/${_hg_tag}.tar.bz2
+	nashorn-${_hg_version_tag}.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk${_majorver}u/nashorn/archive/${_hg_tag}.tar.bz2
+
+	10-portola.patch
+	20-portola-hotspot.patch
+	30-portola-jdk.patch
+
+	TestCryptoLevel.java
+	TestECDSA.java
+	"
+
+builddir="$srcdir/jdk${_majorver}u-${_hg_tag}"
+_jdkrelease="$builddir/build/linux-${CARCH}-normal-server-release/images/jdk"
+_docsrelease="$builddir/build/linux-${CARCH}-normal-server-release/images/docs"
+
+unpack() {
+	if [ -z "$force" ]; then
+		verify
+		initdcheck
+	fi
+	mkdir -p "$srcdir"
+	msg "Unpacking sources..."
+	tar -C "$srcdir" -jxf ${_hg_tag}.tar.bz2
+
+	tar -C "$builddir" -jxf corba-${_hg_version_tag}.tar.bz2
+	mv "$builddir/corba-${_hg_tag}" "$builddir/corba"
+
+	tar -C "$builddir" -jxf hotspot-${_hg_version_tag}.tar.bz2
+	mv "$builddir/hotspot-${_hg_tag}" "$builddir/hotspot"
+
+	tar -C "$builddir" -jxf jaxp-${_hg_version_tag}.tar.bz2
+	mv "$builddir/jaxp-${_hg_tag}" "$builddir/jaxp"
+
+	tar -C "$builddir" -jxf jaxws-${_hg_version_tag}.tar.bz2
+	mv "$builddir/jaxws-${_hg_tag}" "$builddir/jaxws"
+
+	tar -C "$builddir" -jxf jdk-jdk-${_hg_version_tag}.tar.bz2
+	mv "$builddir/jdk-${_hg_tag}" "$builddir/jdk"
+
+	tar -C "$builddir" -jxf langtools-${_hg_version_tag}.tar.bz2
+	mv "$builddir/langtools-${_hg_tag}" "$builddir/langtools"
+
+	tar -C "$builddir" -jxf nashorn-${_hg_version_tag}.tar.bz2
+	mv "$builddir/nashorn-${_hg_tag}" "$builddir/nashorn"
+}
+
+build() {
+	cd "$builddir"
+	NUM_PROC_OPT=''
+	MAKEFLAG_J=$(echo ${MAKEFLAGS} | sed -En 's/.*-j([0-9]+).*/\1/p')
+	if [ -n "${MAKEFLAG_J}" ]; then
+		# http://hg.openjdk.java.net/jdk10/jdk10/file/85e6cb013b98/make/InitSupport.gmk#l105
+		echo "Removing '-j${MAKEFLAG_J}' from MAKEFLAGS to prevent build fail. Passing it directly to ./configure."
+		export MAKEFLAGS=${MAKEFLAGS/-j${MAKEFLAG_J}/}
+		NUM_PROC_OPT="--with-num-cores=${MAKEFLAG_J}"
+	fi
+
+	# CFLAGS, CXXFLAGS and LDFLAGS are ignored as shown by a warning
+	# in the output of ./configure unless used like such:
+	#  --with-extra-cflags="${CFLAGS}"
+	#  --with-extra-cxxflags="${CXXFLAGS}"
+	#  --with-extra-ldflags="${LDFLAGS}"
+	# See also paragraph "Configure Control Variables from "jdk${_majorver}-${_hg_tag}/common/doc/building.md
+	_CFLAGS="$CFLAGS"
+	_CXXFLAGS="$CXXFLAGS"
+	_LDFLAGS="$LDFLAGS"
+	unset CFLAGS
+	unset CXXFLAGS
+	unset LDFLAGS
+	unset MAKEFLAGS
+
+	echo ${NUM_PROC_OPT}
+
+	bash configure \
+		--with-version-build="${_updatever}" \
+		--with-version-pre="" \
+		--with-version-opt="" \
+		--with-stdc++lib=dynamic \
+		--with-extra-cflags="${_CFLAGS}" \
+		--with-extra-cxxflags="${_CXXFLAGS}" \
+		--with-extra-ldflags="${_LDFLAGS}" \
+		--with-libjpeg=system \
+		--with-giflib=system \
+		--with-libpng=system \
+		--with-lcms=system \
+		--with-zlib=system \
+		--with-native-debug-symbols=none \
+		--enable-unlimited-crypto \
+		--disable-warnings-as-errors \
+		--with-extra-cflags="${_CFLAGS}" \
+		--with-extra-cxxflags="${_CXXFLAGS}" \
+		--with-extra-ldflags="${_LDFLAGS}" \
+		--with-jvm-variants=server \
+		${NUM_PROC_OPT}
+	make images docs
+}
+
+# TODO: As long as the JTReg package is not available, we cannot execute the regression tests.
+check() {
+	cd "$_jdkrelease"
+
+	./bin/java --version | grep "${_majorver}.${_minorver}.${_securityver}+${_updatever}"
+
+	# Check unlimited policy has been used
+	./bin/javac -d . $srcdir/TestCryptoLevel.java
+	./bin/java -cp . --add-opens java.base/javax.crypto=ALL-UNNAMED TestCryptoLevel
+
+	# Check ECC is working
+	./bin/javac -d . $srcdir/TestECDSA.java
+	./bin/java -cp . TestECDSA
+
+	# Check src.zip has all sources. See RHBZ#1130490
+	./bin/jar -tf ./lib/src.zip | grep 'sun.misc.Unsafe'
+
+	# Check class files include useful debugging information
+	./bin/javap -l java.lang.Object | grep "Compiled from"
+	./bin/javap -l java.lang.Object | grep LineNumberTable
+	./bin/javap -l java.lang.Object | grep LocalVariableTable
+
+	# Check generated class files include useful debugging information
+	./bin/javap -l java.nio.ByteBuffer | grep "Compiled from"
+	./bin/javap -l java.nio.ByteBuffer | grep LineNumberTable
+	./bin/javap -l java.nio.ByteBuffer | grep LocalVariableTable
+
+}
+
+package() {
+	local file dir
+	for file in lib/libawt_xawt.so \
+				lib/libjawt.so \
+				lib/libsplashscreen.so; do
+
+			dir=${file%/*}
+			mkdir -p "$pkgdir/$_java_home/$dir"
+			mv "$_jdkrelease/$file" "$pkgdir/$_java_home/$dir"
+	done
+
+	local file dir
+	for file in api \
+				resources \
+				specs \
+				index.html; do
+
+		dir=${file%/*}
+		mkdir -p "$pkgdir/usr/share/doc/java-${_majorver}-openjdk/javadoc/$dir"
+		mv "$_docsrelease/"$file "$pkgdir/usr/share/doc/java-${_majorver}-openjdk/javadoc/$dir"
+	done
+
+	for file in 16 \
+				24 \
+				32 \
+				48; do
+
+		dir=${file%/*}
+		mkdir -p "$pkgdir/usr/share/icons/hicolor/${file}x${file}/apps"
+		mv "$builddir"/jdk/src/java.desktop/unix/classes/sun/awt/X11/java-icon${file}.png \
+		   "$pkgdir/usr/share/icons/hicolor/${file}x${file}/apps/java-${_majorver}-openjdk.png"
+	done
+
+	mkdir -p "$pkgdir/usr/share/licenses/java-${_majorver}-openjdk"
+	mv "$_jdkrelease/legal/"* "$pkgdir/usr/share/licenses/java-${_majorver}-openjdk/"
+
+	mkdir -p "$pkgdir/usr/share/man/"
+	mv "$_jdkrelease/man/man1" "$pkgdir/usr/share/man/"
+}
+
+jmods() {
+	pkgdesc="JMods for OpenJDK ${_majorver}"
+
+	local file dir
+	for file in jmods/*.jmod; do
+
+		dir=${file%/*}
+		mkdir -p "$subpkgdir/$_java_home/$dir"
+		mv "$_jdkrelease/"$file "$subpkgdir/$_java_home/$dir"
+	done
+}
+
+headless() {
+	pkgdesc="OpenJDK ${_majorver} Headless Runtime Environment"
+	install="openjdk9-headless.post-install openjdk9-headless.post-upgrade"
+
+	local file dir
+	for file in lib/server/* \
+				lib/jli/* \
+				lib/classlist \
+				lib/jexec \
+				lib/jrt-fs.jar \
+				lib/jvm.cfg \
+				lib/*.so \
+				lib/modules \
+				lib/psfont.properties.ja \
+				lib/psfontj2d.properties \
+				lib/tzdb.dat \
+				bin/java \
+				bin/jjs \
+				bin/keytool \
+				bin/pack200 \
+				bin/rmid \
+				bin/rmiregistry \
+				bin/unpack200; do
+
+		dir=${file%/*}
+		mkdir -p "$subpkgdir/$_java_home/$dir"
+		mv "$_jdkrelease/"$file "$subpkgdir/$_java_home/$dir"
+	done
+	mkdir -p "$subpkgdir/etc/java/java-${_majorver}-openjdk"
+	mv "$_jdkrelease/conf" "$subpkgdir/etc/java/java-${_majorver}-openjdk/"
+	ln -sf /etc/java/java-${_majorver}-openjdk/conf "$subpkgdir/$_java_home/conf"
+}
+
+dev() {
+	pkgdesc="OpenJDK ${_majorver} development tools"
+	depends="$pkgname-headless"
+
+	local file dir
+	for file in include/*.h \
+				include/linux/*.h \
+				lib/ct.sym \
+				bin/jaotc \
+				bin/jar \
+				bin/jarsigner \
+				bin/javac \
+				bin/javadoc \
+				bin/javah \
+				bin/javap \
+				bin/jcmd \
+				bin/jconsole \
+				bin/jdb \
+				bin/jdeprscan \
+				bin/jdeps \
+				bin/jhsdb \
+				bin/jimage \
+				bin/jinfo \
+				bin/jlink \
+				bin/jmap \
+				bin/jmod \
+				bin/jps \
+				bin/jrunscript \
+				bin/jshell \
+				bin/jstack \
+				bin/jstat \
+				bin/jstatd \
+				bin/rmic \
+				bin/serialver; do
+
+		dir=${file%/*}
+		mkdir -p "$subpkgdir/$_java_home/$dir"
+		mv "$_jdkrelease/"$file "$subpkgdir/$_java_home/$dir"
+	done
+}
+
+examples() {
+	pkgdesc="OpenJDK ${_majorver} examples"
+	depends="$pkgname-headless"
+
+	mkdir -p "$subpkgdir/$_java_home/"
+	mv "$_jdkrelease/demo" "$subpkgdir/$_java_home/"
+	mv "$builddir/jdk/src/sample" "$subpkgdir/$_java_home/"
+}
+
+src() {
+	pkgdesc="OpenJDK ${_majorver} Source Bundle"
+	depends="$pkgname-headless"
+
+	mkdir -p "$subpkgdir/$_java_home/lib"
+	mv "$_jdkrelease/lib/src.zip" "$subpkgdir/$_java_home/lib"
+}
+sha512sums="cef3655ae7db657e6c81aa86587e451e58896bb6ee786495f6d757096334435b6a4de26ec3ec927da2487e135f09ce26414f8d6b9b9c508a28d3087be286b1ec  jdk-9.0.4+12.tar.bz2
+455998437a9e3ff538b921025d57e19e6fb5148b3f124c9c427c3604689884d81b3ce5c9dbd93d88de26bf1b43ce76d75f75afd95e473a94973a668575e41748  corba-9.0.4+12.tar.bz2
+49d93764b13085a5626bec1c3d4e790f8748c24577a4e990e76bd1006721a5b8b9a256c40bf6419df4dda6f6390e457485f90c1b1101c010476a04d9056e9f16  hotspot-9.0.4+12.tar.bz2
+82f28586fd576cc01062e2ff37a917987775838910e4a5ecdfd096abec1c8d23028b77bfc87a38ada53bc30d71d89bde7408c1ae572a43c87a71ced64fd08d3a  jaxp-9.0.4+12.tar.bz2
+459978a5e3ca21910781daed848229e043eea5bd82dcd20e9249934ec97a2a982126c6e37aac1a36719e3b73a5e6c8a92a50b63033149913614d8f3edfc0846e  jaxws-9.0.4+12.tar.bz2
+259228d3f439dde239e38cdebb8c3bbb83804ab141d87a9c236310707de9c58cd78cd80ceb4c17755cc1048071f24462839988112c2698f7ec1453a8810610f2  jdk-jdk-9.0.4+12.tar.bz2
+ef3c70be906a4b0dd9c9195c88da045909ee3ef144941fb7b4495ed66b4162f481095cad87626d2bd38e5a62134b440223cd008dd6123b6b43c00e338610a692  langtools-9.0.4+12.tar.bz2
+848c6ece418e250561572ad704baeb565580098cfc5f849d4e1a3b41b916aae3487eb4d8d0b319f3a503d122ec064ed4de0678d06821c9a2bdb09c990e589c97  nashorn-9.0.4+12.tar.bz2
+e8b778552f5feae2f718dd24171724a00950f24db44fff9e8cd5f17f98a73e0506bbaf8327fbec021b133286ca7ca3427987e970599f93238c803fabdbf37d52  10-portola.patch
+a591e8362fb26fe4563adc5a33e65568bf0aec52bfccd004ef34c2dc011f5d428d81b7faa10e9c6e64747848547c7ed6358cd0b7fed3efb084d9739021d5daeb  20-portola-hotspot.patch
+8132364715b015ff9e1bf67abda22fa5ad55e22725bd602011a331222aeef51449d17da627a6def908ae8d155cb5447f775821c781c0438a3748da7f0c7a926c  30-portola-jdk.patch
+b02dff8d549f88317bb4c741a9e269e8d59eef990197d085388fc49c7423a4eb9367dbe1e02bffb10e7862f5980301eb58d4494e177d0e8f60af6b05c7fbbe60  TestCryptoLevel.java
+27e91edef89d26c0c5b9a813e2045f8d2b348745a506ae37b34b660fa7093da9a4e0e676ea41dc4a5c901bce02e5304d95e90f68d6c99cbf461b2da40a7a9853  TestECDSA.java"

--- a/testing/openjdk9/TestCryptoLevel.java
+++ b/testing/openjdk9/TestCryptoLevel.java
@@ -1,0 +1,72 @@
+/* TestCryptoLevel -- Ensure unlimited crypto policy is in use.
+   Copyright (C) 2012 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
+
+import java.security.Permission;
+import java.security.PermissionCollection;
+
+public class TestCryptoLevel
+{
+    public static void main(String[] args)
+            throws NoSuchFieldException, ClassNotFoundException,
+            IllegalAccessException, InvocationTargetException
+    {
+        Class<?> cls = null;
+        Method def = null, exempt = null;
+
+        try
+        {
+            cls = Class.forName("javax.crypto.JceSecurity");
+        }
+        catch (ClassNotFoundException ex)
+        {
+            System.err.println("Running a non-Sun JDK.");
+            System.exit(0);
+        }
+        try
+        {
+            def = cls.getDeclaredMethod("getDefaultPolicy");
+            exempt = cls.getDeclaredMethod("getExemptPolicy");
+        }
+        catch (NoSuchMethodException ex)
+        {
+            System.err.println("Running IcedTea with the original crypto patch.");
+            System.exit(0);
+        }
+        def.setAccessible(true);
+        exempt.setAccessible(true);
+        PermissionCollection defPerms = (PermissionCollection) def.invoke(null);
+        PermissionCollection exemptPerms = (PermissionCollection) exempt.invoke(null);
+        Class<?> apCls = Class.forName("javax.crypto.CryptoAllPermission");
+        Field apField = apCls.getDeclaredField("INSTANCE");
+        apField.setAccessible(true);
+        Permission allPerms = (Permission) apField.get(null);
+        if (defPerms.implies(allPerms) && (exemptPerms == null || exemptPerms.implies(allPerms)))
+        {
+            System.err.println("Running with the unlimited policy.");
+            System.exit(0);
+        }
+        else
+        {
+            System.err.println("WARNING: Running with a restricted crypto policy.");
+            System.exit(-1);
+        }
+    }
+}

--- a/testing/openjdk9/TestECDSA.java
+++ b/testing/openjdk9/TestECDSA.java
@@ -1,0 +1,49 @@
+/* TestECDSA -- Ensure ECDSA signatures are working.
+   Copyright (C) 2016 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+
+/**
+ * @test
+ */
+public class TestECDSA {
+
+    public static void main(String[] args) throws Exception {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+        KeyPair key = keyGen.generateKeyPair();
+
+        byte[] data = "This is a string to sign".getBytes("UTF-8");
+
+        Signature dsa = Signature.getInstance("NONEwithECDSA");
+        dsa.initSign(key.getPrivate());
+        dsa.update(data);
+        byte[] sig = dsa.sign();
+        System.out.println("Signature: " + new BigInteger(1, sig).toString(16));
+
+        Signature dsaCheck = Signature.getInstance("NONEwithECDSA");
+        dsaCheck.initVerify(key.getPublic());
+        dsaCheck.update(data);
+        boolean success = dsaCheck.verify(sig);
+        if (!success) {
+            throw new RuntimeException("Test failed. Signature verification error");
+        }
+        System.out.println("Test passed.");
+    }
+}

--- a/testing/openjdk9/openjdk9-headless.post-install
+++ b/testing/openjdk9/openjdk9-headless.post-install
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/lib/jvm/java-9-openjdk/bin/java -Xshare:dump >/dev/null 2>/dev/null

--- a/testing/openjdk9/openjdk9-headless.post-upgrade
+++ b/testing/openjdk9/openjdk9-headless.post-upgrade
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/lib/jvm/java-9-openjdk/bin/java -Xshare:dump >/dev/null 2>/dev/null


### PR DESCRIPTION
New aport OpenJDK 9. This is a prerequisite for #6468 as OpenJDK 9 is needed as a bootstrap JDK for building OpenJDK 10. 

As OpenJDK 9 does not receive security updates from upstream, this aport should be deleted as soon as OpenJDK 10 is successfully build on all platforms.

I could only test this build on x86_64, I hope that it builds on all other platforms.
