### PR TITLE
community/irrlicht: add irrlicht-static

### DIFF
--- a/community/irrlicht/APKBUILD
+++ b/community/irrlicht/APKBUILD
@@ -9,7 +9,7 @@ arch="all"
 license="zlib"
 depends=""
 makedepends="mesa-dev libjpeg-turbo-dev bzip2 libpng-dev zlib-dev bzip2-dev"
-subpackages="$pkgname-dev $pkgname-doc"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-static"
 source="https://downloads.sourceforge.net/irrlicht/irrlicht-$pkgver.zip
 	irrlicht-1.8.3-mesa-10.x.patch
 	irrlicht-1.8.3-sysctl.patch
@@ -32,8 +32,7 @@ prepare() {
 build() {
        cd "$builddir"/source/Irrlicht/
        export CXXFLAGS="$CXXFLAGS -std=gnu++98"
-       make sharedlib
-
+       make sharedlib staticlib
        #from arch pkgbuild: example build helper
        ln -s libIrrlicht.so.$pkgver "$srcdir"/$pkgname-$pkgver/lib/Linux/libIrrlicht.so
 }
@@ -57,6 +56,12 @@ package() {
        ln -s libIrrlicht.so.$pkgver libIrrlicht.so.1.8
 
        install -m644 "$builddir"/include/* "$pkgdir"/usr/include/$pkgname
+}
+
+static() {
+       pkgdesc="Irrlicht static library"
+       mkdir -p "$subpkgdir"/usr/lib
+       mv "$builddir"/lib/Linux/libIrrlicht.a "$subpkgdir"/usr/lib
 }
 
 sha512sums="de69ddd2c6bc80a1b27b9a620e3697b1baa552f24c7d624076d471f3aecd9b15f71dce3b640811e6ece20f49b57688d428e3503936a7926b3e3b0cc696af98d1  irrlicht-1.8.4.zip


### PR DESCRIPTION
I split to a new `irrlicht-static` package, `libIrrlicht.a` weighting more than 40MB. 