### PR TITLE
testing/perl-perlmagic: new aport

### DIFF
--- a/testing/perlmagick/APKBUILD
+++ b/testing/perlmagick/APKBUILD
@@ -1,0 +1,78 @@
+# Contributor: Timothy Legge <timlegge@gmail.com>
+# Maintainer: Timothy Legge <timlegge@gmail.com>
+pkgname=perlmagick
+pkgver=7.0.8.39
+pkgrel=0
+_pkgver=${pkgver%.*}-${pkgver##*.}
+_abiver=7
+pkgdesc="Perl Module for Image Magick"
+url="https://www.imagemagick.org/"
+arch="all"
+license="ImageMagick"
+options="libtool !checkroot"
+depends="imagemagick imagemagick-libs imagemagick-c++"
+makedepends="perl-dev libtool chrpath"
+subpackages="$pkgname-doc"
+source="https://www.imagemagick.org/download/releases/ImageMagick-$_pkgver.tar.xz"
+builddir="$srcdir/ImageMagick-${_pkgver}"
+
+build() {
+	cd "$builddir"
+	# fix doc dir, Gentoo bug 91911
+	sed -i -e \
+		's:DOCUMENTATION_PATH="${DATA_DIR}/doc/${DOCUMENTATION_RELATIVE_PATH}":DOCUMENTATION_PATH="/usr/share/doc/imagemagick":g' \
+		configure
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--disable-static \
+		--disable-openmp \
+		--with-threads \
+		--with-x \
+		--with-tiff \
+		--with-png \
+		--with-webp \
+		--with-rsvg \
+		--with-gslib \
+		--with-gs-font-dir=/usr/share/fonts/Type1 \
+		--with-modules \
+		--with-xml \
+		--with-perl \
+		--with-perl-options=PREFIX=/usr \
+		$_pic
+	make perl-sources
+	make perl-build
+	cd "$builddir/PerlMagick"
+	chrpath -d ./blib/arch/auto/Image/Magick/Q16HDRI/Q16HDRI.so
+}
+
+check() {
+	cd "$builddir/PerlMagick"
+	if ! [ -e blib/lib/Image/Magick.pm ]; then
+		error "Module does not exist Magick.pm"
+		return 1
+	fi
+	if ! [ -e blib/lib/Image/Magick/Q16HDRI.pm ]; then
+		error "Module does not exist Magick/Q16HDRI.pm"
+		return 1
+	fi
+
+	if ! [ -e blib/arch/auto/Image/Magick/Q16HDRI/Q16HDRI.so ]; then
+		error "library does not exist Q16HDRI.so"
+		return 1
+	fi
+}
+
+package() {
+	cd "$builddir/PerlMagick"
+	make -j1 DESTDIR="$pkgdir" install_vendor
+
+	find "$pkgdir" -name '.packlist' -o -name 'perllocal.pod' \
+		-o -name '*.bs' -delete
+}
+
+sha512sums="545c0e919f58e5d29b0a92b1db8dc32eb8f4aa828c6e8bc8f9bec5ada3468b79c8fbbb57350772f1a87a46f29bbd94af33272f7f8bb0ab720837844d15d7a43b  ImageMagick-7.0.8-39.tar.xz"


### PR DESCRIPTION
@ncopa as you are the maintainer of the ImageMagick aport it would likely be a good idea for you to review this perlmagick aport. 

It needs ImageMagick 7.0.8.36 packages to be updated as well.  