### PR TITLE
main/llvm7: add patch to fix rust build

### DIFF
--- a/main/llvm7/APKBUILD
+++ b/main/llvm7/APKBUILD
@@ -7,7 +7,7 @@ _pkgname=llvm
 pkgver=7.0.1
 _majorver=${pkgver%%.*}
 pkgname=$_pkgname$_majorver
-pkgrel=2
+pkgrel=3
 pkgdesc="Low Level Virtual Machine compiler system, version $_majorver"
 arch="all"
 url="https://llvm.org/"
@@ -21,6 +21,7 @@ source="https://llvm.org/releases/$pkgver/llvm-$pkgver.src.tar.xz
 	fix-memory-mf_exec-on-aarch64.patch
 	fix-LLVMConfig-cmake-install-prefix.patch
 	python3-test.patch
+	rust.patch
 	"
 builddir="$srcdir/$_pkgname-$pkgver.src"
 options="!checkroot"
@@ -250,4 +251,5 @@ sha512sums="ac43a3cb71a53deb55e3693653847cf20bf6f5d9056f224e6956c96d63bc59ebee94
 695502bd3b5454c2f5630c59a8cf5f8aeb0deac16a76a8a4df34849e1e35c12ed4234572a320fe4c7e96f974f572f429eb816c5aa3dcfb17057f550eac596495  0001-Disable-dynamic-lib-tests-for-musl-s-dlclose-is-noop.patch
 c9ef3cd95c4bd1d6ac69bbcd471b01755126d00f59d27d4a2a2ef5623943be73f8407e2fd731294d1a9d81a66e459f45f3f1d5dc5f9646f4f2fb2d8d891b5279  fix-memory-mf_exec-on-aarch64.patch
 7d4825d16107e56a14b7b05be847f03d75e2e05952bea0742a1233b5b0441c9934d8058e612abb6471272884372d9bfd3348355fbd3c19cba82a554003cc3eec  fix-LLVMConfig-cmake-install-prefix.patch
-53cc0d13dd871e9b775bb4e7567de4f9a97d91b8246cd7ce74607fd88d6e3e2ab9455f5b4195bc7f9dbdedbc77d659d43e98ec0b7cd78cd395aaea6919510287  python3-test.patch"
+53cc0d13dd871e9b775bb4e7567de4f9a97d91b8246cd7ce74607fd88d6e3e2ab9455f5b4195bc7f9dbdedbc77d659d43e98ec0b7cd78cd395aaea6919510287  python3-test.patch
+a59417fe9eecb1a134763092a1db99abbd3a0e0960a6c199a3acdb610e4ae71f2619023cf35c130973776ff3d6f5fc7d9a38c592b64789828b68eaef6000bd80  rust.patch"

