### PR TITLE
Update h2o.initd

### DIFF
--- a/community/h2o/h2o.initd
+++ b/community/h2o/h2o.initd
@@ -5,7 +5,7 @@ extra_commands="configtest"
 conffile=/etc/h2o.conf
 pidfile=/var/run/h2o.pid
 command=/usr/bin/h2o
-command_args="-c $conffile -m master"
+command_args="-c $conffile"
 
 depend() {
 	need net


### PR DESCRIPTION
community/h2o: remove "-m master" from init.d file, runs as default "-w worker" instead