### PR TITLE
main/py-tox: add virtualenv dependency

### DIFF
--- a/main/py-tox/APKBUILD
+++ b/main/py-tox/APKBUILD
@@ -3,13 +3,13 @@
 pkgname=py-tox
 _pkgname=${pkgname#py-*}
 pkgver=3.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="virtualenv management and test command line tool"
 url="https://tox.readthedocs.org/"
 arch="noarch"
 license="MIT"
 _depends="py-virtualenv"
-depends="py-py py-pluggy py-argparse"
+depends="py-py py-pluggy py-argparse py-virtualenv"
 makedepends="python2-dev python3-dev py-setuptools"
 options="!check" # disabled as requires itself
 subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"


### PR DESCRIPTION
Tox requires virtualenv as a dependency, but it's not defined as one:

> pkg_resources.DistributionNotFound: The 'virtualenv>=1.11.2' distribution was not found and is required by tox
