### PR TITLE
testing/libzookeeper: fix ppc64le build error by disabling Werror

### DIFF
--- a/testing/libzookeeper/APKBUILD
+++ b/testing/libzookeeper/APKBUILD
@@ -2,14 +2,15 @@
 # Maintainer: Maciej Klak <klak.maciej@gmail.com>
 pkgname=libzookeeper
 pkgver=3.4.13
-pkgrel=0
+pkgrel=1
 pkgdesc="The Apache ZooKeeper system for distributed coordination is a high-performance service for building distributed applications."
 url="https://zookeeper.apache.org"
 arch="all"
 license="Apache License"
 subpackages="$pkgname-dev"
 options="!check" # No test suite
-source="http://www-eu.apache.org/dist/zookeeper/zookeeper-$pkgver/zookeeper-$pkgver.tar.gz"
+source="http://www-eu.apache.org/dist/zookeeper/zookeeper-$pkgver/zookeeper-$pkgver.tar.gz
+	fix-sprintf-overflow.patch"
 builddir="$srcdir/zookeeper-$pkgver/src/c"
 
 build() {
@@ -23,4 +24,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="3481bd19945d80848f81d9dc2896a682ae8b62269b8164ffbae532e55aa4219961403e0208c8e72cf784605eae436d70ddae2b26e0deba0f1f84c74188c32c0a  zookeeper-3.4.13.tar.gz"
+sha512sums="3481bd19945d80848f81d9dc2896a682ae8b62269b8164ffbae532e55aa4219961403e0208c8e72cf784605eae436d70ddae2b26e0deba0f1f84c74188c32c0a  zookeeper-3.4.13.tar.gz
+91c6ef3f4c8edf1e95ccbd85fc961760f21f4943631fc8a7f6e2a7984ca0fc6b381075ac55f7b91c6439e9c7dc2fdb74d016238250e5c156bbd1f4bc11e2abaa  fix-sprintf-overflow.patch"

--- a/testing/libzookeeper/fix-sprintf-overflow.patch
+++ b/testing/libzookeeper/fix-sprintf-overflow.patch
@@ -1,0 +1,11 @@
+--- a/src/zookeeper.c
++++ b/src/zookeeper.c
+@@ -3477,7 +3477,7 @@
+ 
+ static const char* format_endpoint_info(const struct sockaddr_storage* ep)
+ {
+-    static char buf[128];
++    static char buf[128 + 6];	// include space for the port :xxxxx
+     char addrstr[128];
+     void *inaddr;
+ #ifdef WIN32


### PR DESCRIPTION
With gcc 8.2 ppc64le build encounters error:
src/zookeeper.c: In function 'format_endpoint_info':
src/zookeeper.c:3506:21: error: '%d' directive writing between 1 and 5 bytes into a region of size between 0 and 127 [-Werror=format-overflow=]
     sprintf(buf,"%s:%d",addrstr,ntohs(port));

Disabling Werror during compile will fix.