### PR TITLE
testing/gx-go: upgrade vendor minio/sha256-simd, reenable ppc64le

### DIFF
--- a/testing/gx-go/APKBUILD
+++ b/testing/gx-go/APKBUILD
@@ -2,10 +2,10 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=gx-go
 pkgver=1.9.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A tool to use with the gx package manager for packages written in go"
 url="https://github.com/whyrusleeping/gx-go"
-arch="all !ppc64le"
+arch="all"
 license="MIT"
 options="!check" # Test suite issues
 makedepends="git glide go"
@@ -54,4 +54,4 @@ glide_init() {
 
 sha512sums="3df8a99d257098afdf99ba6cbf58d50eab196f823ae53db48865a4f4962e38b84a66ffc99d5a342b43ff9891c8245252a77677b75c770d86f93ef1ad3c9e879f  gx-go-1.9.0.tar.gz
 db824fce3e8094e2806c68b18ba5b8decae4cb62068113f6bc97f72de1224bd326b3342297739ee9b5a86bd4f7c9ec2f9b04aa3610cc95903dc1b3bfd7b0934f  glide.yaml
-0a13f10b02099f2c60a8d1bbc83faf4552ae04358b4df99d431712704004030f3af31142ea81ed5f038e51ef6aeeeb3cf1946fd90e9d164af0d551ce0a0425d9  glide.lock"
+32a2ae3e10d20c0ba1613a592d8b9fd7a6e9678e2bc9f262bb6887c22b65c0a8da2c7aef1f70d35b3d89ae6aa6b50ca26cdddd47c3ee274a8ddc1a8bf0b16016  glide.lock"

--- a/testing/gx-go/glide.lock
+++ b/testing/gx-go/glide.lock
@@ -37,7 +37,7 @@ imports:
 - name: github.com/minio/blake2b-simd
   version: 3f5f724cb5b182a5c278d6d3d55b40e7f8c2efb4
 - name: github.com/minio/sha256-simd
-  version: 3557f3d43a123835ffa5846e4d055146e773d52e
+  version: 05b4dd3047e5d6e86cb4e0477164b850cd896261
 - name: github.com/mitchellh/go-homedir
   version: af06845cf3004701891bf4fdb884bfe4920b3727
 - name: github.com/mr-tron/base58


### PR DESCRIPTION
update glide.lock for minio/sha256-simd, bump pkgrel, re-enable ppc64le