### PR TITLE
[3.6] main/dovecot: security upgrade to 2.2.36.3

### DIFF
--- a/main/dovecot/APKBUILD
+++ b/main/dovecot/APKBUILD
@@ -3,9 +3,9 @@
 # Contributor: Michael Mason <ms13sp@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dovecot
-pkgver=2.2.36.1
+pkgver=2.2.36.3
 _pkgvermajor=2.2
-pkgrel=1
+pkgrel=0
 _pigeonholever=0.4.16
 _pluginextdataver=39
 _pigeonholevermajor=${_pigeonholever%.*}
@@ -38,6 +38,8 @@ _builddirpigeonhole="$srcdir"/$pkgname-${_pkgvermajor}-pigeonhole-$_pigeonholeve
 _builddirpluginextdata="$srcdir"/pigeonhole-${_pigeonholevermajor/./-}-sieve-extdata-$_pluginextdataver
 
 # secfixes:
+#   2.2.36.3-r0:
+#     - CVE-2019-7524
 #   2.2.36.1-r0:
 #     - CVE-2019-3814
 
@@ -205,7 +207,7 @@ sql() {
 	_mv $(cd "$pkgdir" && find usr -name '*-sql.*')
 	_mv $(cd "$pkgdir" && find etc/dovecot -name '*-sql.conf*')
 }
-sha512sums="b085ad919e3a45b209a52920d3462270822bba6f5de93f1a65c4d8522339ce8eff06059fe42f38442c2ffe178f91e4f66b43b2457ab47af379091da40dd860d8  dovecot-2.2.36.1.tar.gz
+sha512sums="47611dbde7ee854ad323dcdb726757c7172376761fa774f28fce3f9d74ed590319d812f0555abed5f8178c326c3cb7661ac0b708ca5982914e255cec60f72e35  dovecot-2.2.36.3.tar.gz
 5f59fb35dbe638f8ddd19c0fd0f3fbd6fec1fa238f3781b94c50a8f7ce72a53ac1381a6f8ad9bcc90df1edfa2b263a6dfba88521578e55ce4b3d840bed022b79  dovecot-2.2-pigeonhole-0.4.16.tar.gz
 832a80264fb9bd3021c4e192eb7594c203100783df547aff35acf4dc4d8de5eddfd676fcc5a07a0691d9bb6eb884c9497a692b72a2af5bf9e9bb7a2d3f38923e  39.tar.gz
 9f19698ab45969f1f94dc4bddf6de59317daee93c9421c81f2dbf8a7efe6acf89689f1d30f60f536737bb9526c315215d2bce694db27e7b8d7896036a59c31f0  dovecot.logrotate


### PR DESCRIPTION
https://dovecot.org/list/dovecot-news/2019-March/000402.html