### PR TITLE
testing/php7-pecl-grpc: remove incorrect dependency

### DIFF
--- a/testing/php7-pecl-grpc/APKBUILD
+++ b/testing/php7-pecl-grpc/APKBUILD
@@ -8,7 +8,7 @@ url="https://pecl.php.net/package/grpc"
 arch="all !s390x !ppc64le"
 license="Apache-2.0"
 depends="php7-common"
-makedepends="php7-dev autoconf re2c openssl-dev protobuf-dev zlib-dev"
+makedepends="php7-dev autoconf re2c openssl-dev zlib-dev"
 source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir"/$_pkgreal-$pkgver
 


### PR DESCRIPTION
@andypost Make dependency on protobuf-dev is not required?