### PR TITLE
main/harfbuzz: upgrade to 2.3.1

### DIFF
--- a/main/harfbuzz/APKBUILD
+++ b/main/harfbuzz/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Sören Tempel <soeren+alpinelinux@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=harfbuzz
-pkgver=2.2.0
-pkgrel=1
+pkgver=2.3.1
+pkgrel=0
 pkgdesc="Text shaping library"
 url="https://freedesktop.org/wiki/Software/HarfBuzz"
 arch="all"
@@ -32,7 +32,7 @@ build() {
 		--with-gobject \
 		--with-graphite2 \
 		--with-icu \
-		--with-truetype
+		--with-freetype
 	make
 }
 
@@ -65,4 +65,4 @@ icu() {
 	mv "$pkgdir"/usr/lib/lib*icu.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="5e8f35c0d7634afc6f623a91d56bfde46b2a1030d439e5dec196001d49a58e409a1bf66c7f9c15a04e030dab4fe2fe2c928061839b1e985459d4f8379b8a0818  harfbuzz-2.2.0.tar.bz2"
+sha512sums="78a8f05bfcc95cfe3fc0f1a595bdc7298c9c1456db6c7ef70914051fda43f37aaff15eac75aa6922eca82d2291baeb8385e02e6aacb44ca05b4873c311a662ac  harfbuzz-2.3.1.tar.bz2"


### PR DESCRIPTION
--with-truetype is an unrecognized option, correct to --with-freetype