### PR TITLE
community/pdns-recursor: enable s390x

### DIFF
--- a/community/pdns-recursor/APKBUILD
+++ b/community/pdns-recursor/APKBUILD
@@ -2,11 +2,10 @@
 # Maintainer: tcely <pdns-recursor+aports@tcely.33mail.com>
 pkgname=pdns-recursor
 pkgver=4.1.12
-pkgrel=1
+pkgrel=2
 pkgdesc="PowerDNS Recursive Server"
 url="https://www.powerdns.com/"
-# s390x: missing boost-context
-arch="all !s390x"
+arch="all"
 license="GPL-2.0-or-later"
 depends="dns-root-hints"
 depends_dev=""


### PR DESCRIPTION
boost-context is now available