### PR TITLE
 main/poppler: upgrade to 0.77.0

### DIFF
--- a/community/atril/APKBUILD
+++ b/community/atril/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Alan Lacerda <alacerda@alpinelinux.org>
 pkgname=atril
 pkgver=1.22.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A document viewer for MATE"
 url="https://github.com/mate-desktop/atril"
 arch="all"

--- a/community/claws-mail/APKBUILD
+++ b/community/claws-mail/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=claws-mail
 pkgver=3.17.3
-pkgrel=6
+pkgrel=7
 pkgdesc="A GTK+ based e-mail client."
 url="https://www.claws-mail.org"
 arch="all"

--- a/community/cups-filters/APKBUILD
+++ b/community/cups-filters/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cups-filters
 pkgver=1.24.0
-pkgrel=0
+pkgrel=1
 pkgdesc="OpenPrinting CUPS filters and backends"
 url="https://wiki.linuxfoundation.org/openprinting/cups-filters"
 arch="all"

--- a/community/diff-pdf/APKBUILD
+++ b/community/diff-pdf/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=diff-pdf
 pkgver=0.2_git20170816
 _gitrev=48416f3ed9085db77cce22f836ef4456bbaacccc
-pkgrel=1
+pkgrel=2
 pkgdesc="A simple tool for visually comparing two PDF files"
 url="https://vslavik.github.io/diff-pdf/"
 arch="all"

--- a/community/evince/APKBUILD
+++ b/community/evince/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: 
 pkgname=evince
 pkgver=3.32.0
-pkgrel=0
+pkgrel=1
 pkgdesc="simple document viewer for GTK+"
 url="http://projects.gnome.org/evince/"
 arch="all"

--- a/community/gimp/APKBUILD
+++ b/community/gimp/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gimp
 pkgver=2.10.10
-pkgrel=0
+pkgrel=1
 pkgdesc="GNU Image Manipulation Program"
 url="https://www.gimp.org/"
 arch="all"

--- a/community/inkscape/APKBUILD
+++ b/community/inkscape/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=inkscape
 pkgver=0.92.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A vector-based drawing program - svg compliant"
 url="https://inkscape.org/"
 arch="all"
@@ -27,7 +27,9 @@ makedepends="
 depends="desktop-file-utils"
 checkdepends="bash py-lxml py-numpy>=1.14.3-r1"
 subpackages="$pkgname-doc $pkgname-lang $pkgname-view"
-source="https://launchpad.net/inkscape/${pkgver%.*}.x/$pkgver/+download/inkscape-$pkgver.tar.bz2"
+source="https://launchpad.net/inkscape/${pkgver%.*}.x/$pkgver/+download/inkscape-$pkgver.tar.bz2
+	poppler-076.patch 
+	"
 options="!check" # cxxtest hangs at least on x86_64
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -78,4 +80,5 @@ doc() {
 		"$subpkgdir"/usr/share/inkscape
 }
 
-sha512sums="b9034605a79cd8aea808edf42e284819951ae1ea67778f0922f4c10224e94aca6c844acbc2294625773f0a7047d4e32ccdada876238a792a2c17db172c88e120  inkscape-0.92.4.tar.bz2"
+sha512sums="b9034605a79cd8aea808edf42e284819951ae1ea67778f0922f4c10224e94aca6c844acbc2294625773f0a7047d4e32ccdada876238a792a2c17db172c88e120  inkscape-0.92.4.tar.bz2
+076730b217fd4963d95df3bdee3204415dfd1a8eee5112624de1b61e5efc6040453e47d402076938f38965f85b6f82e618c848d11bfe911a4bfdb74bfdc366fd  poppler-076.patch"

--- a/community/inkscape/APKBUILD
+++ b/community/inkscape/APKBUILD
@@ -5,7 +5,7 @@ pkgrel=1
 pkgdesc="A vector-based drawing program - svg compliant"
 url="https://inkscape.org/"
 arch="all"
-license="GPL LGPL"
+license="GPL-2.0-or-later LGPL-3.0-or-later"
 makedepends="
 	autoconf
 	automake

--- a/community/inkscape/poppler-076.patch
+++ b/community/inkscape/poppler-076.patch
@@ -1,0 +1,12 @@
+--- a/src/extension/internal/pdfinput/pdf-parser.cpp
++++ b/src/extension/internal/pdfinput/pdf-parser.cpp
+@@ -426,7 +426,7 @@ void PdfParser::parse(Object *obj, GBool topLevel) {
+ 	error(errInternal, -1, "Weird page contents");
+     	return;
+   }
+-  parser = new Parser(xref, new Lexer(xref, obj), gFalse);
++  parser = new Parser(xref, obj, gFalse);
+   go(topLevel);
+   delete parser;
+   parser = NULL;
+

