### PR TITLE
community/gitea: upgrade to 1.7.6

### DIFF
--- a/community/gitea/APKBUILD
+++ b/community/gitea/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=gitea
-pkgver=1.7.5
-pkgrel=1
+pkgver=1.7.6
+pkgrel=0
 pkgdesc="A self-hosted Git service written in Go"
 url="https://gitea.io"
 arch="all"
@@ -68,7 +68,7 @@ check() {
 	"$builddir"/$pkgname help > /dev/null
 }
 
-sha512sums="baa917570bdfb4db86e3a2a666ba5e1e3d6fec245ece675f80a2949d15356534a8b82e29ade7c9f5add99d9a132ebf5dbf7405fec6cb07ca8ba83debb846233f  gitea-1.7.5.tar.gz
+sha512sums="ad39969b5f1246875c006c72f2ea711772f29bfb9c687510efbd2089c9f88e9d218d14b03111715179b2e0f72f85731f22dd46fc022e224be73b7e73e798236b  gitea-1.7.6.tar.gz
 a7c70a144dc0582d6230e59ff717023fddcac001a6a9c895b46a0df1fbd9639453b2f5027d47dad21f442869c145dbc801eda61b6c50a2dd8103f562b8569009  gitea.initd
 27a202006d6e8d4146659f6356eaa99437f9f596dd369e9430d64b859bc6a1ad16091eef09232aa385fe1bf8ca94bbdf31b94975068220ad10338cded384f726  gitea.ini
 05272f3733dffeb75881579ff6553d32515e4de32113ff9395e521e93946a45101d04d4e435d7d8e7bfe49a512e5e4ac300576d2e79d7bcf314fc0ce526a07f9  allow-to-set-version.patch"


### PR DESCRIPTION
SECURITY
- Prevent remote code execution vulnerability with mirror repo URL settings (#6593) (#6595)

BUGFIXES
- Allow resend of confirmation email when logged in (#6482) (#6487)

https://github.com/go-gitea/gitea/releases/tag/v1.7.6