### PR TITLE
community/docker: udpate to 18.09.3

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 
 pkgname=docker
-pkgver=18.09.1
-_gitcommit=4c52b901c6cb019f7552cd93055f9688c6538be4	# https://github.com/docker/docker-ce/commits/v$pkgver
+pkgver=18.09.3
+_gitcommit=774a1f4eee66e29a71ca12e88ac2220670990f7e	# https://github.com/docker/docker-ce/commits/v$pkgver
 _ver=${pkgver/_/-}-ce
 pkgrel=0
 pkgdesc="Pack, ship and run any application as a lightweight container"
@@ -187,7 +187,7 @@ vim() {
 	done
 }
 
-sha512sums="9813d3bd41eff63a089495a976226b93d5d43544530aea0ebce78b96e6b4b38389fe3ad1117f1ca95c38727047a24211ad2c2b44217935c26ffb5496cf90407e  docker-18.09.1.tar.gz
+sha512sums="c7df08c03c6bfd8451977cb86593d8ac68390c846c84cc4d8a32e05e815688ccd84a6296f819e440c850c2aa52c131686492206ec4d47765cd0af90c3c39dc03  docker-18.09.3.tar.gz
 9256eedc6ed530506e4e61673a9f45397274093dd61105097d5c650796f0afebc8ad7c550d2dc3cacf94426e3872a2b764906bca46fc907a21b865314c8927d4  libnetwork-2cfbf9b1f98162a55829a21cc603c76072a75382.tar.gz
 c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 33155a79799cc6c0520a030e1a9bdba60441776d612e5e255574b23bbce1c7a8e5d868284b05a8a92704be6bbb7db905388564e867986a705acbe4884ac58584  docker-openrc-fixes.patch


### PR DESCRIPTION
https://github.com/docker/docker-ce/releases/tag/v18.09.3

The more important fixes in this version:
* When copying existing folder, ignore xattr set errors when the target filesystem doesn't support xattr. docker/engine#135
* Graphdriver: fix device mode not being detected if character-device bit is set. docker/engine#160
* Fix nil pointer derefence on failure to connect to containerd. docker/engine#162
* Delete stale containerd object on start failure. docker/engine#154