### PR TITLE
main/postfix: upgrade to 3.4.4

### DIFF
--- a/main/postfix/APKBUILD
+++ b/main/postfix/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=postfix
-pkgver=3.4.1
+pkgver=3.4.4
 pkgrel=0
 pkgdesc="Secure and fast drop-in replacement for Sendmail (MTA)"
 url="http://www.postfix.org/"
@@ -13,6 +13,7 @@ makedepends="
 	coreutils
 	cyrus-sasl-dev
 	db-dev
+	icu-dev
 	linux-headers
 	lmdb-dev
 	m4
@@ -195,6 +196,6 @@ stone() {
 	find src/smtpstone -mindepth 1 -perm 0755 -exec cp {} "$subpkgdir"/usr/bin \;
 }
 
-sha512sums="14d2fe4e70b28121e99b17c8f5028adb842cfb09f52ec4c279b7cd7fe1f9e47cbf6a142f4472f53e7589ba3dbdb1e17b4c8e76a16af8ae0568bee103979206ad  postfix-3.4.1.tar.gz
+sha512sums="e8398486a41f79da3716024104c178083c80eba7e3eec7669f9dd986914637174423c0328bcc79393b2d21edae72304ca4a89d53083f21598657593d05a05d64  postfix-3.4.4.tar.gz
 2752e69c4e1857bdcf29444ffb458bca818bc60b9c77c20823c5f5b87c36cb5e0f3217a625a7fe5788d5bfcef7570a1f2149e1233fcd23ccf7ee14190aff47a2  postfix.initd
 25cd34f23ca909d4e33aaf3239d1e397260abc7796d9a4456dee4f005682fd3a58aab8106126e5218c95bdddae415a3ef7e2223cd3b0d7b1e2bd76158bb7eaf8  postfix-install.patch"


### PR DESCRIPTION
ref [http://www.postfix.org/announcements/postfix-3.4.4.html](http://www.postfix.org/announcements/postfix-3.4.4.html)

this also includes `icu-dev` lib to support `smtputf8_enable` as in PR #6596