### PR TITLE
community/php7-pecl-timezonedb: upgrade to 2019.1

### DIFF
--- a/community/php7-pecl-timezonedb/APKBUILD
+++ b/community/php7-pecl-timezonedb/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=php7-pecl-timezonedb
 _pkgreal=timezonedb
 pkgver=2019.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Timezone Database to be used with PHP's date and time functions."
 url="https://pecl.php.net/package/timezonedb"
 arch="all"
@@ -12,7 +12,6 @@ depends="php7-common"
 makedepends="php7-dev autoconf re2c"
 source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
-options="!check"  # upstream does not provide tests yet
 provides="php7-timezonedb=$pkgver-r$pkgrel" # for backward compatibility
 replaces="php7-timezonedb" # for backward compatibility
 
@@ -21,6 +20,11 @@ build() {
 	phpize7
 	./configure --prefix=/usr --with-php-config=php-config7
 	make
+}
+
+check() {
+    # Test suite is not a part of pecl release.
+    php7 -d extension="$builddir"/modules/$_pkgreal.so --ri $_pkgreal
 }
 
 package() {

--- a/community/php7-pecl-timezonedb/APKBUILD
+++ b/community/php7-pecl-timezonedb/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
 pkgname=php7-pecl-timezonedb
 _pkgreal=timezonedb
-pkgver=2018.9
+pkgver=2019.1
 pkgrel=0
 pkgdesc="Timezone Database to be used with PHP's date and time functions."
 url="https://pecl.php.net/package/timezonedb"
@@ -30,4 +30,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/40_$_pkgreal.ini
 }
 
-sha512sums="77fabe3aa0283900ea2d3d20caaf7c4b9bac1859249c9df4f0225c203fc92310dfe9b4144640af034a4ba86ba78a748a39980ff796affc67edc99ec874867e06  timezonedb-2018.9.tgz"
+sha512sums="c813f74461b3e4f1cbd6efad41918e632bbcc6481a48c33d677cb5132ff0ef8964995a6f47e8cbcf276f02c48c9a27f3f0301a1d41522405f28ae7dc627db504  timezonedb-2019.1.tgz"


### PR DESCRIPTION
Ref https://pecl.php.net/package-info.php?package=timezonedb&version=2019.1

Related to https://github.com/alpinelinux/aports/pull/6881