### PR TITLE
testing/telegraf: upgrade to 1.10.3

### DIFF
--- a/testing/telegraf/APKBUILD
+++ b/testing/telegraf/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Katie Holly <holly@fuslvz.ws>
 # Maintainer: Katie Holly <holly@fuslvz.ws>
 pkgname=telegraf
-pkgver=1.7.4
-pkgrel=1
+pkgver=1.10.3
+pkgrel=0
 pkgdesc="A plugin-driven server agent for collecting & reporting metrics, part of the InfluxDB project"
 url="https://www.influxdata.com/time-series-platform/telegraf/"
 arch="x86_64"
@@ -52,7 +52,7 @@ package() {
 	install -Dm644 "$builddir"/etc/logrotate.d/$pkgname "$pkgdir"/etc/logrotate.d/$pkgname
 }
 
-sha512sums="180bc7b2077e4fc10f0d13fe08b7293d5632be8e717a63f2463775a95258fedfde106863e56f9dda3f6844d879e2b0e5b06397a62545045874215d9078e391b9  telegraf-1.7.4.tar.gz
+sha512sums="f10505e923305be23400702219f2d24b3bfcf255e8d8ceaec11df965818f559e8227a8e0ee3eb73f44a4239972efe1d055b0613bcf7b4b98f7bfc9a84b970ec1  telegraf-1.10.3.tar.gz
 abc5879cc7a465c1e59d1c421b0ebc3690ea31f946145bc8ed65ecc7fa6392ec7f9536161610c0bdb1fb6f7974692c85bb6408eb1e3ce4af4568926dc2c8bee0  telegraf-makefile-ldflags.patch
 0682835506f8bd2f417fa7edcc8c394445d99545fb7599812a15e63bdcb64e3687b4f20e7adf1d8e640fd8b0e7f2d9144eb23ae6da29025cf2da07bfaa236e71  telegraf.initd
 bf6ead6e3f69be7c82b01ad8e9ec52158d4b543676a4d6aea077cdad91ae477f18b98c6e2cbfa795483055d9604aaf93dcfb2a9af6ddc50f29c5b75a18a7a678  telegraf.logrotate


### PR DESCRIPTION
Ref https://github.com/influxdata/telegraf/releases