### PR TITLE
[3.9] main/zfs: import pool before swap

### DIFF
--- a/main/zfs/APKBUILD
+++ b/main/zfs/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=zfs
 pkgver=0.7.12
-pkgrel=0
+pkgrel=1
 pkgdesc="ZFS for Linux"
 url="http://zfsonlinux.org"
 arch="all !armhf !armv7"
@@ -11,7 +11,9 @@ depends_dev="glib-dev e2fsprogs-dev util-linux-dev libtirpc-dev attr-dev"
 makedepends="$depends_dev automake autoconf libtool linux-headers"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-libs $pkgname-dracut::noarch
 	$pkgname-udev $pkgname-scripts $pkgname-utils-py:utils_py:noarch"
-source="https://github.com/zfsonlinux/zfs/releases/download/zfs-$pkgver/zfs-$pkgver.tar.gz"
+source="https://github.com/zfsonlinux/zfs/releases/download/zfs-$pkgver/zfs-$pkgver.tar.gz
+	zfs-import-should-be-before-swap.patch
+	"
 
 prepare() {
 	default_prepare
@@ -67,4 +69,5 @@ utils_py() {
 	done
 }
 
-sha512sums="278e411eac5fb2a91108671b64521c2bd5c08024d5829e1679d8f243dfc3c6317363ed9c79dabfddecf425acb6b3003eeaf4e7d991513cbcae4d2644f5d30bf2  zfs-0.7.12.tar.gz"
+sha512sums="278e411eac5fb2a91108671b64521c2bd5c08024d5829e1679d8f243dfc3c6317363ed9c79dabfddecf425acb6b3003eeaf4e7d991513cbcae4d2644f5d30bf2  zfs-0.7.12.tar.gz
+d1632b7c7cc3997bf9617ea95a7554220f1d9dc4a10ca461fdcee7b5452f0334a01aa90166e20b657f4a752637022d548d0372fbcb0756d838f146031a8eee74  zfs-import-should-be-before-swap.patch"

--- a/main/zfs/zfs-import-should-be-before-swap.patch
+++ b/main/zfs/zfs-import-should-be-before-swap.patch
@@ -1,0 +1,25 @@
+From 83f01e877fb6b77692c66cbd3f1c6c95217b721d Mon Sep 17 00:00:00 2001
+From: Henrik Riomar <henrik.riomar@gmail.com>
+Date: Wed, 13 Mar 2019 09:32:40 +0100
+Subject: [PATCH] zfs-import: should be before swap
+
+zfs-import must be done before swap in order for swap on zvol to work
+---
+ etc/init.d/zfs-import.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/etc/init.d/zfs-import.in b/etc/init.d/zfs-import.in
+index fea661bbc..420d2e8a7 100644
+--- a/etc/init.d/zfs-import.in
++++ b/etc/init.d/zfs-import.in
+@@ -38,6 +38,7 @@
+ 
+ do_depend()
+ {
++	before swap
+ 	after sysfs udev
+ 	keyword -lxc -openvz -prefix -vserver
+ }
+-- 
+2.21.0
+


### PR DESCRIPTION
Just like for lvm, we need to import the zfs pool before swap is started

(cherry picked from commit f4f23af2e0ed83d17000d9cb19695540cc0d485c)