### PR TITLE
main/tzdata: upgrade to 2019a

### DIFF
--- a/main/tzdata/APKBUILD
+++ b/main/tzdata/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=tzdata
-pkgver=2018i
-_tzcodever=2018i
+pkgver=2019a
+_tzcodever=2019a
 _ptzver=0.5
 pkgrel=0
 pkgdesc="Timezone data"
@@ -57,8 +57,8 @@ package() {
 		"$pkgdir"/usr/bin/posixtz
 }
 
-sha512sums="1a3d53043f20b8252f7598f547d78e7294d9e0cf1fcdd2159354d9769f824c8c8a03cef9cbb7fa579345fdb41372335117d2ef782ecd9c107dd0526e59492d9d  tzcode2018i.tar.gz
-6afcacb377842190648ed26f01abcf3db37aa2e7c63d8c509c29b4bc0078b7ff2d4e5375291b9f53498215b9e2f04936bc6145e2f651ae0be6d8166d8d336f6a  tzdata2018i.tar.gz
+sha512sums="7cc76ce6be4a67c3e1b2222cb632d2de9dabb76899793a938f87a1d4bb20e462cabdae9e3b986aaabaa400795370510095d236dbad5aff4c192d0887f0ecedf5  tzcode2019a.tar.gz
+d8eb5b2b68abee08bd2b0d2134bce85b5c0aee85168e9697a607604ed5be7d1539ac60fda9b37e0c9c793ef6251978bc250563a0af59497fde775499964bb5aa  tzdata2019a.tar.gz
 68dbaab9f4aef166ac2f2d40b49366527b840bebe17a47599fe38345835e4adb8a767910745ece9c384b57af815a871243c3e261a29f41d71f8054df3061b3fd  posixtz-0.5.tar.xz
 0f2a10ee2bb4007f57b59123d1a0b8ef6accf99e568f21537f0bb19f290fff46e24050f55f12569d7787be600e1b62aa790ea85a333153f3ea081a812c81b1b5  0001-posixtz-ensure-the-file-offset-we-pass-to-lseek-is-o.patch
 fb322ab7867517ba39265d56d3576cbcea107c205d524e87015c1819bbb7361f7322232ee3b86ea9b8df2886e7e06a6424e3ac83b2006be290a33856c7d40ac4  0002-fix-implicit-declaration-warnings-by-including-strin.patch"


### PR DESCRIPTION
https://mm.icann.org/pipermail/tz-announce/2019-March/000055.html