### PR TITLE
community/cython: symlink cython to cython3

### DIFF
--- a/community/cython/APKBUILD
+++ b/community/cython/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=cython
 pkgver=0.29.6
-pkgrel=0
+pkgrel=1
 pkgdesc="Cython is an optimising static compiler for both the Python & the extended Cython programming languages."
 url="https://cython.org"
 arch="all"
@@ -45,11 +45,20 @@ package() {
 _py2() {
 	cd "$builddir"-py2
 	_py python2
+
+	local f; for f in cygdb cython cythonize; do
+	  mv "$subpkgdir"/usr/bin/$f "$subpkgdir"/usr/bin/${f}2
+	done
 }
 
 _py3() {
 	cd "$builddir"
 	_py python3
+
+	local f; for f in cygdb cython cythonize; do
+	  mv "$subpkgdir"/usr/bin/$f "$subpkgdir"/usr/bin/${f}3
+	  ln -s ${f}3 "$subpkgdir"/usr/bin/$f
+	done
 }
 
 _py() {


### PR DESCRIPTION
- rename binaries to cython2 and cython3
- choose cython3 as the default binary