--- a/main/llvm7/rust.patch
+++ b/main/llvm7/rust.patch
@@ -1,0 +1,82 @@
+From da1fb72bb305d6bc1f3899d541414146934bf80f Mon Sep 17 00:00:00 2001
+From: Jonas Devlieghere <jonas@devlieghere.com>
+Date: Fri, 21 Sep 2018 12:03:14 +0000
+Subject: [PATCH] Ensure that variant part discriminator is read by
+ MetadataLoader
+
+https://reviews.llvm.org/D42082 introduced variant parts to debug info
+in LLVM. Subsequent work on the Rust compiler has found a bug in that
+patch; namely, there is a path in MetadataLoader that fails to restore
+the discriminator.
+
+This patch fixes the bug.
+
+Patch by: Tom Tromey
+
+Differential revision: https://reviews.llvm.org/D52340
+
+git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@342725 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ lib/Bitcode/Reader/MetadataLoader.cpp         |  2 +-
+ test/Assembler/debug-variant-discriminator.ll | 14 ++++++++++++++
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+ create mode 100644 test/Assembler/debug-variant-discriminator.ll
+
+diff --git a/lib/Bitcode/Reader/MetadataLoader.cpp b/lib/Bitcode/Reader/MetadataLoader.cpp
+index 3fe7d2205631..4781cfe3dea6 100644
+--- a/lib/Bitcode/Reader/MetadataLoader.cpp
++++ b/lib/Bitcode/Reader/MetadataLoader.cpp
+@@ -1313,7 +1313,7 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
+                            (Context, Tag, Name, File, Line, Scope, BaseType,
+                             SizeInBits, AlignInBits, OffsetInBits, Flags,
+                             Elements, RuntimeLang, VTableHolder, TemplateParams,
+-                            Identifier));
++                            Identifier, Discriminator));
+     if (!IsNotUsedInTypeRef && Identifier)
+       MetadataList.addTypeRef(*Identifier, *cast<DICompositeType>(CT));
+ 
+diff --git a/test/Assembler/debug-variant-discriminator.ll b/test/Assembler/debug-variant-discriminator.ll
+new file mode 100644
+index 000000000000..5be001cad6be
+--- /dev/null
++++ b/test/Assembler/debug-variant-discriminator.ll
+@@ -0,0 +1,14 @@
++; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s
++; RUN: verify-uselistorder %s
++
++; CHECK: !named = !{!0, !1, !2}
++!named = !{!0, !1, !2}
++
++; CHECK: !0 = !DICompositeType(tag: DW_TAG_structure_type, name: "Outer", size: 64, align: 64, identifier: "Outer")
++; CHECK-NEXT: !1 = !DICompositeType(tag: DW_TAG_variant_part, scope: !0, size: 64, discriminator: !2)
++; CHECK-NEXT: !2 = !DIDerivedType(tag: DW_TAG_member, scope: !1, baseType: !3, size: 64, align: 64, flags: DIFlagArtificial)
++; CHECK-NEXT: !3 = !DIBasicType(name: "u64", size: 64, encoding: DW_ATE_unsigned)
++!0 = !DICompositeType(tag: DW_TAG_structure_type, name: "Outer", size: 64, align: 64, identifier: "Outer")
++!1 = !DICompositeType(tag: DW_TAG_variant_part, scope: !0, size: 64, discriminator: !2)
++!2 = !DIDerivedType(tag: DW_TAG_member, scope: !1, baseType: !3, size: 64, align: 64, flags: DIFlagArtificial)
++!3 = !DIBasicType(name: "u64", size: 64, encoding: DW_ATE_unsigned)
+From cc1f2a595ead516812a6c50398f0f3480ebe031f Mon Sep 17 00:00:00 2001
+From: Jonas Devlieghere <jonas@devlieghere.com>
+Date: Fri, 21 Sep 2018 12:28:44 +0000
+Subject: [PATCH] [test] Fix Assembler/debug-info.ll
+
+Update Assembler/debug-info.ll to contain discriminator.
+
+git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@342727 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ test/Assembler/debug-info.ll | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/Assembler/debug-info.ll b/test/Assembler/debug-info.ll
+index 4404b741d343..d54dba07ac1e 100644
+--- a/test/Assembler/debug-info.ll
++++ b/test/Assembler/debug-info.ll
+@@ -83,7 +83,7 @@
+ ; CHECK-NEXT: !32 = !DIFile(filename: "file", directory: "dir", checksumkind: CSK_MD5, checksum: "000102030405060708090a0b0c0d0e0f")
+ !35 = !DIFile(filename: "file", directory: "dir", checksumkind: CSK_MD5, checksum: "000102030405060708090a0b0c0d0e0f")
+ 
+-; CHECK-NEXT: !33 = !DICompositeType(tag: DW_TAG_variant_part, name: "A", scope: !14, size: 64)
++; CHECK-NEXT: !33 = !DICompositeType(tag: DW_TAG_variant_part, name: "A", scope: !14, size: 64, discriminator: !34)
+ ; CHECK-NEXT: !34 = !DIDerivedType(tag: DW_TAG_member, scope: !33, baseType: !35, size: 64, align: 64, flags: DIFlagArtificial)
+ ; CHECK-NEXT: !35 = !DIBasicType(name: "u64", size: 64, encoding: DW_ATE_unsigned)
+ !36 = !DICompositeType(tag: DW_TAG_variant_part, name: "A", scope: !16, size: 64, discriminator: !37)


### PR DESCRIPTION
I tried to compile rust 1.32 with llvm7 and lto test failed. After that I found these issue. https://github.com/rust-lang/rust/issues/57762
So it's needed to add these patches to llvm7 to use it with rust
https://github.com/llvm-mirror/llvm/commit/da1fb72
https://github.com/llvm-mirror/llvm/commit/cc1f2a5