### PR TITLE
main/knock: fixes issue with uninitialized tcpflag parameters

### DIFF
--- a/main/knock/APKBUILD
+++ b/main/knock/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=knock
 pkgver=0.7
-pkgrel=1
+pkgrel=2
 pkgdesc="A simple port-knocking daemon"
 url="http://www.zeroflux.org/projects/knock"
 arch="all"
@@ -13,7 +13,8 @@ install=
 subpackages="$pkgname-doc"
 source="http://www.zeroflux.org/proj/knock/files/$pkgname-$pkgver.tar.gz
 	knock.initd
-	knock.confd"
+	knock.confd
+	knockd.c.patch"
 
 _builddir="$srcdir/$pkgname-$pkgver"
 
@@ -52,10 +53,13 @@ package() {
 
 md5sums="cb6373fd4ccb42eeca3ff406b7fdb8a7  knock-0.7.tar.gz
 82eec0859406f1394fcdbbeacad118ce  knock.initd
-8067d3b8401a0b5d513c44d3ff436032  knock.confd"
+8067d3b8401a0b5d513c44d3ff436032  knock.confd
+e05e8f3963688e279f467ff29bda43e8  knockd.c.patch"
 sha256sums="9938479c321066424f74c61f6bee46dfd355a828263dc89561a1ece3f56578a4  knock-0.7.tar.gz
 16a8d08c1fe354ea7bef9b3b7854592e87f16fac4707f8410137c512b4545fc5  knock.initd
-569d0596f28e6df05aeff16331fa5b19c60e4d6a2e36eec57dc9ac377ba3b46e  knock.confd"
+569d0596f28e6df05aeff16331fa5b19c60e4d6a2e36eec57dc9ac377ba3b46e  knock.confd
+14181a02584729d5a69456d08b5bdf425e7bccc6030f2deea90e7fed4763e12c  knockd.c.patch"
 sha512sums="eab5d855f7111d9411e84a56a15e8ea74f41c5bd9dee27ab49f0d8d509eeeb96a60c508928c92916dc0ec9b737c447ca8ca5ed4db6479b389549d60e76a85aa7  knock-0.7.tar.gz
 369010549a1b33efe9f634794f039249421778d49739e8f10e4d6baa83424e066a63c0ef637b70762ee34617e7b67f9ac6683125d35ded85d6779d6b2ef0f7db  knock.initd
-63fa311e6adf21450d4c93008a9537ec1b3c0dbed28e3daf955f2761127d9d756f2f7a84d8357d81a5e1a5a48453f9179d0c18cf18af0b9f30437c862a438d7f  knock.confd"
+63fa311e6adf21450d4c93008a9537ec1b3c0dbed28e3daf955f2761127d9d756f2f7a84d8357d81a5e1a5a48453f9179d0c18cf18af0b9f30437c862a438d7f  knock.confd
+a2eae9ec406b731a7648d82a7ed9984382c651f9ca3fb1373a13d9f2c991afb6bda51129dd0d743ddc936b7f23cc3d2791d2f12499eaa9ecb6c37e54efbf9fa3  knockd.c.patch"

--- a/main/knock/knockd.c.patch
+++ b/main/knock/knockd.c.patch
@@ -1,0 +1,18 @@
+URL: https://github.com/TDFKAOlli/knock/commit/4a5e12b2c01bd13d8d5ece5c8cbc6139ec2de765
+Summary: Fixes issue with uninitialized parameters in door structure for tcpflags
+----
+--- a/src/knockd.c.orig		2019-02-26 06:55:13.667005918 +0000
++++ b/src/knockd.c		2019-02-26 06:56:55.842630851 +0000
+@@ -509,6 +509,12 @@ int parseconfig(char *configfile)
+ 				door->start_command = NULL;
+ 				door->cmd_timeout = CMD_TIMEOUT; /* default command timeout (seconds) */
+ 				door->stop_command = NULL;
++				door->flag_fin = DONT_CARE;
++				door->flag_syn = DONT_CARE;
++				door->flag_rst = DONT_CARE;
++				door->flag_psh = DONT_CARE;
++				door->flag_ack = DONT_CARE;
++				door->flag_urg = DONT_CARE;
+ 				door->one_time_sequences_fd = NULL;
+ 				door->pcap_filter_exp = NULL;
+ 				doors = list_add(doors, door);


### PR DESCRIPTION
Fixes issue with uninitialized parameters in door structure for tcpflags in knock v0.7 by initializing tcpflags variables after malloc of doors memory. Issue was identified by TDFKAOlli (https://github.com/jvinet/knock/issues/54) and solved with commit in forked repository (https://github.com/TDFKAOlli/knock/commit/4a5e12b2c01bd13d8d5ece5c8cbc6139ec2de765). This patch applies the fix to knock v0.7.