### PR TITLE
community/drupal7: security upgrade to 7.65

### DIFF
--- a/community/drupal7/APKBUILD
+++ b/community/drupal7/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
 pkgname=drupal7
-pkgver=7.64
+pkgver=7.65
 pkgrel=0
 pkgdesc="An open source content management platform"
 url="https://www.drupal.org/"
@@ -78,4 +78,4 @@ package() {
 		"$pkgdir"/var/lib/$pkgname/sites/default/files
 }
 
-sha512sums="90d4b863df5597ac7e88dc09317e3ab8b2beacd6051ef267de52d1fe599a8704f25ede708d2a106c18d76f19c2c9de1e5003086ab9116bae5624acd418e8a014  drupal-7.64.tar.gz"
+sha512sums="a79ff93e13456b35160ee17f986dce9cffefa265d0034dab6223a3097eaf45c11ea3548904ff6c125be0817dc71a8ac7320aca91a11eefeaad03d45527725e79  drupal-7.65.tar.gz"


### PR DESCRIPTION
Ref https://www.drupal.org/sa-core-2019-004