### PR TITLE
main/py-urllib3: upgrade to 1.24.2

### DIFF
--- a/main/py-urllib3/APKBUILD
+++ b/main/py-urllib3/APKBUILD
@@ -3,8 +3,8 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=py-urllib3
 _pkgname=${pkgname/py-/}
-pkgver=1.24.1
-pkgrel=1
+pkgver=1.24.2
+pkgrel=0
 pkgdesc="HTTP library with thread-safe connection pooling, file post, and more"
 url="https://github.com/shazow/urllib3"
 arch="noarch"
@@ -14,6 +14,9 @@ subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="$pkgname-$pkgver.tar.gz::https://github.com/shazow/urllib3/archive/$pkgver.tar.gz"
 builddir="$srcdir/$_pkgname-$pkgver"
 
+# secfixes:
+#   1.24.2-r0:
+#     - CVE-2019-11324
 
 build() {
 	cd "$builddir"
@@ -50,4 +53,4 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="2f5453cf0ec1b65de9a9fca0fdb45664f7481507c875b7115c063cb177628b4b611377e588508ab8433e0797fc78b60fd3ea5cc5ac0a3f105d36bfff9a56f1f4  py-urllib3-1.24.1.tar.gz"
+sha512sums="08e8d896f57eb9af5511d07002859f87f2a7bddbd5e66468908188dfe13d2e3985a8cdd2da12d06d0b337945ca8314c1f026d4e82badf23a09bf686fa121e863  py-urllib3-1.24.2.tar.gz"


### PR DESCRIPTION
1.24.2 (2019-04-17)
-------------------

* Don't load system certificates by default when any other ``ca_certs``, ``ca_certs_dir`` or
  ``ssl_context`` parameters are specified.

* Remove Authorization header regardless of case when redirecting to cross-site.

* Add support for IPv6 addresses in subjectAltName section of certificates.