### PR TITLE
[3.7] main/openssl: security upgrade to 1.0.2r

### DIFF
--- a/main/openssl/APKBUILD
+++ b/main/openssl/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Timo Teras <timo.teras@iki.fi>
 pkgname=openssl
-pkgver=1.0.2q
+pkgver=1.0.2r
 pkgrel=0
 pkgdesc="Toolkit for SSL v2/v3 and TLS v1"
 url="https://openssl.org"
@@ -67,6 +67,8 @@ source="https://www.openssl.org/source/${pkgname}-${pkgver}.tar.gz
 #   1.0.2q-r0:
 #     - CVE-2018-0734
 #     - CVE-2018-5407
+#   1.0.2r-r0:
+#     - CVE-2019-1559
 
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -138,7 +140,7 @@ libssl() {
 	done
 }
 
-sha512sums="403e6cad42db3ba860c3fa4fa81c1b7b02f0b873259e5c19a7fc8e42de0854602555f1b1ca74f4e3a7737a4cbd3aac063061e628ec86534586500819fae7fec0  openssl-1.0.2q.tar.gz
+sha512sums="6eb2211f3ad56d7573ac26f388338592c37e5faaf5e2d44c0fa9062c12186e56a324f135d1c956a89b55fcce047e6428bec2756658d103e7275e08b46f741235  openssl-1.0.2r.tar.gz
 2244f46cb18e6b98f075051dd2446c47f7590abccd108fbab707f168a20cad8d32220d704635973f09e3b2879f523be5160f1ffbc12ab3900f8a8891dc855c5c  0002-busybox-basename.patch
 58e42058a0c8086c49d681b1e226da39a8cf8cb88c51cf739dec2ff12e1bb5d7208ac5033264b186d58e9bdfe992fe9ddb95701d01caf1824396b2cefe30c0a4  0003-use-termios.patch
 c67472879a31b5dbdd313892df6d37e7c93e8c0237d406c30d50b1016c2618ead3c13277f5dc723ef1ceed092d36e3c15a9777daa844f59b9fa2b0a4f04fd9ae  0004-fix-default-ca-path-for-apps.patch


### PR DESCRIPTION
Backport of #6491