### PR TITLE
testing/knot-resolver4: new aport

### DIFF
--- a/testing/knot-resolver4/APKBUILD
+++ b/testing/knot-resolver4/APKBUILD
@@ -1,0 +1,90 @@
+# Contributor: tcely <knot-resolver+aports@tcely.33mail.com>
+# Maintainer: tcely <knot-resolver+aports@tcely.33mail.com>
+_pkgname="knot-resolver"
+pkgname="${_pkgname}4"
+pkgver=4.0.0
+pkgrel=0
+pkgdesc="Minimalistic caching DNS resolver implementation"
+url="https://www.knot-resolver.cz/"
+arch="all"
+license="GPL-3.0"
+pkgusers="kresd"
+pkggroups="kresd"
+depends="dns-root-hints dnssec-root lua5.1-sec lua5.1-socket"
+_depends_dnstap_dev="fstrm-dev protobuf-dev protobuf-c-dev"
+_depends_http="$pkgname lua5.1-http"
+depends_dev="knot-dev>=2.8.0 libedit-dev libuv-dev>=1.7 lmdb-dev luajit-dev>=2.0 $_depends_dnstap_dev"
+makedepends="$depends_dev bash cmake gnutls-dev luacheck meson>=0.46 ninja pkgconf py-flake8"
+checkdepends="cmocka-dev"
+install="$pkgname.pre-install"
+subpackages="$pkgname-mod-http:http:noarch $pkgname-mod-dnstap:dnstap $pkgname-dev $pkgname-doc $pkgname-openrc"
+source="
+	https://secure.nic.cz/files/${_pkgname}/${_pkgname}-$pkgver.tar.xz
+	knot-resolver4.logrotate
+	knot-resolver4.confd
+	knot-resolver4.initd
+	"
+builddir="${srcdir}/${_pkgname}-${pkgver}"
+
+build() {
+	meson build \
+		--prefix=/usr \
+		--buildtype=release \
+		--default-library=both \
+		-Dclient=enabled \
+		-Dgroup="$pkggroups" \
+		-Dinstall_kresd_conf=enabled \
+		-Dunit_tests=enabled \
+		-Duser="$pkgusers" \
+		-Droot_hints=/usr/share/dns-root-hints/named.root \
+		-Dmanaged_ta=disabled \
+		-Dkeyfile_default=/usr/share/dnssec-root/trusted-key.key
+
+	ninja -C build
+}
+
+check() {
+	meson test -C build
+}
+
+package() {
+	DESTDIR="$pkgdir" ninja install -C build
+
+	cd "$pkgdir"
+
+	install -m 755 -D "$srcdir"/$pkgname.initd ./etc/init.d/$pkgname
+	install -m 644 -D "$srcdir"/$pkgname.confd ./etc/conf.d/$pkgname
+
+	install -m 644 -D "$srcdir"/$pkgname.logrotate ./etc/logrotate.d/$pkgname
+
+	# Rename -doc directory
+	mkdir -p ./usr/share/doc
+	mv ./usr/share/doc/${_pkgname} ./usr/share/doc/$pkgname
+}
+
+http() {
+	pkgdesc="Knot Resolver - HTTP/2 services"
+	depends="$_depends_http"
+	local moddir="usr/lib/knot-resolver/kres_modules"
+
+	mkdir -p "$subpkgdir"/$moddir
+	mv "$pkgdir"/$moddir/http* "$subpkgdir"/$moddir/
+}
+
+dnstap() {
+	pkgdesc="Knot Resolver - dnstap logging"
+	depends="$_depends_dnstap"
+	local moddir="usr/lib/knot-resolver/kres_modules"
+
+	mkdir -p "$subpkgdir"/$moddir
+	mv "$pkgdir"/$moddir/dnstap.so "$subpkgdir"/$moddir/
+}
+
+sha256sums="37161d931e64535ce38c33b9635f06a43cd1541945bf2c79a55e37f230de1631  knot-resolver-4.0.0.tar.xz
+23a9fff29fae658e669553a385cf5563311a3451bb8f77889a8d8501e8c98c5a  knot-resolver4.logrotate
+bb3e4c1f666c3e1d995aad8fa0af98960298d91b0222fc7f423692493ffbb3a5  knot-resolver4.confd
+41acd36d8f84805d851865daf993cb5f6697190662edf7f95d0e92ab1ff58b80  knot-resolver4.initd"
+sha512sums="e4c7e21ec36b5a733adf9f8e3751bbc347ce9ce7af8d71e8d5f3a7a87da673db753490c5257466e8433cd5fff1651046c8500ee59e91be8e55b1a16614eaf53a  knot-resolver-4.0.0.tar.xz
+86fcd63264a21b83850d42328c89f051055bbd81c95bb96b298fb74a0826fa453b05fd34ae247e176635466d678ea740912047d05cacaea96c67fd2ded6b5bb5  knot-resolver4.logrotate
+0379745f15175aa9a740c7e58b7279b2e1520effb465dd168ea2165118fdb79291082b914dce34d7967068568c35ad381950845e2b03802a1c88fe99b55a7211  knot-resolver4.confd
+2f192e5c66455a211f113ae92a8001711d4b174490bd95617eb66cc2072804ba3881508754c2841dd12bcae15a50d85d32f53b026a04a7f4134942ce4a15edb2  knot-resolver4.initd"

