### PR TITLE
main/spamassassin: Fix sa-compile

### DIFF
--- a/main/spamassassin/APKBUILD
+++ b/main/spamassassin/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=spamassassin
 _pkgreal=Mail-SpamAssassin
 pkgver=3.4.2
-pkgrel=0
+pkgrel=1
 pkgdesc="The Powerful #1 Open-Source Spam Filter"
 url="http://search.cpan.org/dist/Mail-SpamAssassin/"
 arch="all"
@@ -62,7 +62,7 @@ client() {
 
 compiler() {
 	pkgdesc="SpamAssassin rules compiler"
-	depends="re2c gcc perl-dev perl-mail-$pkgname"
+	depends="re2c gcc make libc-dev perl-dev perl-mail-$pkgname"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/sa-compile "$subpkgdir"/usr/bin/
 }


### PR DESCRIPTION
The sa-compile command is missing some dependencies.
Fixes bug #10204
https://bugs.alpinelinux.org/issues/10204