### PR TITLE
main/mini_httpd: upgrade to 1.30

### DIFF
--- a/main/mini_httpd/APKBUILD
+++ b/main/mini_httpd/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mini_httpd
-pkgver=1.29
-pkgrel=2
+pkgver=1.30
+pkgrel=0
 pkgdesc="Small forking webserver with ssl and ipv6 support"
 url="http://www.acme.com/software/mini_httpd/"
 arch="all"
@@ -22,6 +22,8 @@ source="http://www.acme.com/software/$pkgname/$pkgname-$pkgver.tar.gz
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   1.30-r0:
+#     - CVE-2018-18778
 #   1.29-r0:
 #     - CVE-2017-17663
 
@@ -54,7 +56,7 @@ package() {
 	install -dm755 -g $pkggroups "$pkgdir"/var/www/localhost/htdocs
 }
 
-sha512sums="ad72dab7b501c6cc364aac0f8ebd6e967a9150b366f03d2bedb8c7a0001610b9eb55a839cd1c92aad4e9c55a32b3b962cd5a841ac3f159a033457f92a6d1b568  mini_httpd-1.29.tar.gz
+sha512sums="c7464bbd6f9b18ad15f662978ca68fab7db1eea5247d2598134869f098c273b745c7bb0ef9a2841acefb94a369937111858aa84028ed08e9b07d9c6fc257a04c  mini_httpd-1.30.tar.gz
 1e6ef2da61c82ff5e8bb79058c188954d72c69e9d25abdd9bca51f3122aac8729bcfd6e53ae7ee40807b9250698f2cde13dad51ffed962aa07004c7f456f9cb3  mini_httpd.conf
 9daa9052609136a461c912ee2b64829abf2c4c626553a12a3d45c2158be4ed0749126b5ea594fed02a6a4779d7869a073070c259ac28ca19171a168fcbb0632c  mini_httpd.initd
 701c8d393963836267289cba7352caaf61925c6a7e4903f0d418245415b214e17dcab3497697dd5c9ab80f3f71c9cb5dbcc0a3706bc6be25b6031da000ee0ef0  mini_httpd.logrotate


### PR DESCRIPTION
@ncopa fixes CVE-2018-18778