### PR TITLE
main/mariadb-connector-c: upgrade to 3.0.9

### DIFF
--- a/main/mariadb-connector-c/APKBUILD
+++ b/main/mariadb-connector-c/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mariadb-connector-c
-pkgver=3.0.8
+pkgver=3.0.9
 pkgrel=0
 pkgdesc="The MariaDB Native Client library (C driver)"
 url="https://mariadb.org/"
@@ -58,6 +58,6 @@ dev() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="d9f970c7ac164ef7d8dd748bf2f749cc1f877a9c8f68a1d57e9ff62d95046bb9505619feca1f1d0d1cdefc1ac49489742aadf4ad9e47c8e6a9b8b40c56eed788  mariadb-connector-c-3.0.8-src.tar.gz
+sha512sums="6f45bcd4bee07f6d72d1c4fee0bdb903ef4fa879eb7508156bc885a5657caf69b145d95647c4bc663eb2a2b03569b41ef9d87ca532b77901c2f67fd608048a1a  mariadb-connector-c-3.0.9-src.tar.gz
 027a9d383ce27a527b77ac06b9505709cad8fe0173455863590f502996966300fedea87687630113d74e5b9be5349217b18206c2dbb89f7064129cb5417e44cf  cmake.patch
-ad52cccb5517d11838bf16aee5aff63d87075e9ef5787e726d8bfea2854d3e2b5fa7aa94c0e93b1f7e7e21f48d21b1b6fcdd161fadb9999dcc7a3a5b8e12d883  fix-ucontext-header.patch"
+757a2d3531ee271cf5473671bf4d0ac07dc8eb94ab4b6ede848ba7a55415a77f90e7275103be91c73e343e94cdbf2cd652eb6cef6ed48917991733d60d3b8777  fix-ucontext-header.patch"

--- a/main/mariadb-connector-c/fix-ucontext-header.patch
+++ b/main/mariadb-connector-c/fix-ucontext-header.patch
@@ -1,9 +1,7 @@
-diff --git a/cmake/CheckIncludeFiles.cmake b/cmake/CheckIncludeFiles.cmake
-index 89b40ad..cc258ba 100644
 --- a/cmake/CheckIncludeFiles.cmake
 +++ b/cmake/CheckIncludeFiles.cmake
-@@ -73,4 +73,7 @@ CHECK_INCLUDE_FILES (termio.h HAVE_TERMIO_H)
- CHECK_INCLUDE_FILES (termios.h HAVE_TERMIOS_H)
+@@ -46,4 +46,7 @@
+ CHECK_INCLUDE_FILES (sys/un.h HAVE_SYS_UN_H)
  CHECK_INCLUDE_FILES (unistd.h HAVE_UNISTD_H)
  CHECK_INCLUDE_FILES (utime.h HAVE_UTIME_H)
 -CHECK_INCLUDE_FILES (ucontext.h HAVE_UCONTEXT_H)


### PR DESCRIPTION
Ref https://mariadb.org/mariadb-10-3-13-and-mariadb-connector-c-3-0-9-now-available/

ABI 100% BC - https://abi-laboratory.pro/index.php?view=objects_report&l=mariadb-connector-c&v1=3.0.8&v2=3.0.9