### PR TITLE
main/py-certifi: upgrade to 2019.3.9

### DIFF
--- a/main/py-certifi/APKBUILD
+++ b/main/py-certifi/APKBUILD
@@ -1,7 +1,8 @@
-# Maintainer:
+# Contributor: Peter Bui <pnutzh4x0r@gmail.com>
+# Maintainer: Dmitry Romanenko <dmitry@romanenko.in>
 pkgname=py-certifi
 _pkgname=certifi
-pkgver=2018.4.16
+pkgver=2019.3.9
 pkgrel=0
 pkgdesc="Python package for providing Mozilla's CA Bundle"
 url="https://pypi.python.org/pypi/certifi"
@@ -48,4 +49,4 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="96369b318df9592ed4ff48d79ae695f89d27d85e8f5de72548fccb19ac15b83a33fb8bc096a3092d7a7f5b201af08805576888418c7927cf48b892df56464682  certifi-2018.4.16.tar.gz"
+sha512sums="d86559b0d384f8114245b169391c73d5e6df02ba411cf9706c9d4e5958eeef610b6550bcb5eb519856b8fa25f3f5eb1cea02c0df1f6df72e16da8201732b0dd9  certifi-2019.3.9.tar.gz"


### PR DESCRIPTION
https://github.com/certifi/python-certifi/commits/master