### PR TITLE
main/linux-vanilla: support xen_pvh boot via grub

### DIFF
--- a/main/linux-vanilla/APKBUILD
+++ b/main/linux-vanilla/APKBUILD
@@ -7,7 +7,7 @@ case $pkgver in
 	*.*.*)	_kernver=${pkgver%.*};;
 	*.*) _kernver=$pkgver;;
 esac
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux vanilla kernel"
 url="http://kernel.org"
 depends="mkinitfs"
@@ -17,6 +17,12 @@ options="!strip"
 _config=${config:-config-vanilla.${CARCH}}
 install=
 source="https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/linux-$_kernver.tar.xz
+	x86-boot-Add-ACPI-RSDP-address-to-setup_header.patch
+	x86-acpi-x86-boot-Take-RSDP-address-for-boot-params-.patch
+	x86-boot-Mostly-revert-commit-ae7e1238e68f2a-Add-ACP.patch
+	x86-acpi-x86-boot-Take-RSDP-address-from-boot-params.patch
+	x86-boot-Clear-RSDP-address-in-boot_params-for-broke.patch
+
 	config-vanilla.aarch64
 	config-vanilla.armhf
 	config-vanilla.armv7
@@ -222,6 +228,11 @@ _dev() {
 }
 
 sha512sums="ab67cc746b375a8b135e8b23e35e1d6787930d19b3c26b2679787d62951cbdbc3bb66f8ededeb9b890e5008b2459397f9018f1a6772fdef67780b06a4cb9f6f4  linux-4.19.tar.xz
+c5387e273a5456bda1a0459c9878a9c49ffad34a80d6a187a05b0a852935f58444e730a880fb3346f8023a87106a576c9fe08ae3ee602bb162018655c7e63996  x86-boot-Add-ACPI-RSDP-address-to-setup_header.patch
+67934c2fa02549774f5cd0f37dda39992f18e8ecfefa3a1327f589fead711be4509fbd2c9daaee1c5a77deae5674a664f059eee654fb105b345315f477320fc2  x86-acpi-x86-boot-Take-RSDP-address-for-boot-params-.patch
+1f3da4ee0595b1c88fb392f1a981d5d4ad59ce07cd27900310a6dc51ef717b2ef3763dae12ca8a252050a7b4da1679ac577762ef2316669efbdf228cceedbf6c  x86-boot-Mostly-revert-commit-ae7e1238e68f2a-Add-ACP.patch
+eb86602369d58c29042fb1034f1d3b3449b8116eb7708eb9c32c86e1855e862ab1ce436df8692b6835422f8e7464772780babe6972082d9e40c21d5fecf1dd8f  x86-acpi-x86-boot-Take-RSDP-address-from-boot-params.patch
+5db1eae4412a9a6142d8d45219d38030b3197f3d58c6f4c6a7de229de9b3a0afacc64841e957db42eb40174793d382bab33fddd111e89e4804b0d1e998238830  x86-boot-Clear-RSDP-address-in-boot_params-for-broke.patch
 4a604ddbbca6298caa4b0144dacaa52d2e0c3b7050af125d19ffe75232f3a1f01cd8212947d6624ac853551474906fe36e44491d217172f1a3b69d3f6a6e69e5  config-vanilla.aarch64
 17cd16a91f2788e6c7ec39f5aeba7b0c5c5bc4ab304bef98381f36fad8d5f14a897f70ac59eeea79ec024fa8477ed0fb860655fe8db54cb04c47ea55391644cb  config-vanilla.armhf
 17cd16a91f2788e6c7ec39f5aeba7b0c5c5bc4ab304bef98381f36fad8d5f14a897f70ac59eeea79ec024fa8477ed0fb860655fe8db54cb04c47ea55391644cb  config-vanilla.armv7

