### PR TITLE
main/gc: fix static libs

### DIFF
--- a/main/gc/APKBUILD
+++ b/main/gc/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gc
-pkgver=8.0.2
+pkgver=8.0.4
 pkgrel=0
 pkgdesc="A garbage collector for C and C++"
 url="http://hboehm.info/gc/"
@@ -46,5 +46,5 @@ libgccpp() {
 	mv "$pkgdir"/usr/lib/libgccpp.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="b1401abb2e82b143b9a2a9013f5b2efa4015b256e7ea8ef2c897ef3c0d2d41fc893413bf6a49efc1845018e8ab823adb485fb3358eb47715982259ace9ffd7c6  gc-8.0.2.tar.gz
+sha512sums="57ccca15c6e50048d306a30de06c1a844f36103a84c2d1c17cbccbbc0001e17915488baec79737449982da99ce5d14ce527176afae9ae153cbbb5a19d986366e  gc-8.0.4.tar.gz
 0441dfe85b36e9e80b9135d62d56e5e9b67c6db1f927480dd3cf5048765f3a2ab51a45eaa0068066af97ce0398333890fff2f84cd01fec476655f34e0325bc13  0001-Fix-gctest-with-musl-libc-on-s390x.patch"

--- a/main/gc/APKBUILD
+++ b/main/gc/APKBUILD
@@ -24,6 +24,7 @@ build() {
 		--host=$CHOST \
 		--prefix=/usr \
 		--datadir=/usr/share/doc/gc \
+		--enable-static \
 		--enable-cplusplus
 	make
 }


### PR DESCRIPTION
Sort of reborn of https://github.com/alpinelinux/aports/commit/741cdad1351b68cf710497ddb54b35293655226d#diff-1d7c19fb2d3767fae04faf7dad9bbbd4
For some reasons `libgc.a` is no longer present at [edge](https://pkgs.alpinelinux.org/contents?file=&path=&name=gc-dev&branch=edge&repo=main&arch=x86_64), but was at [3.9](https://pkgs.alpinelinux.org/contents?branch=v3.9&name=gc-dev&arch=x86_64&repo=main)

I've also taken this opportunity to upgrade to 8.0.4.