### PR TITLE
Postfix: Added ICU in order to enable UTF8 support.

### DIFF
--- a/main/postfix/APKBUILD
+++ b/main/postfix/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=postfix
 pkgver=3.4.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Secure and fast drop-in replacement for Sendmail (MTA)"
 url="http://www.postfix.org/"
 arch="all"
@@ -13,6 +13,7 @@ makedepends="
 	coreutils
 	cyrus-sasl-dev
 	db-dev
+	icu-dev
 	linux-headers
 	lmdb-dev
 	m4


### PR DESCRIPTION
Added icu-dev to the list of make dependencies which is a prerequisite for UTF8 support in Postfix.
This change resolves the following warning message:

warning: smtputf8_enable is true, but EAI support is not compiled in