### PR TITLE
WIP testing/howard-bc: bump to 1.2.6

### DIFF
--- a/testing/howard-bc/APKBUILD
+++ b/testing/howard-bc/APKBUILD
@@ -2,19 +2,19 @@
 # Maintainer: Gavin D. Howard <yzena.tech@gmail.com>
 pkgname=howard-bc
 _pkgname=bc
-subpackages="$pkgname-doc"
-pkgver=1.1.4
+pkgver=1.2.6
 pkgrel=0
 pkgdesc="POSIX bc with GNU extensions"
 url="https://github.com/gavinhoward/bc"
 arch="all"
 license="BSD-2-Clause"
+subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.xz::https://github.com/gavinhoward/$_pkgname/releases/download/$pkgver/$_pkgname-$pkgver.tar.xz"
 builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
-	PREFIX=/usr DESTDIR="$pkgdir" EXECSUFFIX=-howard ./configure.sh -G
+	PREFIX=/usr DESTDIR="$pkgdir" EXECSUFFIX=-howard ./configure.sh -GN
 	make
 }
 
@@ -23,20 +23,12 @@ check() {
 	make test
 }
 
-doc() {
-	# Man pages
-	mkdir -p "$subpkgdir"/usr/share/man
-	mv "$pkgdir"/usr/share/man/man* "$subpkgdir"/usr/share/man/
-	gzip "$subpkgdir"/usr/share/man/man*/*
-
-	# Doc files
-	install -Dm644 "$builddir"/LICENSE.md \
-			"$subpkgdir"/usr/share/doc/$pkgname/LICENSE.md
-}
-
 package() {
 	cd "$builddir"
 	make install
+
+	install -Dm644 LICENSE.md \
+		"$pkgdir"/usr/share/doc/$pkgname/LICENSE.md
 }
 
-sha512sums="fa67325cc3cb5df7513e6d0ae74d3476d7d9e87722db2f24d0cf0781622f02ec99e6ab27d3e2d57866830dd18dc43eb3c52d460be6c6ec0260ce2bad7765d7aa  howard-bc-1.1.4.tar.xz"
+sha512sums="c8ff2ac542413bf594a00ea9a8a9e4cd24e48081839a4e11546a08551a73b4f460391edf7f3aa3f5143db5c4e7bc1448ff7cd1104599cfa2fb44fba79c5b24fc  howard-bc-1.2.6.tar.xz"


### PR DESCRIPTION
This version includes support for locales, so I also added a `$pkgname-lang` subpackage. I also removed a warning.