### PR TITLE
main/imagemagick: security upgrade to 7.0.8.38

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
-pkgver=7.0.8.26
+pkgver=7.0.8.38
 pkgrel=0
 _pkgver=${pkgver%.*}-${pkgver##*.}
 _abiver=7
@@ -16,8 +16,14 @@ makedepends="zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev fontconfig-dev
 	libwebp-dev libxml2-dev librsvg-dev libx11-dev libxext-dev"
 checkdepends="freetype fontconfig ghostscript ghostscript-fonts lcms2 graphviz"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-c++:_cxx $pkgname-libs"
-source="https://www.imagemagick.org/download/releases/ImageMagick-$_pkgver.tar.xz"
+source="https://github.com/ImageMagick/ImageMagick/archive/$_pkgver.tar.gz"
 builddir="$srcdir/ImageMagick-${_pkgver}"
+
+# secfixes:
+#   7.0.8.38-r0:
+#     - CVE-2019-9956
+#     - CVE-2019-10649
+#     - CVE-2019-10650
 
 build() {
 	cd "$builddir"
@@ -75,4 +81,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="458fa8f6ae70234895bc6b1360bb7e655dc3c8307a98ff0170f8f5c39e262b12dd3bbe7663b881a3b6bdd6a8e2b1d830878c0c7ed5d8cd92c462020a1b16565f  ImageMagick-7.0.8-26.tar.xz"
+sha512sums="db1451d52622151e59ef20f2682c1e9446cd0198a75c5715a4b9faff5b428ddf696172d2b6db52818fc2773e3ba3a6ff6d40199da52202c0b6eb41111512fc73  7.0.8-38.tar.gz"


### PR DESCRIPTION
https://github.com/ImageMagick/ImageMagick/issues/1523

Closes #6550 and #6696