### PR TITLE
Linux firmware

### DIFF
--- a/testing/linux-firmware/APKBUILD
+++ b/testing/linux-firmware/APKBUILD
@@ -23,8 +23,7 @@ brcmfmac43455sdio()
 	cd "${srcdir}/${pkgname}-${_githash}/"
 	install -D -m 644 "LICENCE.cypress" "${subpkgdir}-doc/usr/share/doc/${pkgname}/brcmfmac4355sdio/copying"
 	for file in $(find 'brcm/' -type f -iname 'brcmfmac43455-sdio*'); do
-		install -D -m 644 "${file}" \
-			"${subpkgdir}/lib/firmware/${file}"
+		install -D -m 644 "${file}" "${subpkgdir}/lib/firmware/${file}"
 	done
 }
 

--- a/testing/linux-firmware/APKBUILD
+++ b/testing/linux-firmware/APKBUILD
@@ -34,8 +34,7 @@ radeon()
 	cd "${srcdir}/${pkgname}-${_githash}/"
 	install -D -m 644 "LICENSE.radeon" "${subpkgdir}-doc/usr/share/doc/${pkgname}/radeon/copying"
 	for file in $(find 'radeon/' -type f -iname '*.bin'); do
-		install -D -m 644 "${file}" \
-			"${subpkgdir}/lib/firmware/${file}"
+		install -D -m 644 "${file}" "${subpkgdir}/lib/firmware/${file}"
 	done
 }
 

--- a/testing/linux-firmware/APKBUILD
+++ b/testing/linux-firmware/APKBUILD
@@ -13,6 +13,7 @@ source="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.
 subpackages="
 	${pkgname}-doc
 	${pkgname}-amdgpu ${pkgname}-amdgpu-doc
+	${pkgname}-amdsev ${pkgname}-amdsev-doc
 	${pkgname}-amducode ${pkgname}-amducode-doc
 	${pkgname}-brcmfmac43455sdio ${pkgname}-brcmfmac43455sdio-doc
 	${pkgname}-radeon ${pkgname}-radeon-doc
@@ -25,6 +26,17 @@ amdgpu()
 	cd "${srcdir}/${pkgname}-${_githash}/"
 	install -D -m 644 "LICENSE.amdgpu" "${subpkgdir}-doc/usr/share/doc/${pkgname}/amdgpu/copying"
 	for file in $(find 'amdgpu/' -type f -iname '*.bin'); do
+		install -D -m 644 "${file}" "${subpkgdir}/lib/firmware/${file}"
+	done
+}
+
+amdsev()
+{
+	pkgdesc="AMD SEV microcode updates"
+
+	cd "${srcdir}/${pkgname}-${_githash}/"
+	install -D -m 644 "LICENSE.amd-sev" "${subpkgdir}-doc/usr/share/doc/${pkgname}/amd-sev/copying"
+	for file in $(find 'amd/' -type f -iname '*.sbin'); do
 		install -D -m 644 "${file}" "${subpkgdir}/lib/firmware/${file}"
 	done
 }
