### PR TITLE
main/py-setuptools: remove depends on python2

### DIFF
--- a/main/py-setuptools/APKBUILD
+++ b/main/py-setuptools/APKBUILD
@@ -3,12 +3,11 @@
 pkgname=py-setuptools
 _pkgname=${pkgname#py-}
 pkgver=40.8.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A collection of enhancements to the Python distutils"
 url="https://pypi.python.org/pypi/setuptools"
 arch="noarch"
 license="PSF"
-depends="python2"
 makedepends="python2-dev python3-dev"
 provides="py2-setuptools=$pkgver-r$pkgrel"
 options="!check" #no testsuite


### PR DESCRIPTION
https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v4080