### PR TITLE
main/dovecot: Upgrade Dovecot to 2.3.5 and Pigeonhole to 0.5.5.

### DIFF
--- a/main/dovecot/APKBUILD
+++ b/main/dovecot/APKBUILD
@@ -4,10 +4,10 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dovecot
-pkgver=2.3.4.1
+pkgver=2.3.5
 _pkgvermajor=2.3
-pkgrel=1
-_pigeonholever=0.5.4
+pkgrel=0
+_pigeonholever=0.5.5
 _pigeonholevermajor=${_pigeonholever%.*}
 pkgdesc="IMAP and POP3 server"
 url="https://www.dovecot.org/"
@@ -297,8 +297,8 @@ _submv() {
 	done
 }
 
-sha512sums="ff21aa0f0cae17dfa66617291688856727412defa48bad2b6be057cb509fbec1c2e134afbfee69929d06b8692a0fcbd8451671ba02860e1673ae1c9483c2c17e  dovecot-2.3.4.1.tar.gz
-9c82cce7540f8ab66e2e370e0220c99048d6ac53ed680cd763e0b03d0200e2451cee4303ef97b87a16e7248e1c73b92ba91b47a2a20c75cb2cd62695a28046f3  dovecot-2.3-pigeonhole-0.5.4.tar.gz
+sha512sums="10513c371aeadd52184daaf8dbb9a7559c6db55e34182bbb2c9539dae0897ddcc76f6fe2ce6a81c7ce0cb94c7f79438ae3bb0e7db8ed46615feb337b4078ecc6  dovecot-2.3.5.tar.gz
+21519fc9b1152a947b64ce4251e1a4bdbe003b48233b1856a32696f9c1e29f730268c56eb38f9431bbfac345e6cd42e8c78c87d0702f39ebf20c6d326dcdbb94  dovecot-2.3-pigeonhole-0.5.5.tar.gz
 fe4fbeaedb377d809f105d9dbaf7c1b961aa99f246b77189a73b491dc1ae0aa9c68678dde90420ec53ec877c08f735b42d23edb13117d7268420e001aa30967a  skip-iconv-check.patch
 794875dbf0ded1e82c5c3823660cf6996a7920079149cd8eed54231a53580d931b966dfb17185ab65e565e108545ecf6591bae82f935ab1b6ff65bb8ee93d7d5  split-protocols.patch
 0d8f89c7ba6f884719b5f9fc89e8b2efbdc3e181de308abf9b1c1b0e42282f4df72c7bf62f574686967c10a8677356560c965713b9d146e2770aab17e95bcc07  default-config.patch


### PR DESCRIPTION
References:
https://dovecot.org/download.html
https://pigeonhole.dovecot.org/download.html