### PR TITLE
Update runc and containerd

### DIFF
--- a/community/containerd/APKBUILD
+++ b/community/containerd/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=containerd
 
 # NOTE: containerd's Makefile tries to get REVISION from git, but we're building from a tarball.
-_commit=e6b3f5632f50dbc4e9cb6288d911bf4f5e95b18e
-pkgver=1.2.4
+_commit=bb71b10fd8f58240ca47fbb579b9d1028eea7c84
+pkgver=1.2.5
 pkgrel=0
 pkgdesc="An open and reliable container runtime"
 url="https://containerd.io"
@@ -42,4 +42,4 @@ package() {
 	install -Dm644 "$builddir"/man/*.5 "$pkgdir"/usr/share/man/man5/
 }
 
-sha512sums="8a4e5064b2c1e14d39d9943f445ae18e4653f73bd3bb90f7efe558b9ffd4345db4b308362103dbfbede716eae8b547c1cec3d93962acb0a2ff34d66e4fce0d80  containerd-1.2.4.tar.gz"
+sha512sums="b249d5bfc0c1f884ecc1ad4544f9440405450c31f11e80ac094bfddb7a6660e950116114e563d7655e07f888f2ff62f4476f2b178f4e0e2acbbb9fb84a243b25  containerd-1.2.5.tar.gz"

--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -3,14 +3,13 @@
 
 pkgname=runc
 
-# NOTE: using explicit post-1.0.0_rc6 commit, for CVE-2019-5736
-# (https://nvd.nist.gov/vuln/detail/CVE-2019-5736).  This commit is more recent
-# than the one specified by containerd
-# (https://github.com/containerd/containerd/blob/v1.2.2/vendor.conf)
-_commit=6635b4f0c6af3810594d2770f662f34ddc15b40d
+# NOTE: using explicit post-1.0.0_rc6 commit, later than the one specified by
+# containerd (https://github.com/containerd/containerd/blob/v1.2.5/vendor.conf)
+# for improved mitigation of CVE-2019-5736, which properly compiles with musl libc.
+_commit=f56b4cbeadc407e715d9b2ba49e62185bd81cef4
 
 pkgver=1.0.0_rc6
-pkgrel=1
+pkgrel=2
 pkgdesc="CLI tool for spawning and running containers according to the OCI specification"
 url="https://www.opencontainers.org"
 arch="all"
@@ -21,8 +20,8 @@ source="runc-$_commit.tar.gz::https://github.com/opencontainers/runc/archive/$_c
 builddir="$srcdir/src/github.com/opencontainers/runc"
 
 # secfixes:
-#   1.0.0_rc6-r1:
-#     - CVE-2019-5736
+#   1.0.0_rc6-r2:
+#     - CVE-2019-5736 (fix improved vs. 1.0.0_rc6-r1)
 
 build() {
 	cd "$srcdir"
@@ -46,4 +45,4 @@ package() {
 	install -Dm644 "$builddir"/man/man8/* "$pkgdir"/usr/share/man/man8/
 }
 
-sha512sums="37bb09463df4742b0ea5b1f079f609642ab5621707674844ffef06f733703ec1d09b52a180ccb2d66c284c56ba242f7a1b70ba4c4c45722bf85fd2fd924bb9df  runc-6635b4f0c6af3810594d2770f662f34ddc15b40d.tar.gz"
+sha512sums="cf6c189f06fb4fde78807a71df14c78a9cd1af5c8958bcb4a438e8ae173ac7d6a66013210d7442e47b83552f3d2417300ee9f317bde3c3247173e2e19132fee3  runc-f56b4cbeadc407e715d9b2ba49e62185bd81cef4.tar.gz"


### PR DESCRIPTION
`runc-1.0.0_rc6-r2`
* Improved mitigation of CVE-2019-5736, and properly build with musl libc.

`containerd-1.2.5-r0`
* Update to 1.2.5, see https://github.com/containerd/containerd/releases/tag/v1.2.5 for more details.