@@ -66,6 +78,7 @@ doc()
 {
 	depends="
 		${pkgname}-amdgpu-doc
+		${pkgname}-amdsev-doc
 		${pkgname}-amducode-doc
 		${pkgname}-brcmfmac43455sdio-doc
 		${pkgname}-radeon-doc
@@ -78,6 +91,7 @@ package()
 {
 	depends="
 		${pkgname}-amdgpu
+		${pkgname}-amdsev
 		${pkgname}-amducode
 		${pkgname}-brcmfmac43455sdio
 		${pkgname}-firmware-radeon

--- a/testing/linux-firmware/APKBUILD
+++ b/testing/linux-firmware/APKBUILD
@@ -12,8 +12,21 @@ _githash="9ee52be785cf91fc6a3c6aa27d484873f8270b72"
 source="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-${_githash}.tar.gz"
 subpackages="
 	${pkgname}-doc
+	${pkgname}-brcmfmac43455sdio ${pkgname}-brcmfmac43455sdio-doc
 	${pkgname}-radeon ${pkgname}-radeon-doc
 "
+
+brcmfmac43455sdio()
+{
+	pkgdesc="Broadcom/Cypress FullMAC 43455 SDIO firmware"
+
+	cd "${srcdir}/${pkgname}-${_githash}/"
+	install -D -m 644 "LICENCE.cypress" "${subpkgdir}-doc/usr/share/doc/${pkgname}/brcmfmac4355sdio/copying"
+	for file in $(find 'brcm/' -type f -iname 'brcmfmac43455-sdio*'); do
+		install -D -m 644 "${file}" \
+			"${subpkgdir}/lib/firmware/${file}"
+	done
+}
 
 radeon()
 {
@@ -30,6 +43,7 @@ radeon()
 doc()
 {
 	depends="
+		${pkgname}-brcmfmac43455sdio-doc
 		${pkgname}-radeon-doc
 	"
 
@@ -39,6 +53,7 @@ doc()
 package()
 {
 	depends="
+		${pkgname}-brcmfmac43455sdio
 		${pkgname}-firmware-radeon
 	"
 

--- a/testing/linux-firmware/APKBUILD
+++ b/testing/linux-firmware/APKBUILD
@@ -1,0 +1,48 @@
+# Contributor: Olliver Schinagl <oliver@schinagl.nl>
+# Maintainer: Olliver Schinagl <oliver@schinagl.nl>
+pkgname=linux-firmware
+pkgver="0_git$(date +%Y%m%d)"
+pkgrel=0
+pkgdesc="Linux firmware"
+url="http://git.kernel.org/?p=linux/kernel/git/firmware/linux-firmware.git"
+arch="noarch"
+license="Redistributable"
+options="!check !strip" # No checks available
+_githash="9ee52be785cf91fc6a3c6aa27d484873f8270b72"
+source="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-${_githash}.tar.gz"
+subpackages="
+	${pkgname}-doc
+	${pkgname}-radeon ${pkgname}-radeon-doc
+"
+
+radeon()
+{
+	pkgdesc="AMD Radeon firmware files"
+
+	cd "${srcdir}/${pkgname}-${_githash}/"
+	install -D -m 644 "LICENSE.radeon" "${subpkgdir}-doc/usr/share/doc/${pkgname}/radeon/copying"
+	for file in $(find 'radeon/' -type f -iname '*.bin'); do
+		install -D -m 644 "${file}" \
+			"${subpkgdir}/lib/firmware/${file}"
+	done
+}
+
+doc()
+{
+	depends="
+		${pkgname}-radeon-doc
+	"
+
+	install -d -m 644 "${subpkgdir}/usr/share/doc/${pkgname}/"
+}
+
+package()
+{
+	depends="
+		${pkgname}-firmware-radeon
+	"
+
+	install -d -m 644 "${pkgdir}"
+}
+
+sha512sums="1884c9969afc3b77306bd49c8ac099bfcaa93cba2d6c7da66d22085f85fe94f58b13cdf7f0a191eab46c1832899b6d58eab41f7d0cf4769a8e7fdcdae98d1009  linux-firmware-9ee52be785cf91fc6a3c6aa27d484873f8270b72.tar.gz"

--- a/testing/linux-firmware/APKBUILD
+++ b/testing/linux-firmware/APKBUILD
@@ -12,9 +12,21 @@ _githash="9ee52be785cf91fc6a3c6aa27d484873f8270b72"
 source="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-${_githash}.tar.gz"
 subpackages="
 	${pkgname}-doc
+	${pkgname}-amdgpu ${pkgname}-amdgpu-doc
 	${pkgname}-brcmfmac43455sdio ${pkgname}-brcmfmac43455sdio-doc
 	${pkgname}-radeon ${pkgname}-radeon-doc
 "
+
+amdgpu()
+{
+	pkgdesc="AMD GPU firmware files"
+
+	cd "${srcdir}/${pkgname}-${_githash}/"
+	install -D -m 644 "LICENSE.amdgpu" "${subpkgdir}-doc/usr/share/doc/${pkgname}/amdgpu/copying"
+	for file in $(find 'amdgpu/' -type f -iname '*.bin'); do
+		install -D -m 644 "${file}" "${subpkgdir}/lib/firmware/${file}"
+	done
+}
 
 brcmfmac43455sdio()
 {
@@ -41,6 +53,7 @@ radeon()
 doc()
 {
 	depends="
+		${pkgname}-amdgpu-doc
 		${pkgname}-brcmfmac43455sdio-doc
 		${pkgname}-radeon-doc
 	"
@@ -51,6 +64,7 @@ doc()
 package()
 {
 	depends="
+		${pkgname}-amdgpu
 		${pkgname}-brcmfmac43455sdio
 		${pkgname}-firmware-radeon
 	"

--- a/testing/linux-firmware/APKBUILD
+++ b/testing/linux-firmware/APKBUILD
@@ -13,6 +13,7 @@ source="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.
 subpackages="
 	${pkgname}-doc
 	${pkgname}-amdgpu ${pkgname}-amdgpu-doc
+	${pkgname}-amducode ${pkgname}-amducode-doc
 	${pkgname}-brcmfmac43455sdio ${pkgname}-brcmfmac43455sdio-doc
 	${pkgname}-radeon ${pkgname}-radeon-doc
 "
@@ -24,6 +25,17 @@ amdgpu()
 	cd "${srcdir}/${pkgname}-${_githash}/"
 	install -D -m 644 "LICENSE.amdgpu" "${subpkgdir}-doc/usr/share/doc/${pkgname}/amdgpu/copying"
 	for file in $(find 'amdgpu/' -type f -iname '*.bin'); do
+		install -D -m 644 "${file}" "${subpkgdir}/lib/firmware/${file}"
+	done
+}
+
+amducode()
+{
+	pkgdesc="AMD CPU microcode updates"
+
+	cd "${srcdir}/${pkgname}-${_githash}/"
+	install -D -m 644 "LICENSE.amd-ucode" "${subpkgdir}-doc/usr/share/doc/${pkgname}/amd-ucode/copying"
+	for file in $(find 'amd-ucode/' -type f -iname 'microcode_amd*'); do
 		install -D -m 644 "${file}" "${subpkgdir}/lib/firmware/${file}"
 	done
 }
@@ -54,6 +66,7 @@ doc()
 {
 	depends="
 		${pkgname}-amdgpu-doc
+		${pkgname}-amducode-doc
 		${pkgname}-brcmfmac43455sdio-doc
 		${pkgname}-radeon-doc
 	"
@@ -65,6 +78,7 @@ package()
 {
 	depends="
 		${pkgname}-amdgpu
+		${pkgname}-amducode
 		${pkgname}-brcmfmac43455sdio
 		${pkgname}-firmware-radeon
 	"


### PR DESCRIPTION
Start packaging the linux firmware tree.

In true alpine fashion, we don't want one mega archive containing all the firmware. We start with two packages.

For radeon, we only package all radeon firmware, as I know that one card actually can take various bin files, this is years old knowledge, so if someone can debunk that (and thus split the package further) lets do that.

The broadcom tree is big and a little messy, so lets start with atleast one known combination. Btw, the txt files are nvram configuration files, so the intention is to keep them all in the same package (related to the firmware). So in this case, this is not the firmware only for the rasp-pi; it is currently just the conly configuration.