### PR TITLE
testing/perl-time-parsedate replaces main/perl-time-modules

### DIFF
--- a/testing/perl-time-parsedate/APKBUILD
+++ b/testing/perl-time-parsedate/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=perl-time-parsedate
 _pkgreal=Time-ParseDate
 pkgver=2015.103
-pkgrel=0
+pkgrel=1
 pkgdesc="Parse and format time values"
 url="https://metacpan.org/release/Time-ParseDate/"
 arch="noarch"
@@ -13,6 +13,7 @@ makedepends="perl-dev"
 subpackages="$pkgname-doc"
 source="https://cpan.metacpan.org/authors/id/M/MU/MUIR/modules/Time-ParseDate-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgreal-$pkgver"
+replaces=perl-time-modules
 
 build() {
 	cd "$builddir"


### PR DESCRIPTION
According to https://metacpan.org/changes/distribution/Time-ParseDate#L22 the Time::Modules was renamed to Time::Parsedate in 2013.0916 2013-09-16.  This allows the nwr perl-time-parsedate to replace tthe old perl-time-modules version that has not been updated since 2013