### PR TITLE
testing/wireguard: upgrade to 0.0.20190227

### DIFF
--- a/testing/wireguard-tools/APKBUILD
+++ b/testing/wireguard-tools/APKBUILD
@@ -3,8 +3,8 @@
 
 # NOTE: pkgrel must match _toolsrel in wireguard-vanilla
 pkgname=wireguard-tools
-pkgver=0.0.20190123
-pkgrel=2
+pkgver=0.0.20190227
+pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch='all'
 url='https://www.wireguard.com'
@@ -62,5 +62,5 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="8be40cebabca2a40f98ee10d6fa93708b12b17c6b0eab9aa8b7fab353d78fbd5b280b7b90cb2973cf74a1b9d47c3d250bf3ede6d1318129a45d57e21329b7f59  WireGuard-0.0.20190123.tar.xz
+sha512sums="0c27353f27d7ae758cab84a02f63863681baa5eab2b64aa494be30c411b4dccc3af030b410dbfb72342fb5ea34be04f2d3b36ad0bb6a418d9f389ac34384eca3  WireGuard-0.0.20190227.tar.xz
 4577574333f023217ae6e0945807e1ccd2dec7caa87e329b1d5b44569f6b5969663ad74f8154b85d3dc7063dd762649e3fa87c7667e238ffb77c0e5df9245a5e  alpine-compat.patch"

--- a/testing/wireguard-vanilla/APKBUILD
+++ b/testing/wireguard-vanilla/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20190123
-_rel=0
+_ver=0.0.20190227
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-vanilla}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="8be40cebabca2a40f98ee10d6fa93708b12b17c6b0eab9aa8b7fab353d78fbd5b280b7b90cb2973cf74a1b9d47c3d250bf3ede6d1318129a45d57e21329b7f59  WireGuard-0.0.20190123.tar.xz"
+sha512sums="0c27353f27d7ae758cab84a02f63863681baa5eab2b64aa494be30c411b4dccc3af030b410dbfb72342fb5ea34be04f2d3b36ad0bb6a418d9f389ac34384eca3  WireGuard-0.0.20190227.tar.xz"

--- a/testing/wireguard-virt/APKBUILD
+++ b/testing/wireguard-virt/APKBUILD
@@ -4,8 +4,8 @@
 # when changing _ver we *must* bump _rel
 # we must also match up _toolsrel with wireguard-tools
 _name=wireguard
-_ver=0.0.20190123
-_rel=0
+_ver=0.0.20190227
+_rel=1
 _toolsrel=0
 
 _flavor=${FLAVOR:-virt}
@@ -64,4 +64,4 @@ package() {
 	done
 }
 
-sha512sums="8be40cebabca2a40f98ee10d6fa93708b12b17c6b0eab9aa8b7fab353d78fbd5b280b7b90cb2973cf74a1b9d47c3d250bf3ede6d1318129a45d57e21329b7f59  WireGuard-0.0.20190123.tar.xz"
+sha512sums="0c27353f27d7ae758cab84a02f63863681baa5eab2b64aa494be30c411b4dccc3af030b410dbfb72342fb5ea34be04f2d3b36ad0bb6a418d9f389ac34384eca3  WireGuard-0.0.20190227.tar.xz"


### PR DESCRIPTION
```
* wg-quick: freebsd: allow loopback to work

FreeBSD adds a route for point-to-point destination addresses. We don't
really want to specify any destination address, but unfortunately we
have to. Before we tried to cheat by giving our own address as the
destination, but this had the unfortunate effect of preventing
loopback from working on our local ip address. We work around this with
yet another kludge: we set the destination address to 127.0.0.1. Since
127.0.0.1 is already assigned to an interface, this has the same effect
of not specifying a destination address, and therefore we accomplish the
intended behavior. Note that the bad behavior is still present in Darwin,
where such workaround does not exist.

* tools: remove unused check phony declaration
* highlighter: when subtracting char, cast to unsigned
* chacha20: name enums
* tools: fight compiler slightly harder
* tools: c_acc doesn't need to be initialized
* queueing: more reasonable allocator function convention

Usual nits.

* systemd: wg-quick should depend on nss-lookup.target

Since wg-quick(8) calls wg(8) which does hostname lookups, we should
probably only run this after we're allowed to look up hostnames.

* compat: backport ALIGN_DOWN
* noise: whiten the nanoseconds portion of the timestamp

This mitigates unrelated sidechannel attacks that think they can turn
WireGuard into a useful time oracle.

* hashtables: decouple hashtable allocations from the main device allocation

The hashtable allocations are quite large, and cause the device allocation in
the net framework to stall sometimes while it tries to find a contiguous
region that can fit the device struct. To fix the allocation stalls, decouple
the hashtable allocations from the device allocation and allocate the
hashtables with kvmalloc's implicit __GFP_NORETRY so that the allocations fall
back to vmalloc with little resistance.

* chacha20poly1305: permit unaligned strides on certain platforms

The map allocations required to fix this are mostly slower than unaligned
paths.

* noise: store clamped key instead of raw key

This causes `wg show` to now show the right thing. Useful for doing
comparisons.

* compat: ipv6_stub is sometimes null

On ancient kernels, ipv6_stub is sometimes null in cases where IPv6 has
been disabled with a command line flag or other failures.

* Makefile: don't duplicate code in install and modules-install
* Makefile: make the depmod path configurable

* queueing: net-next has changed signature of skb_probe_transport_header

A 5.1 change. This could change again, but for now it allows us to keep this
snapshot aligned with our upstream submissions.

* netlink: don't remove allowed ips for new peers
* peer: only synchronize_rcu_bh and traverse trie once when removing all peers
* allowedips: maintain per-peer list of allowedips

This is a rather big and important change that makes it much much faster to do
operations involving thousands of peers. Batch peer/allowedip addition and
clearing is several orders of magnitude faster now.
```