### PR TITLE
main/libsodium: upgrade to 1.0.17

### DIFF
--- a/main/libsodium/APKBUILD
+++ b/main/libsodium/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=libsodium
-pkgver=1.0.16
+pkgver=1.0.17
 pkgrel=0
 pkgdesc="P(ortable|ackageable) NaCl-based crypto library"
 url="https://github.com/jedisct1/libsodium"
@@ -31,4 +31,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="eab917d599c9c1fe971a6ecf915b9a6476ccec2d46cf23cbfbf06dd3833089b422f192de4d55f17b93362f1251ba8d5ddeb95ced1a422a3a2631b4b82553907f  libsodium-1.0.16.tar.gz"
+sha512sums="7cc9e4f11e656008ce9dff735acea95acbcb91ae4936de4d26f7798093766a77c373e9bd4a7b45b60ef8a11de6c55bc8dcac13bebf8c23c671d0536430501da1  libsodium-1.0.17.tar.gz"


### PR DESCRIPTION
Ref https://github.com/jedisct1/libsodium/releases/tag/1.0.17

PS ABI is compatible https://abi-laboratory.pro/?view=timeline&l=libsodium
```diff
usr/lib/libsodium.so.23
-usr/lib/libsodium.so.23.1.0
+usr/lib/libsodium.so.23.2.0 
```