### PR TITLE
community/docker: upgrade to 18.09.4

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 
 pkgname=docker
-pkgver=18.09.3
-_gitcommit=774a1f4eee66e29a71ca12e88ac2220670990f7e	# https://github.com/docker/docker-ce/commits/v$pkgver
+pkgver=18.09.4
+_gitcommit=d14af54266dfeb55872100e28d14231b1baafe85	# https://github.com/docker/docker-ce/commits/v$pkgver
 _ver=${pkgver/_/-}-ce
 pkgrel=0
 pkgdesc="Pack, ship and run any application as a lightweight container"
@@ -14,8 +14,8 @@ depends="ca-certificates containerd iptables tini-static"
 makedepends="go go-md2man btrfs-progs-dev bash linux-headers coreutils lvm2-dev libtool"
 install="$pkgname.pre-install"
 
-# https://github.com/docker/docker-ce/blob/v$pkgver/components/engine/hack/dockerfile/install/proxy.installer
-_libnetwork_ver=2cfbf9b1f98162a55829a21cc603c76072a75382
+# from https://github.com/docker/docker-ce/blob/v$pkgver/components/engine/vendor.conf
+_libnetwork_ver=4725f2163fb214a6312f3beae5991f838ec36326
 _cobra_ver="0.0.3"
 
 subpackages="
@@ -187,8 +187,8 @@ vim() {
 	done
 }
 
-sha512sums="c7df08c03c6bfd8451977cb86593d8ac68390c846c84cc4d8a32e05e815688ccd84a6296f819e440c850c2aa52c131686492206ec4d47765cd0af90c3c39dc03  docker-18.09.3.tar.gz
-9256eedc6ed530506e4e61673a9f45397274093dd61105097d5c650796f0afebc8ad7c550d2dc3cacf94426e3872a2b764906bca46fc907a21b865314c8927d4  libnetwork-2cfbf9b1f98162a55829a21cc603c76072a75382.tar.gz
+sha512sums="139d09829b92319f66dea692bac0664decc666d9bc13f0a85b275e3fe2cf3b7e71b7e608a519c7a7baa40626309e2d4da880bee84da19f5eb3107af55d072ddf  docker-18.09.4.tar.gz
+8ffd6fc97df4b63b1f83a5eb6d8e63c8c413bcf3e2ff82f507dbf875d0df6903b6fe1546d8625dd3b4681d611aed4702c423d0d5c9621ed57073cbe16bf35200  libnetwork-4725f2163fb214a6312f3beae5991f838ec36326.tar.gz
 c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 33155a79799cc6c0520a030e1a9bdba60441776d612e5e255574b23bbce1c7a8e5d868284b05a8a92704be6bbb7db905388564e867986a705acbe4884ac58584  docker-openrc-fixes.patch
 9b24dc0c50904c3d12bb04c1a7df169651043ddbc258018647010a5aa01d8a19ad54d10ca79dce6d6283c81f4fa0cc8de417f6180dd824c5a588b22b23546cb5  docker-openrc-busybox-ash.patch"


### PR DESCRIPTION
For more details, see https://github.com/docker/docker-ce/releases/tag/v18.09.4