### PR TITLE
main/postfix: upgrade to 3.4.2

### DIFF
--- a/main/postfix/APKBUILD
+++ b/main/postfix/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=postfix
-pkgver=3.4.1
+pkgver=3.4.2
 pkgrel=0
 pkgdesc="Secure and fast drop-in replacement for Sendmail (MTA)"
 url="http://www.postfix.org/"
@@ -195,6 +195,6 @@ stone() {
 	find src/smtpstone -mindepth 1 -perm 0755 -exec cp {} "$subpkgdir"/usr/bin \;
 }
 
-sha512sums="14d2fe4e70b28121e99b17c8f5028adb842cfb09f52ec4c279b7cd7fe1f9e47cbf6a142f4472f53e7589ba3dbdb1e17b4c8e76a16af8ae0568bee103979206ad  postfix-3.4.1.tar.gz
+sha512sums="1ee197e0503b39157feb6dddc335463001dc857a223829ac66e449e5b02750290ca95dc32148135a55ea6db6f14608a288caffd87d24b0b859e609ef6ab9baeb  postfix-3.4.2.tar.gz
 2752e69c4e1857bdcf29444ffb458bca818bc60b9c77c20823c5f5b87c36cb5e0f3217a625a7fe5788d5bfcef7570a1f2149e1233fcd23ccf7ee14190aff47a2  postfix.initd
 25cd34f23ca909d4e33aaf3239d1e397260abc7796d9a4456dee4f005682fd3a58aab8106126e5218c95bdddae415a3ef7e2223cd3b0d7b1e2bd76158bb7eaf8  postfix-install.patch"


### PR DESCRIPTION
From postfix-announce mailing list:

>[An on-line version of this announcement will be available at
>http://www.postfix.org/announcements/postfix-3.4.2.html]
>
>Postfix stable release 3.4.2 is available.
>  * DANE trust anchor file support was broken after the Postfix 3.4
>    TLS library overhaul. Fix by Scott Kitterman.
>
>  * LINUX5 is supported, based on sanity checks with a Rawhide
>    prerelease.
>
>  * Fixes for two null pointer reads in warnings for errors that
>    never happen (in code from 7 and 18 years ago, respectively).
>
>The plan is to maintain zero code difference between the stable
>release and the development release, until there have been no
>bug-of-the-week patches for much more than several weeks.