### PR TITLE
main/at-spi2-core: fix meson build break by using install_dir

### DIFF
--- a/main/at-spi2-core/APKBUILD
+++ b/main/at-spi2-core/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=at-spi2-core
 pkgver=2.28.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Protocol definitions and daemon for D-Bus at-spi"
 url="http://www.linuxfoundation.org/en/AT-SPI_on_D-Bus"
 arch="all"
@@ -14,7 +14,8 @@ makedepends="$depends_dev dbus dbus-dev glib-dev intltool gobject-introspection-
 	meson"
 install=""
 subpackages="$pkgname-dbg $pkgname-dev $pkgname-lang"
-source="https://download.gnome.org/sources/at-spi2-core/${pkgver%.*}/at-spi2-core-$pkgver.tar.xz"
+source="https://download.gnome.org/sources/at-spi2-core/${pkgver%.*}/at-spi2-core-$pkgver.tar.xz
+	fix-meson-subdir.patch"
 
 builddir="$srcdir"/at-spi2-core-$pkgver
 build() {
@@ -35,4 +36,5 @@ package() {
 	DESTDIR="$pkgdir" ninja -C "$builddir"/build install
 }
 
-sha512sums="ce5251f234d48f657a5fd5fbd9a85799365e9814235ecff62fa5088611c0c8c0489e17fb27a805453a2864163cb83f8d8d5ed4cdb7e37c4ee9ebb897146e2d1d  at-spi2-core-2.28.0.tar.xz"
+sha512sums="ce5251f234d48f657a5fd5fbd9a85799365e9814235ecff62fa5088611c0c8c0489e17fb27a805453a2864163cb83f8d8d5ed4cdb7e37c4ee9ebb897146e2d1d  at-spi2-core-2.28.0.tar.xz
+53a622190785437460383e5b7861469943434ba2949f2e43dbb1c5afb19db33b2fe777bf933c0caf826a1b8a4974b2c0fd08e6357740c63532384f2ba2b4eae3  fix-meson-subdir.patch"

--- a/main/at-spi2-core/fix-meson-subdir.patch
+++ b/main/at-spi2-core/fix-meson-subdir.patch
@@ -1,0 +1,11 @@
+--- a/atspi/meson.build
++++ b/atspi/meson.build
+@@ -57,7 +57,7 @@
+ 
+ atspi_includedir = join_paths(get_option('prefix'), get_option('includedir'), 'at-spi-2.0', 'atspi')
+ 
+-install_headers(atspi_headers, subdir: atspi_includedir)
++install_headers(atspi_headers, install_dir: atspi_includedir)
+ 
+ atspi_enums = gnome.mkenums('atspi-enum-types',
+                             sources: [ 'atspi-constants.h', 'atspi-types.h' ],


### PR DESCRIPTION
Per https://gitlab.gnome.org/GNOME/at-spi2-core/commit/44a812ea51223d82f21a098a2d45fcc5c329ce7a
since meson 0.50.0 it is not possible anymore to specify an absolute directory for subdir. Doing so will result in an error:
atspi/meson.build:60:0: ERROR: Subdir keyword must not be an absolute path.

To fix including patch from referenced commit to use install_dir instead.