### PR TITLE
main/py-jwt: upgrade to 1.7.1 to fix build incompatibility with pytest

### DIFF
--- a/main/py-jwt/APKBUILD
+++ b/main/py-jwt/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer:
 pkgname=py-jwt
 _pkgname=PyJWT
-pkgver=1.6.4
+pkgver=1.7.1
 pkgrel=0
 pkgdesc="Python JSON Web Token implementation"
 url="https://github.com/jpadilla/pyjwt"
@@ -62,5 +62,5 @@ _py() {
 	mv "$pkgdir"$libpath "$subpkgdir"${libpath%/*}
 }
 
-sha512sums="28c448d473f0409d11c2a97bef9f878800a78691250f55a46d79009b09faab0ac179133c4d4795ed9910dd7176adc9d6912189a5b4938f27ae441308e98d5e11  PyJWT-1.6.4.tar.gz
+sha512sums="70cd38127b6848933992c8b88303725ef71bfb430ad42eb63247e549b0bdab2a194137349d43ab02a1c97212dbc89f447ee3f0c5403dd14632b8b4b6b9235fc4  PyJWT-1.7.1.tar.gz
 886877c4e40005d254abf6f00389e7e69e1a781119c29da7632e3f475b526e15b2387ab1bc5bade07234932c3a7396c06298540bdd1596a79a4a5e62b64517fc  no-cov-report.patch"


### PR DESCRIPTION
py-jwt breaks when pytest dependancies are at 4.20 level during check() with errors of this type:
_____________________________________________ ERROR collecting tests/test_utils.py _____________________________________________
/usr/lib/python2.7/site-packages/pluggy/hooks.py:258: in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)

https://github.com/jpadilla/pyjwt/commit/b65e1ac6dc4d11801f3642eaab34ae6a54162c18 commit in the pyjwt project fixes (makes compatible with pytest ver 4.2.0) and is included in upgraded version 1.7.1 of py-jwt.