### PR TITLE
main/libical: fix db.h: No such file or directory

### DIFF
--- a/main/libical/APKBUILD
+++ b/main/libical/APKBUILD
@@ -1,14 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libical
 pkgver=3.0.4
-pkgrel=0
+pkgrel=1
 pkgdesc="Reference implementation of the iCalendar format"
 url="https://libical.github.io/libical/"
 arch="all"
 license="LGPL MPL"
 depends=""
+depends_dev="db-dev"
 # tzdata is needed for tests
-makedepends="db-dev perl cmake glib-dev icu-dev libxml2-dev tzdata"
+makedepends="$depends_dev perl cmake glib-dev icu-dev libxml2-dev tzdata"
 subpackages="$pkgname-dev"
 source="https://github.com/libical/libical/releases/download/v$pkgver/libical-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver/build"


### PR DESCRIPTION
Make libical-dev depend on db-dev, so db.h is available when building
against libical-dev.

Fix this error when building programs that depend on libical-dev:

```
In file included from /home/pmos/build/src/kcalcore-18.12.3/src/icalformat.cpp:45:
/usr/include/libical/icalss.h:492:10: fatal error: db.h: No such file or directory
 #include <db.h>
          ^~~~~~
```

---

I have verified that this fixes building kcalcore:
https://gitlab.com/postmarketOS/pmaports/issues/229

Regression from https://github.com/alpinelinux/aports/commit/e6ee35d11eca7f4d046efe106cc7d5c19d8c76b3 (CC @brebs-gh, @rnalrd)