### PR TITLE
main/postfix: upgrade to 3.4.5

### DIFF
--- a/main/postfix/APKBUILD
+++ b/main/postfix/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=postfix
-pkgver=3.4.1
+pkgver=3.4.5
 pkgrel=0
 pkgdesc="Secure and fast drop-in replacement for Sendmail (MTA)"
 url="http://www.postfix.org/"
@@ -195,6 +195,6 @@ stone() {
 	find src/smtpstone -mindepth 1 -perm 0755 -exec cp {} "$subpkgdir"/usr/bin \;
 }
 
-sha512sums="14d2fe4e70b28121e99b17c8f5028adb842cfb09f52ec4c279b7cd7fe1f9e47cbf6a142f4472f53e7589ba3dbdb1e17b4c8e76a16af8ae0568bee103979206ad  postfix-3.4.1.tar.gz
+sha512sums="af59d960b40799f7667935bef8fafb93ae6dcb70abaa77a15cf498571f37fa0429f411f9f08b1b6bfa588d3f572260d14d6d5409f0cd1e82b1c59928b2124c94  postfix-3.4.5.tar.gz
 2752e69c4e1857bdcf29444ffb458bca818bc60b9c77c20823c5f5b87c36cb5e0f3217a625a7fe5788d5bfcef7570a1f2149e1233fcd23ccf7ee14190aff47a2  postfix.initd
 25cd34f23ca909d4e33aaf3239d1e397260abc7796d9a4456dee4f005682fd3a58aab8106126e5218c95bdddae415a3ef7e2223cd3b0d7b1e2bd76158bb7eaf8  postfix-install.patch"


### PR DESCRIPTION
ref [https://de.postfix.org/ftpmirror/official/postfix-3.4.5.RELEASE_NOTES](https://de.postfix.org/ftpmirror/official/postfix-3.4.5.RELEASE_NOTES)

~~this also includes `icu-dev` lib to support `smtputf8_enable` as in PR #6596~~