### PR TITLE
community/knot: upgrade to 2.8.0

### DIFF
--- a/community/knot/APKBUILD
+++ b/community/knot/APKBUILD
@@ -4,7 +4,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: tcely <knot+aports@tcely.33mail.com>
 pkgname=knot
-pkgver=2.7.6
+pkgver=2.8.0
 pkgrel=0
 pkgdesc="An high-performance authoritative-only DNS server"
 url="https://www.knot-dns.cz"
@@ -24,6 +24,7 @@ subpackages="$pkgname-libs
 	$pkgname-openrc
 	"
 source="https://secure.nic.cz/files/knot-dns/$pkgname-$pkgver.tar.xz
+	knot-2.8.0-fix-include-lmdb_h.patch
 	test_net.patch
 	knotd.confd
 	knotd.initd
@@ -90,7 +91,8 @@ utils() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="6b6a727d57337da01e2d44abec7fde4504d112604769b118fe6254b0317f149ed4e9fab321a04517eccedb08e409818d1817fc1136c27d1fd351538e6816022a  knot-2.7.6.tar.xz
+sha512sums="0cf2840d908bbab3197bff82d37e4a754204a3b79efa7e982719bc19028519d3ff0b2177780dada54e1b070f5f7aa28dab7bbfcc2d2ea086817f3a29b746228e  knot-2.8.0.tar.xz
+a6cc263388c12e83b1da79234781091050cab49f1aa96bb2b9ceb117f69601e7000c558bc4eb7d7baf3415a2a9a299a845eacd1c9b106fb08fe8407d370eaa01  knot-2.8.0-fix-include-lmdb_h.patch
 39503d16603eaff04cb34de97bff987952818d229ccb5b190567198505ece8077efdf230d5402e69ca4ab8acb282c53bfaaf495360dc11191c985a48fbb61318  test_net.patch
 471d3c639a8235ba09491c99d36c0a4f1074d6055ccfd3807be02a30d3ed5bbe69a84f0414ea7810db6bbc1e38f5837108e5744fc59f949ed78a262a7de4597e  knotd.confd
 979f06a83dd4326920a682f8190319577faf904e0e379b3c55e0420eb43dcb55d86c6727015634fa0c2dff1dddac43bbd5a216ff04f217ad91d670eb899dbefa  knotd.initd"

--- a/community/knot/APKBUILD
+++ b/community/knot/APKBUILD
@@ -11,6 +11,7 @@ url="https://www.knot-dns.cz"
 arch="all"
 license="GPL-3.0"
 depends=""
+checkdepends="" # TODO: move testing/softhsm to community for test_keystore_pkcs11
 makedepends="gnutls-dev libedit-dev libcap-ng-dev libidn-dev lmdb-dev
 	openssl-dev userspace-rcu-dev zlib-dev
 	m4 bison flex perl sed jansson-dev libtool bsd-compat-headers"

--- a/community/knot/APKBUILD
+++ b/community/knot/APKBUILD
@@ -11,7 +11,7 @@ url="https://www.knot-dns.cz"
 arch="all"
 license="GPL-3.0"
 depends=""
-checkdepends="" # TODO: move testing/softhsm to community for test_keystore_pkcs11
+checkdepends="softhsm"
 makedepends="gnutls-dev libedit-dev libcap-ng-dev libidn-dev lmdb-dev
 	openssl-dev userspace-rcu-dev zlib-dev
 	m4 bison flex perl sed jansson-dev libtool bsd-compat-headers"

--- a/community/knot/knot-2.8.0-fix-include-lmdb_h.patch
+++ b/community/knot/knot-2.8.0-fix-include-lmdb_h.patch
@@ -1,0 +1,19 @@
+commit bd7cddda33a911b0450fa79f5ab9a380777318b4
+Author: tcely <tcely@users.noreply.github.com>
+Date:   Wed Mar 6 01:14:10 2019 -0500
+
+    do not include from contrib/lmdb directly
+
+diff --git a/src/knot/journal/knot_lmdb.h b/src/knot/journal/knot_lmdb.h
+index 35a8884..b1d09cb 100644
+--- a/src/knot/journal/knot_lmdb.h
++++ b/src/knot/journal/knot_lmdb.h
+@@ -16,7 +16,7 @@
+ 
+ #pragma once
+ 
+-#include "contrib/lmdb/lmdb.h"
++#include <lmdb.h>
+ 
+ #include <stdbool.h>
+ #include <stdlib.h>


### PR DESCRIPTION
Also, patch `knot-resolver` in #6558 to not break when building against `knot-2.8.0`.

~~Depends on #6554~~

For https://bugs.alpinelinux.org/issues/10066