### PR TITLE
main/libuv: upgrade to 1.28.0

### DIFF
--- a/main/libuv/APKBUILD
+++ b/main/libuv/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libuv
-pkgver=1.26.0
+pkgver=1.28.0
 pkgrel=0
 pkgdesc="Cross-platform asychronous I/O"
 url="https://libuv.org"
@@ -46,5 +46,5 @@ package() {
 		"$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 
-sha512sums="ad8d2eb14b98b64b9c81499149cbc3dbed524635be893a9203d0aaaabfe0b623d7e1d26b5cfd16fe5bd63f1656280808faf820d6f4f4aaf93ad89d5615b7952a  libuv-v1.26.0.tar.gz
+sha512sums="d7f635ab99569e96db9ae97d29a302f5eec1fd75c71b035ec597a6b978a3fc797a37c7406fed81a27d4d706fe21cbfe919d829d6dae67399cd5cddd107ad6949  libuv-v1.28.0.tar.gz
 ba85b0be3905be6d5ff2bf825f99420d979eb2db9c665d2de1cea8366470de718670f71addb9611e468befe1f1e9fcdcf8886ae1d4784485abf0beae2ccc8ee3  disable-setuid-test.patch"


### PR DESCRIPTION
https://github.com/libuv/libuv/releases 1.28.0