### PR TITLE
testing/libyang: adopt, update to 1.0-r1

### DIFF
--- a/testing/libyang/APKBUILD
+++ b/testing/libyang/APKBUILD
@@ -1,8 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
-# Contributor: Christian Franke <nobody@nowhere.ws>
-# Maintainer:
+# Maintainer: Christian Franke <nobody@nowhere.ws>
 pkgname=libyang
-pkgver=0.16_p3
+pkgver=1.0_p1
 _realver=${pkgver/_p/-r}
 pkgrel=0
 pkgdesc="YANG data modelling language parser and toolkit"
@@ -14,9 +13,10 @@ makedepends="bison cmake cmocka-dev flex pcre-dev"
 install=""
 subpackages="$pkgname-dev $pkgname-doc"
 source="${pkgname}-${pkgver}.tar.gz::https://github.com/CESNET/$pkgname/archive/v$_realver.tar.gz"
-builddir="$srcdir/$pkgname-$_realver"
+builddir="$srcdir/$pkgname-$_realver/build"
 
 build() {
+	mkdir -p "$builddir"
 	cd "$builddir"
 	if [ "$CBUILD" != "$CHOST" ]; then
 		CMAKE_CROSSOPTS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
@@ -29,7 +29,8 @@ build() {
 		-DCMAKE_C_FLAGS="$CFLAGS" \
 		-DENABLE_BUILD_TESTS=ON \
 		-DENABLE_LYD_PRIV=ON \
-		${CMAKE_CROSSOPTS}
+		${CMAKE_CROSSOPTS} \
+		..
 	make
 }
 
@@ -43,4 +44,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="d4d936e6429379207b763850aab372310e3683d3c26d4158273584efe5835a93d2c58971ae1d1e8b7b2f8688cadfcd863b007ba877776f452bbf55f8ddd420a2  libyang-0.16_p3.tar.gz"
+sha512sums="1f836670c03ffca8738157a8fcddc14fbff7379a8022d99e9f7f2bce0fb2767c33b58ce26030117e4a3aa990dc528c5673ad19e01382a0c5f99445ea390dd132  libyang-1.0_p1.tar.gz"


### PR DESCRIPTION
From version 1.0-r1 forward, the package needs to be built outside of
the main source directory, so adjust builddir.