--- a/community/libreoffice/APKBUILD
+++ b/community/libreoffice/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=libreoffice
 pkgver=6.2.3.2
-pkgrel=2
+pkgrel=3
 pkgdesc="LibreOffice - Meta package for the full office suite"
 url="https://www.libreoffice.org/"
 arch="all !s390x"

--- a/community/pdfgrep/APKBUILD
+++ b/community/pdfgrep/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: André Klitzing <aklitzing@gmail.com>
 pkgname=pdfgrep
 pkgver=2.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Commandline utility to search text in PDF files"
 url="https://pdfgrep.org/"
 arch="all"

--- a/community/poppler-qt5/APKBUILD
+++ b/community/poppler-qt5/APKBUILD
@@ -5,29 +5,27 @@
 
 pkgname=poppler-qt5
 _pkgname=poppler
-pkgver=0.71.0
+pkgver=0.77.0
 pkgrel=0
 pkgdesc="PDF rendering library based on xpdf 3.0"
 url="https://poppler.freedesktop.org/"
 arch="all"
-license="GPL-2.0-only"
-subpackages="$pkgname-dev"
-makedepends="cmake libjpeg-turbo-dev jpeg-dev cairo-dev libxml2-dev
-	fontconfig-dev qt5-qtbase-dev poppler-dev>=$pkgver lcms2-dev
-	openjpeg-dev openjpeg-dev libpng-dev tiff-dev zlib-dev
-	openjpeg-tools
-	"
-depends=
+license="GPL-2.0-or-later"
 replaces="poppler-glib"
-depends_dev="$makedepends"
 provides="poppler-qt4-$pkgver-$pkgrel"
