### PR TITLE
 community/softhsm: handle botan without EDDSA

### DIFF
--- a/community/softhsm/74b06622cdcf4b104349f5803adca9443dce3abb.patch
+++ b/community/softhsm/74b06622cdcf4b104349f5803adca9443dce3abb.patch
@@ -1,0 +1,89 @@
+From e69657101cb219820d7d94d2df4e08815f83d28b Mon Sep 17 00:00:00 2001
+From: Peter Wu <peter@lekensteyn.nl>
+Date: Wed, 12 Dec 2018 21:47:23 +0100
+Subject: [PATCH] Issue #435: Fix botan build without EDDSA
+
+Loading libsofthsm2.so (built on Ubuntu 14.04 with botan) failed with:
+
+    ERROR: Could not load the PKCS#11 library/module: src/lib/libsofthsm2.so: undefined symbol: _ZN17BotanEDPrivateKeyD1Ev
+
+Fixes #435 (a regression in 2.5.0 due to commit 2751555).
+---
+ src/lib/crypto/BotanEDKeyPair.cpp  | 2 ++
+ src/lib/crypto/BotanEDKeyPair.h    | 2 ++
+ src/lib/crypto/BotanEDPrivateKey.h | 2 ++
+ src/lib/crypto/BotanEDPublicKey.h  | 2 ++
+ 4 files changed, 8 insertions(+)
+
+diff --git a/src/lib/crypto/BotanEDKeyPair.cpp b/src/lib/crypto/BotanEDKeyPair.cpp
+index 3be3fa5e..3e967e55 100644
+--- a/src/lib/crypto/BotanEDKeyPair.cpp
++++ b/src/lib/crypto/BotanEDKeyPair.cpp
+@@ -31,6 +31,7 @@
+  *****************************************************************************/
+ 
+ #include "config.h"
++#ifdef WITH_EDDSA
+ #include "log.h"
+ #include "BotanEDKeyPair.h"
+ 
+@@ -67,3 +68,4 @@ const PrivateKey* BotanEDKeyPair::getConstPrivateKey() const
+ {
+ 	return &privKey;
+ }
++#endif
+diff --git a/src/lib/crypto/BotanEDKeyPair.h b/src/lib/crypto/BotanEDKeyPair.h
+index 02d6a4c5..4f2cffee 100644
+--- a/src/lib/crypto/BotanEDKeyPair.h
++++ b/src/lib/crypto/BotanEDKeyPair.h
+@@ -34,6 +34,7 @@
+ #define _SOFTHSM_V2_BOTANEDKEYPAIR_H
+ 
+ #include "config.h"
++#ifdef WITH_EDDSA
+ #include "AsymmetricKeyPair.h"
+ #include "BotanEDPublicKey.h"
+ #include "BotanEDPrivateKey.h"
+@@ -62,5 +63,6 @@ class BotanEDKeyPair : public AsymmetricKeyPair
+ 	// The private key
+ 	BotanEDPrivateKey privKey;
+ };
++#endif
+ #endif // !_SOFTHSM_V2_BOTANEDKEYPAIR_H
+ 
+diff --git a/src/lib/crypto/BotanEDPrivateKey.h b/src/lib/crypto/BotanEDPrivateKey.h
+index d71f6c07..ac236bb8 100644
+--- a/src/lib/crypto/BotanEDPrivateKey.h
++++ b/src/lib/crypto/BotanEDPrivateKey.h
+@@ -34,6 +34,7 @@
+ #define _SOFTHSM_V2_BOTANEDPRIVATEKEY_H
+ 
+ #include "config.h"
++#ifdef WITH_EDDSA
+ #include "EDPrivateKey.h"
+ #include <botan/pk_keys.h>
+ 
+@@ -82,4 +83,5 @@ class BotanEDPrivateKey : public EDPrivateKey
+ 	// Create the Botan representation of the key
+ 	void createBotanKey();
+ };
++#endif
+ #endif // !_SOFTHSM_V2_BOTANEDPRIVATEKEY_H
+diff --git a/src/lib/crypto/BotanEDPublicKey.h b/src/lib/crypto/BotanEDPublicKey.h
+index fce34a5f..15e6d458 100644
+--- a/src/lib/crypto/BotanEDPublicKey.h
++++ b/src/lib/crypto/BotanEDPublicKey.h
+@@ -34,6 +34,7 @@
+ #define _SOFTHSM_V2_BOTANEDPUBLICKEY_H
+ 
+ #include "config.h"
++#ifdef WITH_EDDSA
+ #include "EDPublicKey.h"
+ #include <botan/pk_keys.h>
+ 
+@@ -74,4 +75,5 @@ class BotanEDPublicKey : public EDPublicKey
+ 	// Create the Botan representation of the key
+ 	void createBotanKey();
+ };
++#endif
+ #endif // !_SOFTHSM_V2_BOTANEDPUBLICKEY_H

