### PR TITLE
testing/nlohmann-json: upgrade to 3.6.1

### DIFF
--- a/testing/nlohmann-json/APKBUILD
+++ b/testing/nlohmann-json/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Nick Black <dankamongmen@gmail.com>
 # This is a headers-only implementaiton; there are no libraries.
 pkgname=nlohmann-json-dev
-pkgver=3.5.0
-pkgrel=1
+pkgver=3.6.1
+pkgrel=0
 pkgdesc="JSON for Modern C++"
 url="https://github.com/nlohmann/json"
 arch="noarch"
@@ -36,4 +36,4 @@ doc() {
 	mv README.md doc/html "$subpkgdir/usr/share/doc/nlohmann-json"
 }
 
-sha512sums="e2874e10e12070e8e1b9c01f41ce24002a3859c4aca8bf46083ea08e68f44ed6725bdcdf8e592b1e50d69975d506836c62a8e10fc6da00f0844c149dd6676996  nlohmann-json-3.5.0.tar.gz"
+sha512sums="e0565ccdee34e89a6836a97f039c04a0bac445b44f6f323918ea424b34e4577688a4f4f72d5ef1ec0b53d159bfe87e8e9c97b70ef98231ea463f59f05e16eb2a  nlohmann-json-3.6.1.tar.gz"


### PR DESCRIPTION
Sorry, not sure what happened to #7109. Upgrade nlohmann-json-dev, as released 2019-03-20. This PR addresses the issues raised by @Ikke and @TBK in their review. Thanks!