### PR TITLE
main/gnutls: security upgrade to 3.6.7

### DIFF
--- a/main/gnutls/APKBUILD
+++ b/main/gnutls/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Michael Mason <ms13sp@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gnutls
-pkgver=3.6.6
+pkgver=3.6.7
 pkgrel=0
 pkgdesc="A TLS protocol implementation"
 url="https://www.gnutls.org/"
@@ -21,6 +21,9 @@ source="https://www.gnupg.org/ftp/gcrypt/gnutls/v${_v}/gnutls-$pkgver.tar.xz
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   3.6.7-r0:
+#     - CVE-2019-3836
+#     - CVE-2019-3829
 #   3.5.13-r0:
 #     - CVE-2017-7507
 
@@ -64,5 +67,5 @@ xx() {
 	mv "$pkgdir"/usr/lib/lib*xx.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="4ff34f38d7dc543bc5750d8fdfe9be84af60c66e8d41da45f6cffc11d6c6c726784fd2d471b3416604ca1f3f9efb22ff7a290d5c92c96deda38df6ae3e794cc1  gnutls-3.6.6.tar.xz
+sha512sums="ae9b8996eb9b7269d28213f0aca3a4a17890ba8d47e3dc3b8e754ab8e2b4251e9412aaaa161a8bf56167f04cc169b4cada46f55a7bde92b955eb36cd717a99f3  gnutls-3.6.7.tar.xz
 b9aefaca8a894b223b8bcc738524602e36edf6a49f458606235598470033c81b02e876bec18a41ac57760cb9644d44b4c35969be74d4a8120245fff716429531  tests-date-compat.patch"


### PR DESCRIPTION
https://www.gnutls.org/security-new.html