### PR TITLE
main/wget: security upgrade to 1.20.3

### DIFF
--- a/main/wget/APKBUILD
+++ b/main/wget/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=wget
-pkgver=1.20.2
+pkgver=1.20.3
 pkgrel=0
 pkgdesc="A network utility to retrieve files from the Web"
 url="https://www.gnu.org/software/wget/wget.html"
@@ -17,6 +17,8 @@ source="https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   1.20.3-r0:
+#     - CVE-2019-5953
 #   1.20.1-r0:
 #     - CVE-2018-20483
 #   1.19.5-r0:
@@ -55,4 +57,4 @@ package() {
 	rm -rf "$pkgdir"/usr/lib
 }
 
-sha512sums="42d59ddb3abec6ff30e2be890ceeec35fc144acd8e2def25f5280c2f8c21e6fd54dc71217e9ca7fb1d4f0470716bf288e90501e8e6e39b09938e3f5710a3016a  wget-1.20.2.tar.gz"
+sha512sums="e8b82b40e270296228094a78d47f81580bdbdea9e6b93fd61b37dccb39430aeb9bda5397dc53a31c952a61629383c7e2a8c8abf414c8a4dd369af6ecf2717e6c  wget-1.20.3.tar.gz"


### PR DESCRIPTION
CVE-2019-5953

Ref http://lists.gnu.org/archive/html/bug-wget/2019-04/msg00015.html