### PR TITLE
testing/libtorrent-rasterbar: upgrade to 1.2.1

### DIFF
--- a/testing/btfs/APKBUILD
+++ b/testing/btfs/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: dai9ah <dai9ah@protonmail.com>
 pkgname=btfs
 pkgver=2.19
-pkgrel=0
+pkgrel=1
 pkgdesc="Bittorrent filesystem based on FUSE"
 options="!check" # No testsuite
 url="https://github.com/johang/btfs"

--- a/testing/deluge/APKBUILD
+++ b/testing/deluge/APKBUILD
@@ -2,9 +2,9 @@
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=deluge
 pkgver=2.0.2
-pkgrel=0
+pkgrel=1
 pkgdesc="A lightweight, Free Software, cross-platform BitTorrent client"
-url="https://deluge-torrent.org"
+url="https://deluge-torrent.org/"
 arch="noarch"
 license="GPL-3.0-or-later"
 depends="

--- a/testing/libtorrent-rasterbar/APKBUILD
+++ b/testing/libtorrent-rasterbar/APKBUILD
@@ -1,8 +1,9 @@
 # Contributor: August Klein <amatcoder@gmail.com>
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=libtorrent-rasterbar
-pkgver=1.1.13
-pkgrel=1
+pkgver=1.2.1
+_pkgver=${pkgver//./_}
+pkgrel=0
 pkgdesc="Feature complete C++ bittorrent implementation"
 url="https://www.rasterbar.com/products/libtorrent"
 arch="all"
@@ -10,7 +11,7 @@ license="BSD-3-Clause"
 depends_dev="boost-dev openssl-dev python3-dev"
 makedepends="$depends_dev linux-headers"
 subpackages="py3-$pkgname:_py3 $pkgname-static $pkgname-dev"
-source="https://github.com/arvidn/libtorrent/releases/download/libtorrent-${pkgver//./_}/$pkgname-$pkgver.tar.gz"
+source="https://github.com/arvidn/libtorrent/releases/download/libtorrent-$_pkgver/$pkgname-$pkgver.tar.gz"
 
 build() {
 	PYTHON=/usr/bin/python3 \
@@ -43,4 +44,4 @@ _py3() {
 	mv "$pkgdir"/usr/lib/python* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="021fc54353fdf5063d55ccdc2057dada292bb0008fb92e93e8d94dd89f529630f290fcdc4f4d095e3192522c57fe0f0da260b5ef8e8e15a8c6ac05728f5f7160  libtorrent-rasterbar-1.1.13.tar.gz"
+sha512sums="f9d0f2dd278a56f96f5d6d13996a3647a26acfb31fa9cbd42b2edc68a5ab4818764dec7ab6b0e1a25798adfc6b4460884606af72728c61c7762adbd8bdf4b4c6  libtorrent-rasterbar-1.2.1.tar.gz"

--- a/testing/qbittorrent-nox/APKBUILD
+++ b/testing/qbittorrent-nox/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Jan Tatje <jan@jnt.io>
 pkgname=qbittorrent-nox
 pkgver=4.1.6
-pkgrel=0
+pkgrel=1
 pkgdesc="qBittorrent client (webui only)"
 url="https://www.qbittorrent.org/"
 arch="x86_64"


### PR DESCRIPTION
`libtorrent-rasterbar` is required by `qbittorrent-nox`.