### PR TITLE
Add minikube on 0.35.0

### DIFF
--- a/testing/minikube/APKBUILD
+++ b/testing/minikube/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor:
+# Maintainer: Magicloud <magiclouds@gmail.com>
+pkgname=minikube
+pkgver=0.35.0
+pkgrel=0
+pkgdesc="Minikube is a tool that makes it easy to run Kubernetes locally"
+url="https://github.com/kubernetes/minikube"
+arch="all"
+license="Apache"
+makedepends="make go git"
+source="$pkgname-$pkgver.tar.gz::https://github.com/kubernetes/minikube/archive/v$pkgver.tar.gz"
+options="!check"
+
+prepare () {
+	rm -rf "$srcdir/src"
+	mkdir -p "$srcdir/src/k8s.io"
+	mv "$srcdir/minikube-$pkgver" "$srcdir/src/k8s.io/minikube"
+}
+
+build () {
+	export GOPATH="$srcdir"
+	cd "$GOPATH/src/k8s.io/minikube"
+	make
+}
+
+package () {
+	install -Dm755 "$srcdir/src/k8s.io/minikube/out/minikube" -t "$pkgdir/usr/bin"
+}
+
+sha512sums="ef5158ebf42090570e5bef3ff7cfe3536c091356119925029510a0cec93fa0deba780964fc576e54ccb50336d05d95782a405b3161e0ff2fa0544d82ae0d7682  minikube-0.35.0.tar.gz"


### PR DESCRIPTION
Minikube is kind of useful on one host usercase.

Migrated from Archlinux AUR. Tested in Alpinelinux v3.9 x86_64.