### PR TITLE
testing/grpc: upgrade to 1.19.1

### DIFF
--- a/testing/grpc/APKBUILD
+++ b/testing/grpc/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: wener <wenermail@gmail.com>
 # Maintainer: wener <wenermail@gmail.com>
 pkgname=grpc
-pkgver=1.18.0
+pkgver=1.19.1
 pkgrel=0
 pkgdesc="The C based gRPC (C++, Python, Ruby, Objective-C, PHP, C#) "
 url="https://grpc.io/"
@@ -43,7 +43,7 @@ cli() {
 	make install-grpc-cli prefix="$subpkgdir/usr"
 }
 
-sha512sums="2489860a395b9f59d4eb81db5a8d873683e317145ad140b72fabb13693e166c122ce8526d34e2380a52d18493e8b2b49d6d28e53878af2c43523a5791da8fe52  grpc-1.18.0.tar.gz
+sha512sums="4bb127d946fc16887fd4cf75215f0bc9f6d17dbd36fc4f1b191a64914f96c49dddb41f1b6c72fd24ea0a40f242b4398248f32fcb1fe9a764367be1c2edda9142  grpc-1.19.1.tar.gz
 dd55ab745c43c5c953d8cebd2fb44b4bb2cb87c95194965bffd0bd8219332d5f073c22947c8a8b1e2652805dff1cff4b93fe69645d4c0d635f98ae2cf54af14a  googletest-ec44c6c1675c25b9827aacd08c02433cccde7780.tar.gz
 7fa146ce86ddd4f160bb1ca9ff01cb7aca6b2b8c9aa50e4fa6b84504b9117b104be0d1e31ccb452d846549dfe1e9012ceccfcdc1f2357ed567621d71fb8b08c5  01-chttp2-maybe-uninitialized.patch
 d50885978466137e595ccb8e45fc7e283ff18b61775c4e0d92c0f56310c719802e591816955d800e71aab1da36b52f938f32d46bed3c230dd2b1b08dca7f2a91  disable-Werror.patch"


### PR DESCRIPTION
- https://github.com/grpc/grpc/releases/tag/v1.19.1
- https://github.com/grpc/grpc-java/releases