### PR TITLE
main/spamassassin: Reload spamd after sa-update in crontab

### DIFF
--- a/main/spamassassin/APKBUILD
+++ b/main/spamassassin/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=spamassassin
 _pkgreal=Mail-SpamAssassin
 pkgver=3.4.2
-pkgrel=2
+pkgrel=3
 pkgdesc="The Powerful #1 Open-Source Spam Filter"
 url="http://search.cpan.org/dist/Mail-SpamAssassin/"
 arch="all"
@@ -82,5 +82,5 @@ cpan() {
 sha512sums="85e3d78bb885ad1d0bf2066d1bc919d6ad5e9f86795069397e7c28cc1ba02870566ec014c08c81f68e7ed03b7f60d2de0b9730b3415b35d848abde2c8920a28f  Mail-SpamAssassin-3.4.2.tar.gz
 0a22933290a3abd147689bf3a9de4b6b277628c22966f353c5da932cd98560babf1d0bb9d92c456ea24decfb5af0bbc960192d29a90d9cab437e7986c75c8278  spamd.initd
 274d3aa0d9aab05e83c8d5ad3e93a457649360021a67c8cb19088365bed681ebe26889cfa86f8c46a6044c7ee969231f2a71e3227adf8ad9e38d0286b9caf48d  spamd.confd
-c8c00e4281cefd5e5e15507c8890264a25aa59663c57ccdf7a77905e2550999cfbbfa7271189a9491b0a0e98dff432361f13becdb99e1b583cd9d45d68022a47  spamd.crond
+e0bbdb21020f4b4e5b11fb3ec18ad7e496fa4521d24275d806db96fc91cde3c0b8e8c8215e51b18903bf5916de74e9e2584fe7f62a9ec7da2f185641e533916d  spamd.crond
 66a6daa7e9898864497e7d8e17efc6094aabc5a9a94afbc7da08acf4cf2430fad2cb0128b8db4be637f5dcabe3fa9f03490f9d7cbba3c1cc02b7824f63cd0965  Mail-SpamAssassin.patch"

--- a/main/spamassassin/spamd.crond
+++ b/main/spamassassin/spamd.crond
@@ -1,3 +1,15 @@
 #!/bin/sh
 
+set -e
+
+. /etc/conf.d/spamd
+pidfile="${pidfile:-/run/spamd.pid}"
+
+if [ -f "$pidfile" ]; then
+	_pid="$(cat "$pidfile")"
+fi
 /usr/bin/sa-update
+if [ -n "$_pid" ]; then
+	kill -SIGHUP "$_pid"
+fi
+


### PR DESCRIPTION
This fixes Bug #10208
https://bugs.alpinelinux.org/issues/10208