### PR TITLE
main/pcre2: upgrade to 10.33 and fix URLs

### DIFF
--- a/main/pcre2/APKBUILD
+++ b/main/pcre2/APKBUILD
@@ -2,16 +2,16 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=pcre2
 pkgver=10.32
-pkgrel=1
+pkgrel=2
 pkgdesc="Perl-compatible regular expression library"
-url="http://pcre.sourceforge.net/"
+url="https://pcre.org/"
 arch="all"
 license="BSD-3-Clause"
 depends_dev="libedit-dev zlib-dev"
 makedepends="$depends_dev paxmark"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-tools
 	libpcre2-16:_libpcre libpcre2-32:_libpcre"
-source="ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/$pkgname-$pkgver.tar.gz"
+source="https://ftp.pcre.org/pub/pcre/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 case "$CARCH" in

--- a/main/pcre2/APKBUILD
+++ b/main/pcre2/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=pcre2
-pkgver=10.32
-pkgrel=2
+pkgver=10.33
+pkgrel=0
 pkgdesc="Perl-compatible regular expression library"
 url="https://pcre.org/"
 arch="all"
@@ -87,4 +87,4 @@ tools() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="b0a247dc6411546f231f7588b979bc89f4c6d498a27232fb1e883d5222b9275d7b87c6afc0c67f11a453b35238dca472d14246e8bcb38df70f3701f9f3e8030f  pcre2-10.32.tar.gz"
+sha512sums="649983c7725e2fd2451ba89243b4c08c408fc279b7be3b2d225045cced3b0667ff6da4c9dd37510eb9e5aed6478aff54c2dbd1d92f4d0f1174579df9ec2c1882  pcre2-10.33.tar.gz"


### PR DESCRIPTION
Ref http://www.pcre.org/changelog.txt

```diff
usr/lib/libpcre2-8.so.0
-usr/lib/libpcre2-8.so.0.7.1 
+usr/lib/libpcre2-8.so.0.8.0
usr/lib/libpcre2-posix.so.2 
-usr/lib/libpcre2-posix.so.2.0.1 
+usr/lib/libpcre2-posix.so.2.0.2
```
```diff
usr/lib/libpcre2-32.so.0 
-usr/lib/libpcre2-32.so.0.7.1 
+usr/lib/libpcre2-32.so.0.8.0 
```
No data at https://abi-laboratory.pro/?view=timeline&l=pcre2