### PR TITLE
community/containerd: update to 1.2.6

### DIFF
--- a/community/containerd/APKBUILD
+++ b/community/containerd/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=containerd
 
 # NOTE: containerd's Makefile tries to get REVISION from git, but we're building from a tarball.
-_commit=bb71b10fd8f58240ca47fbb579b9d1028eea7c84
-pkgver=1.2.5
+_commit=894b81a4b802e4eb2a91d1ce216b8817763c29fb
+pkgver=1.2.6
 pkgrel=0
 pkgdesc="An open and reliable container runtime"
 url="https://containerd.io"
@@ -16,6 +16,10 @@ makedepends="btrfs-progs-dev go go-md2man libseccomp-dev"
 subpackages="$pkgname-doc"
 source="containerd-$pkgver.tar.gz::https://github.com/containerd/containerd/archive/v$pkgver.tar.gz"
 builddir="$srcdir/src/github.com/containerd/containerd"
+
+# secfixes:
+#   1.2.6:
+#     - CVE-2019-9946
 
 build() {
 	cd "$srcdir"
@@ -42,4 +46,4 @@ package() {
 	install -Dm644 "$builddir"/man/*.5 "$pkgdir"/usr/share/man/man5/
 }
 
-sha512sums="b249d5bfc0c1f884ecc1ad4544f9440405450c31f11e80ac094bfddb7a6660e950116114e563d7655e07f888f2ff62f4476f2b178f4e0e2acbbb9fb84a243b25  containerd-1.2.5.tar.gz"
+sha512sums="287b064cb3e57369e34f6debb434526d6bd4857e337e489c56e4ca484c66e161bbda911b4fc29cb49808a756f6ec7af5629e46d693644500e3bf2d9e45e87e73  containerd-1.2.6.tar.gz"


### PR DESCRIPTION
See https://github.com/containerd/containerd/releases/tag/v1.2.6 for full details.

Updates CNI to v0.75 to fix CVE-2019-9946

Dependent on PR #6965 