--- a/main/linux-vanilla/x86-acpi-x86-boot-Take-RSDP-address-for-boot-params-.patch
+++ b/main/linux-vanilla/x86-acpi-x86-boot-Take-RSDP-address-for-boot-params-.patch
@@ -1,0 +1,104 @@
+From: Juergen Gross <jgross@suse.com>
+Date: Wed, 10 Oct 2018 08:14:56 +0200
+Subject: x86/acpi, x86/boot: Take RSDP address for boot params if available
+Origin: https://git.kernel.org/linus/e7b66d16fe41722350ba87f5788052ef53ee28bb
+
+In case the RSDP address in struct boot_params is specified don't try
+to find the table by searching, but take the address directly as set
+by the boot loader.
+
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Cc: Andy Lutomirski <luto@kernel.org>
+Cc: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Cc: Baoquan He <bhe@redhat.com>
+Cc: Borislav Petkov <bp@alien8.de>
+Cc: Jia Zhang <qianyue.zj@alibaba-inc.com>
+Cc: Len Brown <len.brown@intel.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Pavel Machek <pavel@ucw.cz>
+Cc: Pavel Tatashin <pasha.tatashin@oracle.com>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Cc: boris.ostrovsky@oracle.com
+Cc: linux-kernel@vger.kernel.org
+Cc: linux-pm@vger.kernel.org
+Cc: xen-devel@lists.xenproject.org
+Link: http://lkml.kernel.org/r/20181010061456.22238-4-jgross@suse.com
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+---
+ arch/x86/include/asm/acpi.h | 7 +++++++
+ arch/x86/kernel/acpi/boot.c | 6 ++++++
+ arch/x86/kernel/x86_init.c  | 3 +--
+ 3 files changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/acpi.h b/arch/x86/include/asm/acpi.h
+index a303d7b7d763..2f01eb4d6208 100644
+--- a/arch/x86/include/asm/acpi.h
++++ b/arch/x86/include/asm/acpi.h
+@@ -142,6 +142,8 @@ static inline u64 acpi_arch_get_root_pointer(void)
+ 
+ void acpi_generic_reduced_hw_init(void);
+ 
++u64 x86_default_get_root_pointer(void);
++
+ #else /* !CONFIG_ACPI */
+ 
+ #define acpi_lapic 0
+@@ -153,6 +155,11 @@ static inline void disable_acpi(void) { }
+ 
+ static inline void acpi_generic_reduced_hw_init(void) { }
+ 
++static inline u64 x86_default_get_root_pointer(void)
++{
++	return 0;
++}
++
+ #endif /* !CONFIG_ACPI */
+ 
+ #define ARCH_HAS_POWER_INIT	1
+diff --git a/arch/x86/kernel/acpi/boot.c b/arch/x86/kernel/acpi/boot.c
+index 3b20607d581b..e8fea7ffa306 100644
+--- a/arch/x86/kernel/acpi/boot.c
++++ b/arch/x86/kernel/acpi/boot.c
+@@ -48,6 +48,7 @@
+ #include <asm/mpspec.h>
+ #include <asm/smp.h>
+ #include <asm/i8259.h>
++#include <asm/setup.h>
+ 
+ #include "sleep.h" /* To include x86_acpi_suspend_lowlevel */
+ static int __initdata acpi_force = 0;
+@@ -1771,3 +1772,8 @@ void __init arch_reserve_mem_area(acpi_physical_address addr, size_t size)
+ 	e820__range_add(addr, size, E820_TYPE_ACPI);
+ 	e820__update_table_print();
+ }
++
++u64 x86_default_get_root_pointer(void)
++{
++	return boot_params.hdr.acpi_rsdp_addr;
++}
+diff --git a/arch/x86/kernel/x86_init.c b/arch/x86/kernel/x86_init.c
+index 2792b5573818..50a2b492fdd6 100644
+--- a/arch/x86/kernel/x86_init.c
++++ b/arch/x86/kernel/x86_init.c
+@@ -31,7 +31,6 @@ static int __init iommu_init_noop(void) { return 0; }
+ static void iommu_shutdown_noop(void) { }
+ static bool __init bool_x86_init_noop(void) { return false; }
+ static void x86_op_int_noop(int cpu) { }
+-static u64 u64_x86_init_noop(void) { return 0; }
+ 
+ /*
+  * The platform setup functions are preset with the default functions
+@@ -96,7 +95,7 @@ struct x86_init_ops x86_init __initdata = {
+ 	},
+ 
+ 	.acpi = {
+-		.get_root_pointer	= u64_x86_init_noop,
++		.get_root_pointer	= x86_default_get_root_pointer,
+ 		.reduced_hw_early_init	= acpi_generic_reduced_hw_init,
+ 	},
+ };
+-- 
+2.19.2
+

--- a/main/linux-vanilla/x86-acpi-x86-boot-Take-RSDP-address-from-boot-params.patch
+++ b/main/linux-vanilla/x86-acpi-x86-boot-Take-RSDP-address-from-boot-params.patch
@@ -1,0 +1,54 @@
+From: Juergen Gross <jgross@suse.com>
+Date: Tue, 20 Nov 2018 08:25:29 +0100
+Subject: x86/acpi, x86/boot: Take RSDP address from boot params if available
+Origin: https://git.kernel.org/linus/e6e094e053af75cbc164e950814d3d084fb1e698
+
+In case the RSDP address in struct boot_params is specified don't try
+to find the table by searching, but take the address directly as set
+by the boot loader.
+
+Suggested-by: "H. Peter Anvin" <hpa@zytor.com>
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Cc: boris.ostrovsky@oracle.com
+Cc: bp@alien8.de
+Cc: daniel.kiper@oracle.com
+Cc: sstabellini@kernel.org
+Cc: xen-devel@lists.xenproject.org
+Link: http://lkml.kernel.org/r/20181120072529.5489-3-jgross@suse.com
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+---
+ arch/x86/include/uapi/asm/bootparam.h | 3 ++-
+ arch/x86/kernel/acpi/boot.c           | 2 +-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/uapi/asm/bootparam.h b/arch/x86/include/uapi/asm/bootparam.h
+index a06cbf019744..60733f137e9a 100644
+--- a/arch/x86/include/uapi/asm/bootparam.h
++++ b/arch/x86/include/uapi/asm/bootparam.h
+@@ -155,7 +155,8 @@ struct boot_params {
+ 	__u8  _pad2[4];					/* 0x054 */
+ 	__u64  tboot_addr;				/* 0x058 */
+ 	struct ist_info ist_info;			/* 0x060 */
+-	__u8  _pad3[16];				/* 0x070 */
++	__u64 acpi_rsdp_addr;				/* 0x070 */
++	__u8  _pad3[8];					/* 0x078 */
+ 	__u8  hd0_info[16];	/* obsolete! */		/* 0x080 */
+ 	__u8  hd1_info[16];	/* obsolete! */		/* 0x090 */
+ 	struct sys_desc_table sys_desc_table; /* obsolete! */	/* 0x0a0 */
+diff --git a/arch/x86/kernel/acpi/boot.c b/arch/x86/kernel/acpi/boot.c
+index fb3b1f3a5aba..06635fbca81c 100644
+--- a/arch/x86/kernel/acpi/boot.c
++++ b/arch/x86/kernel/acpi/boot.c
+@@ -1776,5 +1776,5 @@ void __init arch_reserve_mem_area(acpi_physical_address addr, size_t size)
+ 
+ u64 x86_default_get_root_pointer(void)
+ {
+-	return 0;
++	return boot_params.acpi_rsdp_addr;
+ }
+-- 
+2.19.2
+