--- a/community/softhsm/APKBUILD
+++ b/community/softhsm/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: tcely <softhsm+aports@tcely.33mail.com>
 pkgname=softhsm
 pkgver=2.5.0
-pkgrel=0
+pkgrel=1
 pkgdesc="cryptographic store accessible through a PKCS #11"
 url="https://www.opendnssec.org/softhsm/"
 arch="all"
@@ -35,6 +35,8 @@ check() {
         cd "$builddir"
 
         make check
+
+        ldd src/lib/.libs/libsofthsm2.so
 }
 
 package() {

--- a/community/softhsm/APKBUILD
+++ b/community/softhsm/APKBUILD
@@ -13,7 +13,9 @@ makedepends="autoconf automake botan-dev libtool p11-kit-dev sqlite-dev"
 install=""
 subpackages="$pkgname-doc"
 source="https://dist.opendnssec.org/source/$pkgname-$pkgver.tar.gz
-        softhsm-2.5.0-botan_ecb-exception-fix.patch"
+        74b06622cdcf4b104349f5803adca9443dce3abb.patch
+        softhsm-2.5.0-botan_ecb-exception-fix.patch
+        "
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -46,6 +48,8 @@ package() {
 }
 
 sha256sums="92aa56cf45e25892326e98b851c44de9cac8559e208720e579bf8e2cd1c132b2  softhsm-2.5.0.tar.gz
+a06ca10b3517551f4290b939757cef54bdcf3f42a0c486008fb17125e7dd4d7a  74b06622cdcf4b104349f5803adca9443dce3abb.patch
 ea369cc09a63955a346967041fea7e79438cc6a4f064c7a93a9bdc1b263c6af2  softhsm-2.5.0-botan_ecb-exception-fix.patch"
 sha512sums="a1e686729196dc25591eb3da57c2c8ea8494ed274ba711842b2dcae696f477a202acda13a975b8fb1eb68e8e44a79e839dbbc6ba500cab02ad13072c660752d9  softhsm-2.5.0.tar.gz
+08d10a980d66e8b5f5853b460065098c2a2cdcd9f36b9e0971456030e8bd9be424de249ff79b4f7cd53f4b0e4b18053096eb405d31c6a346387e695021ce2eff  74b06622cdcf4b104349f5803adca9443dce3abb.patch
 25dc68c404f89936df1d7fcdf5460b8f42fff66f4a76d0e50f139337cb515fac853aa76b0b276cdb9186f2cd78a4099fcfa469629c1531dfa4023fa19c23823b  softhsm-2.5.0-botan_ecb-exception-fix.patch"


### PR DESCRIPTION
Resolves symbol not found problem:
```
 $ ldd /usr/lib/softhsm/libsofthsm2.so
        ldd (0x7fcfab5a9000)
	...
        Error relocating /usr/lib/softhsm/libsofthsm2.so: _ZN16BotanEDPublicKeyD1Ev: symbol not found
        Error relocating /usr/lib/softhsm/libsofthsm2.so: _ZN17BotanEDPrivateKeyD1Ev: symbol not found
```

Using patch from:
https://github.com/opendnssec/SoftHSMv2/commit/74b06622cdcf4b104349f5803adca9443dce3abb.patch