### PR TITLE
community/runc: patch for containerd-1.2.6

### DIFF
--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -5,13 +5,13 @@ pkgname=runc
 pkgdesc="CLI tool for spawning and running containers according to the OCI specification"
 url="https://www.opencontainers.org"
 
-_commit=69ae5da6afdcaaf38285a10b36f362e41cb298d6
+_commit=029124da7af7360afa781a0234d1b083550f797c
 pkgver=1.0.0_rc7
-pkgrel=0
+pkgrel=1
 
-_ver=v${pkgver/_rc/-rc}
+#_ver=v${pkgver/_rc/-rc}
 # if we're building against an explicit commit beyond pkgver, use this instead:
-#_ver=${_commit}
+_ver=${_commit}
 
 arch="all"
 license="Apache-2.0"
@@ -46,4 +46,4 @@ package() {
 	install -Dm644 "$builddir"/man/man8/* "$pkgdir"/usr/share/man/man8/
 }
 
-sha512sums="c885f37b47a439a401e2c6bc3127ef5ba36e11159d744de70f10c360c7413cda5f1850918e54aabbba963e4b879041d2e7e0dd1ec11488674d65f17f3f7c609c  runc-v1.0.0-rc7.tar.gz"
+sha512sums="54eccc1ece8f58e90655538938c64289bc4a6180d3abd074d9f5f48f0dd1e2c0139e603e26235ec3efc104f98efbc987207db42490d29a523c52f3526a01e163  runc-029124da7af7360afa781a0234d1b083550f797c.tar.gz"


### PR DESCRIPTION
Upgrading to the commit specified by containerd-1.2.6, see related PR #6966.

Fixes potential container start failure on non-SELinux system.  See https://github.com/opencontainers/runc/pull/2031 for more information