### PR TITLE
testing/cjose: new aport

### DIFF
--- a/testing/cjose/APKBUILD
+++ b/testing/cjose/APKBUILD
@@ -1,0 +1,45 @@
+# Contributor: Johan Bergström <bugs@bergstroem.nu>
+# Maintainer: Johan Bergström <bugs@bergstroem.nu>
+pkgname=cjose
+pkgver=0.6.1
+pkgrel=0
+pkgdesc="A C library implementing the Javascript Object Signing and Encryption"
+url="https://github.com/cisco/cjose"
+arch="all"
+license="MIT"
+depends="jansson openssl"
+makedepends="check-dev coreutils doxygen jansson-dev openssl-dev perl"
+install=""
+subpackages="$pkgname-dev $pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/cisco/$pkgname/archive/$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver/"
+
+build() {
+	cd "$builddir"
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--localstatedir=/var \
+		--enable-static=no \
+		--with-openssl=/usr \
+		--with-jansson=/usr \
+		--disable-doxygen-ps \
+		--disable-doxygen-pdf
+	make
+	# need to invoke doc generation, otherwise it doesn't get installed properly
+	make doxygen
+}
+
+check() {
+	cd "$builddir"
+	make check
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="7ae67a6d19591b3d19b888270ec0ca17df399bea117e42686fc1de39b3741ed9a8816f96d33d090687c49c3123cdc95430a781835a525a02d22561ebf5aaa653  cjose-0.6.1.tar.gz"


### PR DESCRIPTION
cjose is a C library implementing the Javascript Object Signing and Encryption. It depends on jansson and openssl.

Since this is my first "brand new" aport I have a few q's I'd like some guidance on:

1. Who do I add as maintainer? (I assume I'm the contributor?)
2. `-doc` doesn't seem to package correctly and I'm not sure why. It correctly installs into `$DESTDIR/usr/share/cjose/html` but the corresponding `-doc` package is empty.
3. ~the main package also seems to grow an empty `$DESTDIR/usr/share/cjose` folder.~ edit: not according to CI

Note: this library is used by [apache traffic server](https://trafficserver.apache.org/), which I am working to support in Alpine Linux (as of now, only 9.0.x/HEAD). If you're curious you can follow progress [in this Dockerfile](https://github.com/jbergstroem/ts-alpine).