### PR TITLE
testing/lxd: remove incorrect dependency

### DIFF
--- a/testing/lxd/APKBUILD
+++ b/testing/lxd/APKBUILD
@@ -23,7 +23,6 @@ depends="
 	"
 makedepends="
 	lxc-dev
-	protobuf-dev
 	gettext-dev
 	acl-dev
 	libuv-dev


### PR DESCRIPTION
Make dependency on protobuf-dev is not required.