### PR TITLE
[3.9] main/openssl: security update to patch CVE-2019-1543

### DIFF
--- a/main/openssl/APKBUILD
+++ b/main/openssl/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=openssl
 pkgver=1.1.1b
 _abiver=${pkgver%.*}
-pkgrel=0
+pkgrel=1
 pkgdesc="Toolkit for Transport Layer Security (TLS)"
 url="https://www.openssl.org"
 arch="all"
@@ -12,7 +12,8 @@ makedepends_build="perl"
 makedepends_host="linux-headers"
 makedepends="$makedepends_host $makedepends_build"
 subpackages="$pkgname-dbg $pkgname-dev $pkgname-doc libcrypto$_abiver:_libcrypto libssl$_abiver:_libssl"
-source="https://www.openssl.org/source/openssl-$pkgver.tar.gz"
+source="https://www.openssl.org/source/openssl-$pkgver.tar.gz
+	CVE-2019-1543.patch"
 case "$CARCH" in
 s390x) options="$options !check";; # FIXME: test hangs
 esac
@@ -20,6 +21,8 @@ esac
 builddir="$srcdir/openssl-$pkgver"
 
 # secfixes:
+#   1.1.1b-r1:
+#     - CVE-2019-1543
 #   1.1.1a-r0:
 #     - CVE-2018-0734
 #     - CVE-2018-0735
@@ -101,4 +104,5 @@ _libssl() {
 	done
 }
 
-sha512sums="b54025fbb4fe264466f3b0d762aad4be45bd23cd48bdb26d901d4c41a40bfd776177e02230995ab181a695435039dbad313f4b9a563239a70807a2e19ecf045d  openssl-1.1.1b.tar.gz"
+sha512sums="b54025fbb4fe264466f3b0d762aad4be45bd23cd48bdb26d901d4c41a40bfd776177e02230995ab181a695435039dbad313f4b9a563239a70807a2e19ecf045d  openssl-1.1.1b.tar.gz
+f11c7b8e938dca3528eee36ddb64421072e1fdd6d5dfc40452f36e2db954b3e9ae888416bb26dc73068a14c94404eb66352e37a988f04ecc08600554eab16c99  CVE-2019-1543.patch"

--- a/main/openssl/APKBUILD
+++ b/main/openssl/APKBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Timo Teras <timo.teras@iki.fi>
 pkgname=openssl
-pkgver=1.1.1a
+pkgver=1.1.1b
 _abiver=${pkgver%.*}
-pkgrel=1
+pkgrel=0
 pkgdesc="Toolkit for Transport Layer Security (TLS)"
 url="https://www.openssl.org"
 arch="all"
@@ -101,4 +101,4 @@ _libssl() {
 	done
 }
 
-sha512sums="1523985ba90f38aa91aa6c2d57652f4e243cb2a095ce6336bf34b39b5a9b5b876804299a6825c758b65990e57948da532cca761aa12b10958c97478d04dd6d34  openssl-1.1.1a.tar.gz"
+sha512sums="b54025fbb4fe264466f3b0d762aad4be45bd23cd48bdb26d901d4c41a40bfd776177e02230995ab181a695435039dbad313f4b9a563239a70807a2e19ecf045d  openssl-1.1.1b.tar.gz"

--- a/main/openssl/CVE-2019-1543.patch
+++ b/main/openssl/CVE-2019-1543.patch
@@ -1,0 +1,66 @@
+From f426625b6ae9a7831010750490a5f0ad689c5ba3 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Tue, 5 Mar 2019 14:39:15 +0000
+Subject: [PATCH] Prevent over long nonces in ChaCha20-Poly1305
+
+ChaCha20-Poly1305 is an AEAD cipher, and requires a unique nonce input for
+every encryption operation. RFC 7539 specifies that the nonce value (IV)
+should be 96 bits (12 bytes). OpenSSL allows a variable nonce length and
+front pads the nonce with 0 bytes if it is less than 12 bytes. However it
+also incorrectly allows a nonce to be set of up to 16 bytes. In this case
+only the last 12 bytes are significant and any additional leading bytes are
+ignored.
+
+It is a requirement of using this cipher that nonce values are unique.
+Messages encrypted using a reused nonce value are susceptible to serious
+confidentiality and integrity attacks. If an application changes the
+default nonce length to be longer than 12 bytes and then makes a change to
+the leading bytes of the nonce expecting the new value to be a new unique
+nonce then such an application could inadvertently encrypt messages with a
+reused nonce.
+
+Additionally the ignored bytes in a long nonce are not covered by the
+integrity guarantee of this cipher. Any application that relies on the
+integrity of these ignored leading bytes of a long nonce may be further
+affected.
+
+Any OpenSSL internal use of this cipher, including in SSL/TLS, is safe
+because no such use sets such a long nonce value. However user
+applications that use this cipher directly and set a non-default nonce
+length to be longer than 12 bytes may be vulnerable.
+
+CVE-2019-1543
+
+Fixes #8345
+
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/8406)
+
+(cherry picked from commit 2a3d0ee9d59156c48973592331404471aca886d6)
+---
+ crypto/evp/e_chacha20_poly1305.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/crypto/evp/e_chacha20_poly1305.c b/crypto/evp/e_chacha20_poly1305.c
+index c1917bb86a6..d3e2c622a1b 100644
+--- a/crypto/evp/e_chacha20_poly1305.c
++++ b/crypto/evp/e_chacha20_poly1305.c
+@@ -30,6 +30,8 @@ typedef struct {
+ 
+ #define data(ctx)   ((EVP_CHACHA_KEY *)(ctx)->cipher_data)
+ 
++#define CHACHA20_POLY1305_MAX_IVLEN     12
++
+ static int chacha_init_key(EVP_CIPHER_CTX *ctx,
+                            const unsigned char user_key[CHACHA_KEY_SIZE],
+                            const unsigned char iv[CHACHA_CTR_SIZE], int enc)
+@@ -533,7 +535,7 @@ static int chacha20_poly1305_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
+         return 1;
+ 
+     case EVP_CTRL_AEAD_SET_IVLEN:
+-        if (arg <= 0 || arg > CHACHA_CTR_SIZE)
++        if (arg <= 0 || arg > CHACHA20_POLY1305_MAX_IVLEN)
+             return 0;
+         actx->nonce_len = arg;
+         return 1;


### PR DESCRIPTION
Backport of #6562