### PR TITLE
main/haproxy: upgrade to 1.9.5

### DIFF
--- a/main/haproxy/APKBUILD
+++ b/main/haproxy/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Jeff Bilyk <jbilyk@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=haproxy
-pkgver=1.8.12
+pkgver=1.9.5
 _pkgmajorver=${pkgver%.*}
-pkgrel=1
+pkgrel=0
 pkgdesc="A TCP/HTTP reverse proxy for high availability environments"
 url="http://haproxy.1wt.eu"
 arch="all"
@@ -50,6 +50,6 @@ package() {
 	        "$pkgdir"/etc/haproxy/haproxy.cfg
 }
 
-sha512sums="2b782a54988cc88d1af0e5f011af062910e8fac28eab13db7e05a58d0d23961f827da47e3871e8d081f5a2d222588480d81dec2e9f14ec9f54a1c3cb5bf3d56a  haproxy-1.8.12.tar.gz
+sha512sums="af37e766ab8e53afe8113fe35b19d789c753da41eee5e11b4f0e36272a5e9fb9e73b40227b0cc89c025ea4d6f6d38ad2198c30c48a6c4be05fa32204cd053152  haproxy-1.9.5.tar.gz
 3ab277bf77fe864ec6c927118dcd70bdec0eb3c54535812d1c3c0995fa66a3ea91a73c342edeb8944caeb097d2dd1a7761099182df44af5e3ef42de6e2176d26  haproxy.initd
 26bc8f8ac504fcbaec113ecbb9bb59b9da47dc8834779ebbb2870a8cadf2ee7561b3a811f01e619358a98c6c7768e8fdd90ab447098c05b82e788c8212c4c41f  haproxy.cfg"


### PR DESCRIPTION
Refs
- https://www.mail-archive.com/haproxy@formilux.org/msg32143.html
- https://www.haproxy.com/blog/haproxy-1-9-has-arrived/
- detailed changelog http://www.haproxy.org/download/1.9/src/CHANGELOG