### PR TITLE
main/dovecot: add warning Fatal: Dovecot version mismatch

### DIFF
--- a/main/dovecot/APKBUILD
+++ b/main/dovecot/APKBUILD
@@ -6,7 +6,7 @@
 pkgname=dovecot
 pkgver=2.3.5.1
 _pkgvermajor=2.3
-pkgrel=0
+pkgrel=1
 _pigeonholever=0.5.5
 _pigeonholevermajor=${_pigeonholever%.*}
 pkgdesc="IMAP and POP3 server"

--- a/main/dovecot/dovecot.post-upgrade
+++ b/main/dovecot/dovecot.post-upgrade
@@ -9,8 +9,13 @@ if [ "$(apk version -t "$ver_old" "2.3.2.1-r1")" = "<" ]; then
 	* POP3, LMTP and Submission protocols were moved into subpackages:
 	* dovecot-pop3d, dovecot-lmtpd and dovecot-submissiond.  If you use
 	* some of these protocols, you have to install particular subpackage.
-	* 
+	*
 	EOF
 fi
 
-exit 0
+# warn Dovecot version mismatch
+if ! grep ^"version_ignore=yes" /etc/dovecot/dovecot.conf; then
+	printf "dovecot restart required (version_ignore=yes not set)\n"
+fi
+
+exit $?


### PR DESCRIPTION
* fixes: https://bugs.archlinux.org/task/57782