### PR TITLE
community/pdns: upgrade to 4.1.8

### DIFF
--- a/community/pdns/APKBUILD
+++ b/community/pdns/APKBUILD
@@ -5,8 +5,8 @@
 # Contributor: Fabian Zoske <fabian@zoske.it>
 # Maintainer:  Matt Smith <mcs@darkregion.net>
 pkgname=pdns
-pkgver=4.1.7
-pkgrel=1
+pkgver=4.1.8
+pkgrel=0
 pkgdesc="PowerDNS Authoritative Server"
 url="https://www.powerdns.com/"
 arch="all"
@@ -135,6 +135,6 @@ backend_remote()        { _mv_backend remote; }
 backend_sqlite3()       { _mv_backend gsqlite3 sqlite; }
 #backend_tinydns()       { _mv_backend tinydns; }
 
-sha512sums="dc9c693ac2eaf11ddce220e7fedc40f6ae3f9d7a55352643b30db2aad0b2d543ad04a14199a06355275aba2d9dd7873087715a16157b0ff2f7335f1a4a4b96a2  pdns-4.1.7.tar.bz2
+sha512sums="1113745cdaa8fba591c176721893fb478e976861beee0cb6c0240e5afa6b68c9afae286579036b2ed77fffe76ca1e6f103cda915f8b7b875bcdc1253931ad935  pdns-4.1.8.tar.bz2
 3a55547e1b6407e7d2faa6e02982ed903c2364381af1b7eeb626ae3a8b0e32558dd79bf31c982b134414e5636d4868c1f3660ac523f25d2440ed6f7b436843bf  pdns.initd
 3f809f3257680c3e496fa6a4c86c8a636db5d9d5b92aef96fe54c29b8266ee590deb792d13205cc171e27307fa73295dd3b101b09102fd66a2393a7cdbf9dd27  pdns.conf"


### PR DESCRIPTION
https://blog.powerdns.com/2019/03/22/powerdns-authoritative-server-4-1-8-released/