### PR TITLE
testing/skim: upgrade to 0.6.4

### DIFF
--- a/testing/skim/APKBUILD
+++ b/testing/skim/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Chloe Kudryavtsev <toast@toastin.space>
 # Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=skim
-pkgver=0.6.2
-pkgrel=1
+pkgver=0.6.4
+pkgrel=0
 pkgdesc="Fuzzy finder in rust"
 url="https://github.com/lotabout/skim"
 arch="x86_64" # limited by rust/cargo
@@ -41,7 +41,9 @@ check() {
 package() {
 	cd "$builddir"
 	install -Dm755 target/release/sk bin/sk-tmux -t "$pkgdir"/usr/bin
-	install -Dm644 shell/skim.1 -t "$pkgdir"/usr/share/man/man1/
+
+	install -Dm644 man/man1/sk.1 -t "$pkgdir"/usr/share/man/man1/
+	install -Dm644 man/man1/sk-tmux.1 -t "$pkgdir"/usr/share/man/man1/
 
 	install -Dm644 plugin/skim.vim -t "$pkgdir"/usr/share/vim/vimfiles/plugin
 
@@ -116,4 +118,4 @@ zshkey() {
 	mv "$pkgdir"/usr/share/skim/key-bindings.zsh "$subpkgdir"/usr/share/skim
 }
 
-sha512sums="47c89b9f6bdbbc3c470c4edb5b23fcf94165cb34ab7be4de6113b4eb4433d81064395c5495d2129c7877dd8ed3bea9067f1d2b965fd7683c39aec1bb070b7b3d  skim-0.6.2.tar.gz"
+sha512sums="1aaa10158cae58d2fcd0a2c25c03699ef63cf6d2ae94adba5988259c5be23eda5837b22c45643904e96bd095e8ad6efb48c7c36ffb3db14492773e71fe9d66e6  skim-0.6.4.tar.gz"


### PR DESCRIPTION
Manual pages have also moved in-repo, fix that section.