### PR TITLE
[3.7] main/imagemagick: security upgrade to 7.0.8.39 

### DIFF
--- a/community/awesome/APKBUILD
+++ b/community/awesome/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=awesome
 pkgver=4.2
-pkgrel=0
+pkgrel=1
 pkgdesc="lua-configurable window manager framework"
 url="http://awesome.naquadah.org/"
 arch="all"

--- a/community/inkscape/APKBUILD
+++ b/community/inkscape/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=inkscape
 pkgver=0.92.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A vector-based drawing program - svg compliant"
 url="http://inkscape.sourceforge.net/"
 arch="all"

--- a/community/php7-imagick/APKBUILD
+++ b/community/php7-imagick/APKBUILD
@@ -3,17 +3,17 @@
 pkgname=php7-imagick
 _pkgreal=imagick
 pkgver=3.4.3
-pkgrel=3
+pkgrel=4
 _phpver=${pkgname#php}
 _phpver=${_phpver%%-*}
 pkgdesc="PHP$_phpver extension: Provides a wrapper to the ImageMagick library"
-url="http://pecl.php.net/package/imagick"
+url="https://pecl.php.net/package/imagick"
 arch="all"
 license="PHP"
 depends="php$_phpver-common"
 makedepends="php$_phpver-dev autoconf libtool imagemagick-dev pcre-dev"
 subpackages="$pkgname-dev"
-source="http://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
+source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 build() {

--- a/main/a2ps/APKBUILD
+++ b/main/a2ps/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=a2ps
 pkgver=4.14
-pkgrel=7
+pkgrel=8
 pkgdesc="a2ps is an Any to PostScript filter"
 url="https://www.gnu.org/software/a2ps/"
 arch="all"

--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -2,22 +2,28 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
-pkgver=7.0.7.11
-_abiver=7
+pkgver=7.0.8.39
+pkgrel=0
 _pkgver=${pkgver%.*}-${pkgver##*.}
-pkgrel=1
-pkgdesc="A collection of tools and libraries for many image formats"
-url="http://www.imagemagick.org/"
+_abiver=7
+pkgdesc="Collection of tools and libraries for many image formats"
+url="https://www.imagemagick.org/"
 arch="all"
-license="custom"
+license="ImageMagick"
 options="libtool !checkroot"
 makedepends="zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev fontconfig-dev
 	perl-dev ghostscript-dev libwebp-dev libtool tiff-dev lcms2-dev
-	libwebp-dev libxml2-dev librsvg-dev"
-checkdepends="freetype fontconfig ghostscript ghostscript-fonts lcms2"
+	libwebp-dev libxml2-dev librsvg-dev libx11-dev libxext-dev"
+checkdepends="freetype fontconfig ghostscript ghostscript-fonts lcms2 graphviz"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-c++:_cxx $pkgname-libs"
-source="http://www.imagemagick.org/download/releases/ImageMagick-$_pkgver.tar.xz"
+source="https://github.com/ImageMagick/ImageMagick/archive/${_pkgver}.tar.gz"
 builddir="$srcdir/ImageMagick-${_pkgver}"
+
+# secfixes:
+#   7.0.8.39-r0:
+#     - CVE-2019-9956
+#     - CVE-2019-10649
+#     - CVE-2019-10650
 
 build() {
 	cd "$builddir"
@@ -25,11 +31,6 @@ build() {
 	sed -i -e \
 		's:DOCUMENTATION_PATH="${DATA_DIR}/doc/${DOCUMENTATION_RELATIVE_PATH}":DOCUMENTATION_PATH="/usr/share/doc/imagemagick":g' \
 		configure
-	local _openmp=
-	case "$CARCH" in
-	s390x) _openmp="--disable-openmp"
-	esac
-
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -38,9 +39,9 @@ build() {
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		--disable-static \
-		$_openmp \
+		--disable-openmp \
 		--with-threads \
-		--without-x \
+		--with-x \
 		--with-tiff \
 		--with-png \
 		--with-webp \
@@ -72,8 +73,6 @@ package() {
 
 	find "$pkgdir" -name '.packlist' -o -name 'perllocal.pod' \
 		-o -name '*.bs' -delete
-
-	install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 
 _cxx() {
@@ -82,4 +81,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="089c8516ca66845c6b8e6b365815ef1806fc97c785f75c06ed62241d7b6255387ee8f9004b1bcc0a6d03b7aa397d8e25131ca2aadc9255cc1e2368d73f774551  ImageMagick-7.0.7-11.tar.xz"
+sha512sums="545c0e919f58e5d29b0a92b1db8dc32eb8f4aa828c6e8bc8f9bec5ada3468b79c8fbbb57350772f1a87a46f29bbd94af33272f7f8bb0ab720837844d15d7a43b  ImageMagick-7.0.8-39.tar.xz"

--- a/main/tango-icon-theme/APKBUILD
+++ b/main/tango-icon-theme/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=tango-icon-theme
 pkgver=0.8.90
-pkgrel=4
+pkgrel=5
 pkgdesc="The Tango Desktop Project exists to create a consistent user experience"
 url="http://tango.freedesktop.org"
 arch="all"


### PR DESCRIPTION
Retry of #6982. Includes `pkgrel` bump for packages depending on ImageMagick.
cc @rnalrd