### PR TITLE
community/runc: upgrade to 1.0.0_rc7

### DIFF
--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -2,32 +2,33 @@
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 
 pkgname=runc
-
-# NOTE: using explicit post-1.0.0_rc6 commit, later than the one specified by
-# containerd (https://github.com/containerd/containerd/blob/v1.2.5/vendor.conf)
-# for improved mitigation of CVE-2019-5736, which properly compiles with musl libc.
-_commit=f56b4cbeadc407e715d9b2ba49e62185bd81cef4
-
-pkgver=1.0.0_rc6
-pkgrel=2
 pkgdesc="CLI tool for spawning and running containers according to the OCI specification"
 url="https://www.opencontainers.org"
+
+_commit=69ae5da6afdcaaf38285a10b36f362e41cb298d6
+pkgver=1.0.0_rc7
+pkgrel=0
+
+_ver=v${pkgver/_rc/-rc}
+# if we're building against an explicit commit beyond pkgver, use this instead:
+#_ver=${_commit}
+
 arch="all"
 license="Apache-2.0"
 makedepends="go go-md2man libseccomp-dev libtool"
 subpackages="$pkgname-doc"
-source="runc-$_commit.tar.gz::https://github.com/opencontainers/runc/archive/$_commit.tar.gz"
+source="runc-$_ver.tar.gz::https://github.com/opencontainers/runc/archive/$_ver.tar.gz"
 builddir="$srcdir/src/github.com/opencontainers/runc"
 
 # secfixes:
-#   1.0.0_rc6-r2:
+#   1.0.0_rc7:
 #     - CVE-2019-5736
 
 build() {
 	cd "$srcdir"
 	export GOPATH="$PWD"
 	mkdir -p $(dirname "$builddir")
-	ln -s "$PWD/$pkgname-$_commit" "$builddir"
+	ln -s "$PWD/$pkgname-${_ver#v}" "$builddir"
 	cd "$builddir"
 	make COMMIT="$_commit"
 	make man
@@ -45,4 +46,4 @@ package() {
 	install -Dm644 "$builddir"/man/man8/* "$pkgdir"/usr/share/man/man8/
 }
 
-sha512sums="cf6c189f06fb4fde78807a71df14c78a9cd1af5c8958bcb4a438e8ae173ac7d6a66013210d7442e47b83552f3d2417300ee9f317bde3c3247173e2e19132fee3  runc-f56b4cbeadc407e715d9b2ba49e62185bd81cef4.tar.gz"
+sha512sums="c885f37b47a439a401e2c6bc3127ef5ba36e11159d744de70f10c360c7413cda5f1850918e54aabbba963e4b879041d2e7e0dd1ec11488674d65f17f3f7c609c  runc-v1.0.0-rc7.tar.gz"


### PR DESCRIPTION
See https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc7 for more information about what's changed.