### PR TITLE
main/util-linux: upgrade to 2.33.2

### DIFF
--- a/main/util-linux/APKBUILD
+++ b/main/util-linux/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Leonardo Arena <rnalrd@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=util-linux
-pkgver=2.33
+pkgver=2.33.2
 
 case $pkgver in
 	*.*.*) _v=${pkgver%.*};;
@@ -11,7 +11,7 @@ esac
 
 pkgrel=0
 pkgdesc="Random collection of Linux utilities"
-url="http://git.kernel.org/cgit/utils/util-linux/util-linux.git"
+url="https://git.kernel.org/cgit/utils/util-linux/util-linux.git"
 arch="all"
 license="GPL-2.0 GPL-2.0-or-later LGPL-2.0-or-later BSD Public-Domain"
 depends="findmnt"
@@ -170,5 +170,5 @@ _py() {
 	mv "$pkgdir"/usr/lib/python* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="5eb419607c5a2634117a604d425d6413763d1e48910acabc7e19d574a4c3fb0ceb34a68671a8e4fe396a4c6d611932082f77cd669d009e218bf64095da0d5689  util-linux-2.33.tar.xz
+sha512sums="ac88790a0272366b384b54df19cb28318014d98819d5d96aa05528ff17ab57a8c66d012a2f1b59caca4c5d4ea669e8c041e1123517c1f1c2d9960ef701aaf749  util-linux-2.33.2.tar.xz
 876bb9041eca1b2cca1e9aac898f282db576f7860aba690a95c0ac629d7c5b2cdeccba504dda87ff55c2a10b67165985ce16ca41a0694a267507e1e0cafd46d9  ttydefaults.h"


### PR DESCRIPTION
https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/tree/Documentation/releases/v2.33.1-ReleaseNotes?h=stable/v2.33
https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/tree/Documentation/releases/v2.33.2-ReleaseNotes?h=stable/v2.33