### PR TITLE
community/shadow: Fix broken chpasswd program

### DIFF
--- a/community/shadow/APKBUILD
+++ b/community/shadow/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=shadow
 pkgver=4.6
-pkgrel=0
+pkgrel=1
 pkgdesc="PAM-using login and passwd utilities (usermod, useradd, ...)"
 url="http://pkg-shadow.alioth.debian.org/"
 arch="all"
@@ -12,6 +12,7 @@ depends=""
 makedepends="linux-pam-dev"
 subpackages="$pkgname-doc $pkgname-dbg $pkgname-uidmap"
 source="https://github.com/shadow-maint/shadow/releases/download/$pkgver/shadow-$pkgver.tar.xz
+	chpasswd.pamd
 	login.pamd
 	defaults.patch
 	dots-in-usernames.patch
@@ -78,6 +79,9 @@ package() {
 	# However, install our own for login.
 	cp "$srcdir"/login.pamd "$pkgdir"/etc/pam.d/login
 
+	# Also install custom pam configuration for chpasswd (see bug #10209)
+	cp "$srcdir"/chpasswd.pamd "$pkgdir"/etc/pam.d/chpasswd
+
 	# /etc/login.defs is not very useful - replace it with an *almost* blank file.
 	rm "$pkgdir"/etc/login.defs
 	echo "USERGROUPS_ENAB yes" > "$pkgdir"/etc/login.defs
@@ -103,6 +107,7 @@ uidmap() {
 }
 
 sha512sums="e8eee52c649d9973f724bc2d5aeee71fa2e6a2e41ec3487cd6cf6d47af70c32e0cdf304df29b32eae2b6eb6f9066866b5f2c891add0ec87ba583bea3207b3631  shadow-4.6.tar.xz
+38e78aade316350dc26000b35335a778f12f5deb0f54ea23f84000ad92a683c519c7814165b5ed7e63187d11677993082d35dc6c21f7f66c6aee8e3fd4b3694b  chpasswd.pamd
 46a6f83f3698e101b58b8682852da749619412f75dfa85cecad03d0847f6c3dc452d984510db7094220e4570a0565b83b0556e16198ad894a3ec84b3e513d58d  login.pamd
 999eb67be2c1d6bcf752ce217ddbed868e4415d3e60676872db1b3da79b1c7d7da6b5d03335297d6358c41e7d21c32ba2df1bd6834ac4ba364b999ed7170f846  defaults.patch
 745eea04c054226feba165b635dbb8570b8a04537d41e914400a4c54633c3a9cf350da0aabfec754fb8cf3e58fc1c8cf597b895506312f19469071760c11f31d  dots-in-usernames.patch

--- a/community/shadow/chpasswd.pamd
+++ b/community/shadow/chpasswd.pamd
@@ -1,0 +1,3 @@
+auth     sufficient pam_rootok.so
+account  include    base-account
+password include    base-password


### PR DESCRIPTION
The chpasswd command had no custom pam configuration, so the fallback
"other.conf" was used. As this command is non-interactive, this lead to
a "PAM: Authentication failure" error after waiting some seconds.

This fixes bug #10209
https://bugs.alpinelinux.org/issues/10209