### PR TITLE
main/trac: upgrade to 1.2.3

### DIFF
--- a/main/trac/APKBUILD
+++ b/main/trac/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=trac
 _realname=Trac
-pkgver=1.2.2
+pkgver=1.2.3
 pkgrel=0
 pkgusers="tracd"
 pkggroups="tracd"
@@ -31,6 +31,6 @@ package() {
 	install -m644 -D "$srcdir"/tracd.confd "$pkgdir"/etc/conf.d/tracd
 }
 
-sha512sums="1b243bb756a921888be9f2abb591d06acc85857785b41ba703269adc7f7390a77e746369d89986ea225e54f389ef4ab95733ce241a8c190f2d163c0f374c6dd1  Trac-1.2.2.tar.gz
+sha512sums="988aa8c42f4f2e9b657b9fd9070328dc123f56954645def1e17ccffc6ec6da9d2a898ec58dae3045478df0e3c8f7b946dc723b46aec10627b31169eda0a08bad  Trac-1.2.3.tar.gz
 38a961fe59b690eb91e20143aaea6aa1becda8c2afa103599d14ff86c7aae88f06b57b342302de1f067dac5d99024b9cc72896a84349e09b3ff40c9a20f97bb1  tracd.confd
 c5ec9242c8149056cebcd54383f15fe31f30fee7c2062e431df05db4449c2fa250560889ea871516736ec9fd06cdbc7ff341e8e63d5f0bfd938cc9495af426cd  tracd.initd"


### PR DESCRIPTION
Trac v1.2.3 (https://trac.edgewall.org/milestone/1.2.3) released on July 29, 2018. It is the latest stable release.