### PR TITLE
community/go: upgrade to 1.12.4

### DIFF
--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=go
-pkgver=1.12.3
+pkgver=1.12.4
 pkgrel=0
 pkgdesc="Go programming language compiler"
 url="http://www.golang.org/"
@@ -128,6 +128,6 @@ package() {
 		-exec rm -rf \{\} \+
 }
 
-sha512sums="bd33e958f2e8550da14afc0576928d00d2b8ecac569ddcf3551e44a342ce78ad3934e36109cbe6c15d31c55448ccc092f6e1fbf82685d6702402ab67106a1424  go1.12.3.src.tar.gz
+sha512sums="45ced5fc23a2786a652dbe66de7bbc039efaba29d884d797d6d0a6eaffb61dfb897905f0733ce74704f8760b1fdedb9963e26c1d9d8dee4a4676e74da5df8792  go1.12.4.src.tar.gz
 a8f3afd97992f03ccf2680cde214eefccac47daeb9eeb689b5e0b206ea3c19cfb23d448a4eb532894d830d4b91cd97b249e88f04c17feba02d9e243b40243bd0  default-buildmode-pie.patch
 faf8de430df185842902322f064254f3e9ecee0884b3075b5550c85da15ff61ea6c2bb8d0fb7cf3887abc0e40974bd73ee8f8c14da7f914dde7e9220177c4e2a  set-external-linker.patch"


### PR DESCRIPTION
Ref https://golang.org/doc/devel/release.html#go1.12.minor