### PR TITLE
main/curl: fix secfixes

### DIFF
--- a/main/curl/APKBUILD
+++ b/main/curl/APKBUILD
@@ -21,7 +21,7 @@ builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
 #   7.64.0-r0:
-#     - CVE-2018-16980
+#     - CVE-2018-16890
 #     - CVE-2019-3822
 #     - CVE-2019-3823
 #   7.62.0-r0:


### PR DESCRIPTION
Wrong CVE number in secfixes of curl aports file, updated to correct one.