### PR TITLE
testing/minio: upgrade to 0.20190409

### DIFF
--- a/testing/minio/APKBUILD
+++ b/testing/minio/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
 # Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=minio
-_pkgver='RELEASE.2019-03-27T22-35-21Z'
+_pkgver='RELEASE.2019-04-09T01-22-30Z'
 pkgver=${_pkgver#*.}
 pkgver=${pkgver%T*}
 pkgver=0.${pkgver//-}
@@ -36,7 +36,7 @@ prepare() {
 build() {
 	cd "$builddir"
 	local _ldflags=$(go run buildscripts/gen-ldflags.go 2> /dev/null)
-	go build -tags kqueue --ldflags "$_ldflags" -o bin/minio
+	GO111MODULE=on go build -tags kqueue --ldflags "$_ldflags" -o bin/minio
 }
 
 check() {
@@ -53,6 +53,11 @@ package() {
 		"$pkgdir"/etc/conf.d/"$pkgname"
 }
 
+cleanup_srcdir() {
+	go clean -modcache
+	default_cleanup_srcdir
+}
+
 sha512sums="18e55dc143c0d71afa8ba758de2efde40946704de65d7a53bfb5f2162fedc736a3f596d0fa75e514cb615e3bbf65809a60bd4b1c2fa22be39d18613d7ab42395  minio.initd
 ed9790fbadfb38e4d660eb1befd87e803d70dec04d936e8cd26def4a9c21240bb7cae8750ae3395aa4761e6738b9e346c86ba57761cfde30efe46d2cb459a7e4  minio.confd
-1fce454f0cbbb90bd8fff48c20a3a93cac464ea8dda1acb5687a566a5db641e912ff57a9b8e73192df5a7eb896f265945da734f89cf6c57dc9e2a0c8554f8d10  RELEASE.2019-03-27T22-35-21Z.tar.gz"
+dd056bc5317911a49b6fcf1442c94fad0aca1b699605c0d4346aa164cb330b7cb3863f5d68197c453af8c6d3c8541ba92e0b382914dc5a4829ffd8e2db4e9c7d  RELEASE.2019-04-09T01-22-30Z.tar.gz"


### PR DESCRIPTION
1. Minio has moved to the go 1.11 module system.
   Handling this (without failures) requires new abuild features (present in ~3.4).
   For details, see cleanup_srcdir, the patch that added it to abuild, and the related discussion.
2. A critical security release happened (but APKBUILD updates were delayed due to 1.)
3. A minor release happened soon afterwards.