### PR TITLE
testing/sems: Fix project url

### DIFF
--- a/testing/sems/APKBUILD
+++ b/testing/sems/APKBUILD
@@ -4,7 +4,7 @@ pkgname=sems
 pkgver=1.6.0
 pkgrel=9
 pkgdesc="SIP Express Media Server, an extensible SIP media server"
-url="http://iptel.org/sems/"
+url="https://github.com/sems-server/sems/"
 arch="all"
 license="GPL-2.0-or-later"
 # upstream does not provide test


### PR DESCRIPTION
The original url is no longer associated with this project.
See https://github.com/sems-server/sems/issues/89

No pkgrel bump as nothing except the url changes