### PR TITLE
main/sqlite: security upgrade to 3.28.0 CVE-2019-5018

### DIFF
--- a/main/sqlite/APKBUILD
+++ b/main/sqlite/APKBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 pkgname=sqlite
-pkgver=3.27.2
+pkgver=3.28.0
 pkgrel=0
 pkgdesc="C library that implements an SQL database engine"
-url="http://www.sqlite.org"
+url="https://www.sqlite.org/"
 arch="all"
 license="Public-Domain"
 makedepends="readline-dev"
@@ -30,6 +30,10 @@ builddir="$srcdir/$pkgname-autoconf-$_ver"
 source="https://www.sqlite.org/2019/$pkgname-autoconf-$_ver.tar.gz
 	license.txt
 	"
+
+# secfixes:
+#   3.28.0-r0:
+#     - CVE-2019-5018
 
 # additional CFLAGS to set
 _amalgamation="-DSQLITE_ENABLE_FTS4 \
@@ -97,5 +101,5 @@ static() {
 	mv "$pkgdir"/usr/lib/lib*.a "$subpkgdir"/usr/lib/
 }
 
-sha512sums="0ac2515c7816932a4f725e657122c9f202bd7aba637bad9af5b4592b85efdd10a55ad34ac621b60a7aea91b1021c2ef0924c6ddfe05b2edb4f70e3d34b005972  sqlite-autoconf-3270200.tar.gz
+sha512sums="e800c0d9e6c8c01ccf1d714c6c4da4b98e9610c4c06557dda6393d0792a8ae09788703d4a74dcb21844c49b3629ff7ed95a4a86ff79872aafd2b49c672c7a570  sqlite-autoconf-3280000.tar.gz
 5bde14bec5bf18cc686b8b90a8b2324c8c6600bca1ae56431a795bb34b8b5ae85527143f3b5f0c845c776bce60eaa537624104cefc3a47b3820d43083f40c6e9  license.txt"


### PR DESCRIPTION
Ref https://www.sqlite.org/releaselog/3_28_0.html