### PR TITLE
community/whois: upgrade to 5.4.2

### DIFF
--- a/community/whois/APKBUILD
+++ b/community/whois/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=whois
-pkgver=5.4.1
+pkgver=5.4.2
 pkgrel=0
 pkgdesc="Intelligent WHOIS client by Marco d'Itri"
 url="https://github.com/rfc1036/whois"
@@ -36,6 +36,6 @@ package() {
 	install -D -m644 whois.conf "$pkgdir/etc/whois.conf"
 }
 
-sha512sums="ced3462a037788de36351801e9e6a90d5d9d5714649ebca0e20a19bec95b63801738c3ff2584ba89b053201c3acc2f343fb947a4b53a4dbb9ced6db69728a8fe  whois-5.4.1.tar.gz
+sha512sums="71717403805e50da3150937801bf061b346699c05d75687f74e98bb8eebfe4d12f9a888a28c25b167604fd3042240a82c0aea7b2a16d2198ced1f6a3fad35a5a  whois-5.4.2.tar.gz
 efa32ec848e3d3e61481567815e8c02757eab32712eb5a431adb13b59fd359f735eb684fbdf8a5b8334410d17052dc93d65bdda27a328617e2b6772b23717487  undefined-libintl.patch
 66a6b36e4caa00d58ab44c8fb55bfe919994fc6c7631cc283d9f37f9d69bf3e911ab365b27b1720065103e8d7abbf7549dfb260e156c1b52726a8c8b8820c836  enable-sha256-sha512-mkpasswd.patch"


### PR DESCRIPTION
https://github.com/rfc1036/whois/blob/next/debian/changelog