### PR TITLE
testing/git-crypt: new aport

### DIFF
--- a/testing/git-crypt/APKBUILD
+++ b/testing/git-crypt/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Laurent Arnoud <laurent@spkdev.net>
+# Maintainer: Laurent Arnoud <laurent@spkdev.net>
+pkgname=git-crypt
+pkgver=0.6.0
+pkgrel=0
+pkgdesc="Transparent file encryption in git"
+url="https://www.agwa.name/projects/git-crypt"
+arch="all"
+license="GPL-3.0-or-later"
+depends="git"
+makedepends="openssl-dev docbook-xml docbook-xsl"
+install=""
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/AGWA/$pkgname/archive/$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	make ENABLE_MAN=yes
+}
+
+check() {
+	cd "$builddir"
+}
+
+package() {
+	cd "$builddir"
+	make PREFIX="$pkgdir/usr" ENABLE_MAN=yes install
+	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
+}
+sha512sums="06fd9f6dbdc5c9fa9196f3e81a87cd3688089623b2658daf9c98809d5ca14df0b7ca69fdfe8279abf575957c366f2f93bd5a6885092eb533bd0d1ed9fe9dfac5  git-crypt-0.6.0.tar.gz"

--- a/testing/git-crypt/APKBUILD
+++ b/testing/git-crypt/APKBUILD
@@ -8,24 +8,20 @@ url="https://www.agwa.name/projects/git-crypt"
 arch="all"
 license="GPL-3.0-or-later"
 depends="git"
-makedepends="openssl-dev docbook-xml docbook-xsl"
-install=""
+options="!check" # No test suite
+makedepends="docbook-xml docbook-xsl openssl-dev"
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/AGWA/$pkgname/archive/$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
-	make ENABLE_MAN=yes
-}
-
-check() {
-	cd "$builddir"
+	make
 }
 
 package() {
 	cd "$builddir"
-	make PREFIX="$pkgdir/usr" ENABLE_MAN=yes install
+	make PREFIX="/usr" DESTDIR="$pkgdir" ENABLE_MAN=yes install
 	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 sha512sums="06fd9f6dbdc5c9fa9196f3e81a87cd3688089623b2658daf9c98809d5ca14df0b7ca69fdfe8279abf575957c366f2f93bd5a6885092eb533bd0d1ed9fe9dfac5  git-crypt-0.6.0.tar.gz"


### PR DESCRIPTION
Hi,

First packaging for alpine adding git-crypt transparent file encryption in git

Url: https://github.com/AGWA/git-crypt
Description: Transparent file encryption in git

Cheers,
Laurent