### PR TITLE
[3.7] main/dovecot: security upgrade to 2.2.36.3

### DIFF
--- a/main/dovecot/APKBUILD
+++ b/main/dovecot/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Michael Mason <ms13sp@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dovecot
-pkgver=2.2.36.1
+pkgver=2.2.36.3
 _pkgvermajor=2.2
 pkgrel=0
 _pigeonholever=0.4.21
@@ -40,6 +40,8 @@ _builddirpigeonhole="$srcdir/$pkgname-${_pkgvermajor}-pigeonhole-$_pigeonholever
 _builddirpluginextdata="$srcdir/pigeonhole-${_pigeonholevermajor/./-}-sieve-extdata-$_pluginextdataver"
 
 # secfixes:
+#   2.2.36.3-r0:
+#     - CVE-2019-7524
 #   2.2.36.1-r0:
 #     - CVE-2019-3814
 #   2.2.34-r0:
@@ -232,7 +234,7 @@ _fts_lucene() {
 	depends="$pkgname"
 	_mv $(cd "$pkgdir" && find usr -name '*fts*lucene*')
 }
-sha512sums="b085ad919e3a45b209a52920d3462270822bba6f5de93f1a65c4d8522339ce8eff06059fe42f38442c2ffe178f91e4f66b43b2457ab47af379091da40dd860d8  dovecot-2.2.36.1.tar.gz
+sha512sums="47611dbde7ee854ad323dcdb726757c7172376761fa774f28fce3f9d74ed590319d812f0555abed5f8178c326c3cb7661ac0b708ca5982914e255cec60f72e35  dovecot-2.2.36.3.tar.gz
 4751f449ede1b05173c706b414ebf9f7f670ff78589ce6f0b687c32c9abe6dae8b3064ed1b20e893d9ec0147b0139ce479e1d74ebe94747c33f2d8ca177912de  dovecot-2.2-pigeonhole-0.4.21.tar.gz
 832a80264fb9bd3021c4e192eb7594c203100783df547aff35acf4dc4d8de5eddfd676fcc5a07a0691d9bb6eb884c9497a692b72a2af5bf9e9bb7a2d3f38923e  39.tar.gz
 09bae967d35b9e5d7d91c81337e1bf5e5aba3abb7b0ab06427f1a0d6f9bb5b2f2e39306cfe45d80488110fc0414e3e2515c0265286c1584d80f8af366d1568a9  skip-iconv-check.patch


### PR DESCRIPTION
https://dovecot.org/list/dovecot-news/2019-March/000402.html