### PR TITLE
community/gitea: upgrade to 1.7.5

### DIFF
--- a/community/gitea/APKBUILD
+++ b/community/gitea/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=gitea
-pkgver=1.7.3
+pkgver=1.7.5
 pkgrel=0
 pkgdesc="A self-hosted Git service written in Go"
 url="https://gitea.io"
@@ -68,7 +68,7 @@ check() {
 	"$builddir"/$pkgname help > /dev/null
 }
 
-sha512sums="802d4b7c60810a22c0625cb69d2cc83fbb2ff4e0b520c20e2119403d6cfdcdda7ee95bd3a8ab39f3668a259fc0ee5aefdbead80876023a3f6095a37d482ee442  gitea-1.7.3.tar.gz
+sha512sums="baa917570bdfb4db86e3a2a666ba5e1e3d6fec245ece675f80a2949d15356534a8b82e29ade7c9f5add99d9a132ebf5dbf7405fec6cb07ca8ba83debb846233f  gitea-1.7.5.tar.gz
 a7c70a144dc0582d6230e59ff717023fddcac001a6a9c895b46a0df1fbd9639453b2f5027d47dad21f442869c145dbc801eda61b6c50a2dd8103f562b8569009  gitea.initd
 27a202006d6e8d4146659f6356eaa99437f9f596dd369e9430d64b859bc6a1ad16091eef09232aa385fe1bf8ca94bbdf31b94975068220ad10338cded384f726  gitea.ini
 05272f3733dffeb75881579ff6553d32515e4de32113ff9395e521e93946a45101d04d4e435d7d8e7bfe49a512e5e4ac300576d2e79d7bcf314fc0ce526a07f9  allow-to-set-version.patch"


### PR DESCRIPTION
Ref https://github.com/go-gitea/gitea/releases/tag/v1.7.4
https://github.com/go-gitea/gitea/releases/tag/v1.7.5

probably could be backported