### PR TITLE
main/py-py: upgrade to 1.8.0

### DIFF
--- a/main/py-py/APKBUILD
+++ b/main/py-py/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=py-py
 _pkgname=py
-pkgver=1.7.0
+pkgver=1.8.0
 pkgrel=0
 pkgdesc="A python library with cross-python path, ini-parsing, io, code, log facilities"
 url="https://py.readthedocs.io"
@@ -50,4 +50,4 @@ _py3() {
 	_py python3
 }
 
-sha512sums="c522be926c5716d866cb800eaa398a55518889da207a00575212254642eda2107e68c286e72b99cf94ecec1c8dcde1f763e2d8f296ab7e7673ae2671e70d5548  py-1.7.0.tar.gz"
+sha512sums="37b9a66229b834a034d9ba6769a46addf098380b494c1eb863607a52d00b7ec5b9157dd7ac6ffc52535a05006648c775c78716d7f85cf44966065b225be6e95b  py-1.8.0.tar.gz"


### PR DESCRIPTION
https://github.com/pytest-dev/py/blob/master/CHANGELOG#L1
```
1.8.0 (2019-02-21)
==================

- add ``"importlib"`` pyimport mode for python3.5+, allowing unimportable test suites
  to contain identically named modules.

- fix ``LocalPath.as_cwd()`` not calling ``os.chdir()`` with ``None``, when
being invoked from a non-existing directory.
```