### PR TITLE
community/softhsm: handle botan without EDDSA

### DIFF
--- a/community/softhsm/APKBUILD
+++ b/community/softhsm/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: tcely <softhsm+aports@tcely.33mail.com>
 pkgname=softhsm
 pkgver=2.5.0
-pkgrel=0
+pkgrel=1
 pkgdesc="cryptographic store accessible through a PKCS #11"
 url="https://www.opendnssec.org/softhsm/"
 arch="all"
@@ -13,7 +13,9 @@ makedepends="autoconf automake botan-dev libtool p11-kit-dev sqlite-dev"
 install=""
 subpackages="$pkgname-doc"
 source="https://dist.opendnssec.org/source/$pkgname-$pkgver.tar.gz
-        softhsm-2.5.0-botan_ecb-exception-fix.patch"
+        softhsm-2.5.0-botan_ecb-exception-fix.patch
+        Issue-435-Fix-botan-build-without-EDDSA.patch
+        "
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -43,7 +45,6 @@ package() {
         make -j1 DESTDIR="$pkgdir/" install
 }
 
-sha256sums="92aa56cf45e25892326e98b851c44de9cac8559e208720e579bf8e2cd1c132b2  softhsm-2.5.0.tar.gz
-ea369cc09a63955a346967041fea7e79438cc6a4f064c7a93a9bdc1b263c6af2  softhsm-2.5.0-botan_ecb-exception-fix.patch"
 sha512sums="a1e686729196dc25591eb3da57c2c8ea8494ed274ba711842b2dcae696f477a202acda13a975b8fb1eb68e8e44a79e839dbbc6ba500cab02ad13072c660752d9  softhsm-2.5.0.tar.gz
-25dc68c404f89936df1d7fcdf5460b8f42fff66f4a76d0e50f139337cb515fac853aa76b0b276cdb9186f2cd78a4099fcfa469629c1531dfa4023fa19c23823b  softhsm-2.5.0-botan_ecb-exception-fix.patch"
+25dc68c404f89936df1d7fcdf5460b8f42fff66f4a76d0e50f139337cb515fac853aa76b0b276cdb9186f2cd78a4099fcfa469629c1531dfa4023fa19c23823b  softhsm-2.5.0-botan_ecb-exception-fix.patch
+8c76198f9e15878d26ea6daf000895def123d16c099d426c0b633670012ab5a6374a221af4ab14989b10e9e9d73200c5f03eb11fe193091fb991d3b95d2eee70  Issue-435-Fix-botan-build-without-EDDSA.patch"

--- a/community/softhsm/Issue-435-Fix-botan-build-without-EDDSA.patch
+++ b/community/softhsm/Issue-435-Fix-botan-build-without-EDDSA.patch
@@ -1,0 +1,92 @@
+From e69657101cb219820d7d94d2df4e08815f83d28b Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Wed, 12 Dec 2018 21:47:23 +0100
+Subject: [PATCH] Issue #435: Fix botan build without EDDSA
+
+Loading libsofthsm2.so (built on Ubuntu 14.04 with botan) failed with:
+
+    ERROR: Could not load the PKCS#11 library/module: src/lib/libsofthsm2.so: undefined symbol: _ZN17BotanEDPrivateKeyD1Ev
+
+Fixes #435 (a regression in 2.5.0 due to commit 2751555).
+---
+ src/lib/crypto/BotanEDKeyPair.cpp  | 2 ++
+ src/lib/crypto/BotanEDKeyPair.h    | 2 ++
+ src/lib/crypto/BotanEDPrivateKey.h | 2 ++
+ src/lib/crypto/BotanEDPublicKey.h  | 2 ++
+ 4 files changed, 8 insertions(+)
+
+diff --git a/src/lib/crypto/BotanEDKeyPair.cpp b/src/lib/crypto/BotanEDKeyPair.cpp
+index 3be3fa5..3e967e5 100644
+--- a/src/lib/crypto/BotanEDKeyPair.cpp
++++ b/src/lib/crypto/BotanEDKeyPair.cpp
+@@ -31,6 +31,7 @@
+  *****************************************************************************/
+ 
+ #include "config.h"
++#ifdef WITH_EDDSA
+ #include "log.h"
+ #include "BotanEDKeyPair.h"
+ 
+@@ -67,3 +68,4 @@ const PrivateKey* BotanEDKeyPair::getConstPrivateKey() const
+ {
+ 	return &privKey;
+ }
++#endif
+diff --git a/src/lib/crypto/BotanEDKeyPair.h b/src/lib/crypto/BotanEDKeyPair.h
+index 02d6a4c..4f2cffe 100644
+--- a/src/lib/crypto/BotanEDKeyPair.h
++++ b/src/lib/crypto/BotanEDKeyPair.h
+@@ -34,6 +34,7 @@
+ #define _SOFTHSM_V2_BOTANEDKEYPAIR_H
+ 
+ #include "config.h"
++#ifdef WITH_EDDSA
+ #include "AsymmetricKeyPair.h"
+ #include "BotanEDPublicKey.h"
+ #include "BotanEDPrivateKey.h"
+@@ -62,5 +63,6 @@ private:
+ 	// The private key
+ 	BotanEDPrivateKey privKey;
+ };
++#endif
+ #endif // !_SOFTHSM_V2_BOTANEDKEYPAIR_H
+ 
+diff --git a/src/lib/crypto/BotanEDPrivateKey.h b/src/lib/crypto/BotanEDPrivateKey.h
+index d71f6c0..ac236bb 100644
+--- a/src/lib/crypto/BotanEDPrivateKey.h
++++ b/src/lib/crypto/BotanEDPrivateKey.h
+@@ -34,6 +34,7 @@
+ #define _SOFTHSM_V2_BOTANEDPRIVATEKEY_H
+ 
+ #include "config.h"
++#ifdef WITH_EDDSA
+ #include "EDPrivateKey.h"
+ #include <botan/pk_keys.h>
+ 
+@@ -82,4 +83,5 @@ private:
+ 	// Create the Botan representation of the key
+ 	void createBotanKey();
+ };
++#endif
+ #endif // !_SOFTHSM_V2_BOTANEDPRIVATEKEY_H
+diff --git a/src/lib/crypto/BotanEDPublicKey.h b/src/lib/crypto/BotanEDPublicKey.h
+index fce34a5..15e6d45 100644
+--- a/src/lib/crypto/BotanEDPublicKey.h
++++ b/src/lib/crypto/BotanEDPublicKey.h
+@@ -34,6 +34,7 @@
+ #define _SOFTHSM_V2_BOTANEDPUBLICKEY_H
+ 
+ #include "config.h"
++#ifdef WITH_EDDSA
+ #include "EDPublicKey.h"
+ #include <botan/pk_keys.h>
+ 
+@@ -74,4 +75,5 @@ private:
+ 	// Create the Botan representation of the key
+ 	void createBotanKey();
+ };
++#endif
+ #endif // !_SOFTHSM_V2_BOTANEDPUBLICKEY_H
+-- 
+2.21.0
+


### PR DESCRIPTION
fixes:
```
 $ ldd /usr/lib/softhsm/libsofthsm2.so
        ldd (0x7fcfab5a9000)
	...
        Error relocating /usr/lib/softhsm/libsofthsm2.so: _ZN16BotanEDPublicKeyD1Ev: symbol not found
        Error relocating /usr/lib/softhsm/libsofthsm2.so: _ZN17BotanEDPrivateKeyD1Ev: symbol not found
```