### PR TITLE
community/uboot-tools: cleanup the packaging

### DIFF
--- a/community/uboot-tools/APKBUILD
+++ b/community/uboot-tools/APKBUILD
@@ -7,29 +7,25 @@ pkgdesc="U-Boot bootloader utility tools"
 url="https://www.denx.de/wiki/U-Boot/WebHome"
 arch="all !s390x !ppc64le"
 license="GPL"
-makedepends="$depends_dev bison flex openssl-dev linux-headers sdl-dev"
+makedepends="$depends_dev bison flex linux-headers openssl-dev"
 options="!check" # No test suite
 source="http://ftp.denx.de/pub/u-boot/u-boot-$pkgver.tar.bz2"
 builddir="$srcdir/u-boot-$pkgver"
 
 build() {
 	cd "$builddir"
-	make defconfig
-	make tools-all
+	make sandbox_defconfig
+	make V=1 STRIP=true NO_SDL=1 tools-all
 }
 
 package() {
 	cd "$builddir"
-	for tool in bmp_logo dumpimage easylogo/easylogo env/fw_printenv \
-		fit_check_sign fit_info gdb/gdbcont gdb/gdbsend gen_eth_addr img2srec \
-		mkenvimage mkimage ncb proftool ubsha1 xway-swap-bytes env/fw_printenv; do
-			install -D tools/$tool \
-				$pkgdir/usr/bin/$(basename $tool)
+	for tool in dumpimage kwboot mkenvimage mkimage mksunxiboot; do
+		install -D -p -m0755 tools/$tool $pkgdir/usr/bin/$tool
 	done
-	install -Dm644 tools/env/fw_env.config \
-			$pkgdir/etc/fw_env.config
-	cd "$pkgdir"/usr/bin
-	ln -sf fw_printenv fw_setenv
+	install -D -p -m0755 tools/env/fw_printenv $pkgdir/usr/bin/fw_printenv
+	install -D -p -m0644 tools/env/fw_env.config $pkgdir/etc/fw_env.config
+	cd "$pkgdir"/usr/bin && ln -sf fw_printenv fw_setenv
 }
 
 sha512sums="d9699cd22afe9bc747d64208068c2cf8a2c3143d161ede24536f6fd6adfd6b81e28920589722639e2e48fcf34e8dbde3ead7f691f14cbcc38cd75694d14d719b  u-boot-2019.01.tar.bz2"


### PR DESCRIPTION
* get rid of sdl-dev build dependency and use NO_SDL=1 instead.
* use the sandbox_defconfig since we build tools only.
* reduce the number of tools shipped to only the ones used in real world.
  If a particular tool is required, it can be re-added per request or bug
  report.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>