### PR TITLE
main/mariadb: security upgrade to 10.3.15

### DIFF
--- a/main/mariadb/APKBUILD
+++ b/main/mariadb/APKBUILD
@@ -6,8 +6,8 @@
 # Contributor: Marcel Haazen <marcel@haazen.xyz>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mariadb
-pkgver=10.3.13
-pkgrel=4
+pkgver=10.3.15
+pkgrel=0
 pkgdesc="A fast SQL database server"
 url="https://www.mariadb.org"
 pkgusers="mysql"
@@ -49,6 +49,10 @@ source="https://downloads.mariadb.org/interstitial/mariadb-$pkgver/source/mariad
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   10.3.15-r0:
+#     - CVE-2019-2614
+#     - CVE-2019-2627
+#     - CVE-2019-2628
 #   10.3.13-r0:
 #     - CVE-2019-2510
 #     - CVE-2019-2537
@@ -421,7 +425,7 @@ _plugin_rocksdb() {
 		 "$subpkgdir"/usr/lib/mariadb/plugin/ha_rocksdb.so
 }
 
-sha512sums="3cbd93291aa43b235e5b81d953ea69fb32df54fb518f922f69b5485952f01fae693c77b0efac37f414ed7ff132d3b58f899812bdb7be8a5b344c3640e2c3a0dd  mariadb-10.3.13.tar.gz
+sha512sums="35332ac32cba27fef1b4ddd2209236853f4309756fd121fbdbd2b6be0651e817cedc80e276b89ccfa4bc76760811434fab45a4d380d0ebd500c7d9bd7377fe93  mariadb-10.3.15.tar.gz
 c352969f6665b0ffa387f7b185a5dea7751f4b16c12c809627857b27321efa09159369d7dd5c852d6159a9f173cb895fb601f0c52a1fa6e3527899520030964c  mariadb.initd
 b4469f2f0299e71c09b65c91373f2d72b7fe9a9cd58ad24737a78a8097473b29c32b7267e173a2dfe1158f2f7d40a7fb02fb1b35caeda44d16ae3b9e2602a75f  fix-c11-atomics-check.patch
 e9ae4613f1d8c5f0a59b39a3548c46e50674ae78e7457d0e64c49f7e1573125c13634bbce7e29179bb8865a423171f852f43b96f7ef95619a95f02edcfc71efd  ppc-remove-glibc-dep.patch


### PR DESCRIPTION
Refs
- https://mariadb.com/kb/en/library/mariadb-10314-release-notes/
- https://mariadb.com/kb/en/library/mariadb-10315-release-notes/

-    CVE-2019-2614
-    CVE-2019-2627
-    CVE-2019-2628 