### PR TITLE
testing/py-coverage: upgrade to 4.5.3

### DIFF
--- a/testing/py-coverage/APKBUILD
+++ b/testing/py-coverage/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 pkgname=py-coverage
 _pkgname=${pkgname#py-}
-pkgver=4.5.1
+pkgver=4.5.3
 pkgrel=0
 pkgdesc="Code coverage measurement for Python"
 url="https://pypi.python.org/pypi/coverage"
@@ -50,4 +50,4 @@ _py3() {
 	_py python3
 }
 
-sha512sums="82742a572549400778cad99057b1ced4c36b61e917983148eccc86bfa6340de8cfefc4f743e79ff876b641e0b9d21307dd6bde78638a6b20dd8ad215068dda25  coverage-4.5.1.tar.gz"
+sha512sums="4493139c8fdd7e3fd09f8f99af330d270cb48c2a0645ba5131fa3c5190b53e7d779e2c07fddf4f8ddf9f4215ce11536c29b8796602cb113c5d3d89144ddbec82  coverage-4.5.3.tar.gz"


### PR DESCRIPTION
https://coverage.readthedocs.io/en/v4.5.x/changes.html#version-4-5-3-2019-03-09