### PR TITLE
community/librdkafka: upgrade to 1.0.0

### DIFF
--- a/community/librdkafka/APKBUILD
+++ b/community/librdkafka/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: Mike Milner <milner@blissisland.ca>
 # Maintainer: Bennett Goble <nivardus@gmail.com>
 pkgname=librdkafka
-pkgver=0.11.6
-pkgrel=1
+pkgver=1.0.0
+pkgrel=0
 pkgdesc="The Apache Kafka C/C++ library"
 url="https://github.com/edenhill/librdkafka"
 arch="all"
@@ -29,4 +29,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="9657dc53220bbff3eb44941cff2f50ab7f71a82f7486d64ea14f67eabd4abe8c67f225a752cc1f0339439a1cc512e99ade6536d087857979cd198c0102015718  librdkafka-0.11.6.tar.gz"
+sha512sums="15ac1e4c9042debf8d4df602ccdc5eccae3a37b305be24d724fcaffc3d1d0aafa708fc8e29d6af51f51ed6c7daf74b3041b8b9b0444e6702cd73479c8078859a  librdkafka-1.0.0.tar.gz"


### PR DESCRIPTION
Per https://github.com/edenhill/librdkafka/releases/tag/v1.0.0 the 1.0.0 release is API and ABI compatible with the v0 series or the C library.

There ARE upgrade considerations for the configuration parameters. See the link above for details.