### PR TITLE
main/musl: correct FADV macro on s390x

### DIFF
--- a/main/musl/APKBUILD
+++ b/main/musl/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=musl
 pkgver=1.1.21
-pkgrel=0
+pkgrel=1
 pkgdesc="the musl c library (libc) implementation"
 url="http://www.musl-libc.org/"
 arch="all"
@@ -15,6 +15,7 @@ nolibc) ;;
 esac
 source="http://www.musl-libc.org/releases/musl-$pkgver.tar.gz
 	handle-aux-at_base.patch
+	s390x-fadv.patch
 
 	ldconfig
 	__stack_chk_fail_local.c
@@ -144,6 +145,7 @@ compat() {
 
 sha512sums="fa6c4cc012626c5e517e0e10926fc845e3aa5f863ffaceeb38ac5b9ce0af631a37f6b94f470997db09aa0d5e03f4f28a2db83484b0f98481bea2239c1989d363  musl-1.1.21.tar.gz
 6a7ff16d95b5d1be77e0a0fbb245491817db192176496a57b22ab037637d97a185ea0b0d19da687da66c2a2f5578e4343d230f399d49fe377d8f008410974238  handle-aux-at_base.patch
+e9c9135f6dc3260e62ae6e9c45f3c43574af6ff2c2bfe411eb83f7e80d13bb8c86425cb41fc961e27f7bc15f679db1fbfb267e401bbe81d6cd5b872eb9b1f471  s390x-fadv.patch
 8d3a2d5315fc56fee7da9abb8b89bb38c6046c33d154c10d168fb35bfde6b0cf9f13042a3bceee34daf091bc409d699223735dcf19f382eeee1f6be34154f26f  ldconfig
 062bb49fa54839010acd4af113e20f7263dde1c8a2ca359b5fb2661ef9ed9d84a0f7c3bc10c25dcfa10bb3c5a4874588dff636ac43d5dbb3d748d75400756d0b  __stack_chk_fail_local.c
 0d80f37b34a35e3d14b012257c50862dfeb9d2c81139ea2dfa101d981d093b009b9fa450ba27a708ac59377a48626971dfc58e20a3799084a65777a0c32cbc7d  getconf.c

--- a/main/musl/s390x-fadv.patch
+++ b/main/musl/s390x-fadv.patch
@@ -1,0 +1,45 @@
+From 4b125dd408d54487dc8843b9553502aa0c4167f8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jonathan=20Neusch=C3=A4fer?= <j.neuschaefer@gmx.net>
+Date: Wed, 20 Feb 2019 19:07:12 +0100
+Subject: fix POSIX_FADV_DONTNEED/_NOREUSE on s390x
+
+On s390x, POSIX_FADV_DONTNEED and POSIX_FADV_NOREUSE have different
+values than on all other architectures that Linux supports.
+
+Handle this difference by wrapping their definitions in
+include/fcntl.h in #ifdef, so that arch/s390x/bits/fcntl.h can
+override them.
+---
+ arch/s390x/bits/fcntl.h | 3 +++
+ include/fcntl.h         | 2 ++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/arch/s390x/bits/fcntl.h b/arch/s390x/bits/fcntl.h
+index 1eca6ba5..a231efb4 100644
+--- a/arch/s390x/bits/fcntl.h
++++ b/arch/s390x/bits/fcntl.h
+@@ -38,3 +38,6 @@
+ #define F_GETOWN_EX 16
+ 
+ #define F_GETOWNER_UIDS 17
++
++#define POSIX_FADV_DONTNEED   6
++#define POSIX_FADV_NOREUSE    7
+diff --git a/include/fcntl.h b/include/fcntl.h
+index 4d91338b..f6c192f5 100644
+--- a/include/fcntl.h
++++ b/include/fcntl.h
+@@ -66,8 +66,10 @@ int posix_fallocate(int, off_t, off_t);
+ #define POSIX_FADV_RANDOM     1
+ #define POSIX_FADV_SEQUENTIAL 2
+ #define POSIX_FADV_WILLNEED   3
++#ifndef POSIX_FADV_DONTNEED
+ #define POSIX_FADV_DONTNEED   4
+ #define POSIX_FADV_NOREUSE    5
++#endif
+ 
+ #undef SEEK_SET
+ #undef SEEK_CUR
+-- 
+cgit v1.2.1
+


### PR DESCRIPTION
Copy from upstream