### PR TITLE
main/cryptsetup: upgrade to 2.1.0

### DIFF
--- a/main/cryptsetup/APKBUILD
+++ b/main/cryptsetup/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cryptsetup
-pkgver=2.0.6
+pkgver=2.1.0
 pkgrel=0
 pkgdesc="Userspace setup tool for transparent encryption of block devices using the Linux 2.6 cryptoapi"
 url="https://gitlab.com/cryptsetup/cryptsetup"
@@ -61,7 +61,7 @@ libs() {
 	mv "$pkgdir"/lib "$subpkgdir"/
 }
 
-sha512sums="9e3458122e34c86d21b9a9c0c648e8e6134d7e2058bc00514137c5136782cea493cf0db5b0c2884fac759c0c2ea185e99d4a223d6f338c1cb3f5281eadd6626e  cryptsetup-2.0.6.tar.gz
-301e3e3da5a899e0a6f01f44fbf37bb6a3f5b6a4fb41243bae6d3b7aea747276e784626cd1b19721cc264652c10ae8c560c4d20094e33bb82fb2fae0160682c0  flush-stdout.patch
+sha512sums="c8bfe5aa59acbe8c9f8a859dbe2f10c1f3194d578ada8081c4ede0dda0c991f9ef4fde2d268e322e283fbd35e9470e0631c44439d69693965ecc35bb73986dcb  cryptsetup-2.1.0.tar.gz
+dc896fdb7697d01443a168819f01af02db00a9de75589f062a1ebbfc0bc185b6d2109b18352309c41b818e3ad89609dcea3660d6f3cda890de825f053f94de97  flush-stdout.patch
 74422d5e1614b43af894ea01da1ea80d805ec7f77981cbb80a6b1a4becad737a8825d7269812499095a7f50d39fa7da5bf4e4edae63529b1fe87b9176943a733  dmcrypt.confd
 81dad61cdecf1dc529b26eb3cdc15979a582c876b01268f88e7a71c8fae6911137c03bfa63fee64e064e5fb31f673610be27ecab9fc432229f13e7040698bd5c  dmcrypt.initd"

--- a/main/cryptsetup/flush-stdout.patch
+++ b/main/cryptsetup/flush-stdout.patch
@@ -1,17 +1,18 @@
---- ./src/utils_tools.c.orig	2014-10-24 12:58:35.151717616 -0200
-+++ ./src/utils_tools.c	2014-10-24 13:00:42.716855265 -0200
-@@ -105,10 +105,13 @@
+diff -upr cryptsetup-2.1.0.orig/src/utils_tools.c cryptsetup-2.1.0/src/utils_tools.c
+--- cryptsetup-2.1.0.orig/src/utils_tools.c	2019-01-31 21:37:12.000000000 +0100
++++ cryptsetup-2.1.0/src/utils_tools.c	2019-03-16 16:33:13.000000000 +0100
+@@ -105,10 +105,13 @@ void tool_log(int level, const char *msg
  
  	case CRYPT_LOG_NORMAL:
- 		fputs(msg, stdout);
+ 		fprintf(stdout, "%s", msg);
 +		fflush(stdout);
  		break;
  	case CRYPT_LOG_VERBOSE:
 -		if (opt_verbose)
 +		if (opt_verbose) {
- 			fputs(msg, stdout);
+ 			fprintf(stdout, "%s", msg);
 +			fflush(stdout);
 +		}
  		break;
  	case CRYPT_LOG_ERROR:
- 		fputs(msg, stderr);
+ 		fprintf(stderr, "%s", msg);


### PR DESCRIPTION
ChangeLog: https://gitlab.com/cryptsetup/cryptsetup/blob/master/docs/v2.1.0-ReleaseNotes

The most important change probably is the following:

> Cryptsetup 2.1 version uses a new on-disk LUKS2 format as the default LUKS format and increases default LUKS2 header size.