### PR TITLE
main/jsoncpp: add static library

### DIFF
--- a/main/jsoncpp/APKBUILD
+++ b/main/jsoncpp/APKBUILD
@@ -2,13 +2,13 @@
 # Maintainer: 
 pkgname=jsoncpp
 pkgver=1.8.4
-pkgrel=0
+pkgrel=1
 pkgdesc="JSON C++ library"
 url="https://github.com/open-source-parsers/jsoncpp"
 arch="all"
 license="Public-Domain"
 makedepends="meson"
-subpackages="$pkgname-dev"
+subpackages="$pkgname-dev $pkgname-static"
 source="$pkgname-$pkgver.tar.gz::https://github.com/open-source-parsers/jsoncpp/archive/$pkgver.tar.gz"
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -16,18 +16,27 @@ build() {
 	cd "$builddir"
 	# we cannot use cmake since jsoncpp is a dependency for cmake which
 	# means we would get circular buildtime deps
-	meson --prefix /usr --libdir /usr/lib --buildtype release --default-library shared . build
-	ninja -C build
+	meson --prefix /usr --libdir /usr/lib --buildtype release --default-library shared . build-shared
+	ninja -C build-shared
+	meson --prefix /usr --libdir /usr/lib --buildtype release --default-library static . build-static
+	ninja -C build-static
 }
 
 check() {
 	cd "$builddir"
-	ninja -C build test
+	ninja -C build-shared test
+	ninja -C build-static test
 }
 
 package() {
 	cd "$builddir"
-	DESTDIR="$pkgdir" ninja -C build install
+	DESTDIR="$pkgdir" ninja -C build-shared install
+	cp "$builddir"/build-static/libjsoncpp.a "$pkgdir"/usr/lib
 }
 
+static() {
+	pkgdesc="JsonCpp static library"
+	mkdir -p "$subpkgdir"/usr/lib
+	cp "$builddir"/build-static/libjsoncpp.a "$subpkgdir"/usr/lib
+}
 sha512sums="f70361a3263dd8b9441374a9a409462be1426c0d6587c865171a80448ab73b3f69de2b4d70d2f0c541764e1e6cccc727dd53178347901f625ec6fb54fb94f4f1  jsoncpp-1.8.4.tar.gz"


### PR DESCRIPTION
I am not sure if we create `libjsoncpp-static`. `libjsoncpp.a` weights ~420000 KB