### PR TITLE
main/lvm2: update patches for actual version(2.02.182)

### DIFF
--- a/main/lvm2/fix-stdio-usage.patch
+++ b/main/lvm2/fix-stdio-usage.patch
@@ -30,20 +30,20 @@
 --- ./lib/commands/toolcontext.c.orig
 +++ ./lib/commands/toolcontext.c
 @@ -1860,7 +1860,7 @@
- 	/* FIXME Make this configurable? */
- 	reset_lvm_errno(1);
+	/* FIXME Make this configurable? */
+	reset_lvm_errno(1);
  
 -#ifndef VALGRIND_POOL
 +#if !defined(VALGRIND_POOL) && defined(__GLIBC__)
- 	/* Set in/out stream buffering before glibc */
- 	if (set_buffering) {
- 		/* Allocate 2 buffers */
-@@ -2241,7 +2241,7 @@
- 	if (cmd->libmem)
- 		dm_pool_destroy(cmd->libmem);
+	/* Set in/out stream buffering before glibc */
+	if (set_buffering
+ #ifdef SYS_gettid
+@@ -2254,7 +2254,7 @@
+	if (cmd->libmem)
+		dm_pool_destroy(cmd->libmem);
  
 -#ifndef VALGRIND_POOL
 +#if !defined(VALGRIND_POOL) && defined(__GLIBC__)
- 	if (cmd->linebuffer) {
- 		/* Reset stream buffering to defaults */
- 		if (is_valid_fd(STDIN_FILENO) &&
+	if (cmd->linebuffer) {
+	/* Reset stream buffering to defaults */
+	   if (is_valid_fd(STDIN_FILENO) &&

--- a/main/lvm2/mlockall-default-config.patch
+++ b/main/lvm2/mlockall-default-config.patch
@@ -9,16 +9,14 @@
  
  	# Configuration option activation/monitoring.
  	# Monitor LVs that are activated.
-diff --git a/lib/config/defaults.h b/lib/config/defaults.h
-index 8ab1fde..57b2443 100644
---- a/lib/config/defaults.h
-+++ b/lib/config/defaults.h
-@@ -53,7 +53,7 @@
- #define DEFAULT_WAIT_FOR_LOCKS 1
+--- ./lib/config/defaults.h.orig
++++ ./lib/config/defaults.h
+@@ -55,7 +55,7 @@
  #define DEFAULT_LVMLOCKD_LOCK_RETRIES 3
+ #define DEFAULT_LVMETAD_UPDATE_WAIT_TIME 10
  #define DEFAULT_PRIORITISE_WRITE_LOCKS 1
 -#define DEFAULT_USE_MLOCKALL 0
 +#define DEFAULT_USE_MLOCKALL 1
  #define DEFAULT_METADATA_READ_ONLY 0
  #define DEFAULT_LVDISPLAY_SHOWS_FULL_DEVICE_PATH 0
- 
+ #define DEFAULT_UNKNOWN_DEVICE_NAME "[unknown]"


### PR DESCRIPTION
Problem:

Last `fix-stdio-usage.patch` updates for version v2_02_166 in commit(https://github.com/alpinelinux/aports/commit/ea1e601d5000aa6e6ff8348c23bef5568703ebe0)
Last `mlockall-default-config.patch` updates for version v2_02_135 in commit(https://github.com/alpinelinux/aports/commit/be05d69d9f75822e37f283ebb7a6823e2dc46d7f)



In result patches incompatible:
```
/LVM2.2.02.182/patches # wget -q https://git.alpinelinux.org/aports/plain/main/lvm2/fix-stdio-usage.patch
/LVM2.2.02.182/patches # wget -q https://git.alpinelinux.org/aports/plain/main/lvm2/mlockall-default-config.patch
...
/LVM2.2.02.182 # patch --dry-run -p0 < patches/fix-stdio-usage.patch 
patching file ./tools/lvmcmdline.c
patching file ./lib/commands/toolcontext.c
Hunk 1 FAILED 1860/1860.
 	/* FIXME Make this configurable? */
 	reset_lvm_errno(1);
 
-#ifndef VALGRIND_POOL
+#if !defined(VALGRIND_POOL) && defined(__GLIBC__)
 	/* Set in/out stream buffering before glibc */
 	if (set_buffering) {
 		/* Allocate 2 buffers */

/LVM2.2.02.182 # patch --dry-run -p1 < patches/mlockall-default-config.patch 
patching file conf/example.conf.in
patching file lib/config/defaults.h
Hunk 1 FAILED 53/53.
 #define DEFAULT_WAIT_FOR_LOCKS 1
 #define DEFAULT_LVMLOCKD_LOCK_RETRIES 3
 #define DEFAULT_PRIORITISE_WRITE_LOCKS 1
-#define DEFAULT_USE_MLOCKALL 0
+#define DEFAULT_USE_MLOCKALL 1
 #define DEFAULT_METADATA_READ_ONLY 0
 #define DEFAULT_LVDISPLAY_SHOWS_FULL_DEVICE_PATH 0
```


Result of PR:
```
/LVM2.2.02.182 # patch --dry-run -p0 < patches/fix-stdio-usage.patch
patching file ./tools/lvmcmdline.c
patching file ./lib/commands/toolcontext.c
/LVM2.2.02.182 # patch --dry-run -p0 < patches/mlockall-default-config.patch 
patching file ./conf/example.conf.in
patching file ./lib/config/defaults.h
```

