### PR TITLE
commmunity/glm: Fixed constexpr with GCC

### DIFF
--- a/community/glm/APKBUILD
+++ b/community/glm/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=glm
 pkgver=0.9.9.3
-pkgrel=1
+pkgrel=2
 pkgdesc="C++ mathematics library for graphics programming"
 url="http://glm.g-truc.net/"
 arch="noarch"
@@ -10,6 +10,7 @@ makedepends="cmake"
 subpackages="$pkgname-dev"
 source="https://github.com/g-truc/glm/releases/download/$pkgver/glm-$pkgver.zip
 	fix-endian-test.patch
+	fix-const-expr.patch	
 	"
 builddir="$srcdir/$pkgname"
 
@@ -36,4 +37,5 @@ package() {
 }
 
 sha512sums="eb7589345eb627d9fda84771bd2cf3eb0e4e9e48bf6bb7490bd8844b66558717de5dc96cde9d66e81f7ba4e54090f18dbe1bbccb2452ed0ed8c17cdf7b6e4aa2  glm-0.9.9.3.zip
-54fd8926e3e8271ea32ff25b433003e7eef5611ac7b3c397c0e3b5cd6b139071dba774964c8ae4f8859523a354fec45e38d4ad8fdd46f930f21ce529cc95a65e  fix-endian-test.patch"
+54fd8926e3e8271ea32ff25b433003e7eef5611ac7b3c397c0e3b5cd6b139071dba774964c8ae4f8859523a354fec45e38d4ad8fdd46f930f21ce529cc95a65e  fix-endian-test.patch
+e47a8e141b4050f7127b43285afc3b3065b9f5ae034e5543ef04dfe1766829b64854057eb79d5f4c3cf54d7da653c443ee6cdb52522780ea9fbb109faa55ec0f  fix-const-expr.patch"

--- a/community/glm/fix-const-expr.patch
+++ b/community/glm/fix-const-expr.patch
@@ -1,0 +1,10 @@
+--- a/glm/detail/setup.hpp
++++ b/glm/detail/setup.hpp
+@@ -283,7 +283,6 @@
+ #else
+ #	define GLM_HAS_CONSTEXPR ((GLM_LANG & GLM_LANG_CXX0X_FLAG) && GLM_HAS_INITIALIZER_LISTS && (\
+ 		((GLM_COMPILER & GLM_COMPILER_INTEL) && (GLM_COMPILER >= GLM_COMPILER_INTEL17)) || \
+-		((GLM_COMPILER & GLM_COMPILER_GCC) && (GLM_COMPILER >= GLM_COMPILER_GCC6)) || \
+ 		((GLM_COMPILER & GLM_COMPILER_VC) && (GLM_COMPILER >= GLM_COMPILER_VC15))))
+ #endif
+ 


### PR DESCRIPTION
community/gource and community/logstalgia fail to build, generating errors of type:
/usr/include/glm/detail/type_vec2.hpp:90:40: error: 'constexpr const T& glm::vec<2, T, Q>::operator[](glm::vec<2, T, Q>::GLM_FUNC_DECL GLM_CONSTEXPR T const& operator[](length_type i) const;

As discussed in glm issue: https://github.com/g-truc/glm/issues/832
a fix has been committed into glm master branch: https://github.com/g-truc/glm/commit/68c7e7e50b934cd265251a0660096f1415647bbb

Until glm version 0.9.9.4 is released this patch can be backported onto 0.9.9.3 to allow gource and logstaligia packages to build.