### PR TITLE
Perl perlmagick for review only

### DIFF
--- a/testing/perlmagick/APKBUILD
+++ b/testing/perlmagick/APKBUILD
@@ -1,0 +1,82 @@
+# Contributor: Timothy Legge <timlegge@gmail.com>
+# Maintainer: Timothy Legge <timlegge@gmail.com>
+# Natanael Copa <ncopa@alpinelinux.org>
+pkgname=perlmagick
+pkgver=7.0.8.36
+pkgrel=0
+_pkgver=${pkgver%.*}-${pkgver##*.}
+_abiver=7
+pkgdesc="Perl Module for Image Magick"
+url="https://www.imagemagick.org/"
+arch="all"
+license="ImageMagick"
+options="libtool !checkroot"
+depends="imagemagick imagemagick-libs imagemagick-c++"
+makedepends="perl-dev libtool chrpath"
+checkdepends=""
+subpackages="$pkgname-doc"
+source="https://www.imagemagick.org/download/releases/ImageMagick-$_pkgver.tar.xz"
+builddir="$srcdir/ImageMagick-${_pkgver}"
+
+build() {
+	cd "$builddir"
+	# fix doc dir, Gentoo bug 91911
+	sed -i -e \
+		's:DOCUMENTATION_PATH="${DATA_DIR}/doc/${DOCUMENTATION_RELATIVE_PATH}":DOCUMENTATION_PATH="/usr/share/doc/imagemagick":g' \
+		configure
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--disable-static \
+		--disable-openmp \
+		--with-threads \
+		--with-x \
+		--with-tiff \
+		--with-png \
+		--with-webp \
+		--with-rsvg \
+		--with-gslib \
+		--with-gs-font-dir=/usr/share/fonts/Type1 \
+		--with-modules \
+		--with-xml \
+		--with-perl \
+		--with-perl-options=PREFIX=/usr \
+		$_pic
+	make perl-sources
+	make perl-build
+	cd "$builddir/PerlMagick"
+	chrpath -d ./blib/arch/auto/Image/Magick/Q16HDRI/Q16HDRI.so
+}
+
+check() {
+	cd "$builddir/PerlMagick"
+	if ! [ -e blib/lib/Image/Magick.pm ]; then
+		error "Module does not exist Magick.pm"
+		return 1
+	fi
+        if ! [ -e blib/lib/Image/Magick/Q16HDRI.pm ]; then
+		error "Module does not exist Magick/Q16HDRI.pm"
+		return 1
+        fi
+
+        if ! [ -e blib/arch/auto/Image/Magick/Q16HDRI/Q16HDRI.so ]; then
+		error "library does not exist Q16HDRI.so"
+		return 1
+        fi
+
+
+}
+
+package() {
+	cd "$builddir/PerlMagick"
+	make -j1 DESTDIR="$pkgdir" install_vendor
+
+	find "$pkgdir" -name '.packlist' -o -name 'perllocal.pod' \
+		-o -name '*.bs' -delete
+}
+
+sha512sums="d32ccdfac7d410c6d83009d9d97d1a4e0195d5618fc95530424f43c86f369541d36b3fa53eee7f8872a84bb8e5164387aa731d452c2d9e0c8f872406c4044fb8  ImageMagick-7.0.8-36.tar.xz"


### PR DESCRIPTION
@ncopa as you are the maintainer of the ImageMagick aport it would likely be a good idea for you to review this perlmagick aport.  If it looks okay I will pull out the change to the ImageMagick version and squash the commits

This requires a version upgrade of ImageMagick (included in this pull request but likely should not be) as the ImageMagick version cannot be downloaded anymore.

This was a fair amount of trial and error and you may know of a better approach.  I had thought of simply adding it to the ImageMagick but PerlMagic is only really needed if the user needs it.

The check is a hack because the tests provided in the Makefile don't work for me.  Even the docs say expect some of them to fail.
