### PR TITLE
testing/polybar: depend on i3wm-dev

### DIFF
--- a/testing/polybar/APKBUILD
+++ b/testing/polybar/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Taner Tas <taner76@gmail.com>
 pkgname=polybar
 pkgver=3.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A fast and easy-to-use tool for creating status bars."
 url="https://polybar.github.io/"
 arch="all !s390x" # s390x lacks pulseaudio
@@ -12,7 +12,7 @@ makedepends="
 	cairo-dev
 	cmake
 	curl-dev
-	i3wm
+	i3wm-dev
 	jsoncpp-dev
 	libmpdclient-dev
 	libnl3-dev


### PR DESCRIPTION
ERROR: unsatisfiable constraints:
  pulseaudio-dev (missing):
    required by: .makedepends-polybar-0[pulseaudio-dev]