### PR TITLE
main/haproxy: upgrade to 1.9.6

### DIFF
--- a/main/haproxy/APKBUILD
+++ b/main/haproxy/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jeff Bilyk <jbilyk@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=haproxy
-pkgver=1.9.5
+pkgver=1.9.6
 _pkgmajorver=${pkgver%.*}
 pkgrel=0
 pkgdesc="A TCP/HTTP reverse proxy for high availability environments"
@@ -50,6 +50,6 @@ package() {
 	        "$pkgdir"/etc/haproxy/haproxy.cfg
 }
 
-sha512sums="af37e766ab8e53afe8113fe35b19d789c753da41eee5e11b4f0e36272a5e9fb9e73b40227b0cc89c025ea4d6f6d38ad2198c30c48a6c4be05fa32204cd053152  haproxy-1.9.5.tar.gz
+sha512sums="3b823005f02d035435838689ddbf50c4fd9fc14af20450c413526cda7a29eb01ee01f68d6867545ebf966235688eedeeb3d00f5e6011727486d53e881d8e73b6  haproxy-1.9.6.tar.gz
 3ab277bf77fe864ec6c927118dcd70bdec0eb3c54535812d1c3c0995fa66a3ea91a73c342edeb8944caeb097d2dd1a7761099182df44af5e3ef42de6e2176d26  haproxy.initd
 26bc8f8ac504fcbaec113ecbb9bb59b9da47dc8834779ebbb2870a8cadf2ee7561b3a811f01e619358a98c6c7768e8fdd90ab447098c05b82e788c8212c4c41f  haproxy.cfg"


### PR DESCRIPTION
Ref http://www.haproxy.org/download/1.9/src/CHANGELOG