### PR TITLE
testing/libzim: moving gtest from makedepends to checkdepends, skip big memory test

### DIFF
--- a/testing/libzim/APKBUILD
+++ b/testing/libzim/APKBUILD
@@ -8,7 +8,8 @@ url="https://openzim.org/"
 arch="all"
 license="GPL-2.0"
 makedepends="meson zlib-dev xz-dev libexecinfo libexecinfo-dev icu-dev xapian-core-dev 
-gtest gtest-dev python3-dev"
+	     gtest-dev python3-dev"
+checkdepends="gtest"
 subpackages="$pkgname-dev $pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/openzim/$pkgname/archive/$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
@@ -26,7 +27,7 @@ build() {
 }
 
 check() {
-	ninja -C output test
+	SKIP_BIG_MEMORY_TEST=1 ninja -C output test
 }
 
 package() {


### PR DESCRIPTION
There is no need in package rebuild as the gtest is used during check() only.