### PR TITLE
community/pdns-recursor: disable on s390x

### DIFF
--- a/community/pdns-recursor/APKBUILD
+++ b/community/pdns-recursor/APKBUILD
@@ -5,7 +5,8 @@ pkgver=4.1.12
 pkgrel=2
 pkgdesc="PowerDNS Recursive Server"
 url="https://www.powerdns.com/"
-arch="all"
+# build of testrunner fails on s390x
+arch="all !s390x"
 license="GPL-2.0-or-later"
 depends="dns-root-hints"
 depends_dev=""


### PR DESCRIPTION
build step failed on s390x with undefined references to:
- jump_fcontext
- make_fcontext

```
  CXXLD    testrunner
/usr/s390x-alpine-linux-musl/bin/ld: mtasker_context.o: in function
`pdns_swapcontext(pdns_ucontext_t&, pdns_ucontext_t const&)':
mtasker_context.cc:(.text+0xe8): undefined reference to `jump_fcontext'
/usr/s390x-alpine-linux-musl/bin/ld: mtasker_context.o: in function
`pdns_makecontext(pdns_ucontext_t&, boost::function<void ()>&)':
mtasker_context.cc:(.text+0x1ea): undefined reference to `make_fcontext'
/usr/s390x-alpine-linux-musl/bin/ld: mtasker_context.cc:(.text+0x20e):
undefined reference to `jump_fcontext'
/usr/s390x-alpine-linux-musl/bin/ld: mtasker_context.o: in function
`threadWrapper': mtasker_context.cc:(.text+0x27e): undefined reference
to `jump_fcontext'
/usr/s390x-alpine-linux-musl/bin/ld: mtasker_context.cc:(.text+0x382):
undefined reference to `jump_fcontext'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:1210: testrunner] Error 1
```