### PR TITLE
community/py-execnet: upgrade to 1.6.0

### DIFF
--- a/community/py-execnet/APKBUILD
+++ b/community/py-execnet/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Dmitry Romanenko <dmitry@romanenko.in>
 pkgname=py-execnet
 _pkgname=execnet
-pkgver=1.5.0
-pkgrel=1
+pkgver=1.6.0
+pkgrel=0
 pkgdesc="execnet: rapid multi-Python deployment"
 url="https://github.com/pytest-dev/execnet"
 arch="noarch"
@@ -52,4 +52,4 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="ca2b571fafdf8f68b3cc7a04ee326e3255828d4cde28ead65d0cef325569c3a6dee09359e525152248038de65326ffc6b75c8362f53aa5c0b3f736eb596cb2d9  execnet-1.5.0.tar.gz"
+sha512sums="0ac4e7cca95687aa318d696d91ec937b77dd305197b9a73b759fcaae6436eaa16f616aa8492a68de23d9b3aa80622a9924dece97d5afb78b35a9c43f1b6e3932  execnet-1.6.0.tar.gz"


### PR DESCRIPTION

1.6.0 (2019-03-31)
------------------

* ``execnet`` no longer supports Python 2.6 and 3.3 (#85). Users of those Python versions
  using a recent enough ``pip`` should not be affected, as ``pip`` will only install
  ``1.5.0`` for them.

* Update test suite to support ``pytest>4``.