### PR TITLE
Testing/update sopel 6.6.3

### DIFF
--- a/testing/py3-geoip2/APKBUILD
+++ b/testing/py3-geoip2/APKBUILD
@@ -1,0 +1,45 @@
+# Contributor: Kevin Daudt <kdaudt@alpinelinux.org>
+# Maintainer: Kevin Daudt <kdaudt@alpinelinux.org>
+pkgname=py3-geoip2
+pkgver=2.9.0
+pkgrel=0
+pkgdesc="An API for the GeoIP2 web services and databases"
+url="https://www.maxmind.com/en/home"
+arch="noarch"
+license="Apache-2.0"
+depends="py3-requests py3-maxminddb"
+makedepends="python3 py3-setuptools"
+checkdepends="py3-nose py3-mock"
+_test_data_commit=f6ed981c23b0eb33d7c07568e2177236252afda6
+source="$pkgname-$pkgver.tar.gz::https://github.com/maxmind/GeoIP2-python/archive/v${pkgver}.tar.gz
+	MaxMind-DB-test-data-$_test_data_commit.tar.gz::https://github.com/maxmind/MaxMind-DB/archive/$_test_data_commit.tar.gz"
+builddir="$srcdir/GeoIP2-python-$pkgver"
+
+prepare() {
+	cd "$srcdir"
+
+	# Submodule required for tests
+	cp -r "MaxMind-DB-$_test_data_commit/"* "$builddir/tests/data"
+
+        default_prepare
+}
+
+build() {
+	cd "$builddir"
+        python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+
+        python3 setup.py test
+}
+
+package() {
+	cd "$builddir"
+
+        python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+sha512sums="8631a41d9644887d0149678e40a5f9d03bba660853c308c43bf358cd49b3f021566b9d6f65b670c0c1c78bcb4cb7cb007ad2db6f3c032749afa454fc9e06d74c  py3-geoip2-2.9.0.tar.gz
+f7b9d370c330980d9419c7bea486b258aef3fa8ab49f83b860ef73036fc577c402e2f631090c5d1d23f2a8e34f927030a8fc6dc15edcd8002136673685aecb12  MaxMind-DB-test-data-f6ed981c23b0eb33d7c07568e2177236252afda6.tar.gz"

--- a/testing/py3-maxminddb/APKBUILD
+++ b/testing/py3-maxminddb/APKBUILD
@@ -1,0 +1,47 @@
+# Contributor: Kevin Daudt <kdaudt@alpinelinux.org>
+# Maintainer: Kevin Daudt <kdaudt@alpinelinux.org>
+pkgname=py3-maxminddb
+pkgver=1.4.1
+pkgrel=0
+pkgdesc="Python MaxMind DB reader extension"
+url="http://maxminddb.readthedocs.org/"
+arch="all"
+license="Apache-2.0"
+depends="python3"
+makedepends="libmaxminddb-dev python3 python3-dev py3-setuptools"
+checkdepends="py3-nose py3-mock"
+_test_data_commit=90c7fb95d67ee03ca7fc487fb69f525bcc19a671
+source="$pkgname-$pkgver.tar.gz::https://github.com/maxmind/MaxMind-DB-Reader-python/archive/v$pkgver.tar.gz
+	MaxMind-DB-test-data-$_test_data_commit.tar.gz::https://github.com/maxmind/MaxMind-DB/archive/$_test_data_commit.tar.gz"
+
+builddir="$srcdir/MaxMind-DB-Reader-python-$pkgver"
+
+prepare() {
+	cd "$srcdir"
+
+	# Submodule required for tests
+	cp -r "MaxMind-DB-$_test_data_commit/"* "$builddir/tests/data"
+
+        default_prepare
+}
+
+build() {
+	cd "$builddir"
+
+	python3	setup.py build
+}
+
+check() {
+	cd "$builddir"
+
+	python3	setup.py test
+}
+
+package() {
+	cd "$builddir"
+
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+sha512sums="94bee89a0ef9d24f937f12f79dc8b9686be46ba3aeedc5538cc0c2ff4379ad2eb0bb84914849d3baa9120d4bbdb3abc215e30efd237a2c6d5fc0161e7e40c0d6  py3-maxminddb-1.4.1.tar.gz
+6693bc2d100524c7fce61ff556132a78f33793f3e4bd4756661cfdf385198d15f3a0044346d46fef6d50fac2f6ecc755d9bebea4b22edb5be834cd39f64e7434  MaxMind-DB-test-data-90c7fb95d67ee03ca7fc487fb69f525bcc19a671.tar.gz"

--- a/testing/sopel/APKBUILD
+++ b/testing/sopel/APKBUILD
@@ -1,20 +1,20 @@
 # Contributor: Kevin Daudt <kdaudt@alpinelinux.org>
 # Maintainer: Kevin Daudt <kdaudt@alpinelinux.org>
 pkgname=sopel
-pkgver=6.5.3
+pkgver=6.6.3
 pkgrel=0
 pkgdesc="An easy-to-use and highly extensible IRC Bot framework"
 url="https://sopel.chat/"
 arch="noarch"
 license="EFL-2.0"
-depends="python3 ipython py3-requests py3-geoip py3-setuptools py3-enchant
+depends="python3 ipython py3-requests py3-geoip2 py3-setuptools py3-enchant
 	py3-xmltodict py3-praw py3-tz"
 checkdepends="py3-pytest"
 install="$pkgname.pre-install"
 pkgusers="sopel"
 pkggroups="sopel"
 subpackages="$pkgname-openrc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/sopel-irc/sopel/archive/v6.5.3.tar.gz
+source="$pkgname-$pkgver.tar.gz::https://github.com/sopel-irc/sopel/archive/v${pkgver}.tar.gz
 	sopel.initd
         sopel.conf"
 builddir="$srcdir/$pkgname-$pkgver"
@@ -39,6 +39,6 @@ package() {
 	install -Dm0644 "$srcdir"/sopel.conf "$pkgdir"/etc/conf.d/sopel
 }
 
-sha512sums="6f8f3003c87f8092a7a05320197237033f8d650402155f1f71482078e2bb851aa5f1942d2ccf378d3446011326f174087f478754e212b40e2216e2ad46a82812  sopel-6.5.3.tar.gz
+sha512sums="33f9572f49d9b9b3811c0ece5bad8518b4ad13be686525d0e2af268b082eb07bc5d4b746575e9d49a1ead45821697bdb29eed6d2763032b64ad58b3a3fee9a60  sopel-6.6.3.tar.gz
 1d6b39697d767085530f1db5ba763554c6503ab82b792bdb48c7fef65e4424fe30740ab758ebd3f1ccdd6f2340a9ac9e3dfe44fff064969106717169160ece7b  sopel.initd
 d90379dc5a2d8c8ff52a15d1c341d4cbad919707fadc578d4ae78db45efafad5e6add270876aa982086ac78d99729b0346aa565512190b9fc8cd77020ba91445  sopel.conf"


### PR DESCRIPTION
This version requires geoip2, replacing geoip as dependency.