### PR TITLE
testing/grpc-java: upgrade to 1.19.0

### DIFF
--- a/testing/grpc-java/APKBUILD
+++ b/testing/grpc-java/APKBUILD
@@ -1,14 +1,14 @@
 # Contributor: wener <wenermail@gmail.com>
 # Maintainer: wener <wenermail@gmail.com>
 pkgname=grpc-java
-pkgver=1.18.0
+pkgver=1.19.0
 pkgrel=0
 pkgdesc="The Java gRPC implementation. HTTP/2 based RPC"
 url="https://github.com/grpc/grpc-java"
 arch="all !aarch64 !armhf !armv7 !s390x" # fails to build on aarch64 and armhf for some strange reason
 license="Apache2"
 depends="openjdk8-jre"
-makedepends="openjdk8 protobuf-dev"
+makedepends="openjdk8 protobuf-dev nss"
 source="$pkgname-$pkgver.tar.gz::https://github.com/grpc/grpc-java/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 options="!check"
@@ -23,4 +23,4 @@ package() {
 	install -D -m 755 "$builddir"/compiler/build/exe/java_plugin/protoc-gen-grpc-java "$pkgdir"/usr/bin/protoc-gen-grpc-java
 }
 
-sha512sums="2b23d65f3e76f460f5d6cb70ad57f11c2d7a5e45c0a26e32a58d9d7b79ea6dc8ce843c780f4749d5efa927952b0e1c83c25f021a1da20df78215f7064d05dddc  grpc-java-1.18.0.tar.gz"
+sha512sums="43069a40ae1a76b8164b2e4d8fc3b6488d0b7e0742120219043172322e975d1216865ad3649c5ec3a0f339b8d3f9a46c5b2321114b5b5a4957102f2d7e4a8920  grpc-java-1.19.0.tar.gz"


### PR DESCRIPTION
Ref https://github.com/grpc/grpc-java/releases

Related to https://github.com/alpinelinux/aports/pull/6811
