### PR TITLE
community/network-manager-applet: fix after nm upgrade

### DIFF
--- a/community/network-manager-applet/APKBUILD
+++ b/community/network-manager-applet/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: 
 pkgname=network-manager-applet
 pkgver=1.8.18
-pkgrel=0
+pkgrel=1
 pkgdesc="GTK network manager applet"
 url="https://wiki.gnome.org/Projects/NetworkManager"
 arch="all"
@@ -39,7 +39,8 @@ build() {
 		--localstatedir=/var \
 		--with-gcr \
 		--enable-static=no \
-		--without-selinux
+		--without-selinux \
+		--without-libnm-gtk
 	make
 }
 


### PR DESCRIPTION
Currently, it can't be installed (missing so:libnm-glib.so.4).

I've tried to bump the pkgrel only, but it won't build anymore because
the legacy libnm has been removed in the NetworkManager release we are
using (NetworkManager/NetworkManager#308).

Add --without-libnm-gtk to fix it.