### PR TITLE
community/runc: update

### DIFF
--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -3,14 +3,13 @@
 
 pkgname=runc
 
-# NOTE: using explicit post-1.0.0_rc6 commit, for CVE-2019-5736
-# (https://nvd.nist.gov/vuln/detail/CVE-2019-5736).  This commit is more recent
-# than the one specified by containerd
-# (https://github.com/containerd/containerd/blob/v1.2.2/vendor.conf)
-_commit=6635b4f0c6af3810594d2770f662f34ddc15b40d
+# NOTE: using explicit post-1.0.0_rc6 commit, later than the one specified by
+# containerd (https://github.com/containerd/containerd/blob/v1.2.5/vendor.conf)
+# for improved mitigation of CVE-2019-5736, which properly compiles with musl libc.
+_commit=f56b4cbeadc407e715d9b2ba49e62185bd81cef4
 
 pkgver=1.0.0_rc6
-pkgrel=1
+pkgrel=2
 pkgdesc="CLI tool for spawning and running containers according to the OCI specification"
 url="https://www.opencontainers.org"
 arch="all"
@@ -21,8 +20,8 @@ source="runc-$_commit.tar.gz::https://github.com/opencontainers/runc/archive/$_c
 builddir="$srcdir/src/github.com/opencontainers/runc"
 
 # secfixes:
-#   1.0.0_rc6-r1:
-#     - CVE-2019-5736
+#   1.0.0_rc6-r2:
+#     - CVE-2019-5736 (fix improved vs. 1.0.0_rc6-r1)
 
 build() {
 	cd "$srcdir"
@@ -46,4 +45,4 @@ package() {
 	install -Dm644 "$builddir"/man/man8/* "$pkgdir"/usr/share/man/man8/
 }
 
-sha512sums="37bb09463df4742b0ea5b1f079f609642ab5621707674844ffef06f733703ec1d09b52a180ccb2d66c284c56ba242f7a1b70ba4c4c45722bf85fd2fd924bb9df  runc-6635b4f0c6af3810594d2770f662f34ddc15b40d.tar.gz"
+sha512sums="cf6c189f06fb4fde78807a71df14c78a9cd1af5c8958bcb4a438e8ae173ac7d6a66013210d7442e47b83552f3d2417300ee9f317bde3c3247173e2e19132fee3  runc-f56b4cbeadc407e715d9b2ba49e62185bd81cef4.tar.gz"


### PR DESCRIPTION
Improved mitigation of CVE-2019-5736, per containerd-1.2.5 with the added
benefit of actually being able to compile with musl libc.