### PR TITLE
main/gtest: -dev should install libraries too

### DIFF
--- a/main/gtest/APKBUILD
+++ b/main/gtest/APKBUILD
@@ -9,7 +9,7 @@ options="!check"  # googletest-death-test-test hangs
 license="BSD-3-Clause"
 depends=""
 depends_dev="${pkgname}=${pkgver}-r${pkgrel} gmock=${pkgver}-r${pkgrel} cmake"
-makedepends="$depends_dev python2-dev"
+makedepends="$depends_dev python3-dev"
 install=""
 subpackages="$pkgname-dev gmock"
 source="$pkgname-$pkgver.tar.gz::https://github.com/google/googletest/archive/release-$pkgver.tar.gz
@@ -32,7 +32,7 @@ build() {
 	cmake -DCMAKE_INSTALL_PREFIX=/usr \
 	      -DCMAKE_INSTALL_LIBDIR=lib \
 	      -DBUILD_SHARED_LIBS=ON \
-	      -DPYTHON_EXECUTABLE=python2 \
+	      -DPYTHON_EXECUTABLE=python3 \
 	      -Dgtest_build_tests=ON \
 	      ..
 	make

--- a/main/gtest/APKBUILD
+++ b/main/gtest/APKBUILD
@@ -1,14 +1,15 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=gtest
 pkgver=1.8.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Google Test - C++ testing utility based on the xUnit framework (like JUnit)"
 url="https://github.com/google/googletest"
 arch="all"
 options="!check"  # googletest-death-test-test hangs
 license="BSD-3-Clause"
 depends=""
-makedepends="python2-dev cmake"
+depends_dev="${pkgname}=${pkgver}-r${pkgrel} gmock=${pkgver}-r${pkgrel} cmake"
+makedepends="$depends_dev python2-dev"
 install=""
 subpackages="$pkgname-dev gmock"
 source="$pkgname-$pkgver.tar.gz::https://github.com/google/googletest/archive/release-$pkgver.tar.gz


### PR DESCRIPTION
Using *.pc files is difficult when the libraries are not installed.