### PR TITLE
main/cmake: upgrade to 3.14.0

### DIFF
--- a/main/cmake/APKBUILD
+++ b/main/cmake/APKBUILD
@@ -1,13 +1,13 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cmake
-pkgver=3.13.0
+pkgver=3.14.0
 pkgrel=0
 pkgdesc="Cross-platform, open-source make system"
 url="https://www.cmake.org"
 arch="all"
 license="BSD-3-Clause"
-makedepends="bzip2-dev curl-dev expat-dev libarchive-dev
+makedepends="bzip2-dev curl-dev expat-dev libarchive-dev linux-headers
 	libuv-dev ncurses-dev rhash-dev xz-dev zlib-dev"
 options="!checkroot !check"
 checkdepends="file musl-utils"
@@ -69,4 +69,4 @@ bashcomp() {
                 "$subpkgdir"/usr/share/bash-completion/
 }
 
-sha512sums="c353d20afc657f84e71aa5d6e9aa93caaca4eba33e3d1d75d25a504e50a1a8651bce1a27989998629449f36b3ed5c3be4c0a11b7f490f22abec9e73c1aa9073e  cmake-3.13.0.tar.gz"
+sha512sums="a3b47f2b8d3436860e8cc06a8c0288124289560853d24f68dfbb49a2ff3f861ee385463376ad1dafa6d4a618c06d2e9049b20fcac1d2c147b29bb93479a8d400  cmake-3.14.0.tar.gz"


### PR DESCRIPTION
Ref https://blog.kitware.com/cmake-3-14-0-available-for-download/