### PR TITLE
community/docker-registry: upgrade to 2.7.1 and improve

### DIFF
--- a/community/docker-registry/APKBUILD
+++ b/community/docker-registry/APKBUILD
@@ -1,42 +1,36 @@
 # Maintainer: Christian Kampka <christian@kampka.net>
 
 pkgname=docker-registry
-pkgver=2.6.2
+pkgver=2.7.1
 pkgrel=0
 pkgdesc="An implementation of the Docker Registry HTTP API V2 for use with docker 1.6+"
 url="https://github.com/docker/distribution"
-arch="x86 x86_64 ppc64le"
+arch="all !s390x"
 license="Apache-2.0"
 makedepends="git go"
 install="$pkgname.pre-install"
 pkgusers="docker-registry"
 pkggroups="docker-registry"
-subpackages="$pkgname-dbg"
+subpackages="$pkgname-dbg $pkgname-openrc"
 source="$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz
 	docker-registry.initd
 	config-example.patch"
-builddir="$srcdir/distribution-$pkgver"
+builddir="$srcdir/src/github.com/docker/distribution"
 
 prepare() {
-	default_prepare || return 1
+	mkdir -p "${builddir%/*}"
+	mv "$srcdir"/distribution-$pkgver "$builddir"
 
-	cd "$builddir"
-	sed -i '/^VERSION\s*=/d' Makefile
-	sed -Ei "s/^(var Version\s*=\s*).*/\1\"$pkgver\"/" version/version.go
+	default_prepare
 }
 
 build() {
 	cd "$builddir"
 
-	# GOPATH fix
-	mkdir -p Godeps/_workspace/src/github.com/docker
-	ln -s "$builddir" Godeps/_workspace/src/github.com/docker/distribution || return 1
-
 	make clean binaries \
 		DISTRIBUTION_DIR="$builddir" \
-		GOPATH="$builddir/Godeps/_workspace" \
-		VERSION="$pkgver" \
-		|| return 1
+		GOPATH="$srcdir" \
+		VERSION="$pkgver"
 }
 
 check() {
@@ -49,21 +43,21 @@ package() {
 	cd "$builddir"
 
 	install -D -m 755 bin/registry \
-		"$pkgdir"/usr/bin/$pkgname || return 1
+		"$pkgdir"/usr/bin/$pkgname
 
 	install -D -m 644 cmd/registry/config-example.yml \
-		"$pkgdir"/etc/$pkgname/config.yml || return 1
+		"$pkgdir"/etc/$pkgname/config.yml
 
 	install -D -m 644 LICENSE \
-		"$pkgdir"/usr/share/licenses/$pkgname || return 1
+		"$pkgdir"/usr/share/licenses/$pkgname
 
 	install -D -m 755 "$srcdir"/$pkgname.initd \
-		"$pkgdir"/etc/init.d/$pkgname || return 1
+		"$pkgdir"/etc/init.d/$pkgname
 
 	install -d -m 750 -o $pkgusers -g $pkggroups \
 		"$pkgdir"/var/lib/$pkgname
 }
 
-sha512sums="a091db2e15d7c1dc8cd39a40de5bb63cc1ead68e95dfaf6b3735a789adb87f146c03eff81f700e0059e5f6ffc43e6c3dd3358503697882cb080b991629f82c60  docker-registry-2.6.2.tar.gz
+sha512sums="f6baf0e7aa96ebe828c628f7dfd84ee899331c3c1bdab86662aef595b092702b6d9b2c9be766a6de6d153ff4ca55d85c5fd8785a0968f285f56a32a50092c754  docker-registry-2.7.1.tar.gz
 96100a4de311afa19d293a3b8a63105e1fcdf49258aa8b1752befd389e6b4a2b1f70711341ea011b450d4468bd37dbd07a393ffab3b9aa1b2213cf0fdd915904  docker-registry.initd
 5a38f4d3f0ee5cd00c0a5ced744eb5b29b839da5921adea26c5de3eb88b6b2626a7ba29b1ab931e5f8fbfafbed8c94cb972a58737ec0c0a69cf515c32139e387  config-example.patch"


### PR DESCRIPTION
Ref https://github.com/docker/distribution/releases

- starting from 2.7.0 it allows ARM builds
- updated go and nice features