--- a/testing/knot-resolver4/knot-resolver4.confd
+++ b/testing/knot-resolver4/knot-resolver4.confd
@@ -1,0 +1,10 @@
+# Config file for /etc/init.d/knot-resolver4
+
+# Config file path.
+#config="/etc/knot-resolver/kresd.conf"
+
+# Cache (working) directory.
+#cachedir="/var/cache/knot-resolver"
+
+# Path to the logging file.
+#logfile="/var/log/knot-resolver4.log"

--- a/testing/knot-resolver4/knot-resolver4.initd
+++ b/testing/knot-resolver4/knot-resolver4.initd
@@ -1,0 +1,24 @@
+#!/sbin/openrc-run
+
+: ${config:="/etc/knot-resolver/kresd.conf"}
+: ${cachedir:="/var/cache/knot-resolver"}
+: ${logfile:="/var/log/knot-resolver4.log"}
+
+command="/usr/sbin/kresd"
+# Note: Do not change forks=1, it's buggy.
+command_args="--config=$config --forks=1 $cachedir"
+command_background="yes"
+pidfile="/run/$RC_SVCNAME.pid"
+start_stop_daemon_args="
+	--chdir=$cachedir
+	--stdout=$logfile
+	--stderr=$logfile"
+required_files="$config"
+
+depend() {
+	need net
+}
+
+start_pre() {
+	checkpath -d -m 750 -o kresd:kresd "$cachedir"
+}

--- a/testing/knot-resolver4/knot-resolver4.logrotate
+++ b/testing/knot-resolver4/knot-resolver4.logrotate
@@ -1,0 +1,7 @@
+/var/log/knot-resolver4.log {
+	notifempty
+	missingok
+	postrotate
+		/etc/init.d/knot-resolver4 --quiet --ifstarted restart
+	endscript
+}

--- a/testing/knot-resolver4/knot-resolver4.pre-install
+++ b/testing/knot-resolver4/knot-resolver4.pre-install
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+addgroup -S kresd 2>/dev/null
+adduser -S -D -H -h /var/lib/knot-resolver -s /sbin/nologin -G kresd -g kresd kresd 2>/dev/null
+
+exit 0


### PR DESCRIPTION
https://www.knot-resolver.cz/
Minimalistic caching DNS resolver implementation

This is for testing the major upgrade from 3.2.1.
https://www.knot-resolver.cz/2019-04-18-knot-resolver-4.0.0.html
https://knot-resolver.readthedocs.io/en/stable/upgrading.html