### PR TITLE
community/mongodb-tools: fix build error in pcap.go use C.struct, not _Ctype_struct

### DIFF
--- a/community/mongodb-tools/APKBUILD
+++ b/community/mongodb-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Marc Vertes <mvertes@free.fr>
 pkgname=mongodb-tools
 pkgver=4.0.6
-pkgrel=0
+pkgrel=1
 pkgdesc="The MongoDB tools provide import, export, and diagnostic capabilities."
 url="https://github.com/mongodb/mongo-tools"
 arch="all !s390x !aarch64"
@@ -10,6 +10,7 @@ license="Apache"
 makedepends="$depends_dev go cyrus-sasl-dev openssl-dev libpcap-dev bash perl"
 options="!check"
 source="$pkgname-$pkgver.tar.gz::https://github.com/mongodb/mongo-tools/archive/r$pkgver.tar.gz
+	fix-cstruct-decls.patch
 	fix-build.patch
 	"
 builddir="$srcdir/src/github.com/mongodb/mongo-tools"
@@ -35,4 +36,5 @@ package() {
 }
 
 sha512sums="d6185d7442a593d29db78889c55aba53e070bedd522d78d8c0bf52bb27f26c5fee6d010457f65774ea36a2e6d5280f38c95433ff76ed53ed9d74b1c811198cb7  mongodb-tools-4.0.6.tar.gz
+e95ff1c3583ad8c3c4b8f14c6743fe8a5029c91e83b78bc33eae762d1d3aa48a6536c5b27183fca81b93034f4f3d91d23fef857a1f85f725d57f3a45a599fedf  fix-cstruct-decls.patch
 74e432b354fd75209b87461e54f79a173ba0d647a2e45a48d520ee9342236b6a50ef1c634312f4804402578b8534d59ebf10973ce90cae2bbe76407102f2b404  fix-build.patch"

