### PR TITLE
community/phodav: fix subpkgs

### DIFF
--- a/community/phodav/APKBUILD
+++ b/community/phodav/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=phodav
 pkgver=2.3
-pkgrel=0
+pkgrel=1
 pkgdesc="A WebDAV server using libsoup"
 url="https://wiki.gnome.org/phodav"
 arch="all"
 license="LGPL-2.0-or-later"
 options="!check" # No test suite
-makedepends="avahi-dev gtk-doc intltool libsoup-dev meson eudev-dev"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-lang $pkgname-openrc
-	chezdav	spice-webdavd:spice"
+makedepends="asciidoc attr-dev avahi-dev eudev-dev gtk-doc intltool libsoup-dev meson xmlto"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang chezdav chezdav-doc:chezdav_doc
+	spice-webdavd:spice spice-webdavd-openrc:spice_openrc"
 source="https://download.gnome.org/sources/phodav/$pkgver/phodav-$pkgver.tar.xz
 	spice-webdavd.initd
 	meson_build-udev.patch
@@ -27,6 +27,7 @@ build() {
 		--infodir=/usr/share/info \
 		--localstatedir=/var \
 		-Davahi=enabled \
+		-Dsystemd=disabled \
 		-Dudev=enabled
 
 	# print config options to log
@@ -41,8 +42,6 @@ package() {
 	DESTDIR="$pkgdir" ninja -C build install
 
 	rm -rf "$pkgdir"/usr/lib/systemd
-	install -Dm755 "$srcdir"/spice-webdavd.initd \
-		"$pkgdir"/etc/init.d/spice-webdavd
 }
 
 chezdav() {
@@ -51,13 +50,25 @@ chezdav() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
+chezdav_doc() {
+	pkgdesc="A simple WebDAV server program (documentation)"
+	mkdir -p "$subpkgdir"/usr/share
+	mv "$pkgdir"/../phodav-doc/usr/share/man "$subpkgdir"/usr/share/
+}
+
 spice() {
 	pkgdesc="Spice daemon for the DAV channel"
 	mkdir -p "$subpkgdir"/usr
 	mv "$pkgdir"/usr/sbin "$subpkgdir"/usr/
-	mv "$pkgdir"/lib "$pkgdir"/etc "$subpkgdir"/
+	mv "$pkgdir"/lib "$subpkgdir"/
 }
 
+spice_openrc() {
+	pkgdesc="Spice daemon for the DAV channel (OpenRC init scripts)"
+	install_if="spice-webdavd openrc"
+	mkdir -p "$subpkgdir"/etc/init.d
+	install "$srcdir"/spice-webdavd.initd "$subpkgdir"/etc/init.d/spice-webdavd	
+}
 
 sha512sums="5f76ed0a4322707d117fc40a7bcab3a0bed7e53de52e0517e3ad79e3a6d93fc0200f6b54d8e001941d76ae22bd7f9ad158c0bee19354a316a18691057b65a002  phodav-2.3.tar.xz
 26db271c92760c38cf88bee6f8486e1c64aeaf81b19906783a3ea5e60054b2d5e7effdd26c59789ae3e964baa8bb498358724322b360bce229b45b6bee68f538  spice-webdavd.initd


### PR DESCRIPTION
- Add missing makedepends which result in chezdav man page being generated
- Split chezdav man page into its own subpkg (chezdav-doc)
- Correct openrc subpkg, it is related to the spice-webdavd (spice-webdavd-openrc)