### PR TITLE
main/raspberrypi: fix components failing

### DIFF
--- a/main/raspberrypi/APKBUILD
+++ b/main/raspberrypi/APKBUILD
@@ -33,6 +33,7 @@ build() {
 		-DARM64=$ARM64 \
 		-DCMAKE_BUILD_TYPE=MinSizeRel \
 		-DCMAKE_INSTALL_RPATH=/opt/vc/lib \
+		-DCMAKE_SHARED_LINKER_FLAGS="-Wl,--no-as-needed" \
 		$_sourcedir
 	make
 }

--- a/main/raspberrypi/APKBUILD
+++ b/main/raspberrypi/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=raspberrypi
 pkgver=0.20181212
 _commitid=7cbfbd38d9824535164f93a1d32c81a33a00ca31
-pkgrel=0
+pkgrel=1
 pkgdesc="Raspberry Pi support tools"
 url="https://github.com/raspberrypi/userland"
 arch="armhf armv7 aarch64"


### PR DESCRIPTION
added "--no-as-needed" linker flag to make mmal vc.ril.* components stop failing.
Description here: https://github.com/raspberrypi/userland/issues/178