### PR TITLE
main/alpine-baselayout: Properly initialize TZ

### DIFF
--- a/main/alpine-baselayout/APKBUILD
+++ b/main/alpine-baselayout/APKBUILD
@@ -119,7 +119,6 @@ package() {
 		"$srcdir"/kms.conf \
 		"$pkgdir"/etc/modprobe.d/
 
-	echo "UTC" > "$pkgdir"/etc/TZ
 	echo "localhost" > "$pkgdir"/etc/hostname
 	cat > "$pkgdir"/etc/hosts <<-EOF
 		127.0.0.1	localhost localhost.localdomain


### PR DESCRIPTION
Patch 1 in fixing setup-alpine's TZ handling.
Second patch is against alpine-conf.