### PR TITLE
testing/openjdk9: Add more testcases

### DIFF
--- a/testing/openjdk9/APKBUILD
+++ b/testing/openjdk9/APKBUILD
@@ -6,7 +6,7 @@ _pkgver=${pkgver/_p/+}
 pkgrel=0
 pkgdesc="Oracle OpenJDK 9"
 url="https://hg.openjdk.java.net/jdk-updates/jdk9u"
-arch="all !x86 !armhf" # build fails on x86 and armhf. disable for now
+arch="all !x86 !armhf !armv7" # build fails on 32 bit archs. disable for now
 license="GPL-2.0 with Classpath"
 makedepends="autoconf
 bash
@@ -32,13 +32,13 @@ libxtst-dev
 linux-headers
 zlib-dev
 "
-depends="$pkgname-jmods $pkgname-demos $pkgname-doc $pkgname-dbg $pkgname-jdk" # for the virtual openjdk9 package
+depends="$pkgname-jmods $pkgname-demos $pkgname-doc $pkgname-jdk" # for the virtual openjdk9 package
 subpackages="$pkgname-jmods:_jmods:noarch
 $pkgname-demos:_demos:noarch
 $pkgname-doc:_doc:noarch
 $pkgname-dbg:_dbg
 $pkgname-jre:_jre
-$pkgname-src:_src
+$pkgname-src:_src:noarch
 $pkgname-jre-headless:_jre_headless
 $pkgname-jdk:_jdk
 "
@@ -59,6 +59,9 @@ ppc64le.patch
 x86.patch
 
 HelloWorld.java
+TestECDSA.java
+TestCryptoLevel.java
+Alpine_Bug_10126.java
 "
 builddir="$srcdir/jdk9u-jdk-$_pkgver"
 
