### PR TITLE
community/nx-libs: fix build break by FontEncDirectory return of const char *

### DIFF
--- a/community/nx-libs/APKBUILD
+++ b/community/nx-libs/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=nx-libs
 pkgver=3.5.0.32
-pkgrel=0
+pkgrel=1
 pkgdesc="NoMachine libraries (redistributed by x2go)"
 url="http://x2go.org"
 arch="all"
@@ -15,6 +15,7 @@ install=""
 subpackages="$pkgname-dev $pkgname-doc"
 source="http://code.x2go.org/releases/source/$pkgname/$pkgname-$pkgver-full.tar.gz
 	xf86bigfont.patch
+	fix-const-char.patch	
 	fix-musl-headers-x86.patch"
 
 builddir="$srcdir"/$pkgname-$pkgver
@@ -37,4 +38,5 @@ package() {
 
 sha512sums="8b4a042993d45e1aee3e13e8b86f68cd5b2a8b52e9299de6129abd8e3bb89d73cf2b44b03d3c7fabbd8329abc06dc912ac95bbf936b6478b05fc202cc29a090f  nx-libs-3.5.0.32-full.tar.gz
 ee090f4e7f5933cbea6398ac461539cbdc8b7fd62f32934c78298c1e217d2a60e7f796bffdb88d36816bbfa9becd810846f5b988b5191e5a5b9da5def5d730fa  xf86bigfont.patch
+3eba6a605357c0c40c1144ae296d732426c4c9c7399f7ac3d30a10eba25d7396af28af7244a55ebb27f859ce6a13af1541ec2f665991b71be9158f0cb134a6bf  fix-const-char.patch
 d4a881b66f0258d6d9fb947a526868944e58217d534316dfa3f0837035415467a1e8841bf6c5b821ccedcc0c9e07b425f05243ddbd22aaec7ea2165c87d9211e  fix-musl-headers-x86.patch"

--- a/community/nx-libs/fix-const-char.patch
+++ b/community/nx-libs/fix-const-char.patch
@@ -1,0 +1,28 @@
+--- a/nx-X11/lib/font/fontfile/encparse.c
++++ b/nx-X11/lib/font/fontfile/encparse.c
+@@ -785,13 +785,13 @@
+     return 0;
+ }
+ 
+-char*
++const char*
+ FontEncDirectory()
+ {
+-    static char* dir = NULL;
++    static const char* dir = NULL;
+ 
+     if(dir == NULL) {
+-        char *c = getenv("FONT_ENCODINGS_DIRECTORY");
++        const char *c = getenv("FONT_ENCODINGS_DIRECTORY");
+         if(c) {
+             dir = malloc(strlen(c) + 1);
+             if(!dir)
+@@ -899,7 +899,7 @@
+ {
+     FontEncPtr encoding;
+     char dir[MAXFONTFILENAMELEN], dirname[MAXFONTFILENAMELEN];
+-    char *d;
++    const char *d;
+ 
+     if(fontFileName) {
+         parseFontFileName(fontFileName, dirname, dir);


### PR DESCRIPTION
Build fails with error:
encparse.c:789:1: error: conflicting types for 'FontEncDirectory'
 FontEncDirectory()
 ^~~~~~~~~~~~~~~~
In file included from encparse.c:62:
/usr/include/X11/fonts/fontenc.h:112:13: note: previous declaration of 'FontEncDirectory' was here
 const char *FontEncDirectory(void);

In the 1.1.4 version of libfontenc-dev that provides /usr/include/X11/fonts/fontenc.h a change was introduced to  have FontEncDirectory return a const char *:
- char *FontEncDirectory(void);
+ const char *FontEncDirectory(void);

This patch modifies nx-libs to be consistent with this new calling convention.