### PR TITLE
testing/rakudo: upgrade to 2019.03.1

### DIFF
--- a/testing/moarvm/APKBUILD
+++ b/testing/moarvm/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=moarvm
-pkgver=2018.11
+pkgver=2019.03
 pkgrel=0
 pkgdesc="A VM for NQP And Rakudo Perl 6"
 url="http://moarvm.org/"
@@ -52,4 +52,4 @@ doc() {
 	done
 }
 
-sha512sums="90cf3d6885dd556fbb6aea61c939504abbce202919268866bcdb90e92f8179650436563fe7de58bd6b278737aa0960fe2bdc54ad380241fa73fb59589fed294d  MoarVM-2018.11.tar.gz"
+sha512sums="aa50dcf1499e83247c4c490384f80896160d08fb72a5a6da1f91748c6dc343fa30dcf35adca3e9e8329a2919026a4bdb299129865abf611ce49d73d05cce4285  MoarVM-2019.03.tar.gz"

--- a/testing/nqp/APKBUILD
+++ b/testing/nqp/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=nqp
-pkgver=2018.11
+pkgver=2019.03
 pkgrel=0
 pkgdesc="Not Quite Perl"
 url="https://github.com/perl6/nqp"
@@ -39,4 +39,4 @@ doc() {
 	done
 }
 
-sha512sums="2d5cf38fd153a4fb96e7597347e31315b87771554f0c7fce4fe7957628da95f219baf2111fce2ce2cfead9008125926f7be79515c3ab28b4d5ea8f41bf352ef2  nqp-2018.11.tar.gz"
+sha512sums="6d4e00fa8d103db7c8b65c4174d1b5170d65d1246cb9baacd73ccf247979d4e135e9ca573a5f7140d5dc6cffb0576313029fafff1559a88464b543a8fe6fe020  nqp-2019.03.tar.gz"

--- a/testing/rakudo/APKBUILD
+++ b/testing/rakudo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Curt Tilmes <Curt.Tilmes@nasa.gov>
 # Maintainer: Curt Tilmes <Curt.Tilmes@nasa.gov>
 pkgname=rakudo
-pkgver=2018.11
+pkgver=2019.03.1
 pkgrel=0
 pkgdesc="A compiler for the Perl 6 programming language"
 url="http://rakudo.org/"
@@ -53,5 +53,5 @@ doc() {
 	done
 }
 
-sha512sums="3ade13f51bcfccaa445043368d4b46d3bb2a4d934cd404f04374418a15f81b1bf431125b8133e61936df319b5d11426e77e99b118fd42a35dfbe1efd7267763f  rakudo-2018.11.tar.gz
+sha512sums="a9c9243a0dcafc6b010d931dcac3afadd08c04fb997ecb10328b26b881ae7c0d0e261dbac790f1c72fca3beeacb95bf74b59fbd2250d4cf4b5f8d0b68aeafac5  rakudo-2019.03.1.tar.gz
 74a3e3bff623a8922d2aae2f43e25be1a7b8a2b0b128bc8eb15fa9f03307fe603cb342b644607b7d74b3a084fb936c47113ab6249a0e23bb3107727383201152  perf-increase-tolerance.patch"


### PR DESCRIPTION
Upgrade moarvm, nqp, and rakudo to version 2019.03 (2019.03.1 for rakudo), must upgrade all three together.
