### PR TITLE
testing/openjdk10: new aport

### DIFF
--- a/testing/openjdk10/10-portola.patch
+++ b/testing/openjdk10/10-portola.patch
@@ -1,0 +1,1446 @@
+Author: Portola Project <portola-dev@openjdk.java.net>
+URL: https://openjdk.java.net/projects/portola/
+Summary: Provide a port of the JDK to the musl C library
+----
+
+diff -upr a/make/autoconf/build-aux/config.guess b/make/autoconf/build-aux/config.guess
+--- a/make/autoconf/build-aux/config.guess
++++ b/make/autoconf/build-aux/config.guess
+@@ -30,6 +30,17 @@
+ DIR=`dirname $0`
+ OUT=`. $DIR/autoconf-config.guess`
+ 
++# config.guess doesn't identify systems running the musl C library, and will
++# instead return a string with a -gnu suffix. This block detects musl and
++# modifies the string to have a -musl suffix instead. 
++echo $OUT | grep -- -linux- > /dev/null 2> /dev/null
++if test $? = 0; then
++  ldd_version=`ldd --version 2>&1 | head -1 | cut -f1 -d' '`
++  if [ x"${ldd_version}" = x"musl" ]; then
++    OUT=`echo $OUT | sed 's/-gnu/-musl/'`
++  fi
++fi
++
+ # Test and fix solaris on x86_64
+ echo $OUT | grep i386-pc-solaris > /dev/null 2> /dev/null
+ if test $? = 0; then
+diff -upr a/make/autoconf/build-aux/config.sub b/make/autoconf/build-aux/config.sub
+--- a/make/autoconf/build-aux/config.sub
++++ b/make/autoconf/build-aux/config.sub
+@@ -29,6 +29,11 @@
+ 
+ DIR=`dirname $0`
+ 
++if [ "$1"x = "x86_64-unknown-linux-musl"x ]; then
++    echo $1
++    exit
++fi
++
+ # First, filter out everything that doesn't begin with "aarch64-"
+ if ! echo $* | grep '^aarch64-' >/dev/null ; then
+     . $DIR/autoconf-config.sub "$@"
+diff -upr a/make/autoconf/buildjdk-spec.gmk.in b/make/autoconf/buildjdk-spec.gmk.in
+--- a/make/autoconf/buildjdk-spec.gmk.in
++++ b/make/autoconf/buildjdk-spec.gmk.in
+@@ -50,17 +50,20 @@ IMAGES_OUTPUTDIR := $(patsubst $(OUTPUTD
+ 
+ OPENJDK_BUILD_CPU_LEGACY := @OPENJDK_BUILD_CPU_LEGACY@
+ OPENJDK_BUILD_CPU_LEGACY_LIB := @OPENJDK_BUILD_CPU_LEGACY_LIB@
++OPENJDK_BUILD_LIBC := @OPENJDK_BUILD_LIBC@
+ OPENJDK_TARGET_CPU := @OPENJDK_BUILD_CPU@
+ OPENJDK_TARGET_CPU_ARCH := @OPENJDK_BUILD_CPU_ARCH@
+ OPENJDK_TARGET_CPU_BITS := @OPENJDK_BUILD_CPU_BITS@
+ OPENJDK_TARGET_CPU_ENDIAN := @OPENJDK_BUILD_CPU_ENDIAN@
+ OPENJDK_TARGET_CPU_LEGACY := @OPENJDK_BUILD_CPU_LEGACY@
++OPENJDK_TARGET_LIBC := @OPENJDK_BUILD_LIBC@
+ 
+ HOTSPOT_TARGET_OS := @HOTSPOT_BUILD_OS@
+ HOTSPOT_TARGET_OS_TYPE := @HOTSPOT_BUILD_OS_TYPE@
+ HOTSPOT_TARGET_CPU := @HOTSPOT_BUILD_CPU@
+ HOTSPOT_TARGET_CPU_ARCH := @HOTSPOT_BUILD_CPU_ARCH@
+ HOTSPOT_TARGET_CPU_DEFINE := @HOTSPOT_BUILD_CPU_DEFINE@
++HOTSPOT_TARGET_LIBC := @HOTSPOT_BUILD_LIBC@
+ 
+ CFLAGS_JDKLIB := @OPENJDK_BUILD_CFLAGS_JDKLIB@
+ CXXFLAGS_JDKLIB := @OPENJDK_BUILD_CXXFLAGS_JDKLIB@
+diff -upr a/make/autoconf/configure.ac b/make/autoconf/configure.ac
+--- a/make/autoconf/configure.ac
++++ b/make/autoconf/configure.ac
+@@ -208,6 +208,7 @@ JDKOPT_SETUP_ADDRESS_SANITIZER
+ 
+ # Need toolchain to setup dtrace
+ HOTSPOT_SETUP_DTRACE
++HOTSPOT_SETUP_SA
+ HOTSPOT_ENABLE_DISABLE_AOT
+ HOTSPOT_ENABLE_DISABLE_CDS
+ HOTSPOT_ENABLE_DISABLE_GTEST
+diff -upr a/make/autoconf/generated-configure.sh b/make/autoconf/generated-configure.sh
+--- a/make/autoconf/generated-configure.sh
++++ b/make/autoconf/generated-configure.sh
+@@ -700,6 +700,7 @@ FIXPATH
+ BUILD_GTEST
+ ENABLE_CDS
+ ENABLE_AOT
++INCLUDE_SA_ATTACH
+ ASAN_ENABLED
+ GCOV_ENABLED
+ ZIP_EXTERNAL_DEBUG_SYMBOLS
+@@ -970,6 +971,7 @@ JDK_VARIANT
+ USERNAME
+ TOPDIR
+ PATH_SEP
++HOTSPOT_BUILD_LIBC
+ HOTSPOT_BUILD_CPU_DEFINE
+ HOTSPOT_BUILD_CPU_ARCH
+ HOTSPOT_BUILD_CPU
+@@ -980,6 +982,7 @@ OPENJDK_BUILD_CPU_OSARCH
+ OPENJDK_BUILD_CPU_ISADIR
+ OPENJDK_BUILD_CPU_LEGACY_LIB
+ OPENJDK_BUILD_CPU_LEGACY
++HOTSPOT_TARGET_LIBC
+ HOTSPOT_TARGET_CPU_DEFINE
+ HOTSPOT_TARGET_CPU_ARCH
+ HOTSPOT_TARGET_CPU
+@@ -995,6 +998,7 @@ RELEASE_FILE_OS_ARCH
+ RELEASE_FILE_OS_NAME
+ OPENJDK_MODULE_TARGET_PLATFORM
+ COMPILE_TYPE
++OPENJDK_TARGET_LIBC
+ OPENJDK_TARGET_CPU_ENDIAN
+ OPENJDK_TARGET_CPU_BITS
+ OPENJDK_TARGET_CPU_ARCH
+@@ -1002,6 +1006,7 @@ OPENJDK_TARGET_CPU
+ OPENJDK_TARGET_OS_ENV
+ OPENJDK_TARGET_OS_TYPE
+ OPENJDK_TARGET_OS
++OPENJDK_BUILD_LIBC
+ OPENJDK_BUILD_CPU_ENDIAN
+ OPENJDK_BUILD_CPU_BITS
+ OPENJDK_BUILD_CPU_ARCH
+@@ -1095,6 +1100,7 @@ infodir
+ docdir
+ oldincludedir
+ includedir
++runstatedir
+ localstatedir
+ sharedstatedir
+ sysconfdir
+@@ -1183,6 +1189,7 @@ enable_zip_debug_info
+ enable_native_coverage
+ enable_asan
+ enable_dtrace
++enable_sa_attach
+ enable_aot
+ enable_cds
+ enable_hotspot_gtest
+@@ -1387,6 +1394,7 @@ datadir='${datarootdir}'
+ sysconfdir='${prefix}/etc'
+ sharedstatedir='${prefix}/com'
+ localstatedir='${prefix}/var'
++runstatedir='${localstatedir}/run'
+ includedir='${prefix}/include'
+ oldincludedir='/usr/include'
+ docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
+@@ -1639,6 +1647,15 @@ do
+   | -silent | --silent | --silen | --sile | --sil)
+     silent=yes ;;
+ 
++  -runstatedir | --runstatedir | --runstatedi | --runstated \
++  | --runstate | --runstat | --runsta | --runst | --runs \
++  | --run | --ru | --r)
++    ac_prev=runstatedir ;;
++  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
++  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
++  | --run=* | --ru=* | --r=*)
++    runstatedir=$ac_optarg ;;
++
+   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
+     ac_prev=sbindir ;;
+   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
+@@ -1776,7 +1793,7 @@ fi
+ for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
+ 		datadir sysconfdir sharedstatedir localstatedir includedir \
+ 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
+-		libdir localedir mandir
++		libdir localedir mandir runstatedir
+ do
+   eval ac_val=\$$ac_var
+   # Remove trailing slashes.
+@@ -1929,6 +1946,7 @@ Fine tuning of the installation director
+   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
+   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
+   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
++  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
+   --libdir=DIR            object code libraries [EPREFIX/lib]
+   --includedir=DIR        C header files [PREFIX/include]
+   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
+@@ -1993,6 +2011,9 @@ Optional Features:
+   --enable-dtrace[=yes/no/auto]
+                           enable dtrace. Default is auto, where dtrace is
+                           enabled if all dependencies are present.
++  --enable-sa-attach[=yes/no/auto]
++                          enable serviceability agent attach. Default is auto,
++                          where it is enabled if all dependencies are present.
+   --enable-aot[=yes/no/auto]
+                           enable ahead of time compilation feature. Default is
+                           auto, where aot is enabled if all dependencies are
+@@ -4355,6 +4376,11 @@ VALID_JVM_VARIANTS="server client minima
+ 
+ 
+ ###############################################################################
++# Check if the serviceability agent attach functionality should be included.
++#
++
++
++###############################################################################
+ # Set up all JVM features for each JVM variant.
+ #
+ 
+@@ -15740,6 +15766,18 @@ test -n "$target_alias" &&
+       ;;
+   esac
+ 
++  case "$build_os" in
++    *linux*-musl)
++      VAR_LIBC=musl
++      ;;
++    *linux*-gnu)
++      VAR_LIBC=gnu
++      ;;
++    *)
++      VAR_LIBC=default
++      ;;
++  esac
++
+ 
+   # First argument is the cpu name from the trip/quad
+   case "$build_cpu" in
+@@ -15878,6 +15916,8 @@ test -n "$target_alias" &&
+   OPENJDK_BUILD_CPU_ARCH="$VAR_CPU_ARCH"
+   OPENJDK_BUILD_CPU_BITS="$VAR_CPU_BITS"
+   OPENJDK_BUILD_CPU_ENDIAN="$VAR_CPU_ENDIAN"
++  OPENJDK_BUILD_LIBC="$VAR_LIBC"
++
+ 
+ 
+ 
+@@ -15891,6 +15931,13 @@ $as_echo_n "checking openjdk-build os-cp
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OPENJDK_BUILD_OS-$OPENJDK_BUILD_CPU" >&5
+ $as_echo "$OPENJDK_BUILD_OS-$OPENJDK_BUILD_CPU" >&6; }
+ 
++  if test "x$OPENJDK_BUILD_OS" = "xlinux"; then
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking openjdk-build C library" >&5
++$as_echo_n "checking openjdk-build C library... " >&6; }
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OPENJDK_BUILD_LIBC" >&5
++$as_echo "$OPENJDK_BUILD_LIBC" >&6; }
++  fi
++
+   # Convert the autoconf OS/CPU value to our own data, into the VAR_OS/CPU variables.
+ 
+   case "$host_os" in
+@@ -15927,6 +15974,18 @@ $as_echo "$OPENJDK_BUILD_OS-$OPENJDK_BUI
+       ;;
+   esac
+ 
++  case "$host_os" in
++    *linux*-musl)
++      VAR_LIBC=musl
++      ;;
++    *linux*-gnu)
++      VAR_LIBC=gnu
++      ;;
++    *)
++      VAR_LIBC=default
++      ;;
++  esac
++
+ 
+   # First argument is the cpu name from the trip/quad
+   case "$host_cpu" in
+@@ -16065,6 +16124,8 @@ $as_echo "$OPENJDK_BUILD_OS-$OPENJDK_BUI
+   OPENJDK_TARGET_CPU_ARCH="$VAR_CPU_ARCH"
+   OPENJDK_TARGET_CPU_BITS="$VAR_CPU_BITS"
+   OPENJDK_TARGET_CPU_ENDIAN="$VAR_CPU_ENDIAN"
++  OPENJDK_TARGET_LIBC="$VAR_LIBC"
++
+ 
+ 
+ 
+@@ -16078,6 +16139,13 @@ $as_echo_n "checking openjdk-target os-c
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" >&5
+ $as_echo "$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" >&6; }
+ 
++  if test "x$OPENJDK_TARGET_OS" = "xlinux"; then
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking openjdk-target C library" >&5
++$as_echo_n "checking openjdk-target C library... " >&6; }
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OPENJDK_TARGET_LIBC" >&5
++$as_echo "$OPENJDK_TARGET_LIBC" >&6; }
++  fi
++
+ 
+ 
+ # Check whether --with-target-bits was given.
+@@ -16240,7 +16308,13 @@ $as_echo "$COMPILE_TYPE" >&6; }
+   else
+     OPENJDK_TARGET_CPU_BUNDLE="$OPENJDK_TARGET_CPU"
+   fi
+-  OPENJDK_TARGET_BUNDLE_PLATFORM="${OPENJDK_TARGET_OS_BUNDLE}-${OPENJDK_TARGET_CPU_BUNDLE}"
++
++  OPENJDK_TARGET_LIBC_BUNDLE=""
++  if test "x$OPENJDK_TARGET_LIBC" = "xmusl"; then
++    OPENJDK_TARGET_LIBC_BUNDLE="-$OPENJDK_TARGET_LIBC"
++  fi
++
++  OPENJDK_TARGET_BUNDLE_PLATFORM="${OPENJDK_TARGET_OS_BUNDLE}-${OPENJDK_TARGET_CPU_BUNDLE}${OPENJDK_TARGET_LIBC_BUNDLE}"
+ 
+ 
+   if test "x$OPENJDK_TARGET_CPU_BITS" = x64; then
+@@ -16318,6 +16392,12 @@ $as_echo "$COMPILE_TYPE" >&6; }
+   fi
+ 
+ 
++  if test "x$OPENJDK_TARGET_LIBC" = "xmusl"; then
++    HOTSPOT_TARGET_LIBC=$OPENJDK_TARGET_LIBC
++  else
++    HOTSPOT_TARGET_LIBC=""
++  fi
++
+ 
+ 
+   # Also store the legacy naming of the cpu.
+@@ -16391,7 +16471,13 @@ $as_echo "$COMPILE_TYPE" >&6; }
+   else
+     OPENJDK_BUILD_CPU_BUNDLE="$OPENJDK_BUILD_CPU"
+   fi
+-  OPENJDK_BUILD_BUNDLE_PLATFORM="${OPENJDK_BUILD_OS_BUNDLE}-${OPENJDK_BUILD_CPU_BUNDLE}"
++
++  OPENJDK_BUILD_LIBC_BUNDLE=""
++  if test "x$OPENJDK_BUILD_LIBC" = "xmusl"; then
++    OPENJDK_BUILD_LIBC_BUNDLE="-$OPENJDK_BUILD_LIBC"
++  fi
++
++  OPENJDK_BUILD_BUNDLE_PLATFORM="${OPENJDK_BUILD_OS_BUNDLE}-${OPENJDK_BUILD_CPU_BUNDLE}${OPENJDK_BUILD_LIBC_BUNDLE}"
+ 
+ 
+   if test "x$OPENJDK_BUILD_CPU_BITS" = x64; then
+@@ -16469,6 +16555,12 @@ $as_echo "$COMPILE_TYPE" >&6; }
+   fi
+ 
+ 
++  if test "x$OPENJDK_BUILD_LIBC" = "xmusl"; then
++    HOTSPOT_BUILD_LIBC=$OPENJDK_BUILD_LIBC
++  else
++    HOTSPOT_BUILD_LIBC=""
++  fi
++
+ 
+ 
+ 
+@@ -55155,6 +55247,97 @@ $as_echo "yes, dependencies present" >&6
+   fi
+ 
+ 
++  # Test for serviceability agent attach dependencies
++  # Check whether --enable-sa-attach was given.
++if test "${enable_sa_attach+set}" = set; then :
++  enableval=$enable_sa_attach;
++fi
++
++
++  SA_ATTACH_DEP_MISSING=false
++
++  for ac_header in thread_db.h
++do :
++  ac_fn_cxx_check_header_mongrel "$LINENO" "thread_db.h" "ac_cv_header_thread_db_h" "$ac_includes_default"
++if test "x$ac_cv_header_thread_db_h" = xyes; then :
++  cat >>confdefs.h <<_ACEOF
++#define HAVE_THREAD_DB_H 1
++_ACEOF
++ SA_ATTACH_HEADERS_OK=yes
++else
++  SA_ATTACH_HEADERS_OK=no
++fi
++
++done
++
++  if test "x$SA_ATTACH_HEADERS_OK" != "xyes"; then
++    SA_ATTACH_DEP_MISSING=true
++  fi
++
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if serviceability agent attach should be included" >&5
++$as_echo_n "checking if serviceability agent attach should be included... " >&6; }
++  if test "x$enable_sa_attach" = "xyes"; then
++    if test "x$SA_ATTACH_DEP_MISSING" = "xtrue"; then
++      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no, missing dependencies" >&5
++$as_echo "no, missing dependencies" >&6; }
++
++  # Print a helpful message on how to acquire the necessary build dependency.
++  # sa-attach is the help tag: freetype, cups, alsa etc
++  MISSING_DEPENDENCY=sa-attach
++
++  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
++    cygwin_help $MISSING_DEPENDENCY
++  elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.msys"; then
++    msys_help $MISSING_DEPENDENCY
++  else
++    PKGHANDLER_COMMAND=
++
++    case $PKGHANDLER in
++      apt-get)
++        apt_help     $MISSING_DEPENDENCY ;;
++      yum)
++        yum_help     $MISSING_DEPENDENCY ;;
++      brew)
++        brew_help    $MISSING_DEPENDENCY ;;
++      port)
++        port_help    $MISSING_DEPENDENCY ;;
++      pkgutil)
++        pkgutil_help $MISSING_DEPENDENCY ;;
++      pkgadd)
++        pkgadd_help  $MISSING_DEPENDENCY ;;
++    esac
++
++    if test "x$PKGHANDLER_COMMAND" != x; then
++      HELP_MSG="You might be able to fix this by running '$PKGHANDLER_COMMAND'."
++    fi
++  fi
++
++      as_fn_error $? "Cannot enable sa-attach with missing dependencies. See above. $HELP_MSG" "$LINENO" 5
++    else
++      INCLUDE_SA_ATTACH=true
++      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, forced" >&5
++$as_echo "yes, forced" >&6; }
++    fi
++  elif test "x$enable_sa_attach" = "xno"; then
++    INCLUDE_SA_ATTACH=false
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no, forced" >&5
++$as_echo "no, forced" >&6; }
++  elif test "x$enable_sa_attach" = "xauto" || test "x$enable_sa_attach" = "x"; then
++    if test "x$SA_ATTACH_DEP_MISSING" = "xtrue"; then
++      INCLUDE_SA_ATTACH=false
++      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no, missing dependencies" >&5
++$as_echo "no, missing dependencies" >&6; }
++    else
++      INCLUDE_SA_ATTACH=true
++      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes, dependencies present" >&5
++$as_echo "yes, dependencies present" >&6; }
++    fi
++  else
++    as_fn_error $? "Invalid value for --enable-sa-attach: $enable_sa_attach" "$LINENO" 5
++  fi
++
++
++
+   # Check whether --enable-aot was given.
+ if test "${enable_aot+set}" = set; then :
+   enableval=$enable_aot;
+diff -upr a/make/autoconf/hotspot.m4 b/make/autoconf/hotspot.m4
+--- a/make/autoconf/hotspot.m4
++++ b/make/autoconf/hotspot.m4
+@@ -259,6 +259,50 @@ AC_DEFUN_ONCE([HOTSPOT_ENABLE_DISABLE_CD
+ ])
+ 
+ ###############################################################################
++# Check if the serviceability agent attach functionality should be included.
++#
++AC_DEFUN_ONCE([HOTSPOT_SETUP_SA],
++[
++  # Test for serviceability agent attach dependencies
++  AC_ARG_ENABLE([sa-attach], [AS_HELP_STRING([--enable-sa-attach@<:@=yes/no/auto@:>@],
++      [enable serviceability agent attach. Default is auto, where it is enabled if all dependencies
++      are present.])])
++
++  SA_ATTACH_DEP_MISSING=false
++
++  AC_CHECK_HEADERS([thread_db.h], [SA_ATTACH_HEADERS_OK=yes],[SA_ATTACH_HEADERS_OK=no])
++  if test "x$SA_ATTACH_HEADERS_OK" != "xyes"; then
++    SA_ATTACH_DEP_MISSING=true
++  fi
++
++  AC_MSG_CHECKING([if serviceability agent attach should be included])
++  if test "x$enable_sa_attach" = "xyes"; then
++    if test "x$SA_ATTACH_DEP_MISSING" = "xtrue"; then
++      AC_MSG_RESULT([no, missing dependencies])
++      HELP_MSG_MISSING_DEPENDENCY([sa-attach])
++      AC_MSG_ERROR([Cannot enable sa-attach with missing dependencies. See above. $HELP_MSG])
++    else
++      INCLUDE_SA_ATTACH=true
++      AC_MSG_RESULT([yes, forced])
++    fi
++  elif test "x$enable_sa_attach" = "xno"; then
++    INCLUDE_SA_ATTACH=false
++    AC_MSG_RESULT([no, forced])
++  elif test "x$enable_sa_attach" = "xauto" || test "x$enable_sa_attach" = "x"; then
++    if test "x$SA_ATTACH_DEP_MISSING" = "xtrue"; then
++      INCLUDE_SA_ATTACH=false
++      AC_MSG_RESULT([no, missing dependencies])
++    else
++      INCLUDE_SA_ATTACH=true
++      AC_MSG_RESULT([yes, dependencies present])
++    fi
++  else
++    AC_MSG_ERROR([Invalid value for --enable-sa-attach: $enable_sa_attach])
++  fi
++  AC_SUBST(INCLUDE_SA_ATTACH)
++])
++
++###############################################################################
+ # Set up all JVM features for each JVM variant.
+ #
+ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_FEATURES],
+diff -upr a/make/autoconf/platform.m4 b/make/autoconf/platform.m4
+--- a/make/autoconf/platform.m4
++++ b/make/autoconf/platform.m4
+@@ -188,6 +188,18 @@ AC_DEFUN([PLATFORM_EXTRACT_VARS_FROM_OS]
+       AC_MSG_ERROR([unsupported operating system $1])
+       ;;
+   esac
++
++  case "$1" in
++    *linux*-musl)
++      VAR_LIBC=musl
++      ;;
++    *linux*-gnu)
++      VAR_LIBC=gnu
++      ;;
++    *)
++      VAR_LIBC=default
++      ;;
++  esac
+ ])
+ 
+ # Expects $host_os $host_cpu $build_os and $build_cpu
+@@ -226,6 +238,7 @@ AC_DEFUN([PLATFORM_EXTRACT_TARGET_AND_BU
+   OPENJDK_BUILD_CPU_ARCH="$VAR_CPU_ARCH"
+   OPENJDK_BUILD_CPU_BITS="$VAR_CPU_BITS"
+   OPENJDK_BUILD_CPU_ENDIAN="$VAR_CPU_ENDIAN"
++  OPENJDK_BUILD_LIBC="$VAR_LIBC"
+   AC_SUBST(OPENJDK_BUILD_OS)
+   AC_SUBST(OPENJDK_BUILD_OS_TYPE)
+   AC_SUBST(OPENJDK_BUILD_OS_ENV)
+@@ -233,10 +246,16 @@ AC_DEFUN([PLATFORM_EXTRACT_TARGET_AND_BU
+   AC_SUBST(OPENJDK_BUILD_CPU_ARCH)
+   AC_SUBST(OPENJDK_BUILD_CPU_BITS)
+   AC_SUBST(OPENJDK_BUILD_CPU_ENDIAN)
++  AC_SUBST(OPENJDK_BUILD_LIBC)
+ 
+   AC_MSG_CHECKING([openjdk-build os-cpu])
+   AC_MSG_RESULT([$OPENJDK_BUILD_OS-$OPENJDK_BUILD_CPU])
+ 
++  if test "x$OPENJDK_BUILD_OS" = "xlinux"; then
++    AC_MSG_CHECKING([openjdk-build C library])
++    AC_MSG_RESULT([$OPENJDK_BUILD_LIBC])
++  fi
++
+   # Convert the autoconf OS/CPU value to our own data, into the VAR_OS/CPU variables.
+   PLATFORM_EXTRACT_VARS_FROM_OS($host_os)
+   PLATFORM_EXTRACT_VARS_FROM_CPU($host_cpu)
+@@ -256,6 +275,7 @@ AC_DEFUN([PLATFORM_EXTRACT_TARGET_AND_BU
+   OPENJDK_TARGET_CPU_ARCH="$VAR_CPU_ARCH"
+   OPENJDK_TARGET_CPU_BITS="$VAR_CPU_BITS"
+   OPENJDK_TARGET_CPU_ENDIAN="$VAR_CPU_ENDIAN"
++  OPENJDK_TARGET_LIBC="$VAR_LIBC"
+   AC_SUBST(OPENJDK_TARGET_OS)
+   AC_SUBST(OPENJDK_TARGET_OS_TYPE)
+   AC_SUBST(OPENJDK_TARGET_OS_ENV)
+@@ -263,9 +283,15 @@ AC_DEFUN([PLATFORM_EXTRACT_TARGET_AND_BU
+   AC_SUBST(OPENJDK_TARGET_CPU_ARCH)
+   AC_SUBST(OPENJDK_TARGET_CPU_BITS)
+   AC_SUBST(OPENJDK_TARGET_CPU_ENDIAN)
++  AC_SUBST(OPENJDK_TARGET_LIBC)
+ 
+   AC_MSG_CHECKING([openjdk-target os-cpu])
+   AC_MSG_RESULT([$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])
++
++  if test "x$OPENJDK_TARGET_OS" = "xlinux"; then
++    AC_MSG_CHECKING([openjdk-target C library])
++    AC_MSG_RESULT([$OPENJDK_TARGET_LIBC])
++  fi
+ ])
+ 
+ # Check if a reduced build (32-bit on 64-bit platforms) is requested, and modify behaviour
+@@ -400,7 +426,13 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS_HEL
+   else
+     OPENJDK_$1_CPU_BUNDLE="$OPENJDK_$1_CPU"
+   fi
+-  OPENJDK_$1_BUNDLE_PLATFORM="${OPENJDK_$1_OS_BUNDLE}-${OPENJDK_$1_CPU_BUNDLE}"
++
++  OPENJDK_$1_LIBC_BUNDLE=""
++  if test "x$OPENJDK_$1_LIBC" = "xmusl"; then  
++    OPENJDK_$1_LIBC_BUNDLE="-$OPENJDK_$1_LIBC"
++  fi
++
++  OPENJDK_$1_BUNDLE_PLATFORM="${OPENJDK_$1_OS_BUNDLE}-${OPENJDK_$1_CPU_BUNDLE}${OPENJDK_$1_LIBC_BUNDLE}"
+   AC_SUBST(OPENJDK_$1_BUNDLE_PLATFORM)
+ 
+   if test "x$OPENJDK_$1_CPU_BITS" = x64; then
+@@ -478,6 +510,12 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS_HEL
+   fi
+   AC_SUBST(HOTSPOT_$1_CPU_DEFINE)
+ 
++  if test "x$OPENJDK_$1_LIBC" = "xmusl"; then
++    HOTSPOT_$1_LIBC=$OPENJDK_$1_LIBC
++  else
++    HOTSPOT_$1_LIBC=""
++  fi
++  AC_SUBST(HOTSPOT_$1_LIBC)
+ ])
+ 
+ AC_DEFUN([PLATFORM_SET_RELEASE_FILE_OS_VALUES],
+diff -upr a/make/autoconf/spec.gmk.in b/make/autoconf/spec.gmk.in
+--- a/make/autoconf/spec.gmk.in
++++ b/make/autoconf/spec.gmk.in
+@@ -71,6 +71,8 @@ OPENJDK_TARGET_CPU_ARCH:=@OPENJDK_TARGET
+ OPENJDK_TARGET_CPU_BITS:=@OPENJDK_TARGET_CPU_BITS@
+ OPENJDK_TARGET_CPU_ENDIAN:=@OPENJDK_TARGET_CPU_ENDIAN@
+ 
++OPENJDK_TARGET_LIBC:=@OPENJDK_TARGET_LIBC@
++
+ COMPILE_TYPE:=@COMPILE_TYPE@
+ 
+ # Legacy support
+@@ -86,6 +88,8 @@ HOTSPOT_TARGET_CPU := @HOTSPOT_TARGET_CP
+ HOTSPOT_TARGET_CPU_ARCH := @HOTSPOT_TARGET_CPU_ARCH@
+ HOTSPOT_TARGET_CPU_DEFINE := @HOTSPOT_TARGET_CPU_DEFINE@
+ 
++HOTSPOT_TARGET_LIBC := @HOTSPOT_TARGET_LIBC@
++
+ OPENJDK_TARGET_BUNDLE_PLATFORM:=@OPENJDK_TARGET_BUNDLE_PLATFORM@
+ JDK_ARCH_ABI_PROP_NAME := @JDK_ARCH_ABI_PROP_NAME@
+ 
+@@ -100,6 +104,8 @@ OPENJDK_BUILD_CPU_ARCH:=@OPENJDK_BUILD_C
+ OPENJDK_BUILD_CPU_BITS:=@OPENJDK_BUILD_CPU_BITS@
+ OPENJDK_BUILD_CPU_ENDIAN:=@OPENJDK_BUILD_CPU_ENDIAN@
+ 
++OPENJDK_BUILD_LIBC:=@OPENJDK_BUILD_LIBC@
++
+ # Target platform value in ModuleTarget class file attribute.
+ OPENJDK_MODULE_TARGET_PLATFORM:=@OPENJDK_MODULE_TARGET_PLATFORM@
+ 
+@@ -801,6 +807,7 @@ PNG_CFLAGS:=@PNG_CFLAGS@
+ #
+ 
+ INCLUDE_SA=@INCLUDE_SA@
++INCLUDE_SA_ATTACH=@INCLUDE_SA_ATTACH@
+ INCLUDE_GRAAL=@INCLUDE_GRAAL@
+ 
+ OS_VERSION_MAJOR:=@OS_VERSION_MAJOR@
+diff -upr a/make/conf/jib-profiles.js b/make/conf/jib-profiles.js
+--- a/make/conf/jib-profiles.js
++++ b/make/conf/jib-profiles.js
+@@ -58,8 +58,10 @@
+  * input.build_id
+  * input.target_os
+  * input.target_cpu
++ * input.target_libc
+  * input.build_os
+  * input.build_cpu
++ * input.build_libc
+  * input.target_platform
+  * input.build_platform
+  * // The build_osenv_* variables describe the unix layer on Windows systems,
+@@ -99,13 +101,17 @@
+  *       target_os; <string>
+  *       // Name of cpu the profile is built to run on
+  *       target_cpu; <string>
+- *       // Combination of target_os and target_cpu for convenience
++ *       // Optional libc string if non standard
++ *       target_libc; <string>
++ *       // Optional combination of target_os and target_cpu for convenience
+  *       target_platform; <string>
+  *       // Name of os the profile is built on
+  *       build_os; <string>
+  *       // Name of cpu the profile is built on
+  *       build_cpu; <string>
+- *       // Combination of build_os and build_cpu for convenience
++ *       // Optional libc string if non standard
++ *       build_libc; <string>
++ *       // Optional combination of build_os and build_cpu for convenience
+  *       build_platform; <string>
+  *
+  *       // List of dependencies needed to build this profile
+@@ -188,7 +194,7 @@ var getJibProfiles = function (input) {
+ 
+     // Organization, product and version are used when uploading/publishing build results
+     data.organization = "";
+-    data.product = "jdk";
++    data.product = "jdk-portola";
+     data.version = getVersion();
+ 
+     // The base directory for the build output. JIB will assume that the
+@@ -230,7 +236,7 @@ var getJibProfilesCommon = function (inp
+ 
+     // List of the main profile names used for iteration
+     common.main_profile_names = [
+-        "linux-x64", "linux-x86", "macosx-x64", "solaris-x64",
++        "linux-x64", "linux-x64-musl", "linux-x86", "macosx-x64", "solaris-x64",
+         "solaris-sparcv9", "windows-x64", "windows-x86",
+         "linux-arm64", "linux-arm-vfp-hflt", "linux-arm-vfp-hflt-dyn"
+     ];
+@@ -417,6 +423,14 @@ var getJibProfilesProfiles = function (i
+             default_make_targets: ["docs-bundles"],
+         },
+ 
++        "linux-x64-musl": {
++            target_os: "linux",
++            target_cpu: "x64",
++            target_libc: "musl",
++            configure_args: concat(common.configure_args_64bit,
++                "--with-zlib=system"),
++        },
++
+         "linux-x86": {
+             target_os: "linux",
+             target_cpu: "x86",
+@@ -562,6 +576,10 @@ var getJibProfilesProfiles = function (i
+         "linux-x64": {
+             platform: "linux-x64",
+         },
++        "linux-x64-musl": {
++            platform: "linux-x64-musl",
++            demo_ext: "tar.gz"
++        },
+         "linux-x86": {
+             platform: "linux-x86",
+         },
+@@ -781,7 +799,16 @@ var getJibProfilesDependencies = functio
+         : input.target_platform);
+ 
+     var boot_jdk_platform = (input.build_os == "macosx" ? "osx" : input.build_os)
+-        + "-" + input.build_cpu;
++        + "-" + input.build_cpu +
++        (input.build_libc ? "-" + input.build_libc : "");
++
++    var boot_jdk_version = common.boot_jdk_version;
++    var boot_jdk_build_number = "181";
++
++    if (input.build_libc == "musl") {
++        boot_jdk_version = "jdk9-alpine";
++        boot_jdk_build_number = "181_2017-08-07-2007_6744";
++    }
+ 
+     var freetype_version = {
+         windows_x64: "2.7.1-v120+1.1",
+@@ -798,8 +825,8 @@ var getJibProfilesDependencies = functio
+         boot_jdk: {
+             server: "jpg",
+             product: "jdk",
+-            version: common.boot_jdk_version,
+-            build_number: "181",
++            version: boot_jdk_version,
++            build_number: boot_jdk_build_number,
+             file: "bundles/" + boot_jdk_platform + "/jdk-" + common.boot_jdk_version + "_"
+                 + boot_jdk_platform + "_bin.tar.gz",
+             configure_args: "--with-boot-jdk=" + common.boot_jdk_home,
+diff -upr a/make/hotspot/lib/CompileJvm.gmk b/make/hotspot/lib/CompileJvm.gmk
+--- a/make/hotspot/lib/CompileJvm.gmk
++++ b/make/hotspot/lib/CompileJvm.gmk
+@@ -133,6 +133,10 @@ else
+   OPENJDK_TARGET_CPU_VM_VERSION := $(OPENJDK_TARGET_CPU)
+ endif
+ 
++ifneq ($(HOTSPOT_TARGET_LIBC),)
++  LIBC_DEFINE := -DHOTSPOT_LIBC='"$(HOTSPOT_TARGET_LIBC)"'
++endif
++
+ CFLAGS_VM_VERSION := \
+     $(VERSION_CFLAGS) \
+     -DHOTSPOT_VERSION_STRING='"$(VERSION_STRING)"' \
+@@ -140,6 +144,7 @@ CFLAGS_VM_VERSION := \
+     -DHOTSPOT_BUILD_USER='"$(USERNAME)"' \
+     -DHOTSPOT_VM_DISTRO='"$(HOTSPOT_VM_DISTRO)"' \
+     -DCPU='"$(OPENJDK_TARGET_CPU_VM_VERSION)"' \
++    $(LIBC_DEFINE) \
+     #
+ 
+ # -DDONT_USE_PRECOMPILED_HEADER will exclude all includes in precompiled.hpp.
+diff -upr a/make/lib/CoreLibraries.gmk b/make/lib/CoreLibraries.gmk
+--- a/make/lib/CoreLibraries.gmk
++++ b/make/lib/CoreLibraries.gmk
+@@ -339,6 +339,9 @@ else
+   LIBJLI_OUTPUT_DIR := $(INSTALL_LIBRARIES_HERE)/jli
+ endif
+ 
++
++LIBJLI_CFLAGS += -DLIBC=\"$(OPENJDK_TARGET_LIBC)\"
++
+ LIBJLI_CFLAGS += $(addprefix -I, $(LIBJLI_SRC_DIRS))
+ 
+ ifneq ($(USE_EXTERNAL_LIBZ), true)
+diff -upr a/make/lib/Lib-jdk.hotspot.agent.gmk b/make/lib/Lib-jdk.hotspot.agent.gmk
+--- a/make/lib/Lib-jdk.hotspot.agent.gmk
++++ b/make/lib/Lib-jdk.hotspot.agent.gmk
+@@ -1,5 +1,5 @@
+ #
+-# Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
++# Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ #
+ # This code is free software; you can redistribute it and/or modify it
+@@ -57,7 +57,10 @@ ifeq ($(OPENJDK_TARGET_OS), linux)
+   SA_CFLAGS := $(CFLAGS_JDKLIB) -D_FILE_OFFSET_BITS=64 \
+       $(SA_MACHINE_FLAG_linux)
+   SA_LDFLAGS := $(LDFLAGS_JDKLIB) $(SA_MACHINE_FLAG_linux)
+-  SA_LIBS := -lthread_db $(LIBDL)
++  SA_LIBS := $(LIBDL)
++  ifeq ($(INCLUDE_SA_ATTACH), true)
++    SA_LIBS += -lthread_db
++  endif
+ 
+ else ifeq ($(OPENJDK_TARGET_OS), solaris)
+   SA_TOOLCHAIN := TOOLCHAIN_LINK_CXX
+@@ -95,6 +98,12 @@ else ifeq ($(OPENJDK_TARGET_OS), windows
+   endif
+ endif
+ 
++ifeq ($(INCLUDE_SA_ATTACH), true)
++  SA_CFLAGS += -DINCLUDE_SA_ATTACH
++endif
++
++SA_CFLAGS += -DLIBC=\"$(OPENJDK_TARGET_LIBC)\"
++
+ ################################################################################
+ 
+ $(eval $(call SetupNativeCompilation, BUILD_LIBSA, \
+diff -upr a/make/ReleaseFile.gmk b/make/ReleaseFile.gmk
+--- a/make/ReleaseFile.gmk
++++ b/make/ReleaseFile.gmk
+@@ -53,6 +53,7 @@ define create-info-file
+   $(call info-file-item, "JAVA_VERSION_DATE", "$(VERSION_DATE)")
+   $(call info-file-item, "OS_NAME", "$(RELEASE_FILE_OS_NAME)")
+   $(call info-file-item, "OS_ARCH", "$(RELEASE_FILE_OS_ARCH)")
++  $(call info-file-item, "LIBC", "$(OPENJDK_TARGET_LIBC)")
+ endef
+ 
+ # Param 1 - The file containing the MODULES list
+diff -upr a/src/hotspot/os/linux/os_linux.cpp b/src/hotspot/os/linux/os_linux.cpp
+--- a/src/hotspot/os/linux/os_linux.cpp
++++ b/src/hotspot/os/linux/os_linux.cpp
+@@ -100,7 +100,6 @@
+ # include <string.h>
+ # include <syscall.h>
+ # include <sys/sysinfo.h>
+-# include <gnu/libc-version.h>
+ # include <sys/ipc.h>
+ # include <sys/shm.h>
+ # include <link.h>
+@@ -146,8 +145,8 @@ pthread_t os::Linux::_main_thread;
+ int os::Linux::_page_size = -1;
+ bool os::Linux::_supports_fast_thread_cpu_time = false;
+ uint32_t os::Linux::_os_version = 0;
+-const char * os::Linux::_glibc_version = NULL;
+-const char * os::Linux::_libpthread_version = NULL;
++const char * os::Linux::_glibc_version = "unknown";
++const char * os::Linux::_libpthread_version = "unknown";
+ 
+ static jlong initial_time_count=0;
+ 
+@@ -530,17 +529,21 @@ void os::Linux::libpthread_init() {
+   #error "glibc too old (< 2.3.2)"
+ #endif
+ 
+-  size_t n = confstr(_CS_GNU_LIBC_VERSION, NULL, 0);
+-  assert(n > 0, "cannot retrieve glibc version");
+-  char *str = (char *)malloc(n, mtInternal);
+-  confstr(_CS_GNU_LIBC_VERSION, str, n);
+-  os::Linux::set_glibc_version(str);
++  size_t n;
++
++  n = confstr(_CS_GNU_LIBC_VERSION, NULL, 0);
++  if (n > 0) {
++    char* str = (char *)malloc(n, mtInternal);
++    confstr(_CS_GNU_LIBC_VERSION, str, n);
++    os::Linux::set_glibc_version(str);
++  }
+ 
+   n = confstr(_CS_GNU_LIBPTHREAD_VERSION, NULL, 0);
+-  assert(n > 0, "cannot retrieve pthread version");
+-  str = (char *)malloc(n, mtInternal);
+-  confstr(_CS_GNU_LIBPTHREAD_VERSION, str, n);
+-  os::Linux::set_libpthread_version(str);
++  if (n > 0) {
++    char* str = (char *)malloc(n, mtInternal);
++    confstr(_CS_GNU_LIBPTHREAD_VERSION, str, n);
++    os::Linux::set_libpthread_version(str);
++  }
+ }
+ 
+ /////////////////////////////////////////////////////////////////////////////
+@@ -2897,20 +2900,36 @@ void os::Linux::sched_getcpu_init() {
+ extern "C" JNIEXPORT void numa_warn(int number, char *where, ...) { }
+ extern "C" JNIEXPORT void numa_error(char *where) { }
+ 
++static void* dlvsym_if_available(void* handle, const char* name, const char* version) {
++  typedef void* (*dlvsym_func_type)(void* handle, const char* name, const char* version);
++  static dlvsym_func_type dlvsym_func;
++  static bool initialized = false;
++
++  if (!initialized) {
++    dlvsym_func = (dlvsym_func_type)dlsym(RTLD_NEXT, "dlvsym");
++    initialized = true;
++  }
++
++  if (dlvsym_func != NULL) {
++    void *f = dlvsym_func(handle, name, version);
++    if (f != NULL) {
++      return f;
++    }
++  }
++
++  return dlsym(handle, name);
++}
++
+ // Handle request to load libnuma symbol version 1.1 (API v1). If it fails
+ // load symbol from base version instead.
+ void* os::Linux::libnuma_dlsym(void* handle, const char *name) {
+-  void *f = dlvsym(handle, name, "libnuma_1.1");
+-  if (f == NULL) {
+-    f = dlsym(handle, name);
+-  }
+-  return f;
++  return dlvsym_if_available(handle, name, "libnuma_1.1");
+ }
+ 
+ // Handle request to load libnuma symbol version 1.2 (API v2) only.
+ // Return NULL if the symbol is not defined in this particular version.
+ void* os::Linux::libnuma_v2_dlsym(void* handle, const char* name) {
+-  return dlvsym(handle, name, "libnuma_1.2");
++  return dlvsym_if_available(handle, name, "libnuma_1.2");
+ }
+ 
+ bool os::Linux::libnuma_init() {
+@@ -4887,6 +4906,63 @@ void os::Linux::check_signal_handler(int
+ extern void report_error(char* file_name, int line_no, char* title,
+                          char* format, ...);
+ 
++// Some linux distributions (notably: Alpine Linux) include the
++// grsecurity in the kernel by default. Of particular interest from a
++// JVM perspective is PaX (https://pax.grsecurity.net/), which adds
++// some security features related to page attributes. Specifically,
++// the MPROTECT PaX functionality
++// (https://pax.grsecurity.net/docs/mprotect.txt) prevents dynamic
++// code generation by disallowing a (previously) writable page to be
++// marked as executable. This is, of course, exactly what HotSpot does
++// for both JIT compiled method, as well as for stubs, adapters, etc.
++//
++// Instead of crashing "lazily" when trying to make a page executable,
++// this code probes for the presence of PaX and reports the failure
++// eagerly.
++static void check_pax(void) {
++  // Zero doesn't generate code dynamically, so no need to perform the PaX check
++#ifndef ZERO
++  size_t size = os::Linux::page_size();
++
++  void* p = ::mmap(NULL, size, PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
++  if (p == MAP_FAILED) {
++    vm_exit_out_of_memory(size, OOM_MMAP_ERROR, "failed to allocate memory for PaX check.");
++  }
++
++  int res = ::mprotect(p, size, PROT_WRITE|PROT_EXEC);
++  if (res == -1) {
++    vm_exit_during_initialization("Failed to mark memory page as executable",
++                                  "Please check if grsecurity/PaX is enabled in your kernel.\n"
++                                  "\n"
++                                  "For example, you can do this by running (note: you may need root privileges):\n"
++                                  "\n"
++                                  "    sysctl kernel.pax.softmode\n"
++                                  "\n"
++                                  "If PaX is included in the kernel you will see something like this:\n"
++                                  "\n"
++                                  "    kernel.pax.softmode = 0\n"
++                                  "\n"
++                                  "In particular, if the value is 0 (zero), then PaX is enabled.\n"
++                                  "\n"
++                                  "PaX includes security functionality which interferes with the dynamic code\n"
++                                  "generation the JVM relies on. Specifically, the MPROTECT functionality as\n"
++                                  "described on https://pax.grsecurity.net/docs/mprotect.txt is not compatible\n"
++                                  "with the JVM. If you want to allow the JVM to run you will have to disable PaX.\n"
++                                  "You can do this on a per-executable basis using the paxctl tool, for example:\n"
++                                  "\n"
++                                  "    paxctl -cm bin/java\n"
++                                  "\n"
++                                  "Please note that this modifies the executable binary in-place, so you may want\n"
++                                  "to make a backup of it first. Also note that you have to repeat this for other\n"
++                                  "executables like javac, jar, jcmd, etc.\n"
++                                  );
++
++  }
++
++  ::munmap(p, size);
++#endif
++}
++
+ // this is called _before_ most of the global arguments have been parsed
+ void os::init(void) {
+   char dummy;   // used to get a guess on initial stack address
+@@ -4916,6 +4992,8 @@ void os::init(void) {
+   Linux::_pthread_setname_np =
+     (int(*)(pthread_t, const char*))dlsym(RTLD_DEFAULT, "pthread_setname_np");
+ 
++  check_pax();
++
+   os::Posix::init();
+ }
+ 
+diff -upr a/src/hotspot/share/runtime/vm_version.cpp b/src/hotspot/share/runtime/vm_version.cpp
+--- a/src/hotspot/share/runtime/vm_version.cpp
++++ b/src/hotspot/share/runtime/vm_version.cpp
+@@ -259,8 +259,14 @@ const char* Abstract_VM_Version::interna
+     #define FLOAT_ARCH_STR XSTR(FLOAT_ARCH)
+   #endif
+ 
++  #ifdef HOTSPOT_LIBC
++    #define LIBC_STR "-" HOTSPOT_LIBC
++  #else
++    #define LIBC_STR ""
++  #endif
++
+   #define INTERNAL_VERSION_SUFFIX VM_RELEASE ")" \
+-         " for " OS "-" CPU FLOAT_ARCH_STR \
++         " for " OS "-" CPU FLOAT_ARCH_STR LIBC_STR \
+          " JRE (" VERSION_STRING "), built on " __DATE__ " " __TIME__ \
+          " by " XSTR(HOTSPOT_BUILD_USER) " with " HOTSPOT_BUILD_COMPILER
+ 
+diff -upr a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
++++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+@@ -204,7 +204,7 @@ inline int g_isnan(double f) { return is
+ #elif defined(__APPLE__)
+ inline int g_isnan(double f) { return isnan(f); }
+ #elif defined(LINUX) || defined(_ALLBSD_SOURCE)
+-inline int g_isnan(float  f) { return isnanf(f); }
++inline int g_isnan(float  f) { return isnan(f); }
+ inline int g_isnan(double f) { return isnan(f); }
+ #else
+ #error "missing platform-specific definition here"
+diff -upr a/src/java.base/linux/native/libnet/linux_close.c b/src/java.base/linux/native/libnet/linux_close.c
+--- a/src/java.base/linux/native/libnet/linux_close.c
++++ b/src/java.base/linux/native/libnet/linux_close.c
+@@ -60,7 +60,7 @@ typedef struct {
+ /*
+  * Signal to unblock thread
+  */
+-static int sigWakeup = (__SIGRTMAX - 2);
++static int sigWakeup;
+ 
+ /*
+  * fdTable holds one entry per file descriptor, up to a certain
+@@ -149,6 +149,7 @@ static void __attribute((constructor)) i
+     /*
+      * Setup the signal handler
+      */
++    sigWakeup = SIGRTMAX - 2;
+     sa.sa_handler = sig_wakeup;
+     sa.sa_flags   = 0;
+     sigemptyset(&sa.sa_mask);
+diff -upr a/src/java.base/unix/native/libjava/jdk_util_md.h b/src/java.base/unix/native/libjava/jdk_util_md.h
+--- a/src/java.base/unix/native/libjava/jdk_util_md.h
++++ b/src/java.base/unix/native/libjava/jdk_util_md.h
+@@ -37,7 +37,7 @@
+ #define ISNAND(d) isnan(d)
+ #elif defined(__linux__) || defined(_ALLBSD_SOURCE)
+ #include <math.h>
+-#define ISNANF(f) isnanf(f)
++#define ISNANF(f) isnan(f)
+ #define ISNAND(d) isnan(d)
+ #elif defined(_AIX)
+ #include <math.h>
+diff -upr a/src/java.base/unix/native/libjli/java_md_solinux.c b/src/java.base/unix/native/libjli/java_md_solinux.c
+--- a/src/java.base/unix/native/libjli/java_md_solinux.c
++++ b/src/java.base/unix/native/libjli/java_md_solinux.c
+@@ -235,6 +235,39 @@ RequiresSetenv(const char *jvmpath) {
+     char *dmllp = NULL;
+     char *p; /* a utility pointer */
+ 
++#ifdef __linux
++#ifndef LIBC
++#error "LIBC not set"
++#endif
++
++    if (strcmp(LIBC, "musl") == 0) {
++      /*
++       * The musl library loader requires LD_LIBRARY_PATH to be set in
++       * order to correctly resolve the dependency libjava.so has on libjvm.so.
++       *
++       * Specifically, it differs from glibc in the sense that even if
++       * libjvm.so has already been loaded it will not be considered a
++       * candidate for resolving the dependency unless the *full* path
++       * of the already loaded library matches the dependency being loaded.
++       *
++       * libjvm.so is being loaded by the launcher using a long path to
++       * dlopen, not just the basename of the library. Typically this
++       * is something like "../lib/server/libjvm.so". However, if/when
++       * libjvm.so later tries to dlopen libjava.so (which it does in
++       * order to get access to a few functions implemented in
++       * libjava.so) the musl loader will, as part of loading
++       * dependent libraries, try to load libjvm.so using only its
++       * basename "libjvm.so". Since this does not match the longer
++       * path path it was first loaded with, the already loaded
++       * library is not considered a candidate, and the loader will
++       * instead look for libjvm.so elsewhere. If it's not in
++       * LD_LIBRARY_PATH the dependency load will fail, and libjava.so
++       * will therefore fail as well.
++       */
++      return JNI_TRUE;
++    }
++#endif
++
+ #ifdef AIX
+     /* We always have to set the LIBPATH on AIX because ld doesn't support $ORIGIN. */
+     return JNI_TRUE;
+diff -upr a/src/java.base/unix/native/libnio/ch/NativeThread.c b/src/java.base/unix/native/libnio/ch/NativeThread.c
+--- a/src/java.base/unix/native/libnio/ch/NativeThread.c
++++ b/src/java.base/unix/native/libnio/ch/NativeThread.c
+@@ -36,7 +36,7 @@
+ #ifdef __linux__
+   #include <pthread.h>
+   /* Also defined in net/linux_close.c */
+-  #define INTERRUPT_SIGNAL (__SIGRTMAX - 2)
++  #define INTERRUPT_SIGNAL (SIGRTMAX - 2)
+ #elif _AIX
+   #include <pthread.h>
+   /* Also defined in net/aix_close.c */
+diff -upr a/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c b/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
+--- a/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
++++ b/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
+@@ -27,9 +27,6 @@
+ #include <X11/Xutil.h>
+ #include <X11/Xos.h>
+ #include <X11/Xatom.h>
+-#ifdef __linux__
+-#include <execinfo.h>
+-#endif
+ 
+ #include <jvm.h>
+ #include <jni.h>
+@@ -787,26 +784,6 @@ JNIEXPORT jstring JNICALL Java_sun_awt_X
+     return ret;
+ }
+ 
+-#ifdef __linux__
+-void print_stack(void)
+-{
+-  void *array[10];
+-  size_t size;
+-  char **strings;
+-  size_t i;
+-
+-  size = backtrace (array, 10);
+-  strings = backtrace_symbols (array, size);
+-
+-  fprintf (stderr, "Obtained %zd stack frames.\n", size);
+-
+-  for (i = 0; i < size; i++)
+-     fprintf (stderr, "%s\n", strings[i]);
+-
+-  free (strings);
+-}
+-#endif
+-
+ Window get_xawt_root_shell(JNIEnv *env) {
+   static jclass classXRootWindow = NULL;
+   static jmethodID methodGetXRootWindow = NULL;
+diff -upr a/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c b/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
+--- a/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
++++ b/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.c
+@@ -26,7 +26,11 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <fcntl.h>
++#ifdef INCLUDE_SA_ATTACH
+ #include <thread_db.h>
++#else
++#include <dirent.h>
++#endif
+ #include "libproc_impl.h"
+ 
+ #define SA_ALTROOT "SA_ALTROOT"
+@@ -116,11 +120,13 @@ bool init_libproc(bool debug) {
+    // init debug mode
+    _libsaproc_debug = debug;
+ 
++#ifdef INCLUDE_SA_ATTACH
+    // initialize the thread_db library
+    if (td_init() != TD_OK) {
+      print_debug("libthread_db's td_init failed\n");
+      return false;
+    }
++#endif
+ 
+    return true;
+ }
+@@ -273,6 +279,7 @@ thread_info* add_thread_info(struct ps_p
+ }
+ 
+ 
++#ifdef INCLUDE_SA_ATTACH
+ // struct used for client data from thread_db callback
+ struct thread_db_client_data {
+    struct ps_prochandle* ph;
+@@ -299,9 +306,12 @@ static int thread_db_callback(const td_t
+ 
+   return TD_OK;
+ }
++#endif // INCLUDE_SA_ATTACH
+ 
+-// read thread_info using libthread_db
++// read thread_info using libthread_db or by iterating through the entries
++// in /proc/<pid>/task/
+ bool read_thread_info(struct ps_prochandle* ph, thread_info_callback cb) {
++#ifdef INCLUDE_SA_ATTACH
+   struct thread_db_client_data mydata;
+   td_thragent_t* thread_agent = NULL;
+   if (td_ta_new(ph, &thread_agent) != TD_OK) {
+@@ -322,10 +332,33 @@ bool read_thread_info(struct ps_prochand
+ 
+   // delete thread agent
+   td_ta_delete(thread_agent);
++#else
++  DIR *dir = NULL;
++  struct dirent *ent = NULL;
++  char taskpath[80];
++  pid_t pid = ph->pid;
++
++  // Find the lwpids to attach to by traversing the /proc/<pid>/task/ directory.
++  snprintf(taskpath, sizeof (taskpath), "/proc/%ld/task", (unsigned long)pid);
++  if ((dir = opendir(taskpath)) != NULL) {
++    while ((ent = readdir(dir)) != NULL) {
++      unsigned long lwp;
++
++      if ((lwp = strtoul(ent->d_name, NULL, 10)) != 0) {
++        // Create and add the thread info.
++        (*cb)(ph, 0, lwp);
++      }
++    }
++  } else {
++    print_debug("Could not open /proc/%ld/task.\n", (unsigned long)pid);
++    return false;
++  }
++
++  closedir(dir);
++#endif
+   return true;
+ }
+ 
+-
+ // get number of threads
+ int get_num_threads(struct ps_prochandle* ph) {
+    return ph->num_threads;
+diff -upr a/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.h b/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.h
+--- a/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.h
++++ b/src/jdk.hotspot.agent/linux/native/libsaproc/libproc_impl.h
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+@@ -27,6 +27,9 @@
+ 
+ #include <unistd.h>
+ #include <limits.h>
++
++struct ps_prochandle;
++
+ #include "libproc.h"
+ #include "symtab.h"
+ 
+@@ -126,4 +129,32 @@ thread_info* add_thread_info(struct ps_p
+ // a test for ELF signature without using libelf
+ bool is_elf_file(int fd);
+ 
++// ps_getpid() is only defined on Linux to return a thread's process ID
++pid_t ps_getpid(struct ps_prochandle *ph);
++
++// ps_pglobal_lookup() looks up the symbol sym_name in the symbol table
++// of the load object object_name in the target process identified by ph.
++// It returns the symbol's value as an address in the target process in
++// *sym_addr.
++
++ps_err_e ps_pglobal_lookup(struct ps_prochandle *ph, const char *object_name,
++                    const char *sym_name, psaddr_t *sym_addr);
++// read "size" bytes of data from debuggee at address "addr"
++ps_err_e ps_pdread(struct ps_prochandle *ph, psaddr_t  addr,
++                   void *buf, size_t size);
++
++// write "size" bytes of data to debuggee at address "addr"
++ps_err_e ps_pdwrite(struct ps_prochandle *ph, psaddr_t addr,
++                    const void *buf, size_t size);
++
++ps_err_e ps_lsetfpregs(struct ps_prochandle *ph, lwpid_t lid, const prfpregset_t *fpregs);
++
++ps_err_e ps_lsetregs(struct ps_prochandle *ph, lwpid_t lid, const prgregset_t gregset);
++
++ps_err_e  ps_lgetfpregs(struct  ps_prochandle  *ph,  lwpid_t lid, prfpregset_t *fpregs);
++
++ps_err_e ps_lgetregs(struct ps_prochandle *ph, lwpid_t lid, prgregset_t gregset);
++
++// new libthread_db of NPTL seem to require this symbol
++ps_err_e ps_get_thread_area();
+ #endif //_LIBPROC_IMPL_H_
+diff -upr a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.c b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.c
+--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.c
++++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2002, 2017, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+@@ -24,6 +24,7 @@
+ 
+ #include <jni.h>
+ #include "libproc.h"
++#include "libproc_impl.h"
+ 
+ #include <elf.h>
+ #include <sys/types.h>
+diff -upr a/src/jdk.hotspot.agent/linux/native/libsaproc/proc_service.h b/src/jdk.hotspot.agent/linux/native/libsaproc/proc_service.h
+--- a/src/jdk.hotspot.agent/linux/native/libsaproc/proc_service.h
++++ b/src/jdk.hotspot.agent/linux/native/libsaproc/proc_service.h
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+@@ -26,7 +26,10 @@
+ #define _PROC_SERVICE_H_
+ 
+ #include <stdio.h>
++#include <sys/procfs.h>
++#ifdef INCLUDE_SA_ATTACH
+ #include <thread_db.h>
++#endif
+ 
+ // Linux does not have the proc service library, though it does provide the
+ // thread_db library which can be used to manipulate threads without having
+@@ -42,35 +45,4 @@ typedef enum {
+         PS_NOSYM,       /* p_lookup() could not find given symbol */
+         PS_NOFREGS      /* FPU register set not available for given lwp */
+ } ps_err_e;
+-
+-// ps_getpid() is only defined on Linux to return a thread's process ID
+-pid_t ps_getpid(struct ps_prochandle *ph);
+-
+-// ps_pglobal_lookup() looks up the symbol sym_name in the symbol table
+-// of the load object object_name in the target process identified by ph.
+-// It returns the symbol's value as an address in the target process in
+-// *sym_addr.
+-
+-ps_err_e ps_pglobal_lookup(struct ps_prochandle *ph, const char *object_name,
+-                    const char *sym_name, psaddr_t *sym_addr);
+-
+-// read "size" bytes of data from debuggee at address "addr"
+-ps_err_e ps_pdread(struct ps_prochandle *ph, psaddr_t  addr,
+-                   void *buf, size_t size);
+-
+-// write "size" bytes of data to debuggee at address "addr"
+-ps_err_e ps_pdwrite(struct ps_prochandle *ph, psaddr_t addr,
+-                    const void *buf, size_t size);
+-
+-ps_err_e ps_lsetfpregs(struct ps_prochandle *ph, lwpid_t lid, const prfpregset_t *fpregs);
+-
+-ps_err_e ps_lsetregs(struct ps_prochandle *ph, lwpid_t lid, const prgregset_t gregset);
+-
+-ps_err_e  ps_lgetfpregs(struct  ps_prochandle  *ph,  lwpid_t lid, prfpregset_t *fpregs);
+-
+-ps_err_e ps_lgetregs(struct ps_prochandle *ph, lwpid_t lid, prgregset_t gregset);
+-
+-// new libthread_db of NPTL seem to require this symbol
+-ps_err_e ps_get_thread_area();
+-
+ #endif /* _PROC_SERVICE_H_ */
+diff -upr a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
++++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+@@ -731,6 +731,10 @@ static bool read_lib_segments(struct ps_
+   ELF_PHDR* phbuf;
+   ELF_PHDR* lib_php = NULL;
+ 
++#ifndef LIBC
++#error "LIBC not set"
++#endif
++
+   int page_size = sysconf(_SC_PAGE_SIZE);
+ 
+   if ((phbuf = read_program_header_table(lib_fd, lib_ehdr)) == NULL) {
+@@ -754,8 +758,8 @@ static bool read_lib_segments(struct ps_
+       } else {
+         // Coredump stores value of p_memsz elf field
+         // rounded up to page boundary.
+-
+-        if ((existing_map->memsz != page_size) &&
++        if ((strcmp(LIBC, "musl")) &&
++            (existing_map->memsz != page_size) &&
+             (existing_map->fd != lib_fd) &&
+             (ROUNDUP(existing_map->memsz, page_size) != ROUNDUP(lib_php->p_memsz, page_size))) {
+ 
+diff -upr a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
++++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+@@ -218,9 +218,11 @@ static bool ptrace_waitpid(pid_t pid) {
+ static bool ptrace_attach(pid_t pid, char* err_buf, size_t err_buf_len) {
+   if (ptrace(PTRACE_ATTACH, pid, NULL, NULL) < 0) {
+     char buf[200];
+-    char* msg = strerror_r(errno, buf, sizeof(buf));
+-    snprintf(err_buf, err_buf_len, "ptrace(PTRACE_ATTACH, ..) failed for %d: %s", pid, msg);
+-    print_debug("%s\n", err_buf);
++    if (strerror_r(errno, buf, sizeof(buf) == 0)) {
++      snprintf(err_buf, err_buf_len,
++               "ptrace(PTRACE_ATTACH, ..) failed for %d: %s", pid, buf);
++      print_debug("%s\n", err_buf);
++    }
+     return false;
+   } else {
+     return ptrace_waitpid(pid);
+@@ -406,7 +408,7 @@ struct ps_prochandle* Pgrab(pid_t pid, c
+   thr = ph->threads;
+   while (thr) {
+      // don't attach to the main thread again
+-    if (ph->pid != thr->lwp_id && ptrace_attach(thr->lwp_id, err_buf, err_buf_len) != true) {
++     if (pid != thr->lwp_id && ptrace_attach(thr->lwp_id, err_buf, err_buf_len) != true) {
+         // even if one attach fails, we get return NULL
+         Prelease(ph);
+         return NULL;
+diff -upr a/src/jdk.jdwp.agent/share/native/libjdwp/util.h b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
++++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+@@ -35,15 +35,15 @@
+ #ifdef DEBUG
+     /* Just to make sure these interfaces are not used here. */
+     #undef free
+-    #define free(p) Do not use this interface.
++    #define free do_not_use_this_interface_free
+     #undef malloc
+-    #define malloc(p) Do not use this interface.
++    #define malloc do_not_use_this_interface_malloc
+     #undef calloc
+-    #define calloc(p) Do not use this interface.
++    #define calloc do_not_use_this_interface_calloc
+     #undef realloc
+-    #define realloc(p) Do not use this interface.
++    #define realloc do_not_use_this_interface_realloc
+     #undef strdup
+-    #define strdup(p) Do not use this interface.
++    #define strdup do_not_use_this_interface_strdup
+ #endif
+ 
+ #include "log_messages.h"

--- a/testing/openjdk10/APKBUILD
+++ b/testing/openjdk10/APKBUILD
@@ -1,0 +1,296 @@
+# Contributor: Holger Jaekel <holger.jaekel@gmx.de>
+# Maintainer: Holger Jaekel <holger.jaekel@gmx.de>
+pkgname=openjdk10
+_majorver=10
+_minorver=0
+_securityver=2
+_updatever=13
+pkgver=${_majorver}.${_minorver}.${_securityver}.u${_updatever}
+_hg_tag=jdk-${_majorver}.${_minorver}.${_securityver}+${_updatever}
+pkgrel=0
+pkgdesc="OpenJDK Java ${_majorver} environment"
+url="http://openjdk.java.net/"
+arch="all"
+license="GPLv2+CE"
+depends="$pkgname-headless"
+depends_dev=""
+makedepends="
+	$depends_dev
+	alsa-lib-dev
+	autoconf
+	bash
+	cups-dev
+	fontconfig-dev
+	giflib-dev
+	graphviz
+	grep
+	lcms2-dev
+	libexecinfo-dev
+	libjpeg-turbo-dev
+	libpng-dev
+	libx11-dev
+	libxext-dev
+	libxrender-dev
+	libxt-dev
+	libxtst-dev
+	linux-headers
+	openjdk9-dev
+	unzip
+	zip
+	zlib-dev
+	"
+
+case $CARCH in
+x86)	_jarch=i386;;
+x86_64)	_jarch=amd64;;
+arm*)	_jarch=aarch32;;
+*)	_jarch="$CARCH";;
+esac
+
+_java_home="/usr/lib/jvm/java-${_majorver}-openjdk"
+_jrelib="$_java_home/jre/lib/$_jarch"
+
+install=""
+subpackages="
+	$pkgname-jmods
+	$pkgname-headless
+	$pkgname-dev
+	$pkgname-examples:examples:noarch
+	$pkgname-doc
+	$pkgname-src:src:noarch
+	"
+source="
+	http://hg.openjdk.java.net/jdk-updates/jdk${_majorver}u/archive/${_hg_tag}.tar.bz2
+	10-portola.patch
+
+	TestCryptoLevel.java
+	TestECDSA.java
+	"
+builddir="$srcdir/jdk${_majorver}u-${_hg_tag}"
+_jdkrelease="$builddir/build/linux-${CARCH}-normal-server-release/images/jdk"
+_docsrelease="$builddir/build/linux-${CARCH}-normal-server-release/images/docs"
+
+build() {
+	cd "$builddir"
+	NUM_PROC_OPT=''
+	MAKEFLAG_J=$(echo ${MAKEFLAGS} | sed -En 's/.*-j([0-9]+).*/\1/p')
+	if [ -n "${MAKEFLAG_J}" ]; then
+		# http://hg.openjdk.java.net/jdk10/jdk10/file/85e6cb013b98/make/InitSupport.gmk#l105
+		echo "Removing '-j${MAKEFLAG_J}' from MAKEFLAGS to prevent build fail. Passing it directly to ./configure."
+		export MAKEFLAGS=${MAKEFLAGS/-j${MAKEFLAG_J}/}
+		NUM_PROC_OPT="--with-num-cores=${MAKEFLAG_J}"
+	fi
+
+	# CFLAGS, CXXFLAGS and LDFLAGS are ignored as shown by a warning
+	# in the output of ./configure unless used like such:
+	#  --with-extra-cflags="${CFLAGS}"
+	#  --with-extra-cxxflags="${CXXFLAGS}"
+	#  --with-extra-ldflags="${LDFLAGS}"
+	# See also paragraph "Configure Control Variables from "jdk${_majorver}-${_hg_tag}/common/doc/building.md
+	_CFLAGS="$CFLAGS"
+	_CXXFLAGS="$CXXFLAGS"
+	_LDFLAGS="$LDFLAGS"
+	unset CFLAGS
+	unset CXXFLAGS
+	unset LDFLAGS
+	unset MAKEFLAGS
+
+	bash configure \
+		--with-version-build="${_updatever}" \
+		--with-version-pre="" \
+		--with-version-opt="" \
+		--with-stdc++lib=dynamic \
+		--with-extra-cflags="${_CFLAGS}" \
+		--with-extra-cxxflags="${_CXXFLAGS}" \
+		--with-extra-ldflags="${_LDFLAGS}" \
+		--with-libjpeg=system \
+		--with-giflib=system \
+		--with-libpng=system \
+		--with-lcms=system \
+		--with-zlib=system \
+		--with-native-debug-symbols=none \
+		--enable-unlimited-crypto \
+		--disable-warnings-as-errors \
+		--with-extra-cflags="${_CFLAGS}" \
+		--with-extra-cxxflags="${_CXXFLAGS}" \
+		--with-extra-ldflags="${_LDFLAGS}" \
+		--with-jvm-variants=server \
+		${NUM_PROC_OPT}
+	make images docs
+}
+
+# TODO: As long as the JTReg package is not available, we cannot execute the regression tests.
+check() {
+	cd "$_jdkrelease"
+
+	./bin/java --version | grep "${_majorver}.${_minorver}.${_securityver}+${_updatever}"
+
+	# Check unlimited policy has been used
+	./bin/javac -d . $srcdir/TestCryptoLevel.java
+	./bin/java -cp . --add-opens java.base/javax.crypto=ALL-UNNAMED TestCryptoLevel
+
+	# Check ECC is working
+	./bin/javac -d . $srcdir/TestECDSA.java
+	./bin/java -cp . TestECDSA
+
+	# Check src.zip has all sources. See RHBZ#1130490
+	./bin/jar -tf ./lib/src.zip | grep 'sun.misc.Unsafe'
+
+	# Check class files include useful debugging information
+	./bin/javap -l java.lang.Object | grep "Compiled from"
+	./bin/javap -l java.lang.Object | grep LineNumberTable
+	./bin/javap -l java.lang.Object | grep LocalVariableTable
+
+	# Check generated class files include useful debugging information
+	./bin/javap -l java.nio.ByteBuffer | grep "Compiled from"
+	./bin/javap -l java.nio.ByteBuffer | grep LineNumberTable
+	./bin/javap -l java.nio.ByteBuffer | grep LocalVariableTable
+
+}
+
+package() {
+	local file dir
+	for file in lib/libawt_xawt.so \
+		lib/libjawt.so \
+		lib/libsplashscreen.so; do
+
+		dir=${file%/*}
+		mkdir -p "$pkgdir/$_java_home/$dir"
+		mv "$_jdkrelease/$file" "$pkgdir/$_java_home/$dir"
+	done
+
+
+
+	local file dir
+	for file in api \
+				resources \
+				specs \
+				index.html; do
+
+		dir=${file%/*}
+		mkdir -p "$pkgdir/usr/share/doc/java-${_majorver}-openjdk/javadoc/$dir"
+		mv "$_docsrelease/"$file "$pkgdir/usr/share/doc/java-${_majorver}-openjdk/javadoc/$dir"
+	done
+
+	for file in 16 \
+				24 \
+				32 \
+				48; do
+
+		dir=${file%/*}
+		mkdir -p "$pkgdir/usr/share/icons/hicolor/${file}x${file}/apps"
+		mv "$builddir"/src/java.desktop/unix/classes/sun/awt/X11/java-icon${file}.png "$pkgdir/usr/share/icons/hicolor/${file}x${file}/apps/java-${_majorver}openjdk.png"
+	done
+
+	mkdir -p "$pkgdir/usr/share/licenses/java-${_majorver}-openjdk"
+	mv "$_jdkrelease/legal/"* "$pkgdir/usr/share/licenses/java-${_majorver}-openjdk/"
+
+	mkdir -p "$pkgdir/usr/share/man/"
+	mv "$_jdkrelease/man/man1" "$pkgdir/usr/share/man/"
+}
+
+jmods() {
+	pkgdesc="JMods for OpenJDK ${_majorver}"
+
+	local file dir
+	for file in jmods/*.jmod; do
+
+		dir=${file%/*}
+		mkdir -p "$subpkgdir/$_java_home/$dir"
+		mv "$_jdkrelease/"$file "$subpkgdir/$_java_home/$dir"
+	done
+}
+
+headless() {
+	pkgdesc="OpenJDK ${_majorver} Headless Runtime Environment"
+	install="openjdk10-headless.post-install openjdk10-headless.post-upgrade"
+
+	local file dir
+	for file in lib/server/* \
+				lib/jli/* \
+				lib/classlist \
+				lib/jexec \
+				lib/jrt-fs.jar \
+				lib/jvm.cfg \
+				lib/*.so \
+				lib/modules \
+				lib/psfont.properties.ja \
+				lib/psfontj2d.properties \
+				lib/tzdb.dat \
+				bin/java \
+				bin/jjs \
+				bin/keytool \
+				bin/pack200 \
+				bin/rmid \
+				bin/rmiregistry \
+				bin/unpack200; do
+
+		dir=${file%/*}
+		mkdir -p "$subpkgdir/$_java_home/$dir"
+		mv "$_jdkrelease/"$file "$subpkgdir/$_java_home/$dir"
+	done
+	mkdir -p "$subpkgdir/etc/java/java-${_majorver}-openjdk"
+	mv "$_jdkrelease/conf" "$subpkgdir/etc/java/java-${_majorver}-openjdk/"
+	ln -sf /etc/java/java-${_majorver}-openjdk/conf "$subpkgdir/$_java_home/conf"
+}
+
+dev() {
+	pkgdesc="OpenJDK ${_majorver} development tools"
+	depends="$pkgname-headless"
+
+	local file dir
+	for file in include/*.h \
+				include/linux/*.h \
+				lib/ct.sym \
+				bin/jaotc \
+				bin/jar \
+				bin/jarsigner \
+				bin/javac \
+				bin/javadoc \
+				bin/javap \
+				bin/jcmd \
+				bin/jconsole \
+				bin/jdb \
+				bin/jdeprscan \
+				bin/jdeps \
+				bin/jhsdb \
+				bin/jimage \
+				bin/jinfo \
+				bin/jlink \
+				bin/jmap \
+				bin/jmod \
+				bin/jps \
+				bin/jrunscript \
+				bin/jshell \
+				bin/jstack \
+				bin/jstat \
+				bin/jstatd \
+				bin/rmic \
+				bin/serialver; do
+
+		dir=${file%/*}
+		mkdir -p "$subpkgdir/$_java_home/$dir"
+		mv "$_jdkrelease/"$file "$subpkgdir/$_java_home/$dir"
+	done
+}
+
+examples() {
+	pkgdesc="OpenJDK ${_majorver} examples"
+	depends="$pkgname-headless"
+
+	mkdir -p "$subpkgdir/$_java_home/"
+	mv "$_jdkrelease/demo" "$subpkgdir/$_java_home/"
+	mv "$builddir/src/sample" "$subpkgdir/$_java_home/"
+}
+
+src() {
+	pkgdesc="OpenJDK ${_majorver} Source Bundle"
+	depends="$pkgname-headless"
+
+	mkdir -p "$subpkgdir/$_java_home/lib"
+	mv "$_jdkrelease/lib/src.zip" "$subpkgdir/$_java_home/lib"
+}
+sha512sums="7491da11d5e0013db75d33e09be7a91ac0dbcde6282541a39fe471fd5368d49b15403bc7508b330ca60210b3ca02730743ba280657283a231853f6882a3ca74d  jdk-10.0.2+13.tar.bz2
+20d2431ab6aee9ca13e6a349e2e147cbc1d83a631e2ff210999234a26516a3c5b84b21dfd2e02f7a4709611f9358661488d54a7ef60e2723940bc32fc9591778  10-portola.patch
+b02dff8d549f88317bb4c741a9e269e8d59eef990197d085388fc49c7423a4eb9367dbe1e02bffb10e7862f5980301eb58d4494e177d0e8f60af6b05c7fbbe60  TestCryptoLevel.java
+27e91edef89d26c0c5b9a813e2045f8d2b348745a506ae37b34b660fa7093da9a4e0e676ea41dc4a5c901bce02e5304d95e90f68d6c99cbf461b2da40a7a9853  TestECDSA.java"

--- a/testing/openjdk10/TestCryptoLevel.java
+++ b/testing/openjdk10/TestCryptoLevel.java
@@ -1,0 +1,72 @@
+/* TestCryptoLevel -- Ensure unlimited crypto policy is in use.
+   Copyright (C) 2012 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
+
+import java.security.Permission;
+import java.security.PermissionCollection;
+
+public class TestCryptoLevel
+{
+    public static void main(String[] args)
+            throws NoSuchFieldException, ClassNotFoundException,
+            IllegalAccessException, InvocationTargetException
+    {
+        Class<?> cls = null;
+        Method def = null, exempt = null;
+
+        try
+        {
+            cls = Class.forName("javax.crypto.JceSecurity");
+        }
+        catch (ClassNotFoundException ex)
+        {
+            System.err.println("Running a non-Sun JDK.");
+            System.exit(0);
+        }
+        try
+        {
+            def = cls.getDeclaredMethod("getDefaultPolicy");
+            exempt = cls.getDeclaredMethod("getExemptPolicy");
+        }
+        catch (NoSuchMethodException ex)
+        {
+            System.err.println("Running IcedTea with the original crypto patch.");
+            System.exit(0);
+        }
+        def.setAccessible(true);
+        exempt.setAccessible(true);
+        PermissionCollection defPerms = (PermissionCollection) def.invoke(null);
+        PermissionCollection exemptPerms = (PermissionCollection) exempt.invoke(null);
+        Class<?> apCls = Class.forName("javax.crypto.CryptoAllPermission");
+        Field apField = apCls.getDeclaredField("INSTANCE");
+        apField.setAccessible(true);
+        Permission allPerms = (Permission) apField.get(null);
+        if (defPerms.implies(allPerms) && (exemptPerms == null || exemptPerms.implies(allPerms)))
+        {
+            System.err.println("Running with the unlimited policy.");
+            System.exit(0);
+        }
+        else
+        {
+            System.err.println("WARNING: Running with a restricted crypto policy.");
+            System.exit(-1);
+        }
+    }
+}

--- a/testing/openjdk10/TestECDSA.java
+++ b/testing/openjdk10/TestECDSA.java
@@ -1,0 +1,49 @@
+/* TestECDSA -- Ensure ECDSA signatures are working.
+   Copyright (C) 2016 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+
+/**
+ * @test
+ */
+public class TestECDSA {
+
+    public static void main(String[] args) throws Exception {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+        KeyPair key = keyGen.generateKeyPair();
+
+        byte[] data = "This is a string to sign".getBytes("UTF-8");
+
+        Signature dsa = Signature.getInstance("NONEwithECDSA");
+        dsa.initSign(key.getPrivate());
+        dsa.update(data);
+        byte[] sig = dsa.sign();
+        System.out.println("Signature: " + new BigInteger(1, sig).toString(16));
+
+        Signature dsaCheck = Signature.getInstance("NONEwithECDSA");
+        dsaCheck.initVerify(key.getPublic());
+        dsaCheck.update(data);
+        boolean success = dsaCheck.verify(sig);
+        if (!success) {
+            throw new RuntimeException("Test failed. Signature verification error");
+        }
+        System.out.println("Test passed.");
+    }
+}

--- a/testing/openjdk10/openjdk10-headless.post-install
+++ b/testing/openjdk10/openjdk10-headless.post-install
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/lib/jvm/java-10-openjdk/bin/java -Xshare:dump >/dev/null 2>/dev/null

--- a/testing/openjdk10/openjdk10-headless.post-upgrade
+++ b/testing/openjdk10/openjdk10-headless.post-upgrade
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/lib/jvm/java-10-openjdk/bin/java -Xshare:dump >/dev/null 2>/dev/null


### PR DESCRIPTION
New aport OpenJDK 10. This is a prerequisite for #6469 as OpenJDK 10 is needed as a bootstrap JDK for building OpenJDK 11. This PR depends on #6467.

As OpenJDK 10 does not receive security updates from upstream, this aport should be deleted as soon as OpenJDK 11 is successfully build on all platforms.

I could only test this build on x86_64, I hope that it builds on all other platforms.
