### PR TITLE
testing/xmrig: upgrade to 2.14.1, added aarch64, armv7 and armhf

### DIFF
--- a/testing/xmrig/APKBUILD
+++ b/testing/xmrig/APKBUILD
@@ -2,22 +2,28 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 
 pkgname=xmrig
-pkgver=2.13.1
+pkgver=2.14.1
 pkgrel=0
 pkgdesc="XMRig is a high performance Monero (XMR) miner"
 url="https://github.com/xmrig/xmrig"
-arch="x86_64 x86"
+arch="x86_64 x86 aarch64 armv7 armhf"
 license="GPL-3.0"
 makedepends="cmake libmicrohttpd-dev libuv-dev openssl-dev"
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/xmrig/xmrig/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
+case "$CARCH" in
+	aarch64*) CMAKE_CROSSOPTS="-DARM_TARGET=8"; makedepends="$makedepends linux-headers" ;;
+	armv7*)   CMAKE_CROSSOPTS="-DARM_TARGET=7"; makedepends="$makedepends linux-headers" ;;
+	armhf*)   CMAKE_CROSSOPTS="-DARM_TARGET=7"; makedepends="$makedepends linux-headers" ;;
+esac
+
 build() {
 	cd "$builddir"
 	mkdir build
 	cd build
-	cmake ..
+	cmake .. ${CMAKE_CROSSOPTS}
 	make
 }
 
@@ -34,4 +40,4 @@ package() {
 	install -Dm 644 -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
 }
 
-sha512sums="5d15bc869c698a675fbb7b08ae7b1052858861c2622c5090889659f5aecad64e3b90c320c8285293f230641ad00e78eac82cc17717c836c8be6d9d2e15ebb2f9  xmrig-2.13.1.tar.gz"
+sha512sums="a9e11964e1fc7f040d835734cd418319e289f4def0004311ac1b0a7edaad74ea30698ffcea4ca80bc39b8b2620ee0ebdfeef3d13a8b0c93be9ebb2be5fdd10c7  xmrig-2.14.1.tar.gz"


### PR DESCRIPTION
https://github.com/xmrig/xmrig/releases 2.14.0