### PR TITLE
 community/fstrm: disable s390x

### DIFF
--- a/community/fstrm/APKBUILD
+++ b/community/fstrm/APKBUILD
@@ -1,14 +1,14 @@
 # Contributor: tcely <tcely@users.noreply.github.com>
 # Maintainer: tcely <fstrm+aports@tcely.33mail.com>
 pkgname="fstrm"
-pkgver="0.4.0"
+pkgver="0.5.0"
 pkgrel=0
 pkgdesc="Frame Streams implementation in C"
 url="https://github.com/farsightsec/fstrm"
-arch="all !s390x"
+arch="all"
 # check failure on s390x reported upstream:
 #    https://github.com/farsightsec/fstrm/issues/58
-license="Apache-2.0"
+license="MIT"
 depends=""
 depends_dev="libevent-dev"
 makedepends="$depends_dev"
@@ -40,4 +40,5 @@ package() {
 	make -j1 DESTDIR="$pkgdir" install
 }
 
-sha256sums="b20564cb2ebc7783a8383fbef5bcef5726f94baf48b83843553c9e1030b738ef  fstrm-0.4.0.tar.gz"
+sha256sums="10ee7792a86face1d2271dc591652ab8c7af6976883887c69fdb11f10da135fc  fstrm-0.5.0.tar.gz"
+sha512sums="cc60d8974d73d4f5327c46fe642151c88cf8d670ac9bb5db6cb5990b6c0995a0e09c9ae1a6c86ecbfd35fe03664b5402becd68bc6e81e83e9f4b84668d866f25  fstrm-0.5.0.tar.gz"

--- a/community/fstrm/APKBUILD
+++ b/community/fstrm/APKBUILD
@@ -5,7 +5,7 @@ pkgver="0.5.0"
 pkgrel=0
 pkgdesc="Frame Streams implementation in C"
 url="https://github.com/farsightsec/fstrm"
-arch="all"
+arch="all !s390x"
 # check failure on s390x reported upstream:
 #    https://github.com/farsightsec/fstrm/issues/58
 license="MIT"


### PR DESCRIPTION
check is still failing with this version

@Ikke Would you be able to pull the `test-suite.log` from the `s390x` build machine?