### PR TITLE
testing/hiawatha: add letsencrypt subpkg / helper

### DIFF
--- a/testing/hiawatha/APKBUILD
+++ b/testing/hiawatha/APKBUILD
@@ -1,18 +1,21 @@
 # Maintainer: Kurt Marasco <celilo@lavabit.com>
 # Contributor: Pascal Ernster <aur at hardfalcon dot net>
+# Contributor: Stuart Cardall <developer at it-offshore dot co.uk>
 pkgname=hiawatha
 pkgver=10.9
-pkgrel=0
+pkgrel=1
 pkgdesc='Secure and advanced webserver'
 url='https://www.hiawatha-webserver.org/'
 arch=all
 license='GPL-2.0-only'
 options="suid !check"
-subpackages="$pkgname-doc $pkgname-openrc"
+subpackages="$pkgname-doc $pkgname-openrc $pkgname-letsencrypt"
 makedepends="cmake libxml2-dev libxslt-dev mbedtls-dev"
 source="https://hiawatha-webserver.org/files/$pkgname-$pkgver.tar.gz
         hiawatha.initd
-        hiawatha.conf.sample"
+        hiawatha.conf.sample
+        letsencrypt.helper
+        "
 builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
@@ -48,6 +51,21 @@ package() {
     "$pkgdir"/usr/share/doc/hiawatha/hiawatha.conf.sample
 }
 
+letsencrypt() {
+  subpkgarch=noarch
+  depends="php7 php7-openssl php7-json"
+  pkgdesc="PHP scripts to generate SSL certificates with letsencrypt"
+
+  mkdir -p "$subpkgdir"/usr/sbin "$subpkgdir"/usr/share/man/man1
+  mv "$pkgdir"-doc/usr/share/man/man1/lefh.1.gz "$subpkgdir"/usr/share/man/man1/
+  mv "$pkgdir"/usr/lib "$subpkgdir"/usr/
+  mv "$pkgdir"/usr/sbin/lefh "$subpkgdir"/usr/sbin/
+  mkdir -p "$subpkgdir"/usr/lib/hiawatha/letsencrypt/scripts
+  install -Dm750 "$builddir"/extra/letsencrypt/scripts/* "$subpkgdir"/usr/lib/hiawatha/letsencrypt/scripts/
+  install -Dm750 "$srcdir"/letsencrypt.helper "$subpkgdir"/usr/sbin/letsencrypt
+}
+
 sha512sums="ccd59d6c302d797a88d88206c770e794b9a2a374040bd08da67530c13a36d0232bf759df1f8d54790dcf1ae3dc25cadbd7d3af542f559b845a5cf346020eb74a  hiawatha-10.9.tar.gz
 4e1201110396e13b979948caae9c2dfb34f55398225d924164d2f0818b6778500ef3426b0ad358210ef7780289fbd752f7e006220941437fbcdd378746bf5a3d  hiawatha.initd
-b2aad6d02e03a3e25dc6dc30deab4637a7de5448255b6b707363e8c71ae1029e669bacdb6b88889ec1aa804fe717560e872dc44d049127af9aa155a8895c8a60  hiawatha.conf.sample"
+b2aad6d02e03a3e25dc6dc30deab4637a7de5448255b6b707363e8c71ae1029e669bacdb6b88889ec1aa804fe717560e872dc44d049127af9aa155a8895c8a60  hiawatha.conf.sample
+bc31823ba0894bf4dc2f1d9aac3c03382d60a1302f4d35027ca4d3e38d8a14cfdbc94af3235800b9e8cc68c4efceb1ba04c654d16ee0d297591f25a470cc567c  letsencrypt.helper"

--- a/testing/hiawatha/letsencrypt.helper
+++ b/testing/hiawatha/letsencrypt.helper
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+phplist="php7"
+letsencrypt=/usr/sbin/lefh
+
+find_php() {
+	local x= path=
+
+	for x in $phplist; do
+		path=$(which $x)
+
+		if [ -n "$path" ]; then
+			echo $path
+			break
+		fi
+	done
+}
+
+# start
+php=$(find_php)
+
+if [ -n "$php" ]; then
+	$php $letsencrypt "$@"
+else
+	printf "ERROR: missing php interpreter\n"
+	exit 1
+fi
+
+exit $?


### PR DESCRIPTION
* moves the letsencrypt `php` scripts to a subpkg for running outside
  containers

* adds a wrapper script to detect a `php` interpreter