### PR TITLE
testing/polybar: disable s390x

### DIFF
--- a/testing/polybar/APKBUILD
+++ b/testing/polybar/APKBUILD
@@ -5,7 +5,7 @@ pkgver=3.3.0
 pkgrel=1
 pkgdesc="A fast and easy-to-use tool for creating status bars."
 url="https://polybar.github.io/"
-arch="all"
+arch="all !s390x" # s390x does not have pulseaudio-dev
 license="MIT"
 makedepends="
 	alsa-lib-dev


### PR DESCRIPTION
ERROR: unsatisfiable constraints:
  pulseaudio-dev (missing):
    required by: .makedepends-polybar-0[pulseaudio-dev]