### PR TITLE
community/php7-pear-net_socket: upgrade to 1.2.2

### DIFF
--- a/community/php7-pear-net_socket/APKBUILD
+++ b/community/php7-pear-net_socket/APKBUILD
@@ -2,7 +2,7 @@
 _php=php7
 pkgname=${_php}-pear-net_socket
 _pkgreal=Net_Socket
-pkgver=1.1.0
+pkgver=1.2.2
 pkgrel=0
 pkgdesc="Network Socket Interface"
 url="http://pear.php.net/package/$_pkgreal"
@@ -20,4 +20,4 @@ package() {
 	mv Net "$pkgdir"/$_phpdir/PEAR
 }
 
-sha512sums="e2dcccc21451ec7fd232764ae061c0b63689c0f6c5f972aa408b74490504f2540bf525f6a0decbcef60ad7fe78f3718b8cc21bf625f31c3811f3ff5824e07b4b  Net_Socket-1.1.0.tgz"
+sha512sums="fd415fbd4a6801b63cda3168ff275fdeae233a3cc4c62f9bfe561f83f24f89795a7e7ad862641a73bb6d6e3c0da8b56cd00e7e7a1db616de040ea7883d84caa5  Net_Socket-1.2.2.tgz"


### PR DESCRIPTION
Compatibility with php 7.2 https://pear.php.net/package/Net_Socket/download/