### PR TITLE
testing/polybar: fix wstringop-trunction that is faiing ppc64le build

### DIFF
--- a/testing/polybar/APKBUILD
+++ b/testing/polybar/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Taner Tas <taner76@gmail.com>
 pkgname=polybar
 pkgver=3.3.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A fast and easy-to-use tool for creating status bars."
 url="https://polybar.github.io/"
 arch="all"
@@ -40,6 +40,7 @@ source="
 	$pkgname-$pkgver.tar.gz::https://github.com/jaagr/polybar/archive/$pkgver.tar.gz
 	xpp-$_xppver.tar.gz::https://github.com/jaagr/xpp/archive/$_xppver.tar.gz
 	https://github.com/jaagr/i3ipcpp/archive/v$_i3ipcppver.tar.gz
+	fix-wstringop-truncation.patch
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 options="!check" # No test suite
@@ -85,4 +86,5 @@ zshcomp() {
 
 sha512sums="59b6ef2509fae8c520ad4dd176f642c79891ce069946c3ae84559de76710e586c669d0a03d49535ccdbcfdef40fe685f3e02d15bee95138dd0e2b212a64d0403  polybar-3.3.0.tar.gz
 22581067ddda3ac75ef2747d77ab7fc2ea228da3cd6f974533e4e2777beaacd4ca0618b8ee53ba26dd319ffeed0b317d10ca99b5a2769b9bc92841f619d3c33c  xpp-56fbf8459809ba65f9ea4a65b8f467a6e9890c4e.tar.gz
-ef9f591bb4436916ad038bcb0c15ea3415d1978ff264fb276108ddac89c98515c464fbf252429f6a76589cb78e1434adba2efefb5a844dadad0e261f3806fb72  v0.7.1.tar.gz"
+ef9f591bb4436916ad038bcb0c15ea3415d1978ff264fb276108ddac89c98515c464fbf252429f6a76589cb78e1434adba2efefb5a844dadad0e261f3806fb72  v0.7.1.tar.gz
+5313c9a20b3f56d878dde0b053c8ca689bbbec077b7c7ba47549dac96393de809e14313e76f68b975f334876a472b14a4d82166c10a64623e753007b26e686ca  fix-wstringop-truncation.patch"

--- a/testing/polybar/fix-wstringop-truncation.patch
+++ b/testing/polybar/fix-wstringop-truncation.patch
@@ -1,0 +1,11 @@
+--- a/lib/i3ipcpp/src/ipc-util.cpp
++++ b/lib/i3ipcpp/src/ipc-util.cpp
+@@ -34,7 +34,7 @@
+ 	data = new uint8_t[size];
+ 	header = (header_t*)data;
+ 	payload = (char*)(data + sizeof(header_t));
+-	strncpy(header->magic, g_i3_ipc_magic.c_str(), sizeof(header->magic));
++	memcpy(header->magic, g_i3_ipc_magic.c_str(), sizeof(header->magic));
+ 	header->size = payload_size;
+ 	header->type = 0x0;
+ }


### PR DESCRIPTION
Building on ppc64le fails with error:
/home/buildozer/aports/testing/polybar/src/polybar-3.3.0/lib/i3ipcpp/src/ipc-util.cpp:37:9: error: 'char* strncpy(char*, const char*, size_t)' specified bound 6 equals destination size [-Werror=stringop-truncation]
  strncpy(header->magic, g_i3_ipc_magic.c_str(), sizeof(header->magic));

Fix cherry picked from https://github.com/jaagr/i3ipcpp/pull/7 
gcc >=8 will complain, if strncpy truncates the source string or gcc can prove there is no NUL terminating byte.

The header_t.magic field is a non-NUL terminated 6 byte string, so we use memcpy here