### PR TITLE
testing/ocaml-xml-light: fix ppc64le bld err by adding explicit Makefile target

### DIFF
--- a/testing/ocaml-xml-light/APKBUILD
+++ b/testing/ocaml-xml-light/APKBUILD
@@ -2,14 +2,15 @@
 # Maintainer: Fernando Casas Schossow <casasfernando@outlook.com>
 pkgname=ocaml-xml-light
 pkgver=2.4
-pkgrel=0
+pkgrel=1
 pkgdesc="Minimal XML parser and printer for OCaml"
 url="https://github.com/ncannasse/xml-light"
-arch="x86_64" # restrict by ocaml, build fails on aarch64 and ppc64le
+arch="x86_64 ppc64le" # restrict by ocaml, build fails on aarch64
 license="LGPL-2.1-or-later-WITH-linking-exception"
 makedepends="ocaml ocaml-findlib-dev ocaml-ocamldoc gawk"
 subpackages="$pkgname-dev $pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/ncannasse/xml-light/archive/$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/ncannasse/xml-light/archive/$pkgver.tar.gz
+	Makefile-explicit-target-fix.patch"
 builddir="$srcdir/xml-light-$pkgver"
 
 build() {
@@ -42,4 +43,5 @@ package() {
 	install -D -m644 -t "$pkgdir/usr/share/doc/$pkgname/html/" doc/*
 }
 
-sha512sums="029068c6eb48cd1223438dc0f86e1c5e6fd0412d160ea4d79928eec5e5f5843af46260d7240e4260851e9580e7f92d578c764c63c8e0acab348637455493ef02  ocaml-xml-light-2.4.tar.gz"
+sha512sums="029068c6eb48cd1223438dc0f86e1c5e6fd0412d160ea4d79928eec5e5f5843af46260d7240e4260851e9580e7f92d578c764c63c8e0acab348637455493ef02  ocaml-xml-light-2.4.tar.gz
+6fd6d9131cb652df96c7fd7b68e9161a6e9a0c08fedfd2e2ee00a474d3d249ce16d4a8631a02ca36e158d8c61ff8fb0fe440b5e620eb64f865b23dcfd433e476  Makefile-explicit-target-fix.patch"

--- a/testing/ocaml-xml-light/Makefile-explicit-target-fix.patch
+++ b/testing/ocaml-xml-light/Makefile-explicit-target-fix.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
++++ b/Makefile
+@@ -78,6 +78,8 @@
+ 
+ xml.cmi: 
+ 
++xml_parser.mli:
++
+ xmlParser.cmi: dtd.cmi xml.cmi
+ 
+ xml_lexer.cmi: dtd.cmi


### PR DESCRIPTION
On ppc64le build fails with:
make: *** No rule to make target 'xml_parser.mli', needed by 'xml_parser.cmo'.  Stop.

Adding explicit target in Makefile for xml_parser.mli will fix.