@@ -154,11 +157,24 @@ build() {
 check() {
 	cd "$builddir"
 
-	# compile and run a simple hello world
-	cp "$srcdir/HelloWorld.java" .
-	./build/*-normal-server-release/images/jdk/bin/javac HelloWorld.java
-	./build/*-normal-server-release/images/jdk/bin/java HelloWorld
+	local _java_bin=./build/*-normal-server-release/images/jdk/bin
 
+	# 1) compile and run a simple hello world
+	$_java_bin/javac -d . "$srcdir"/HelloWorld.java
+	$_java_bin/java HelloWorld
+
+	# 2) compile and run a testcase for unlimited policy
+	$_java_bin/javac -d . "$srcdir"/TestCryptoLevel.java
+	$_java_bin/java -cp . --add-opens java.base/javax.crypto=ALL-UNNAMED TestCryptoLevel
+
+	# 3) compile and run a testcase for ECDSA signatures
+	$_java_bin/javac -d . "$srcdir"/TestECDSA.java
+	$_java_bin/java TestECDSA
+
+	# 4) compile and run testcase for bug 10126
+	$_java_bin/javac -d . "$srcdir"/Alpine_Bug_10126.java
+	$_java_bin/java Alpine_Bug_10126
+	
 	# run the gtest unittest suites
 	# they don't take long, DO NOT DISABLE THEM!
 	MAKEFLAGS= make test-hotspot-gtest
@@ -331,4 +347,7 @@ ef3c70be906a4b0dd9c9195c88da045909ee3ef144941fb7b4495ed66b4162f481095cad87626d2b
 fa9fcc0c2f0972435b078669175c44f7d5d3cc29fbecb3e053d196c041ef0ff3feee8ec189a86fce0b35c5fd647ff71963a15e1e6fa50775cc2b6fa35d2ccf0a  arm.patch
 7244d0dfdb78d2f03ea992ef770ed888e2bd48f49e58438e7f0a763633c9aa8fc27b953d82c023f8f99ff23009a15031c99b2ef5550d277c63db684cd984ce8e  ppc64le.patch
 427c525e184e2a74f511aad8192dd411fe7fcc4e7a4dc03a3496fb030cec0177b3b520cbdd1c7700f6761a15ff2e5cce59c93d7079b744954122f684d34ce723  x86.patch
-d1767dddd8e0956e25c0f77ed45c6fc86a1191bae1704a6dc33be490fd20eaa50461fe5c2a3349512059d555651e2eb41437dd3c1096c351e8ee68b4534a2579  HelloWorld.java"
+d1767dddd8e0956e25c0f77ed45c6fc86a1191bae1704a6dc33be490fd20eaa50461fe5c2a3349512059d555651e2eb41437dd3c1096c351e8ee68b4534a2579  HelloWorld.java
+27e91edef89d26c0c5b9a813e2045f8d2b348745a506ae37b34b660fa7093da9a4e0e676ea41dc4a5c901bce02e5304d95e90f68d6c99cbf461b2da40a7a9853  TestECDSA.java
+b02dff8d549f88317bb4c741a9e269e8d59eef990197d085388fc49c7423a4eb9367dbe1e02bffb10e7862f5980301eb58d4494e177d0e8f60af6b05c7fbbe60  TestCryptoLevel.java
+18f72fcc3b09e772da10d6875a7081fe21d3b387e1d4d9a45bb9cc3e306393960b19c27dac61d33a20d7484c22109c2d091c062523d5575b8d30b20949b74f70  Alpine_Bug_10126.java"

--- a/testing/openjdk9/Alpine_Bug_10126.java
+++ b/testing/openjdk9/Alpine_Bug_10126.java
@@ -1,0 +1,13 @@
+public class Alpine_Bug_10126 {
+    public static void main(String[] args) throws Exception {
+        try (java.net.Socket sock = javax.net.ssl.SSLSocketFactory.getDefault().createSocket("bugs.alpinelinux.org", 443);
+             java.io.InputStream in = sock.getInputStream();
+             java.io.OutputStream out = sock.getOutputStream()) {
+            out.write("GET / HTTP/1.0\n\nHost: bugs.alpinelinux.org\n\nConnection: close\n\n\n\n".getBytes());
+            out.flush();
+            while (in.read(new byte[1024]) != -1) ;
+        }
+        System.out.println("Secured connection performed successfully");
+    }
+}
+

--- a/testing/openjdk9/TestCryptoLevel.java
+++ b/testing/openjdk9/TestCryptoLevel.java
@@ -1,0 +1,72 @@
+/* TestCryptoLevel -- Ensure unlimited crypto policy is in use.
+   Copyright (C) 2012 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
+
+import java.security.Permission;
+import java.security.PermissionCollection;
+
+public class TestCryptoLevel
+{
+    public static void main(String[] args)
+            throws NoSuchFieldException, ClassNotFoundException,
+            IllegalAccessException, InvocationTargetException
+    {
+        Class<?> cls = null;
+        Method def = null, exempt = null;
+
+        try
+        {
+            cls = Class.forName("javax.crypto.JceSecurity");
+        }
+        catch (ClassNotFoundException ex)
+        {
+            System.err.println("Running a non-Sun JDK.");
+            System.exit(0);
+        }
+        try
+        {
+            def = cls.getDeclaredMethod("getDefaultPolicy");
+            exempt = cls.getDeclaredMethod("getExemptPolicy");
+        }
+        catch (NoSuchMethodException ex)
+        {
+            System.err.println("Running IcedTea with the original crypto patch.");
+            System.exit(0);
+        }
+        def.setAccessible(true);
+        exempt.setAccessible(true);
+        PermissionCollection defPerms = (PermissionCollection) def.invoke(null);
+        PermissionCollection exemptPerms = (PermissionCollection) exempt.invoke(null);
+        Class<?> apCls = Class.forName("javax.crypto.CryptoAllPermission");
+        Field apField = apCls.getDeclaredField("INSTANCE");
+        apField.setAccessible(true);
+        Permission allPerms = (Permission) apField.get(null);
+        if (defPerms.implies(allPerms) && (exemptPerms == null || exemptPerms.implies(allPerms)))
+        {
+            System.err.println("Running with the unlimited policy.");
+            System.exit(0);
+        }
+        else
+        {
+            System.err.println("WARNING: Running with a restricted crypto policy.");
+            System.exit(-1);
+        }
+    }
+}

--- a/testing/openjdk9/TestECDSA.java
+++ b/testing/openjdk9/TestECDSA.java
@@ -1,0 +1,49 @@
+/* TestECDSA -- Ensure ECDSA signatures are working.
+   Copyright (C) 2016 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+
+/**
+ * @test
+ */
+public class TestECDSA {
+
+    public static void main(String[] args) throws Exception {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+        KeyPair key = keyGen.generateKeyPair();
+
+        byte[] data = "This is a string to sign".getBytes("UTF-8");
+
+        Signature dsa = Signature.getInstance("NONEwithECDSA");
+        dsa.initSign(key.getPrivate());
+        dsa.update(data);
+        byte[] sig = dsa.sign();
+        System.out.println("Signature: " + new BigInteger(1, sig).toString(16));
+
+        Signature dsaCheck = Signature.getInstance("NONEwithECDSA");
+        dsaCheck.initVerify(key.getPublic());
+        dsaCheck.update(data);
+        boolean success = dsaCheck.verify(sig);
+        if (!success) {
+            throw new RuntimeException("Test failed. Signature verification error");
+        }
+        System.out.println("Test passed.");
+    }
+}


### PR DESCRIPTION
This PR adds two extra tests from #6467 and disables the build on all 32 bit archs due to various errors:

## x86:
> Error: failed /home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-x86-normal-server-release/buildjdk/jdk/lib/server/libjvm.so, because Error relocating /home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-x86-normal-server-release/buildjdk/jdk/lib/server/libjvm.so: strtok: initial-exec TLS resolves to dynamic definition in /home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-x86-normal-server-release/buildjdk/jdk/lib/server/libjvm.so

and
> /home/buildozer/drone/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/hotspot/src/share/vm/utilities/globalDefinitions.hpp:1064:42: error: overflow in constant expression [-fpermissive] 


## armhf:
> /bin/bash: line 1: 48703 Segmentation fault      /home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/tools/adlc/adlc -q -T -DLINUX=1 -D_GNU_SOURCE=1 -g -DARM=1 -U_LP64 -DARM=1 /home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/all-ad-src.ad -c/home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/ad_arm.cpp -h/home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/ad_arm.hpp -a/home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/dfa_arm.cpp -v/home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/adGlobals_arm.hpp > >(/usr/bin/tee /home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/adlc_run.log) 2> >(/usr/bin/tee /home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/adlc_run.log >&2)

## armv7:
> /bin/bash: line 1: 64739 Segmentation fault      /home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/tools/adlc/adlc -q -T -DLINUX=1 -D_GNU_SOURCE=1 -g -DARM=1 -U_LP64 -DARM=1 /home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/all-ad-src.ad -c/home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/ad_arm.cpp -h/home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/ad_arm.hpp -a/home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/dfa_arm.cpp -v/home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/adGlobals_arm.hpp > >(/usr/bin/tee /home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/adlc_run.log) 2> >(/usr/bin/tee /home/buildozer/aports/testing/openjdk9/src/jdk9u-jdk-9.0.4+12/build/linux-arm-normal-server-release/buildjdk/hotspot/variant-server/support/adlc/adlc_run.log >&2)