### PR TITLE
community/colord-gtk: fix build error by updating makedepends with lcms2-dev

### DIFF
--- a/community/colord-gtk/APKBUILD
+++ b/community/colord-gtk/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Kevin Daudt <ops@ikke.info>
 pkgname=colord-gtk
 pkgver=0.1.26
-pkgrel=1
+pkgrel=2
 pkgdesc="GTK support library for colord"
 url="https://www.freedesktop.org/software/colord/"
 arch="all"
 license="GPL-3.0"
-makedepends="intltool glib-dev gtk+3.0-dev colord-dev"
+makedepends="intltool glib-dev gtk+3.0-dev colord-dev lcms2-dev"
 subpackages="$pkgname-dev"
 source="https://www.freedesktop.org/software/colord/releases/colord-gtk-$pkgver.tar.xz"
 builddir="$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Build failing with:
configure: error: Package requirements (lcms2 >= 2.2) were not met:

fix adds lcms2-dev to makedepends