### PR TITLE
[3.7] main/bind: security upgrade to 9.11.5_p4

### DIFF
--- a/main/bind/APKBUILD
+++ b/main/bind/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=bind
-pkgver=9.11.5
+pkgver=9.11.5_p4
 _ver=${pkgver%_p*}
 _p=${pkgver#*_p}
 [ "$_p" != "$pkgver" ] && _ver="${_ver}-P$_p"
@@ -11,7 +11,7 @@ pkgrel=0
 pkgdesc="The ISC DNS server"
 url="http://www.isc.org"
 arch="all"
-license="MIT BSD"
+license="MPL-2.0"
 depends=""
 pkgusers="named"
 pkggroups="named"
@@ -30,6 +30,11 @@ source="http://ftp.isc.org/isc/bind9/${_ver}/bind-${_ver}.tar.gz
 	"
 
 # secfixes:
+#   9.11.5_p4-r0:
+#     - CVE-2019-6465
+#     - CVE-2018-5745
+#     - CVE-2018-5744
+#     - CVE-2018-5738
 #   9.11.5-r0:
 #     - CVE-2018-5741
 #   9.11.4_p1-r0:
@@ -148,7 +153,7 @@ tools() {
 	done
 }
 
-sha512sums="7e34c8033dabaed232479b1dc2849d1247c0137bcb2b63f08f8f72ff2cca0f73e0f05d0b9b8959f8c4db8ee36a700af30fe869be186c7bab7c81a25843384b8d  bind-9.11.5.tar.gz
+sha512sums="ba750ffd080a47309db8be3df3d80896c5872aadb1a14ac7effd1bb783c2a2ae1e82959d6999eecc3d694336887060a84ae8813a17836b9064515cdd96fcb573  bind-9.11.5-P4.tar.gz
 f3e3d1b680617485b9db20a59a10fec3b3b539d423984493228a7d5aaa29d699b9012ad60e863e56bdaf15b73952c22710d0ded1c86cd24417ac775ee062cfa3  bind.so_bsdcompat.patch
 196c0a3b43cf89e8e3547d7fb63a93ff9a3306505658dfd9aa78e6861be6b226580b424dd3dd44b955b2d9f682b1dc62c457f3ac29ce86200ef070140608c015  named.initd
 127bdcc0b5079961f0951344bc3fad547450c81aee2149eac8c41a8c0c973ea0ffe3f956684c6fcb735a29c43d2ff48c153b6a71a0f15757819a72c492488ddf  named.confd


### PR DESCRIPTION
https://ftp.isc.org/isc/bind9/9.11.5-P4/RELEASE-NOTES-bind-9.11.5-P4.html

- CVE-2019-6465
- CVE-2018-5745
- CVE-2018-5744
- CVE-2018-5740
- CVE-2018-5738

With the release of BIND 9.11.0, ISC changed to the open source license
for BIND from the ISC license to the Mozilla Public License (MPL 2.0).

BIND 9.11 (Extended Support Version) will be supported until at least
December, 2021.