### PR TITLE
testing/mmc-utils: Fix a few small details to the APKBUILD

### DIFF
--- a/testing/mmc-utils/APKBUILD
+++ b/testing/mmc-utils/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Olliver Schinagl <oliver@schinagl.nl>
 # Maintainer: Olliver Schinagl <oliver@schinagl.nl>
 pkgname=mmc-utils
-pkgver="4.3.0_git20181024"
-pkgrel=0
+pkgver="0_git20181024"
+pkgrel=1
 pkgdesc="Configure MMC storage devices from userspace."
-url="http://pyropus.ca/software/memtester/"
+url="https://git.kernel.org/pub/scm/linux/kernel/git/cjb/mmc-utils.git"
 arch="all"
 license="GPL-2.0"
 depends=""
@@ -12,19 +12,19 @@ makedepends="linux-headers"
 options="!check" # No checks available
 subpackages="${pkgname}-doc"
 _githash="aef913e31b659462fe6b9320d241676cba97f67b"
-source="https://git.kernel.org/pub/scm/linux/kernel/git/cjb/mmc-utils.git/snapshot/mmc-utils-${_githash}.tar.gz"
+source="https://git.kernel.org/pub/scm/linux/kernel/git/cjb/${pkgname}.git/snapshot/${pkgname}-${_githash}.tar.gz"
+builddir="${srcdir}/${pkgname}-${_githash}"
 
 build()
 {
-	cd "${srcdir}/mmc-utils-${_githash}"
 	make
 }
 
 package()
 {
-	cd "${srcdir}/mmc-utils-${_githash}"
 	make DESTDIR="${pkgdir}" prefix="/usr" install install-man
 	gzip -c "man/mmc.1" > "mmc.1.gz" && \
 		install -D -m 644 "mmc.1.gz" "${pkgdir}/usr/share/man/man1/mmc.1.gz"
 }
+
 sha512sums="afadc665f1c181d4ae2fd5e1e1fc0b05f79a0de039d04ee8db333254aafd7b90edc49accb54d8d7e29a2e541fce34037f83449f91a7b2ebbd2f28e415d9904fd  mmc-utils-aef913e31b659462fe6b9320d241676cba97f67b.tar.gz"


### PR DESCRIPTION
There are some copy-paste mistakes in the pkgver and url among others.

This patch addresses those small oversights.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>