-options="!check" # no test suite
+options="!check" # Requires dl of testfiles and only checks qt5 libs
+makedepends="cairo-dev cmake fontconfig-dev jpeg-dev lcms2-dev libjpeg-turbo-dev
+	libpng-dev libxml2-dev openjpeg-dev openjpeg-tools poppler-dev>=$pkgver
+	qt5-qtbase-dev tiff-dev zlib-dev
+	"
+depends_dev="$makedepends"
+subpackages="$pkgname-dev"
 source="https://poppler.freedesktop.org/poppler-$pkgver.tar.xz"
 builddir="$srcdir/$_pkgname-$pkgver/build"
 
 prepare() {
 	local _linked_pkg=poppler
-	local _linked_apkbuild="$startdir"/../$_linked_pkg/APKBUILD
+	local _linked_apkbuild="$startdir"/../../main/$_linked_pkg/APKBUILD
 	mkdir -p "$builddir"
 	cd "$builddir"
 	if  [ -f "$_linked_apkbuild" ]; then
@@ -47,8 +45,10 @@ build() {
 	cmake .. \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
-		-DENABLE_GLIB=ON \
-		-DENABLE_XPDF_HEADERS=ON \
+		-DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
+		-DBUILD_GTK_TESTS=OFF \
+		-DBUILD_QT5_TESTS=ON \
+		-DBUILD_CPP_TESTS=OFF \
 		-DENABLE_QT5=ON
 	make
 }
@@ -60,4 +60,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="8e0ce95e7b58c37761c36a20f1282e63373a9557bf9f746ce2936562f12648506043d9559cf816944aa238814fc1b3f3a3c0a6cb002fd214b067e399bcc6ab1e  poppler-0.71.0.tar.xz"
+sha512sums="7c82cf584541fcbfa7cecdb06be9c4ba6d03479fc248377b874afeab561eac24015915eee566edc35fafe785b9f381f492c1789c070e67a2c1b344879c156040  poppler-0.77.0.tar.xz"

--- a/community/texlive/APKBUILD
+++ b/community/texlive/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
 pkgname=texlive
 pkgver=20190410
-pkgrel=1
+pkgrel=2
 pkgdesc="Comprehensive TeX document production system"
 url="http://tug.org/texlive/"
 arch="all !x86 !ppc64le"

--- a/community/tumbler/APKBUILD
+++ b/community/tumbler/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=tumbler
 pkgver=0.2.4
-pkgrel=0
+pkgrel=1
 pkgdesc="D-Bus thumbnail service"
 url="http://git.xfce.org/xfce/tumbler"
 arch="all"

--- a/community/zathura-pdf-poppler/APKBUILD
+++ b/community/zathura-pdf-poppler/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Jean-Louis Fuchs <ganwell@fangorn.ch>
 pkgname=zathura-pdf-poppler
 pkgver=0.2.9
-pkgrel=2
+pkgrel=3
 pkgdesc="zathura-pdf-poppler - poppler plugin adds PDF support to zathura"
 url="https://git.pwmt.org/pwmt/zathura-pdf-poppler"
 arch="all"

--- a/community/zathura-ps/APKBUILD
+++ b/community/zathura-ps/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Jean-Louis Fuchs <ganwell@fangorn.ch>
 pkgname=zathura-ps
 pkgver=0.2.6
-pkgrel=3
+pkgrel=4
 pkgdesc="zathura-ps - plugin adds PostScript support to zathura"
 url="https://git.pwmt.org/pwmt/zathura-ps"
 arch="all"

--- a/main/poppler/APKBUILD
+++ b/main/poppler/APKBUILD
@@ -1,25 +1,24 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=poppler
-pkgver=0.71.0
+pkgver=0.77.0
 pkgrel=0
 pkgdesc="PDF rendering library based on xpdf 3.0"
 url="https://poppler.freedesktop.org/"
 arch="all"
-options="!check"  # No test suite.
-license="GPL-2.0+"
-depends=
+options="!check" # Requires dl of testfiles and only checks qt5 libs
+license="GPL-2.0-or-later"
 depends_dev="cairo-dev glib-dev"
-makedepends="$depends_dev cmake libjpeg-turbo-dev cairo-dev libxml2-dev
-	fontconfig-dev lcms2-dev gobject-introspection-dev
-	openjpeg-dev openjpeg-tools libpng-dev tiff-dev zlib-dev"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-utils $pkgname-glib
-	"
+makedepends="$depends_dev cairo-dev cmake fontconfig-dev
+	gobject-introspection-dev lcms2-dev libjpeg-turbo-dev
+	libpng-dev libxml2-dev openjpeg-dev openjpeg-tools
+	tiff-dev zlib-dev"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-glib $pkgname-utils"
 source="https://poppler.freedesktop.org/poppler-$pkgver.tar.xz"
 builddir="$srcdir/$pkgname-$pkgver/build"
 
 prepare() {
-	local _linked_pkg=poppler-qt4
-	local _linked_apkbuild="$startdir"/../$_linked_pkg/APKBUILD
+	local _linked_pkg=poppler-qt5
+	local _linked_apkbuild="$startdir"/../../community/$_linked_pkg/APKBUILD
 	mkdir -p "$builddir"
 	cd "$builddir"
 	if  [ -f "$_linked_apkbuild" ]; then
@@ -40,8 +39,8 @@ build() {
 	cmake .. \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
-		-DENABLE_GLIB=ON \
-		-DENABLE_XPDF_HEADERS=ON \
+		-DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
+		-DBUILD_QT5_TESTS=OFF \
 		-DENABLE_QT5=OFF
 	make
 }
@@ -73,4 +72,4 @@ _cpp() {
 		"$subpkgdir"/usr/lib/
 }
 
-sha512sums="8e0ce95e7b58c37761c36a20f1282e63373a9557bf9f746ce2936562f12648506043d9559cf816944aa238814fc1b3f3a3c0a6cb002fd214b067e399bcc6ab1e  poppler-0.71.0.tar.xz"
+sha512sums="7c82cf584541fcbfa7cecdb06be9c4ba6d03479fc248377b874afeab561eac24015915eee566edc35fafe785b9f381f492c1789c070e67a2c1b344879c156040  poppler-0.77.0.tar.xz"

--- a/testing/py-poppler/APKBUILD
+++ b/testing/py-poppler/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 pkgname=py-poppler
 pkgver=0.12.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Python bindings for the poppler PDF library"
 url="https://launchpad.net/poppler-python"
 arch="all"

--- a/testing/xournal/APKBUILD
+++ b/testing/xournal/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Ivan Tham <pickfire@riseup.net>
 pkgname=xournal
 pkgver=0.4.8
-pkgrel=2
+pkgrel=3
 pkgdesc="Notetaking, sketching, keeping a journal using a stylus"
 url="http://xournal.sourceforge.net/"
 arch="all !aarch64"


### PR DESCRIPTION
ABI 100% backwards compatible https://abi-laboratory.pro/index.php?view=timeline&l=poppler

```
Release 0.77.0:
        core:
         * Fix crash on signature handling. Issue #766
         * Fix small memory leak in SignatureHandler::getCertificateInfo
         * Splash: Restrict filling of overlapping boxes. Issue #750
         * Fix crash on malformed files

        qt5:
         * Fix optional content handling with exclusive layers

        cpp:
         * Make render_page thread-safe

        utils:
         * pdfsig: Fix small memory leak
         * pdftotext: Fix typo in manpage

Release 0.76.1:
        core:
         * Make the mul tables be calculated at compile time with constexpr.
         * splash: Fix compile with SPLASH_CMYK enabled
         * Some typo fixing in error messages

        qt5:
         * Fix regression in annotation handling

        build system:
         * Fix some typos in build system output and comments

Release 0.76.0:
        core:
         * Fix regression on case-insensitive search. Issue #743
         * Remove GooList, use std::vector instead
         * Fix radiobutton reporting wrong state. Issue #159
         * Handle UTF16-LE strings
         * Don't error out if there's no DA in FreeText annotation
         * cairo: Compute correct coverage values for box filter.
         * cairo: Constrain number of cycles in rescale filter. 
         * Read more fields from ViewerPreferences
         * Introduce and use Ref::INVALID
         * Fix crashes in broken files
         * Fix mismatched free/delete
         * Add missing include guards

        utils:
         * pdftohtml: Properly initialize HtmlOutputDev::page to avoid SIGSEGV upon error exit. Issue #742

Release 0.75.0:
        core:
         * Fix rendering of some annotations
         * Fix crashes in broken files
         * Small internal code improvements

        cpp:
         * Improve documentation
         * tests: Add showing version information to poppler-dump

        utils:
         * pdfattach: new util
         * pdftohtml: add -dataurls parameter
         * pdftoppm: add -sep and -forcenum parameters
         * pdftohtml: make singleHtml and stout not mutually exclusive
         * pdfsig: fix use after free

Release 0.74.0:
        core:
         * Remove support for obsolete systems. Issue #709
         * Include timezone in timeToDateString()
         * Fix/silence some warnings
         * Fix issues with broken files

        build system:
         * Fix linking in FreeBSD
         * Fix fseeko configure check on Android for API level < 24
         * Remove unused MacroPushRequiredVars.cmake

        qt5:
         * Add API that lazily builds an outline by wrapping the internal objects
         * Demo: Use new API to build Table Of Contents lazily

        glib:
         * Improve documentation
         * Fix cast from 'GTime *' (aka 'int *') to 'time_t *' (aka 'long *')

        utils:
         * pdfsig: add -nssdir option

        cpp:
         * Add a way to get all the named destinations in a document.

Release 0.73.0:
        core:
         * Fix regression reading some encrypted files. Issue #690
         * Add X509CertificateInfo classes
         * Add new 'IgnoreDiacritics' option to ::findText(). Issue #637
         * Open files with CLOEXEC flag set
         * Remove Gulong, Guint, Gushort, Guchar typedefs
         * Fix handling of some broken files.

        cpp:
         * Make initialization of globalParams threadsafe
         * Fix page::text_list encoding issue
         * Improve handling of UTF-16 by considering Endianess
         * Add API to specify a custom data directory

        qt5:
         * Expose X509CertificateInfo
         * Add the possibility of getting version
         * Add new 'IgnoreDiacritics' search flag. Issue #637
         * Make initialization of globalParams threadsafe
         * ArthurOutputDev: Remove all Splash code usage

        glib:
         * add new 'POPPLER_FIND_IGNORE_DIACRITICS' find flag. Issue #637
         * Fix named destinations. Issue #631
         * Make PrintScaling preference available in API. Bug #92779

        build system:
         * Rename ENABLE_XPDF_HEADERS to ENABLE_UNSTABLE_API_ABI_HEADERS
         * support enabling NSS on mingw
         * Windows: only set SOVERSION for shared libs

Release 0.72.0:
        core:
         * Fix checkbox lacking AP not bein able to change state. Issue #655
         * Draw line annotation endings (arrow, circle, ...)
         * cairo: Don't use UNIQUE_ID for PS output, to avoid using PS memory on cairo >= 1.5.10
         * Be more stubborn looking for a nssdb. Issue #669
         * GooString::fromInt: Repair the return value.
         * Minor performance improvements
         * Avoid cycles in PDF parsing
         * Stream::makeFilter: Fix memory leak
         * Fix various issues with malformed files
         * Rename GooString::getCString to GooString::c_str
         * Regenerate UnicodeDecompTables.h from python 3.7.1

        utils:
         * pdfdetach: Check for valid embedded file before trying to save it. Issue #661
         * pdfdetach: Check for valid file name of embedded file before using it to determine save path. Issue #660
         * Fix typos in utils.

        glib:
         * Fix missing PopplerAttachment destructor call
         * Support getting form widget additional actions.
         * docs: Small improvements

        qt5:
         * Internally compile with -DQT_NO_SIGNALS_SLOTS_KEYWORDS
```