### PR TITLE
community/containerd: upgrade to 1.2.5

### DIFF
--- a/community/containerd/APKBUILD
+++ b/community/containerd/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=containerd
 
 # NOTE: containerd's Makefile tries to get REVISION from git, but we're building from a tarball.
-_commit=e6b3f5632f50dbc4e9cb6288d911bf4f5e95b18e
-pkgver=1.2.4
+_commit=bb71b10fd8f58240ca47fbb579b9d1028eea7c84
+pkgver=1.2.5
 pkgrel=0
 pkgdesc="An open and reliable container runtime"
 url="https://containerd.io"
@@ -42,4 +42,4 @@ package() {
 	install -Dm644 "$builddir"/man/*.5 "$pkgdir"/usr/share/man/man5/
 }
 
-sha512sums="8a4e5064b2c1e14d39d9943f445ae18e4653f73bd3bb90f7efe558b9ffd4345db4b308362103dbfbede716eae8b547c1cec3d93962acb0a2ff34d66e4fce0d80  containerd-1.2.4.tar.gz"
+sha512sums="b249d5bfc0c1f884ecc1ad4544f9440405450c31f11e80ac094bfddb7a6660e950116114e563d7655e07f888f2ff62f4476f2b178f4e0e2acbbb9fb84a243b25  containerd-1.2.5.tar.gz"


### PR DESCRIPTION
Update containerd to 1.2.5, see https://github.com/containerd/containerd/releases/tag/v1.2.5
for more details.