### PR TITLE
main/nginx: upgrade lua-nginx-module to 0.10.14

### DIFF
--- a/main/nginx/APKBUILD
+++ b/main/nginx/APKBUILD
@@ -15,9 +15,9 @@ pkgname=nginx
 # NOTE: Upgrade only to even-numbered versions (e.g. 1.14.z, 1.16.z)!
 # Odd-numbered versions are mainline (development) versions.
 pkgver=1.14.2
-pkgrel=1
+pkgrel=2
 # Revision of nginx-tests to use for check().
-_tests_hgrev=d6daf03478ad
+_tests_hgrev=4bc1490cedbc
 _njs_ver=0.2.0
 pkgdesc="HTTP and reverse proxy server (stable version)"
 url="http://www.nginx.org/en"
@@ -94,7 +94,7 @@ _add_module "http-fancyindex" "v0.4.3" "https://github.com/aperezdc/ngx-fancyind
 _add_module "http-headers-more" "v0.33" "https://github.com/openresty/headers-more-nginx-module"
 _http_headers_more_so="ngx_http_headers_more_filter_module.so"
 
-_add_module "http-lua" "v0.10.13" "https://github.com/openresty/lua-nginx-module"
+_add_module "http-lua" "v0.10.14" "https://github.com/openresty/lua-nginx-module"
 _http_lua_depends="$pkgname-mod-devel-kit"
 _http_lua_provides="$pkgname-lua"  # for backward compatibility
 
@@ -203,6 +203,7 @@ build() {
 check() {
 	msg "Running nginx tests..."
 	cd "$srcdir"/nginx-tests-*
+	rm -f upstream_ip_hash_ipv6.t # no ipv6 check in test
 	TEST_NGINX_BINARY="$builddir/objs/nginx" prove .
 
 	msg "Running njs tests..."
@@ -285,7 +286,7 @@ _module() {
 }
 
 sha512sums="d8362dbd86435657d6b13156bd6ad1b251d2ab10bc11cdda959b142dd6120b087e4b314f0025d9bbcc88529cb4b9407fb4df1cfae5d081b7ea1db51ccfc2dbe7  nginx-1.14.2.tar.gz
-775f8fcc55e0e670f7b509974cc9e9cfb56e4bd2a88d1c7716c96b63ad87c14fd6d07f293545639972e798fb20f81414ef6483451d00ae5a4eaa262ccf2cbc98  nginx-tests-d6daf03478ad.tar.gz
+0554870cda61df9dcb614e151d40b271e0c2f6ff5ef2f8b8c88e966af866242af8b33ff525a51a3336ac261637e785fc9a122008c31beac7be0b5ae405f1a393  nginx-tests-4bc1490cedbc.tar.gz
 be07e635f5e0e50a28366b28180344568b5cca9d67c79bc80d0c6758d8d4097ff9428393fb6951ed239c6e9c9e3f84b46f9c92a6e2c313f1f35e677b3662512f  nginx-njs-0.2.0.tar.gz
 cd6983c164383100e0239be85dfeddc7879ab9c29589aecdd9bb4b6772d1f0a5d4cd70bf728d0fb5181765cbed77b7e4c99fd85c0ec59c55826c52e923510017  njs~fix-test-exit-code.patch
 ac7e3153ab698b4cde077f0d5d7ac0a58897927eb36cf3b58cb01268ca0296f1d589c0a5b4f889b96b5b4a57bef05b17c59be59a9d7c4d7a3d3be58f101f7f41  nginx.conf
@@ -297,7 +298,7 @@ eb183860cd511361346e4079c1fcf470985e1c3b2a034a57f8b2a92ba851fed99256261f9b779770
 c90b81a4e85a8e9beeb5ff591dc91adb25fa4e0b6cb47086b577e5fa36db2368442dd011187675e358781956c364b949bc4d920ca2b534481b21c9987d2a9a3b  echo-nginx-module-0.61.tar.gz
 fe5f6afc29c99f66151c1a06e27b5749b0a16227638583d9c961adc94b2942b981184382f95e70d927f00b09b43f597b963a85a41bde5903b10e42f86bc321f1  ngx-fancyindex-0.4.3.tar.gz
 13165b1b8d4be281b8bd2404fa48d456013d560bace094c81da08a35dc6a4f025a809a3ae3a42be6bbf67abbcbe41e0730aba06f905220f3baeb01e1192a7d37  headers-more-nginx-module-0.33.tar.gz
-8c316b9d12dc35779fcddc6bb90942c096f19fd8c2e090b8397e1e1ca6f0ebd7a4edddc03fddb31310147ba4e9db9fc4b3749cfd2323046d88045b3b3333f07d  lua-nginx-module-0.10.13.tar.gz
+f2c4241ff52130cd116220e48a1032b9cbc8ff70f0ed0fbb918e18bb7681f0b1e07a2108b2ba5bc551a6557d87971ae4c8bda30e255acff1f7d72dd9232132ba  lua-nginx-module-0.10.14.tar.gz
 72887c4490854b099cb26bb3f840073a36b0d812bde4486f04dc1be182ca74f0d1e3fd709e77c240c2dcf37665f74cf04e188ea9efe8e127c6789b27b487d0cd  lua-upstream-nginx-module-0.07.tar.gz
 e2f23ec82669af4be77cb4d6ee24347fc8438b658a0d16d42d6a8e81b074685f5cd1d2060ccf314e610f9d3aee3720181243133af3e450d2c0d7105a1873f13f  nchan-1.2.3.tar.gz
 1730845ea2e52be8c2f6cfceb2894304c5a07959a96940bb1617ee0e7cf81d22283304f411d9a219ddb71e4d9a66012bba0f6f5574d101aeb3c406f26c5d6a4e  nginx-http-shibboleth-2.0.1.tar.gz


### PR DESCRIPTION
https://github.com/openresty/lua-nginx-module/releases/tag/v0.10.14

The most important change in this release is the added support for aarch64.
Ref: https://github.com/openresty/lua-nginx-module/commit/7286812116940216344ade33722c49ae47037605
