### PR TITLE
main/redis: upgrade to 4.0.13

### DIFF
--- a/main/redis/APKBUILD
+++ b/main/redis/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: V.Krishn <vkrishn4@gmail.com>
 # Maintainer: TBK <alpine@jjtc.eu>
 pkgname=redis
-pkgver=4.0.12
+pkgver=4.0.13
 pkgrel=0
 pkgdesc="Advanced key-value store"
 url="https://redis.io/"
@@ -73,7 +73,7 @@ package() {
 		var/log/redis
 }
 
-sha512sums="d19020f7ebed9ad5d04c6e1cb7e2a49dd1e226fe17d86e860df11bcb798c61c09f6f9fc3572a7ee32232ac34ec5eb1d6189f8139b5991bd87297c5243c3b54d2  redis-4.0.12.tar.gz
+sha512sums="c220420bf6cb2781a3fb9e002188b1663743c89c262fd5aff02e585c969b56e7691fe1073e7427e6d38cf7b5a096f86b83af84cfa6b01a5bdf56048789e0bb70  redis-4.0.13.tar.gz
 5fd8a478771642b9c0dc285f1d95896f7680b94c7edab0ce60ad19ba0c2979028c7d9b0afb846dbf3e1be146ec5ded52ebb059a5b25b0a8e52bf8e57f18c0cf4  makefile-dont-duplicate-binary.patch
 c8a35e3c30be99fef8678acb2502f424bcca478dcc1ef1750f8c8c8e9e9c462f97586159f32ebba84b6a4eb398a9d568e3200241fb0de1f96293c9fdaafb06c9  redis.conf.patch
 d9bbb3fcc69022633d7fea3227c41d8777422ce9778623efb6aa539468fc51d2d1de09d364e21c7c8b45c61e7bbc7aaaf22745257d60ea937f77a8673facf286  sentinel.conf.patch


### PR DESCRIPTION
Ref https://raw.githubusercontent.com/antirez/redis/4.0/00-RELEASENOTES

While 5.x is not passing tests
```
*** [err]: slave buffer are counted correctly in tests/unit/maxmemory.tcl
Expected condition '$delta < 50*1024 && $delta > -50*1024' to be true (60090 < 50*1024 && 60090 > -50*1024)
```