### PR TITLE
testing/tuptime: Add install line to APKBUILD

### DIFF
--- a/testing/tuptime/APKBUILD
+++ b/testing/tuptime/APKBUILD
@@ -8,6 +8,7 @@ url="https://github.com/rfrail3/tuptime"
 arch="noarch"
 license="GPL-2.0-only"
 depends="python3"
+install="$pkgname.pre-install $pkgname.post-install"
 subpackages="$pkgname-doc $pkgname-openrc"
 options="!check"
 source="$pkgname-$pkgver.tar.gz::https://github.com/rfrail3/$pkgname/archive/$pkgver.tar.gz


### PR DESCRIPTION
Up until now, the .pre-install and .post-install scripts aren't executed, so the package didn't work. This fix the issue adding the line on APKBUILD.