### PR TITLE
Remove outdated win headers

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -213,9 +213,7 @@ prepare() {
 		TSRM/tsrm_config.w32.h \
 		Zend/zend_config.w32.h \
 		ext/mysqlnd/config-win.h \
-		ext/standard/winver.h \
-		main/win32_internal_function_disabled.h \
-		main/win95nt.h
+		ext/standard/winver.h
 
 	# Fix some bogus permissions.
 	find . -name \*.[ch] -exec chmod 644 {} \;


### PR DESCRIPTION
Some windows specific outdated headers already got refactored upstream since PHP 7.0+ and can be removed from the APKBUILD file also:

* https://github.com/php/php-src/commits/master/main/win32_internal_function_disabled.h
* https://github.com/php/php-src/commits/master/main/win95nt.h