### PR TITLE
testing/supermin: new aport

### DIFF
--- a/testing/supermin/APKBUILD
+++ b/testing/supermin/APKBUILD
@@ -1,0 +1,50 @@
+# Contributor:
+# Maintainer: Fathi Boudra <fathi.boudra@linaro.org>
+pkgname=supermin
+pkgver=5.1.20
+pkgrel=0
+pkgdesc="tool for building supermin appliances"
+url="http://libguestfs.org/"
+arch="x86_64"
+license="GPL2"
+depends="cpio e2fsprogs"
+makedepends="\
+ bash \
+ cpio \
+ e2fsprogs \
+ e2fsprogs-dev \
+ gawk \
+ ocaml \
+ ocaml-findlib \
+ perl \
+"
+install=""
+subpackages="$pkgname-doc"
+source="http://download.libguestfs.org/supermin/$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+options="!check" # Disable tests as they fail under Alpine
+
+build() {
+	cd "$builddir"
+	./configure \
+		--prefix=/usr \
+		--mandir=/usr/share/man \
+		--disable-network-tests
+	# https://bugs.alpinelinux.org/issues/10030
+	# -no-pie is required to produce a statically linked init binary
+	make -C init LDFLAGS="-no-pie"
+	make
+}
+
+# Disable tests as they fail under Alpine
+#check() {
+#       cd "$builddir"
+#       make check
+#}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="ccc9ada98593f91399b323f0beb027185874f82547a1df4274c1206a9b6d4465e98b7aef5618274d41fb902747f6843fd2cc6192a4ea8526811261ac5a16848e  supermin-5.1.20.tar.gz"


### PR DESCRIPTION
Used by libguestfs, as part of https://bugs.alpinelinux.org/issues/1792

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>