--- a/main/linux-vanilla/x86-boot-Add-ACPI-RSDP-address-to-setup_header.patch
+++ b/main/linux-vanilla/x86-boot-Add-ACPI-RSDP-address-to-setup_header.patch
@@ -1,0 +1,235 @@
+From: Juergen Gross <jgross@suse.com>
+Date: Wed, 10 Oct 2018 08:14:55 +0200
+Subject: x86/boot: Add ACPI RSDP address to setup_header
+Origin: https://git.kernel.org/linus/ae7e1238e68f2a472a125673ab506d49158c1889
+
+Xen PVH guests receive the address of the RSDP table from Xen. In order
+to support booting a Xen PVH guest via Grub2 using the standard x86
+boot entry we need a way for Grub2 to pass the RSDP address to the
+kernel.
+
+For this purpose expand the struct setup_header to hold the physical
+address of the RSDP address. Being zero means it isn't specified and
+has to be located the legacy way (searching through low memory or
+EBDA).
+
+While documenting the new setup_header layout and protocol version
+2.14 add the missing documentation of protocol version 2.13.
+
+There are Grub2 versions in several distros with a downstream patch
+violating the boot protocol by writing past the end of setup_header.
+This requires another update of the boot protocol to enable the kernel
+to distinguish between a specified RSDP address and one filled with
+garbage by such a broken Grub2.
+
+From protocol 2.14 on Grub2 will write the version it is supporting
+(but never a higher value than found to be supported by the kernel)
+ored with 0x8000 to the version field of setup_header. This enables
+the kernel to know up to which field Grub2 has written information
+to. All fields after that are supposed to be clobbered.
+
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Cc: boris.ostrovsky@oracle.com
+Cc: bp@alien8.de
+Cc: corbet@lwn.net
+Cc: linux-doc@vger.kernel.org
+Cc: xen-devel@lists.xenproject.org
+Link: http://lkml.kernel.org/r/20181010061456.22238-3-jgross@suse.com
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+---
+ Documentation/x86/boot.txt            | 32 ++++++++++++++++++++++++++-
+ arch/x86/boot/header.S                |  6 ++++-
+ arch/x86/include/asm/x86_init.h       |  2 ++
+ arch/x86/include/uapi/asm/bootparam.h |  4 ++++
+ arch/x86/kernel/head32.c              |  1 +
+ arch/x86/kernel/head64.c              |  2 ++
+ arch/x86/kernel/setup.c               | 17 ++++++++++++++
+ 7 files changed, 62 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/x86/boot.txt b/Documentation/x86/boot.txt
+index 5e9b826b5f62..7727db8f94bc 100644
+--- a/Documentation/x86/boot.txt
++++ b/Documentation/x86/boot.txt
+@@ -61,6 +61,18 @@ Protocol 2.12:	(Kernel 3.8) Added the xloadflags field and extension fields
+ 	 	to struct boot_params for loading bzImage and ramdisk
+ 		above 4G in 64bit.
+ 
++Protocol 2.13:	(Kernel 3.14) Support 32- and 64-bit flags being set in
++		xloadflags to support booting a 64-bit kernel from 32-bit
++		EFI
++
++Protocol 2.14:	(Kernel 4.20) Added acpi_rsdp_addr holding the physical
++		address of the ACPI RSDP table.
++		The bootloader updates version with:
++		0x8000 | min(kernel-version, bootloader-version)
++		kernel-version being the protocol version supported by
++		the kernel and bootloader-version the protocol version
++		supported by the bootloader.
++
+ **** MEMORY LAYOUT
+ 
+ The traditional memory map for the kernel loader, used for Image or
+@@ -197,6 +209,7 @@ Offset	Proto	Name		Meaning
+ 0258/8	2.10+	pref_address	Preferred loading address
+ 0260/4	2.10+	init_size	Linear memory required during initialization
+ 0264/4	2.11+	handover_offset	Offset of handover entry point
++0268/8	2.14+	acpi_rsdp_addr	Physical address of RSDP table
+ 
+ (1) For backwards compatibility, if the setup_sects field contains 0, the
+     real value is 4.
+@@ -309,7 +322,7 @@ Protocol:	2.00+
+   Contains the magic number "HdrS" (0x53726448).
+ 
+ Field name:	version
+-Type:		read
++Type:		modify
+ Offset/size:	0x206/2
+ Protocol:	2.00+
+ 
+@@ -317,6 +330,12 @@ Protocol:	2.00+
+   e.g. 0x0204 for version 2.04, and 0x0a11 for a hypothetical version
+   10.17.
+ 
++  Up to protocol version 2.13 this information is only read by the
++  bootloader. From protocol version 2.14 onwards the bootloader will
++  write the used protocol version or-ed with 0x8000 to the field. The
++  used protocol version will be the minimum of the supported protocol
++  versions of the bootloader and the kernel.
++
+ Field name:	realmode_swtch
+ Type:		modify (optional)
+ Offset/size:	0x208/4
+@@ -744,6 +763,17 @@ Offset/size:	0x264/4
+ 
+   See EFI HANDOVER PROTOCOL below for more details.
+ 
++Field name:	acpi_rsdp_addr
++Type:		write
++Offset/size:	0x268/8
++Protocol:	2.14+
++
++  This field can be set by the boot loader to tell the kernel the
++  physical address of the ACPI RSDP table.
++
++  A value of 0 indicates the kernel should fall back to the standard
++  methods to locate the RSDP.
++
+ 
+ **** THE IMAGE CHECKSUM
+ 
+diff --git a/arch/x86/boot/header.S b/arch/x86/boot/header.S
+index 850b8762e889..4c881c850125 100644
+--- a/arch/x86/boot/header.S
++++ b/arch/x86/boot/header.S
+@@ -300,7 +300,7 @@ _start:
+ 	# Part 2 of the header, from the old setup.S
+ 
+ 		.ascii	"HdrS"		# header signature
+-		.word	0x020d		# header version number (>= 0x0105)
++		.word	0x020e		# header version number (>= 0x0105)
+ 					# or else old loadlin-1.5 will fail)
+ 		.globl realmode_swtch
+ realmode_swtch:	.word	0, 0		# default_switch, SETUPSEG
+@@ -558,6 +558,10 @@ pref_address:		.quad LOAD_PHYSICAL_ADDR	# preferred load addr
+ init_size:		.long INIT_SIZE		# kernel initialization size
+ handover_offset:	.long 0			# Filled in by build.c
+ 
++acpi_rsdp_addr:		.quad 0			# 64-bit physical pointer to the
++						# ACPI RSDP table, added with
++						# version 2.14
++
+ # End of setup header #####################################################
+ 
+ 	.section ".entrytext", "ax"
+diff --git a/arch/x86/include/asm/x86_init.h b/arch/x86/include/asm/x86_init.h
+index b85a7c54c6a1..0f842104862c 100644
+--- a/arch/x86/include/asm/x86_init.h
++++ b/arch/x86/include/asm/x86_init.h
+@@ -303,4 +303,6 @@ extern void x86_init_noop(void);
+ extern void x86_init_uint_noop(unsigned int unused);
+ extern bool x86_pnpbios_disabled(void);
+ 
++void x86_verify_bootdata_version(void);
++
+ #endif
+diff --git a/arch/x86/include/uapi/asm/bootparam.h b/arch/x86/include/uapi/asm/bootparam.h
+index a06cbf019744..22f89d040ddd 100644
+--- a/arch/x86/include/uapi/asm/bootparam.h
++++ b/arch/x86/include/uapi/asm/bootparam.h
+@@ -16,6 +16,9 @@
+ #define RAMDISK_PROMPT_FLAG		0x8000
+ #define RAMDISK_LOAD_FLAG		0x4000
+ 
++/* version flags */
++#define VERSION_WRITTEN	0x8000
++
+ /* loadflags */
+ #define LOADED_HIGH	(1<<0)
+ #define KASLR_FLAG	(1<<1)
+@@ -86,6 +89,7 @@ struct setup_header {
+ 	__u64	pref_address;
+ 	__u32	init_size;
+ 	__u32	handover_offset;
++	__u64	acpi_rsdp_addr;
+ } __attribute__((packed));
+ 
+ struct sys_desc_table {
+diff --git a/arch/x86/kernel/head32.c b/arch/x86/kernel/head32.c
+index ec6fefbfd3c0..76fa3b836598 100644
+--- a/arch/x86/kernel/head32.c
++++ b/arch/x86/kernel/head32.c
+@@ -37,6 +37,7 @@ asmlinkage __visible void __init i386_start_kernel(void)
+ 	cr4_init_shadow();
+ 
+ 	sanitize_boot_params(&boot_params);
++	x86_verify_bootdata_version();
+ 
+ 	x86_early_init_platform_quirks();
+ 
+diff --git a/arch/x86/kernel/head64.c b/arch/x86/kernel/head64.c
+index ddee1f0870c4..5dc377dc9d7b 100644
+--- a/arch/x86/kernel/head64.c
++++ b/arch/x86/kernel/head64.c
+@@ -457,6 +457,8 @@ void __init x86_64_start_reservations(char *real_mode_data)
+ 	if (!boot_params.hdr.version)
+ 		copy_bootdata(__va(real_mode_data));
+ 
++	x86_verify_bootdata_version();
++
+ 	x86_early_init_platform_quirks();
+ 
+ 	switch (boot_params.hdr.hardware_subarch) {
+diff --git a/arch/x86/kernel/setup.c b/arch/x86/kernel/setup.c
+index b4866badb235..8e226b7a1753 100644
+--- a/arch/x86/kernel/setup.c
++++ b/arch/x86/kernel/setup.c
+@@ -1281,6 +1281,23 @@ void __init setup_arch(char **cmdline_p)
+ 	unwind_init();
+ }
+ 
++/*
++ * From boot protocol 2.14 onwards we expect the bootloader to set the
++ * version to "0x8000 | <used version>". In case we find a version >= 2.14
++ * without the 0x8000 we assume the boot loader supports 2.13 only and
++ * reset the version accordingly. The 0x8000 flag is removed in any case.
++ */
++void __init x86_verify_bootdata_version(void)
++{
++	if (boot_params.hdr.version & VERSION_WRITTEN)
++		boot_params.hdr.version &= ~VERSION_WRITTEN;
++	else if (boot_params.hdr.version >= 0x020e)
++		boot_params.hdr.version = 0x020d;
++
++	if (boot_params.hdr.version < 0x020e)
++		boot_params.hdr.acpi_rsdp_addr = 0;
++}
++
+ #ifdef CONFIG_X86_32
+ 
+ static struct resource video_ram_resource = {
+-- 
+2.19.2
+

--- a/main/linux-vanilla/x86-boot-Clear-RSDP-address-in-boot_params-for-broke.patch
+++ b/main/linux-vanilla/x86-boot-Clear-RSDP-address-in-boot_params-for-broke.patch
@@ -1,0 +1,43 @@
+From: Juergen Gross <jgross@suse.com>
+Date: Mon, 3 Dec 2018 11:38:11 +0100
+Subject: x86/boot: Clear RSDP address in boot_params for broken loaders
+Origin: https://git.kernel.org/linus/182ddd16194cd082f25fa1b063dae3c7c5cce384
+
+Gunnar Krueger reported a systemd-boot failure and bisected it down to:
+
+  e6e094e053af75 ("x86/acpi, x86/boot: Take RSDP address from boot params if available")
+
+In case a broken boot loader doesn't clear its 'struct boot_params', clear
+rsdp_addr in sanitize_boot_params().
+
+Reported-by: Gunnar Krueger <taijian@posteo.de>
+Tested-by: Gunnar Krueger <taijian@posteo.de>
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Cc: H. Peter Anvin <hpa@zytor.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Cc: bp@alien8.de
+Cc: sstabellini@kernel.org
+Fixes: e6e094e053af75 ("x86/acpi, x86/boot: Take RSDP address from boot params if available")
+Link: http://lkml.kernel.org/r/20181203103811.17056-1-jgross@suse.com
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+---
+ arch/x86/include/asm/bootparam_utils.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/x86/include/asm/bootparam_utils.h b/arch/x86/include/asm/bootparam_utils.h
+index a07ffd23e4dd..f6f6ef436599 100644
+--- a/arch/x86/include/asm/bootparam_utils.h
++++ b/arch/x86/include/asm/bootparam_utils.h
+@@ -36,6 +36,7 @@ static void sanitize_boot_params(struct boot_params *boot_params)
+ 	 */
+ 	if (boot_params->sentinel) {
+ 		/* fields in boot_params are left uninitialized, clear them */
++		boot_params->acpi_rsdp_addr = 0;
+ 		memset(&boot_params->ext_ramdisk_image, 0,
+ 		       (char *)&boot_params->efi_info -
+ 			(char *)&boot_params->ext_ramdisk_image);
+-- 
+2.19.2
+

--- a/main/linux-vanilla/x86-boot-Mostly-revert-commit-ae7e1238e68f2a-Add-ACP.patch
+++ b/main/linux-vanilla/x86-boot-Mostly-revert-commit-ae7e1238e68f2a-Add-ACP.patch
@@ -1,0 +1,239 @@
+From: Juergen Gross <jgross@suse.com>
+Date: Tue, 20 Nov 2018 08:25:28 +0100
+Subject: x86/boot: Mostly revert commit ae7e1238e68f2a ("Add ACPI RSDP address
+ to setup_header")
+Origin: https://git.kernel.org/linus/3841840449817ba6cf3e636008bc4e1061a03388
+
+Peter Anvin pointed out that commit:
+
+  ae7e1238e68f2a ("x86/boot: Add ACPI RSDP address to setup_header")
+
+should be reverted as setup_header should only contain items set by the
+legacy BIOS.
+
+So revert said commit. Instead of fully reverting the dependent commit
+of:
+
+  e7b66d16fe4172 ("x86/acpi, x86/boot: Take RSDP address for boot params if available")
+
+just remove the setup_header reference in order to replace it by
+a boot_params in a followup patch.
+
+Suggested-by: "H. Peter Anvin" <hpa@zytor.com>
+Signed-off-by: Juergen Gross <jgross@suse.com>
+Cc: Linus Torvalds <torvalds@linux-foundation.org>
+Cc: Peter Zijlstra <peterz@infradead.org>
+Cc: Thomas Gleixner <tglx@linutronix.de>
+Cc: boris.ostrovsky@oracle.com
+Cc: bp@alien8.de
+Cc: daniel.kiper@oracle.com
+Cc: sstabellini@kernel.org
+Cc: xen-devel@lists.xenproject.org
+Link: http://lkml.kernel.org/r/20181120072529.5489-2-jgross@suse.com
+Signed-off-by: Ingo Molnar <mingo@kernel.org>
+---
+ Documentation/x86/boot.txt            | 32 +--------------------------
+ arch/x86/boot/header.S                |  6 +----
+ arch/x86/include/asm/x86_init.h       |  2 --
+ arch/x86/include/uapi/asm/bootparam.h |  4 ----
+ arch/x86/kernel/acpi/boot.c           |  2 +-
+ arch/x86/kernel/head32.c              |  1 -
+ arch/x86/kernel/head64.c              |  2 --
+ arch/x86/kernel/setup.c               | 17 --------------
+ 8 files changed, 3 insertions(+), 63 deletions(-)
+
+diff --git a/Documentation/x86/boot.txt b/Documentation/x86/boot.txt
+index 7727db8f94bc..5e9b826b5f62 100644
+--- a/Documentation/x86/boot.txt
++++ b/Documentation/x86/boot.txt
+@@ -61,18 +61,6 @@ Protocol 2.12:	(Kernel 3.8) Added the xloadflags field and extension fields
+ 	 	to struct boot_params for loading bzImage and ramdisk
+ 		above 4G in 64bit.
+ 
+-Protocol 2.13:	(Kernel 3.14) Support 32- and 64-bit flags being set in
+-		xloadflags to support booting a 64-bit kernel from 32-bit
+-		EFI
+-
+-Protocol 2.14:	(Kernel 4.20) Added acpi_rsdp_addr holding the physical
+-		address of the ACPI RSDP table.
+-		The bootloader updates version with:
+-		0x8000 | min(kernel-version, bootloader-version)
+-		kernel-version being the protocol version supported by
+-		the kernel and bootloader-version the protocol version
+-		supported by the bootloader.
+-
+ **** MEMORY LAYOUT
+ 
+ The traditional memory map for the kernel loader, used for Image or
+@@ -209,7 +197,6 @@ Offset	Proto	Name		Meaning
+ 0258/8	2.10+	pref_address	Preferred loading address
+ 0260/4	2.10+	init_size	Linear memory required during initialization
+ 0264/4	2.11+	handover_offset	Offset of handover entry point
+-0268/8	2.14+	acpi_rsdp_addr	Physical address of RSDP table
+ 
+ (1) For backwards compatibility, if the setup_sects field contains 0, the
+     real value is 4.
+@@ -322,7 +309,7 @@ Protocol:	2.00+
+   Contains the magic number "HdrS" (0x53726448).
+ 
+ Field name:	version
+-Type:		modify
++Type:		read
+ Offset/size:	0x206/2
+ Protocol:	2.00+
+ 
+@@ -330,12 +317,6 @@ Protocol:	2.00+
+   e.g. 0x0204 for version 2.04, and 0x0a11 for a hypothetical version
+   10.17.
+ 
+-  Up to protocol version 2.13 this information is only read by the
+-  bootloader. From protocol version 2.14 onwards the bootloader will
+-  write the used protocol version or-ed with 0x8000 to the field. The
+-  used protocol version will be the minimum of the supported protocol
+-  versions of the bootloader and the kernel.
+-
+ Field name:	realmode_swtch
+ Type:		modify (optional)
+ Offset/size:	0x208/4
+@@ -763,17 +744,6 @@ Offset/size:	0x264/4
+ 
+   See EFI HANDOVER PROTOCOL below for more details.
+ 
+-Field name:	acpi_rsdp_addr
+-Type:		write
+-Offset/size:	0x268/8
+-Protocol:	2.14+
+-
+-  This field can be set by the boot loader to tell the kernel the
+-  physical address of the ACPI RSDP table.
+-
+-  A value of 0 indicates the kernel should fall back to the standard
+-  methods to locate the RSDP.
+-
+ 
+ **** THE IMAGE CHECKSUM
+ 
+diff --git a/arch/x86/boot/header.S b/arch/x86/boot/header.S
+index 4c881c850125..850b8762e889 100644
+--- a/arch/x86/boot/header.S
++++ b/arch/x86/boot/header.S
+@@ -300,7 +300,7 @@ _start:
+ 	# Part 2 of the header, from the old setup.S
+ 
+ 		.ascii	"HdrS"		# header signature
+-		.word	0x020e		# header version number (>= 0x0105)
++		.word	0x020d		# header version number (>= 0x0105)
+ 					# or else old loadlin-1.5 will fail)
+ 		.globl realmode_swtch
+ realmode_swtch:	.word	0, 0		# default_switch, SETUPSEG
+@@ -558,10 +558,6 @@ pref_address:		.quad LOAD_PHYSICAL_ADDR	# preferred load addr
+ init_size:		.long INIT_SIZE		# kernel initialization size
+ handover_offset:	.long 0			# Filled in by build.c
+ 
+-acpi_rsdp_addr:		.quad 0			# 64-bit physical pointer to the
+-						# ACPI RSDP table, added with
+-						# version 2.14
+-
+ # End of setup header #####################################################
+ 
+ 	.section ".entrytext", "ax"
+diff --git a/arch/x86/include/asm/x86_init.h b/arch/x86/include/asm/x86_init.h
+index 0f842104862c..b85a7c54c6a1 100644
+--- a/arch/x86/include/asm/x86_init.h
++++ b/arch/x86/include/asm/x86_init.h
+@@ -303,6 +303,4 @@ extern void x86_init_noop(void);
+ extern void x86_init_uint_noop(unsigned int unused);
+ extern bool x86_pnpbios_disabled(void);
+ 
+-void x86_verify_bootdata_version(void);
+-
+ #endif
+diff --git a/arch/x86/include/uapi/asm/bootparam.h b/arch/x86/include/uapi/asm/bootparam.h
+index 22f89d040ddd..a06cbf019744 100644
+--- a/arch/x86/include/uapi/asm/bootparam.h
++++ b/arch/x86/include/uapi/asm/bootparam.h
+@@ -16,9 +16,6 @@
+ #define RAMDISK_PROMPT_FLAG		0x8000
+ #define RAMDISK_LOAD_FLAG		0x4000
+ 
+-/* version flags */
+-#define VERSION_WRITTEN	0x8000
+-
+ /* loadflags */
+ #define LOADED_HIGH	(1<<0)
+ #define KASLR_FLAG	(1<<1)
+@@ -89,7 +86,6 @@ struct setup_header {
+ 	__u64	pref_address;
+ 	__u32	init_size;
+ 	__u32	handover_offset;
+-	__u64	acpi_rsdp_addr;
+ } __attribute__((packed));
+ 
+ struct sys_desc_table {
+diff --git a/arch/x86/kernel/acpi/boot.c b/arch/x86/kernel/acpi/boot.c
+index 92c76bf97ad8..fb3b1f3a5aba 100644
+--- a/arch/x86/kernel/acpi/boot.c
++++ b/arch/x86/kernel/acpi/boot.c
+@@ -1776,5 +1776,5 @@ void __init arch_reserve_mem_area(acpi_physical_address addr, size_t size)
+ 
+ u64 x86_default_get_root_pointer(void)
+ {
+-	return boot_params.hdr.acpi_rsdp_addr;
++	return 0;
+ }
+diff --git a/arch/x86/kernel/head32.c b/arch/x86/kernel/head32.c
+index 76fa3b836598..ec6fefbfd3c0 100644
+--- a/arch/x86/kernel/head32.c
++++ b/arch/x86/kernel/head32.c
+@@ -37,7 +37,6 @@ asmlinkage __visible void __init i386_start_kernel(void)
+ 	cr4_init_shadow();
+ 
+ 	sanitize_boot_params(&boot_params);
+-	x86_verify_bootdata_version();
+ 
+ 	x86_early_init_platform_quirks();
+ 
+diff --git a/arch/x86/kernel/head64.c b/arch/x86/kernel/head64.c
+index 7663a8eb602b..16b1cbd3a61e 100644
+--- a/arch/x86/kernel/head64.c
++++ b/arch/x86/kernel/head64.c
+@@ -457,8 +457,6 @@ void __init x86_64_start_reservations(char *real_mode_data)
+ 	if (!boot_params.hdr.version)
+ 		copy_bootdata(__va(real_mode_data));
+ 
+-	x86_verify_bootdata_version();
+-
+ 	x86_early_init_platform_quirks();
+ 
+ 	switch (boot_params.hdr.hardware_subarch) {
+diff --git a/arch/x86/kernel/setup.c b/arch/x86/kernel/setup.c
+index b74e7bfed6ab..d494b9bfe618 100644
+--- a/arch/x86/kernel/setup.c
++++ b/arch/x86/kernel/setup.c
+@@ -1280,23 +1280,6 @@ void __init setup_arch(char **cmdline_p)
+ 	unwind_init();
+ }
+ 
+-/*
+- * From boot protocol 2.14 onwards we expect the bootloader to set the
+- * version to "0x8000 | <used version>". In case we find a version >= 2.14
+- * without the 0x8000 we assume the boot loader supports 2.13 only and
+- * reset the version accordingly. The 0x8000 flag is removed in any case.
+- */
+-void __init x86_verify_bootdata_version(void)
+-{
+-	if (boot_params.hdr.version & VERSION_WRITTEN)
+-		boot_params.hdr.version &= ~VERSION_WRITTEN;
+-	else if (boot_params.hdr.version >= 0x020e)
+-		boot_params.hdr.version = 0x020d;
+-
+-	if (boot_params.hdr.version < 0x020e)
+-		boot_params.hdr.acpi_rsdp_addr = 0;
+-}
+-
+ #ifdef CONFIG_X86_32
+ 
+ static struct resource video_ram_resource = {
+-- 
+2.19.2
+


### PR DESCRIPTION
Patches from Debian Buster (backport from Linux 4.20)