### PR TITLE
community/docker: upgrade to 18.09.5

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 
 pkgname=docker
-pkgver=18.09.4
-_gitcommit=d14af54266dfeb55872100e28d14231b1baafe85	# https://github.com/docker/docker-ce/commits/v$pkgver
+pkgver=18.09.5
+_gitcommit=e8ff056dbcfadaeca12a5f508b0cec281126c01d	# https://github.com/docker/docker-ce/commits/v$pkgver
 _ver=${pkgver/_/-}-ce
 pkgrel=0
 pkgdesc="Pack, ship and run any application as a lightweight container"
@@ -15,7 +15,7 @@ makedepends="go go-md2man btrfs-progs-dev bash linux-headers coreutils lvm2-dev 
 install="$pkgname.pre-install"
 
 # from https://github.com/docker/docker-ce/blob/v$pkgver/components/engine/vendor.conf
-_libnetwork_ver=4725f2163fb214a6312f3beae5991f838ec36326
+_libnetwork_ver=c9029898e32f7c89bbb81511fbb721df252ce61a
 _cobra_ver="0.0.3"
 
 subpackages="
@@ -187,8 +187,8 @@ vim() {
 	done
 }
 
-sha512sums="139d09829b92319f66dea692bac0664decc666d9bc13f0a85b275e3fe2cf3b7e71b7e608a519c7a7baa40626309e2d4da880bee84da19f5eb3107af55d072ddf  docker-18.09.4.tar.gz
-8ffd6fc97df4b63b1f83a5eb6d8e63c8c413bcf3e2ff82f507dbf875d0df6903b6fe1546d8625dd3b4681d611aed4702c423d0d5c9621ed57073cbe16bf35200  libnetwork-4725f2163fb214a6312f3beae5991f838ec36326.tar.gz
+sha512sums="a6012d202761d6449e347b03759d92f5f45309e72562fd4a619b2a21c62b3f50b1256d2e4820317aa6b412f1eecda66dbd960d322293699433417a5f7ee73486  docker-18.09.5.tar.gz
+a24061cd29c3c9852a435f742e6653da48edd419205be18a37d065b50c2fbf005bfe62a1f909b91781f521b70cb3a9639a4a67e8563e2e39e6dd22f1c7bf82b2  libnetwork-c9029898e32f7c89bbb81511fbb721df252ce61a.tar.gz
 c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 33155a79799cc6c0520a030e1a9bdba60441776d612e5e255574b23bbce1c7a8e5d868284b05a8a92704be6bbb7db905388564e867986a705acbe4884ac58584  docker-openrc-fixes.patch
 9b24dc0c50904c3d12bb04c1a7df169651043ddbc258018647010a5aa01d8a19ad54d10ca79dce6d6283c81f4fa0cc8de417f6180dd824c5a588b22b23546cb5  docker-openrc-busybox-ash.patch"


### PR DESCRIPTION
The latest release of Docker CE.  See https://github.com/docker/docker-ce/releases/tag/v18.09.5 for more information.