### PR TITLE
main/openrc: allow rsa and ed25519 SSH keys in firstboot.init

### DIFF
--- a/main/openrc/APKBUILD
+++ b/main/openrc/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=openrc
 pkgver=0.41.2
 _ver=${pkgver/_git*/}
-pkgrel=0
+pkgrel=1
 pkgdesc="OpenRC manages the services, startup and shutdown of a host"
 url="https://github.com/OpenRC/openrc"
 arch="all"
@@ -131,4 +131,4 @@ b04058ec630e19de0bafefe06198dc1bff8c8d5d2c89e4660dd83dda8bb82a76cdb1d8661cce88e4
 55df0ac13dac1f215f0c573ac07b150d31232a5204eccfc8941d5af73f91b4535a85d79b7f6514217038ecbe6bffa28cb83fd8d46fd4c596e07103deb8bc8a57  networking.initd
 80e43ded522e2d48b876131c7c9997debd43f3790e0985801a8c1dd60bc6e09f625b35a127bf225eb45a65eec7808a50d1c08a5e8abceafc61726211e061e0a2  modloop.confd
 d76c75c58e6f4b0801edac4e081b725ef3d50a9a8c9bbb5692bf4d0f804af7d383bf71a73d5d03ed348a89741ef0b2427eb6a7cbf5a9b9ff60a240639fa6ec88  sysfsconf.initd
-f65b061b4272463071022e88a7392d5573f2d95f91e42c8b4f3ef69171604460ddd3d426dfbab382f73a3fac68d4b4ff3a923fdc49fb6fd9f27ebd3ab24e0d0e  firstboot.initd"
+2fa8e0ca9789804cdf999cf5eb12aabd40819795f083cf8c1925f03d9030164960b93ebf933c682ae66b65e4865a22f1e8553061431866aca8eb5bdc1ef19f53  firstboot.initd"

--- a/main/openrc/firstboot.initd
+++ b/main/openrc/firstboot.initd
@@ -24,7 +24,8 @@ start() {
 			https://*|ftps://*|http://*)
 				wget -q "$KOPT_ssh_key" -O /root/.ssh/authorized_keys
 				rc=$?;;
-			*) echo "$KOPT_ssh_key" > /root/.ssh/authorized_keys;;
+			ssh-rsa*|rsa*) echo "ssh-rsa ${KOPT_ssh_key#*:}" > /root/.ssh/authorized_keys;;
+			ssh-ed25519*|ed25519*) echo "ssh-ed25519 ${KOPT_ssh_key#*:}" > /root/.ssh/authorized_keys;;
 		esac
 		chmod 600 /root/.ssh/authorized_keys
 	fi


### PR DESCRIPTION
The kernel parm could be like:
ssh_key=rsa:< key content >
ssh_key=ed25519:< key content >