--- a/community/mongodb-tools/fix-cstruct-decls.patch
+++ b/community/mongodb-tools/fix-cstruct-decls.patch
@@ -1,0 +1,78 @@
+--- a/vendor/github.com/google/gopacket/pcap/pcap.go
++++ b/vendor/github.com/google/gopacket/pcap/pcap.go
+@@ -170,7 +170,7 @@
+ // BPF is a compiled filter program, useful for offline packet matching.
+ type BPF struct {
+ 	orig string
+-	bpf  _Ctype_struct_bpf_program // takes a finalizer, not overriden by outsiders
++	bpf  C.struct_bpf_program // takes a finalizer, not overriden by outsiders
+ }
+ 
+ // BPFInstruction is a byte encoded structure holding a BPF instruction
+@@ -381,7 +381,7 @@
+ 
+ // Stats returns statistics on the underlying pcap handle.
+ func (p *Handle) Stats() (stat *Stats, err error) {
+-	var cstats _Ctype_struct_pcap_stat
++	var cstats C.struct_pcap_stat
+ 	if -1 == C.pcap_stats(p.cptr, &cstats) {
+ 		return nil, p.Error()
+ 	}
+@@ -418,7 +418,7 @@
+ 	return datalinks, nil
+ }
+ 
+-func (p *Handle) compileBPFFilter(expr string) (_Ctype_struct_bpf_program, error) {
++func (p *Handle) compileBPFFilter(expr string) (C.struct_bpf_program, error) {
+ 	errorBuf := (*C.char)(C.calloc(errorBufferSize, 1))
+ 	defer C.free(unsafe.Pointer(errorBuf))
+ 
+@@ -441,7 +441,7 @@
+ 		}
+ 	}
+ 
+-	var bpf _Ctype_struct_bpf_program
++	var bpf C.struct_bpf_program
+ 	cexpr := C.CString(expr)
+ 	defer C.free(unsafe.Pointer(cexpr))
+ 
+@@ -459,7 +459,7 @@
+ 		return nil, err
+ 	}
+ 
+-	bpfInsn := (*[bpfInstructionBufferSize]_Ctype_struct_bpf_insn)(unsafe.Pointer(bpf.bf_insns))[0:bpf.bf_len:bpf.bf_len]
++	bpfInsn := (*[bpfInstructionBufferSize]C.struct_bpf_insn)(unsafe.Pointer(bpf.bf_insns))[0:bpf.bf_len:bpf.bf_len]
+ 	bpfInstruction := make([]BPFInstruction, len(bpfInsn), len(bpfInsn))
+ 
+ 	for i, v := range bpfInsn {
+@@ -535,7 +535,7 @@
+ 
+ 	return nil
+ }
+-func bpfInstructionFilter(bpfInstructions []BPFInstruction) (bpf _Ctype_struct_bpf_program, err error) {
++func bpfInstructionFilter(bpfInstructions []BPFInstruction) (bpf C.struct_bpf_program, err error) {
+ 	if len(bpfInstructions) < 1 {
+ 		return bpf, errors.New("bpfInstructions must not be empty")
+ 	}
+@@ -548,7 +548,7 @@
+ 	cbpfInsns := C.calloc(C.size_t(len(bpfInstructions)), C.size_t(unsafe.Sizeof(bpfInstructions[0])))
+ 
+ 	copy((*[bpfInstructionBufferSize]BPFInstruction)(cbpfInsns)[0:len(bpfInstructions)], bpfInstructions)
+-	bpf.bf_insns = (*_Ctype_struct_bpf_insn)(cbpfInsns)
++	bpf.bf_insns = (*C.struct_bpf_insn)(cbpfInsns)
+ 
+ 	return
+ }
+@@ -656,10 +656,10 @@
+ 	return
+ }
+ 
+-func findalladdresses(addresses *_Ctype_struct_pcap_addr) (retval []InterfaceAddress) {
++func findalladdresses(addresses *C.struct_pcap_addr) (retval []InterfaceAddress) {
+ 	// TODO - make it support more than IPv4 and IPv6?
+ 	retval = make([]InterfaceAddress, 0, 1)
+-	for curaddr := addresses; curaddr != nil; curaddr = (*_Ctype_struct_pcap_addr)(curaddr.next) {
++	for curaddr := addresses; curaddr != nil; curaddr = (*C.struct_pcap_addr)(curaddr.next) {
+ 		// Strangely, it appears that in some cases, we get a pcap address back from
+ 		// pcap_findalldevs with a nil .addr.  It appears that we can skip over
+ 		// these.


### PR DESCRIPTION
Build fails with errors:
Building mongoreplay...
# github.com/mongodb/mongo-tools/vendor/github.com/google/gopacket/pcap
vendor/github.com/google/gopacket/pcap/pcap.go:173:7: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor/github.com/google/gopacket/pcap/pcap.go:384:13: identifier "_Ctype_struct_pcap_stat" may conflict with identifiers generated by cgo
vendor/github.com/google/gopacket/pcap/pcap.go:421:49: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor/github.com/google/gopacket/pcap/pcap.go:444:10: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor/github.com/google/gopacket/pcap/pcap.go:462:41: identifier "_Ctype_struct_bpf_insn" may conflict with identifiers generated by cgo
vendor/github.com/google/gopacket/pcap/pcap.go:538:66: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor/github.com/google/gopacket/pcap/pcap.go:551:19: identifier "_Ctype_struct_bpf_insn" may conflict with identifiers generated by cgo
vendor/github.com/google/gopacket/pcap/pcap.go:659:34: identifier "_Ctype_struct_pcap_addr" may conflict with identifiers generated by cgo
vendor/github.com/google/gopacket/pcap/pcap.go:662:56: identifier "_Ctype_struct_pcap_addr" may conflict with identifiers generated by cgo           

commit https://github.com/google/gopacket/commit/0c245453667e53d789b6dc8e74134345437f3312#diff-69b81a223850b8b6476f978036525756 changes this upstream to use proper defines. Attached is backported patch.
