### PR TITLE
[3.8] main/bind: security upgrade to 9.12.3_p4

### DIFF
--- a/main/bind/APKBUILD
+++ b/main/bind/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=bind
-pkgver=9.12.3
+pkgver=9.12.3_p4
 _ver=${pkgver%_p*}
 _p=${pkgver#*_p}
 _major=${pkgver%%.*}
@@ -16,7 +16,7 @@ arch="all"
 # the IP addresses 10.53.0.1 through 10.53.0.8 are configured
 #  as alias addresses on the loopback interface.
 options="!check"
-license="MIT BSD"
+license="MPL-2.0"
 pkgusers="named"
 pkggroups="named"
 makedepends="bash libressl-dev libcap-dev perl linux-headers bsd-compat-headers libxml2-dev json-c-dev"
@@ -35,6 +35,10 @@ source="https://ftp.isc.org/isc/${pkgname}${_major}/$_ver/$pkgname-$_ver.tar.gz
 builddir="$srcdir/$pkgname-$_ver"
 
 # secfixes:
+#   9.12.3_p4-r0:
+#     - CVE-2019-6465
+#     - CVE-2018-5745
+#     - CVE-2018-5744
 #   9.12.3-r0:
 #     - CVE-2018-5741
 #   9.12.2_p1-r0:
@@ -83,7 +87,6 @@ build() {
 		--with-libxml2 \
 		--with-libjson \
 		--enable-threads \
-		--enable-filter-aaaa \
 		--enable-ipv6 \
 		--enable-shared \
 		--enable-static \
@@ -142,7 +145,7 @@ tools() {
 	done
 }
 
-sha512sums="ffb9a1fbf2ae06f5af51754ef3809ebd7239184359eda11c6f09a9959e362a3fbc78bad81538bfdb2aea64c4d9718f5e4fc06e726f465b888d1099bac6020922  bind-9.12.3.tar.gz
+sha512sums="42c41f47a0282dc08ee875fe098ce84b26384dba5efbaf99b557d34c4271e0d6aac70126f280a3ee157e8604cce16901c8cd51fab791dec82f4a3d00c054f363  bind-9.12.3-P4.tar.gz
 7167dccdb2833643dfdb92994373d2cc087e52ba23b51bd68bd322ff9aca6744f01fa9d8a4b9cd8c4ce471755a85c03ec956ec0d8a1d4fae02124ddbed6841f6  bind.so_bsdcompat.patch
 196c0a3b43cf89e8e3547d7fb63a93ff9a3306505658dfd9aa78e6861be6b226580b424dd3dd44b955b2d9f682b1dc62c457f3ac29ce86200ef070140608c015  named.initd
 127bdcc0b5079961f0951344bc3fad547450c81aee2149eac8c41a8c0c973ea0ffe3f956684c6fcb735a29c43d2ff48c153b6a71a0f15757819a72c492488ddf  named.confd


### PR DESCRIPTION
https://ftp.isc.org/isc/bind9/9.12.3-P4/RELEASE-NOTES-bind-9.12.3-P4.html

- CVE-2019-6465
- CVE-2018-5745
- CVE-2018-5744
- CVE-2018-5740
- CVE-2018-5738
- CVE-2018-5737
- CVE-2018-5736

BIND is open source software licenced under the terms of the Mozilla
Public License, version 2.0 (see the LICENSE file for the full text).

BIND 9.12 will be supported until at least May, 2019.