### PR TITLE
community/bareos: Fix segfaults on startup and job run

### DIFF
--- a/community/bareos/APKBUILD
+++ b/community/bareos/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=bareos
 pkgver=17.2.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Bareos - Backup Archiving REcovery Open Sourced"
 url="http://www.bareos.org"
 arch="all"
@@ -22,6 +22,8 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/Re
 	$pkgname-sd.initd
 	$pkgname-fd.initd
 	path-mounted.patch
+	fix-bsmtp-segfault.patch
+	pthread-double-detach.patch
 	"
 builddir="$srcdir"/${pkgname}-Release-${pkgver}
 
@@ -127,4 +129,6 @@ sha512sums="254eddacb067ef7e82b7a54bdfcbffd5cfa033fa045f697c7e5b5c28dd064b5e1ce9
 eb1e7072b579bf9ae21f2e351d6900abb277db64e373f4760bac8188b82929376e4a196d2c935cefe1ae4cc2c396f2fcba1a25642b26e2f92a0d008fbdc4b5f2  bareos-dir.initd
 c770b1d041fafef93d4eb0269ba8d9733e85ef465657fe8dd5d5c68a27ec773cec9c5c582d4a16596d95bbf6dbd3f7194dc9c0d8ed73138e9fb438fba9aa9445  bareos-sd.initd
 c6347079dbcef5f4a69ec0c4ecc31803520d715d599d89c6bbfbb3741a86c50d7295c30432889b13ee9c16f2feaa84b1c6ae992cfee6505d569c6493d7e85a5b  bareos-fd.initd
-eac4614c1b29ff0f12061837e425ae495890076021b6d1b0f1beb93501cfb905170342dac5dab69b09f825d5b9416eea25fa02e2174b5a704315c7feb08ff3d3  path-mounted.patch"
+eac4614c1b29ff0f12061837e425ae495890076021b6d1b0f1beb93501cfb905170342dac5dab69b09f825d5b9416eea25fa02e2174b5a704315c7feb08ff3d3  path-mounted.patch
+0974ce1ad1a7acd834d75253fe1decdcf40fb1fc0a9248f848514fb201d8482af5319a91b3d0032ee91f6e034225a46ddd9c8058d7f86a514a261408c84f31d1  fix-bsmtp-segfault.patch
+1487e1294ade656e63877994d33621c8cc22258c8db7e95c2e1fdc16a0c5cf6ce77d6a232f46642fe5b3672c404a6f3a79628a983aa01dc4192882bda0e8c51e  pthread-double-detach.patch"

--- a/community/bareos/fix-bsmtp-segfault.patch
+++ b/community/bareos/fix-bsmtp-segfault.patch
@@ -1,0 +1,46 @@
+Patch from Michael Cassaniti, posted here:
+https://bugs.alpinelinux.org/issues/10156#note-5
+Until this issue is fixed upstream this patch is needed.
+
+diff --git a/src/lib/jcr.c b/src/lib/jcr.c
+index 00bfe8c87..338f90e59 100644
+--- a/src/lib/jcr.c
++++ b/src/lib/jcr.c
+@@ -77,6 +77,7 @@ static pthread_mutex_t jcr_lock = PTHREAD_MUTEX_INITIALIZER;
+ static pthread_mutex_t job_start_mutex = PTHREAD_MUTEX_INITIALIZER;
+ static pthread_mutex_t last_jobs_mutex = PTHREAD_MUTEX_INITIALIZER;
+
++static bool jcr_initialized = false;
+ #ifdef HAVE_WIN32
+ static bool tsd_initialized = false;
+ static pthread_key_t jcr_key;         /* Pointer to jcr for each thread */
+@@ -351,6 +352,8 @@ static void create_jcr_key()
+       berrno be;
+       Jmsg1(NULL, M_ABORT, 0, _("pthread key create failed: ERR=%s\n"),
+             be.bstrerror(status));
++   } else {
++     jcr_initialized = true;
+    }
+ }
+
+@@ -719,7 +722,10 @@ void set_jcr_in_tsd(JCR *jcr)
+  */
+ JCR *get_jcr_from_tsd()
+ {
+-   JCR *jcr = (JCR *)pthread_getspecific(jcr_key);
++   JCR *jcr = (JCR *)INVALID_JCR;
++   if (jcr_initialized){
++     jcr = (JCR *)pthread_getspecific(jcr_key);
++   }
+
+    /*
+     * Set any INVALID_JCR to NULL which the rest of BAREOS understands
+@@ -736,7 +742,7 @@ JCR *get_jcr_from_tsd()
+  */
+ uint32_t get_jobid_from_tsd()
+ {
+-   JCR *jcr = (JCR *)pthread_getspecific(jcr_key);
++   JCR *jcr = get_jcr_from_tsd();
+    uint32_t JobId = 0;
+
+    if (jcr && jcr != INVALID_JCR) {

--- a/community/bareos/pthread-double-detach.patch
+++ b/community/bareos/pthread-double-detach.patch
@@ -1,0 +1,43 @@
+This patch fixes a double pthread_detach(), which is undefined behaviour
+and leads to a segfault when running with musl libc.
+Until this issue is fixed upstream this patch is needed.
+
+--- a/src/dird/ua_server.c
++++ b/src/dird/ua_server.c
+@@ -73,7 +73,15 @@
+    UAContext *ua;
+    JCR *jcr;
+ 
+-   pthread_detach(pthread_self());
++   /* only detach if not yet detached */
++   int _detachstate;
++   pthread_attr_t _gattr;
++   pthread_getattr_np(pthread_self(), &_gattr);
++   pthread_attr_getdetachstate(&_gattr, &_detachstate);
++   pthread_attr_destroy(&_gattr);
++   if(_detachstate != PTHREAD_CREATE_DETACHED) {
++      pthread_detach(pthread_self());
++   }
+ 
+    jcr = new_control_jcr("-Console-", JT_CONSOLE);
+ 
+--- a/src/dird/job.c
++++ b/src/dird/job.c
+@@ -420,7 +420,16 @@
+ {
+    JCR *jcr = (JCR *)arg;
+ 
+-   pthread_detach(pthread_self());
++   /* only detach if not yet detached */
++   int _detachstate;
++   pthread_attr_t _gattr;
++   pthread_getattr_np(pthread_self(), &_gattr);
++   pthread_attr_getdetachstate(&_gattr, &_detachstate);
++   pthread_attr_destroy(&_gattr);
++   if(_detachstate != PTHREAD_CREATE_DETACHED) {
++      pthread_detach(pthread_self());
++   }
++
+    Dsm_check(100);
+ 
+    Dmsg0(200, "=====Start Job=========\n");


### PR DESCRIPTION
This PR fixes two undefined behaviours with pthreads leading to
segfaults.

Closes Bug #10156
https://bugs.alpinelinux.org/issues/10156
Additionally opened upstream issue: https://bugs.bareos.org/view.php?id=1073