### PR TITLE
main/samba: upgrade to 4.10.2

### DIFF
--- a/main/cmocka/APKBUILD
+++ b/main/cmocka/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=cmocka
-pkgver=1.1.1
-pkgrel=1
+pkgver=1.1.5
+pkgrel=0
 pkgdesc="An elegant unit testing framework for C with support for mock objects"
 url="https://cmocka.org/"
 arch="all"
@@ -30,6 +30,7 @@ build() {
 
 	cmake .. \
 		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_SHARED_LIBS=True \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_C_FLAGS="$CFLAGS" \
@@ -48,6 +49,6 @@ package() {
 	make -C "$builddir"/build DESTDIR="$pkgdir" install
 }
 
-sha512sums="801c4a3e1bb9047241b1cb5a90c1cbdee1b0aff5e3d0a84ec8b2dbaee79274618c24fbe5e9fedbf0b3ee18c6c98b55d93e135d037ac33ab872edc7665af41577  cmocka-1.1.1.tar.xz
-16dfd8e6e2b21bda549a31cae0e60405039ff3559c879bc35811b55b06d64dcc75402d6a0cb89d029d69faeaa6484329ce03788feb9e69c1a844e63ac8d21f69  wordsize.patch
+sha512sums="cad7f04757183d004f6eaad39036fc0e24c5e0e987f80e85bc43bc66dba22389cb02b08e25531cc28a541d0a24a86b29be134a2d6fc339128e87d66952f502bd  cmocka-1.1.5.tar.xz
+773b8675f38eda0ca4df919c23646f029390892dd8f8675ce67c2f736f112d243d4e03aff4f013983bbefc2657cfa6c7563416b7b6dd15dd7aa4015228bb6ad1  wordsize.patch
 b20b5c0d172a9df756ec093a3df4bf5bdf2a0c06a3d3ad39ec001248ccb86e6fd3dcedfc9ce42e8309cc01ea34fadffd4ebcc0fb3af9f5e795e7fe40c461ac60  musl_uintptr.patch"

--- a/main/cmocka/wordsize.patch
+++ b/main/cmocka/wordsize.patch
@@ -1,16 +1,12 @@
-musl defines __WORDSIZE in bits/reg.h so include that. Also
-error out on if it's not defined, otherwise we might get wrong
-assumption which causes weird failures.
-
---- cmocka-1.1.1.orig/include/cmocka.h
-+++ cmocka-1.1.1/include/cmocka.h
-@@ -55,12 +55,9 @@
+--- cmocka-1.1.5/include/cmocka.h.orig
++++ cmocka-1.1.5/include/cmocka.h
+@@ -57,12 +57,9 @@
   */
  
  /* If __WORDSIZE is not set, try to figure it out and default to 32 bit. */
 +#include <bits/reg.h>
  #ifndef __WORDSIZE
--# if defined(__x86_64__) && !defined(__ILP32__)
+-# if (defined(__x86_64__) && !defined(__ILP32__)) || defined(__sparc_v9__) || defined(__sparcv9)
 -#  define __WORDSIZE 64
 -# else
 -#  define __WORDSIZE 32

--- a/main/ldb/0002-ldb-Run-at-least-some-tests-on-32-bit-machines.patch
+++ b/main/ldb/0002-ldb-Run-at-least-some-tests-on-32-bit-machines.patch
@@ -1,0 +1,60 @@
+From c161c5d4a3184c0ae9a33d977f061458337d4ca1 Mon Sep 17 00:00:00 2001
+From: Lukas Slebodnik <lslebodn@fedoraproject.org>
+Date: Wed, 30 May 2018 23:22:40 +0200
+Subject: [PATCH] ldb: Run at least some tests on 32 bit machines
+
+lmdb is supported only on 64 bit machines. But there also
+unit tests which pass just with tdb on 32 bit architectures.
+
+Signed-off-by: Lukas Slebodnik <lslebodn@fedoraproject.org>
+---
+ wscript | 19 +++++++++++--------
+ 1 file changed, 11 insertions(+), 8 deletions(-)
+
+diff --git a/wscript b/wscript
+index ca0bf410f1029f33bab9b71514935011d57b1dbc..851344733645f51186d0b568f2741ac888a52660 100644
+--- a/wscript
++++ b/wscript
+@@ -540,10 +540,6 @@ def test(ctx):
+     env = samba_utils.LOAD_ENVIRONMENT()
+     ctx.env = env
+ 
+-    if not env.HAVE_LMDB:
+-        raise Errors.WafError('make test called, but ldb was built '
+-                             '--without-ldb-lmdb')
+-
+     test_prefix = "%s/st" % (Context.g_module.out)
+     shutil.rmtree(test_prefix, ignore_errors=True)
+     os.makedirs(test_prefix)
+@@ -559,9 +555,13 @@ def test(ctx):
+     tmp_dir = os.path.join(test_prefix, 'tmp')
+     if not os.path.exists(tmp_dir):
+         os.mkdir(tmp_dir)
+-    pyret = samba_utils.RUN_PYTHON_TESTS(
+-        ['tests/python/api.py', 'tests/python/index.py'],
+-        extra_env={'SELFTEST_PREFIX': test_prefix})
++
++    if env.HAVE_LMDB:
++        pyret = samba_utils.RUN_PYTHON_TESTS(
++            ['tests/python/api.py', 'tests/python/index.py'],
++            extra_env={'SELFTEST_PREFIX': test_prefix})
++    else:
++        pyret = 0
+     print("Python testsuite returned %d" % pyret)
+ 
+     cmocka_ret = 0
+@@ -572,7 +572,10 @@ def test(ctx):
+                  'ldb_tdb_guid_mod_op_test',
+                  'ldb_msg_test',
+                  'ldb_tdb_kv_ops_test',
+-                 'ldb_tdb_test',
++                 'ldb_tdb_test']
++
++    if env.HAVE_LMDB:
++        test_exes += [
+                  'ldb_mdb_mod_op_test',
+                  'ldb_lmdb_test',
+                  # we don't want to run ldb_lmdb_size_test (which proves we can
+-- 
+2.20.1
+

--- a/main/ldb/APKBUILD
+++ b/main/ldb/APKBUILD
@@ -1,16 +1,17 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=ldb
-pkgver=1.3.8
-pkgrel=1
+pkgver=1.5.4
+pkgrel=0
 pkgdesc="A schema-less, ldap like, API and database"
 url="https://ldb.samba.org/"
 arch="all"
 license="LGPL-3.0-or-later"
-makedepends="libtirpc-dev tevent-dev py2-tevent tdb-dev py2-tdb talloc-dev
-	python2-dev python3-dev popt-dev cmocka-dev"
-subpackages="$pkgname-dev py2-$pkgname:_py2 py3-$pkgname:_py3 $pkgname-tools"
+makedepends="libtirpc-dev tevent-dev py3-tevent tdb-dev py3-tdb talloc-dev
+	python3-dev popt-dev cmocka-dev docbook-xsl lmdb-dev"
+subpackages="$pkgname-dev py3-$pkgname:_py3 $pkgname-tools $pkgname-doc"
 source="https://www.samba.org/ftp/pub/ldb/$pkgname-$pkgver.tar.gz
-	disable-compile-error-test.patch"
+	disable-compile-error-test.patch
+	0002-ldb-Run-at-least-some-tests-on-32-bit-machines.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
@@ -27,8 +28,7 @@ build() {
 		--disable-rpath-install \
 		--builtin-libraries=replace \
 		--bundled-libraries=NONE \
-		--with-modulesdir=/usr/lib/ldb/modules \
-		--extra-python=/usr/bin/python3
+		--with-modulesdir=/usr/lib/ldb/modules
 	"$_waf" build
 }
 
@@ -40,16 +40,6 @@ check() {
 package() {
 	cd "$builddir"
 	DESTDIR="$pkgdir" "$_waf" install
-}
-
-_py2() {
-	pkgdesc="Python 2 binding for the ldb library"
-	provides="py-ldb=$pkgver-r$pkgrel"  # for backward compatibility
-	replaces="py-ldb"  # for backward compatibility
-
-	mkdir -p "$subpkgdir"/usr/lib
-	mv "$pkgdir"/usr/lib/python2* "$subpkgdir"/usr/lib/
-	mv "$pkgdir"/usr/lib/libpyldb-util.so.* "$subpkgdir"/usr/lib/
 }
 
 _py3() {
@@ -67,5 +57,6 @@ tools() {
 	mv "$pkgdir"/usr/lib/ldb/libldb-cmdline.* "$subpkgdir"/usr/lib/ldb/
 }
 
-sha512sums="06d1b4c2badbf0c27733a64f979c48af8b599747cef7cd7f5417cd55a76447e8f8987bd061694c5af63261fdb35433e3844122c14103d5cc8b4eaab1f4752541  ldb-1.3.8.tar.gz
-ed55d5151bbcaf5c0a1b70a1f44b461a501ad94ce02ee97e3ea10c560ce3656a190510697bbd3c5b6f70a74519bf7c0a91210bcb415ffd97d9440045e10a02e8  disable-compile-error-test.patch"
+sha512sums="fc323e4283671c14d6dd4feb7e9ca943a63a166688077dbf3591f9d957cf821f9e739869842e15ca1ec4fd3764123d5afc6f4954b1af437bd1ec54df58366a22  ldb-1.5.4.tar.gz
+ed55d5151bbcaf5c0a1b70a1f44b461a501ad94ce02ee97e3ea10c560ce3656a190510697bbd3c5b6f70a74519bf7c0a91210bcb415ffd97d9440045e10a02e8  disable-compile-error-test.patch
+619db1e1cbf991546b92cfa4fd2100a0b74f563d366981b552a9997152a98ee2c5e9029c77015ab57860d0ca48a98aa24b6e5bc1c330880cd85f39c1df811e55  0002-ldb-Run-at-least-some-tests-on-32-bit-machines.patch"

--- a/main/samba/APKBUILD
+++ b/main/samba/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=samba
-pkgver=4.8.11
-pkgrel=1
+pkgver=4.10.2
+pkgrel=0
 pkgdesc="Tools to access a server's filespace and printers via SMB"
 url="https://www.samba.org/"
 arch="all"
@@ -31,9 +31,9 @@ subpackages="
 	$pkgname-server
 	$pkgname-server-libs:_server_libs
 	$pkgname-pidl::noarch
-	py-$pkgname:_py
+	py3-$pkgname:_py3
 	$pkgname-test:_test
-	$pkgname-libs-py:_libs_py
+	$pkgname-libs-py3:_libs_py3
 	$pkgname-libs
 	"
 
@@ -47,10 +47,12 @@ depends="
 makedepends="
 	acl-dev
 	cups-dev
+	dbus-dev
 	docbook-xsl
 	e2fsprogs-dev
 	fuse-dev
 	iniparser-dev
+	jansson-dev
 	ldb-dev
 	libarchive-dev
 	libcap-dev
@@ -60,9 +62,9 @@ makedepends="
 	openldap-dev
 	perl
 	popt-dev
-	py2-tdb
-	py2-tevent
-	python2-dev
+	py3-tdb
+	py3-tevent
+	python3-dev
 	rpcgen
 	subunit-dev
 	talloc-dev
@@ -78,6 +80,7 @@ source="
 	netapp.patch
 	bind-9.12.patch
 	missing-headers.patch
+	musl_rm_unistd_incl.patch
 	$pkgname.initd
 	$pkgname.confd
 	$pkgname.logrotate
@@ -113,11 +116,6 @@ builddir="$srcdir/$pkgname-$pkgver"
 #   4.6.1-r0:
 #     - CVE-2017-2619
 
-prepare() {
-	cd "$builddir"
-	default_prepare
-}
-
 build() {
 	cd "$builddir"
 	local _jobs=$JOBS
@@ -145,7 +143,8 @@ build() {
 		--enable-cups \
 		--without-gettext \
 		--bundled-libraries=NONE,ntdb,roken,wind,hx509,asn1,heimbase,hcrypto,krb5,gssapi,heimntlm,hdb,kdc,cmocka \
-		--disable-rpath-install
+		--disable-rpath-install \
+		--without-gpgme
 	make
 }
 
@@ -193,13 +192,13 @@ common() {
 }
 
 # common-libs is an attempt to avoid libpython dependency for libsmbclient
-_libs_py() {
+_libs_py3() {
 	pkgdesc="Libraries that require libpython"
 	depends=
 	cd "$pkgdir"
 	_mv_files \
-		usr/lib/$pkgname/libsamba-net-samba4.so \
-		usr/lib/$pkgname/libsamba-python-samba4.so
+		usr/lib/$pkgname/libsamba-net*samba4.so \
+		usr/lib/$pkgname/libsamba-python*samba4.so
 	return 0
 }
 
@@ -269,11 +268,13 @@ _client_libs() {
 	_mv_files \
 		usr/lib/libdcerpc.so.* \
 		usr/lib/$pkgname/libcli-ldap-samba4.so \
+		usr/lib/$pkgname/libclidns-samba4.so \
 		usr/lib/$pkgname/libcmdline-contexts-samba4.so \
 		usr/lib/$pkgname/libcmdline-credentials-samba4.so \
 		usr/lib/$pkgname/libdsdb-garbage-collect-tombstones-samba4.so \
 		usr/lib/$pkgname/libevents-samba4.so \
 		usr/lib/$pkgname/libhttp-samba4.so \
+		usr/lib/$pkgname/libmscat-samba4.so \
 		usr/lib/$pkgname/libnetif-samba4.so \
 		usr/lib/$pkgname/libpopt-samba3-cmdline-samba4.so \
 		usr/lib/$pkgname/libregistry-samba4.so \
@@ -286,6 +287,7 @@ client() {
 	cd "$pkgdir"
 	_mv_files \
 		usr/bin/cifsdd \
+		usr/bin/dumpmscat \
 		usr/bin/findsmb \
 		usr/bin/dbwrap_tool \
 		usr/bin/mvxattr \
@@ -386,7 +388,7 @@ dc() {
 	depends="$pkgname-common=$pkgver-r$pkgrel
 		$pkgname-server=$pkgver-r$pkgrel
 		$pkgname-winbind=$pkgver-r$pkgrel
-		py-$pkgname=$pkgver-r$pkgrel tdb"
+		py3-$pkgname=$pkgver-r$pkgrel tdb"
 	cd "$pkgdir"
 	_mv_files \
 		usr/bin/samba-tool \
@@ -405,7 +407,7 @@ _dc_libs() {
 	_mv_files \
 		usr/lib/libdcerpc-samr.so.* \
 		usr/lib/libdcerpc-server.so.* \
-		usr/lib/libsamba-policy.so.* \
+		usr/lib/libsamba-policy.* \
 		usr/lib/$pkgname/bind9 \
 		usr/lib/$pkgname/libHDB-SAMBA4-samba4.so \
 		usr/lib/$pkgname/libLIBWBCLIENT-OLD-samba4.so \
@@ -420,6 +422,7 @@ _dc_libs() {
 		usr/lib/$pkgname/libpac-samba4.so \
 		usr/lib/$pkgname/libposix-eadb-samba4.so \
 		usr/lib/$pkgname/libprocess-model-samba4.so \
+		usr/lib/$pkgname/libscavenge-dns-records-samba4.so \
 		usr/lib/$pkgname/libservice-samba4.so \
 		usr/lib/$pkgname/libshares-samba4.so \
 		usr/lib/$pkgname/process_model \
@@ -450,7 +453,7 @@ server() {
 	_mv_files \
 		usr/sbin/nmbd \
 		usr/sbin/smbd \
-		usr/bin/eventlogadm \
+		usr/sbin/eventlogadm \
 		usr/bin/smbstatus \
 		\
 		usr/lib/$pkgname/auth \
@@ -468,9 +471,9 @@ pidl() {
 		usr/share/perl*
 }
 
-_py() {
+_py3() {
 	pkgdesc="Samba python libraries"
-	depends="py2-tdb"
+	depends="py3-tdb"
 	mkdir -p "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/lib/python* "$subpkgdir"/usr/lib/
 }
@@ -560,14 +563,15 @@ libs() {
 		"$pkgdir"/usr
 }
 
-sha512sums="65f3791ca3300f0e9760730962978bffc4ae22bf3bb3e58e7f2249bab6db9758dfcde9487ae0c8bc862fe7a507252cad131f8ea5dec826aceac214227d8e75cd  samba-4.8.11.tar.gz
-62d373dbaee75121a1d73f2c09cdca7239705808ff807b171d1d5a28fd4ffc66bdb52494b62786d7aaba8aeece5c08433b532ca96a28d712452fe9daac8d8d2e  domain.patch
+sha512sums="3d146ea12567ebb02a7babcad779b82339ffbfb19f6f2be5cac33eb18af2c9b546dc1cd910072a5c9e152ba9c4a632ed6870c48a8f6ad9d04304b130f240a4bf  samba-4.10.2.tar.gz
+188ed177d593906ac2ee532b40be20169f4379288480d71a79344702636208872fe50d54ec73f7c4477270f36c2c27308d1ae197b153b388ac4f3df9c8593347  domain.patch
 0d4fd9862191554dc9c724cec0b94fd19afbfd0c4ed619e4c620c075e849cb3f3d44db1e5f119d890da23a3dd0068d9873703f3d86c47b91310521f37356208b  getpwent_r.patch
 a99e771f28d787dc22e832b97aa48a1c5e13ddc0c030c501a3c12819ff6e62800ef084b62930abe88c6767d785d5c37e2e9f18a4f9a24f2ee1f5d9650320c556  musl_uintptr.patch
 1854577d0e4457e27da367a6c7ec0fb5cfd63cefea0a39181c9d6e78cf8d3eb50878cdddeea3daeec955d00263151c2f86ea754ff4276ef98bc52c0276d9ffe8  netdb-defines.patch
 202667cb0383414d9289cd67574f5e1140c9a0ff63bb82a746a59b2397a00db15654bfb30cb5ec1cd68a097899be0f849d9aab4c0d210152386c9e66c640f0c0  netapp.patch
 27f12c8395be25d9806d232cc30334f2f7c7d175971d2d1944dd886d699e0381a6f222c17e3d7bc087cf7a29bfb3e98cf25ba98f414c4afe0297b9d134a28bd8  bind-9.12.patch
 c0afe8b1dfddc5290c9aa611163d20adc3a546f54bba0081f739cda4255829f1a72bae422b6cb049aca82e58d4daf63ad5553f4c5c51671019bfbbc2781460f0  missing-headers.patch
+5cda0a07089b99d99f33de74aae89a338954451167f72a9972cc437a7d06d92590c07386fd24e94c72ff34f1dd42494c5d7fcb48ca1823affa8168e83c239067  musl_rm_unistd_incl.patch
 96070e2461370437f48571e7de550c13a332fef869480cfe92e7cac73a998f6c2ee85d2580df58211953bebd0e577691aa710c8edddf3ea0f30e9d47d0a2fd44  samba.initd
 e2b49cb394e758447ca97de155a61b4276499983a0a5c00b44ae621c5559b759a766f8d1c8d3ee98ad5560f4064a847a7a20cfa2e14f85c061bec8b80fd649eb  samba.confd
 3458a4e1f8a8b44c966afb339b2dca51615be049f594c14911fc4d8203623deee416b6fe881436e246fc7d49c97a2b3bf9c5f33ba774302b24190a1103d6b67d  samba.logrotate"

--- a/main/samba/domain.patch
+++ b/main/samba/domain.patch
@@ -1,12 +1,12 @@
 --- ./python/samba/netcmd/domain.py.orig
 +++ ./python/samba/netcmd/domain.py
-@@ -301,8 +301,10 @@
+@@ -388,8 +388,10 @@
              def ask(prompt, default=None):
                  if default is not None:
-                     print "%s [%s]: " % (prompt, default),
+                     print("%s [%s]: " % (prompt, default), end=' ')
 +                    sys.stdout.flush()
                  else:
-                     print "%s: " % (prompt,),
+                     print("%s: " % (prompt,), end=' ')
 +                    sys.stdout.flush()
                  return sys.stdin.readline().rstrip("\n") or default
  

--- a/main/samba/musl_rm_unistd_incl.patch
+++ b/main/samba/musl_rm_unistd_incl.patch
@@ -1,0 +1,13 @@
+--- a/lib/replace/replace.h
++++ b/lib/replace/replace.h
+@@ -162,10 +162,6 @@
+ #include <bsd/unistd.h>
+ #endif
+ 
+-#ifdef HAVE_UNISTD_H
+-#include <unistd.h>
+-#endif
+-
+ #ifdef HAVE_STRING_H
+ #include <string.h>
+ #endif

--- a/main/talloc/APKBUILD
+++ b/main/talloc/APKBUILD
@@ -1,15 +1,15 @@
 # Contributor: 
 # Maintainer: 
 pkgname=talloc
-pkgver=2.1.14
-pkgrel=2
+pkgver=2.2.0
+pkgrel=0
 pkgdesc="Memory pool management library"
 url="https://talloc.samba.org"
 arch="all"
 license="LGPL-3.0-or-later"
 replaces="samba-common"
-makedepends="docbook-xsl libxslt python2-dev python3-dev"
-subpackages="$pkgname-dev py2-$pkgname:_py2 py3-$pkgname:_py3 $pkgname-doc"
+makedepends="docbook-xsl libxslt python3-dev"
+subpackages="$pkgname-dev py3-$pkgname:_py3 $pkgname-doc"
 source="https://samba.org/ftp/$pkgname/$pkgname-$pkgver.tar.gz
 	always-libs.patch
 	"
@@ -29,12 +29,11 @@ build() {
 		--builtin-libraries=replace \
 		--disable-rpath \
 		--disable-rpath-install \
-		--without-gettext \
-		--extra-python=/usr/bin/python3
+		--without-gettext
 	make
 
 	# talloc's Waf setup doesn't build static libraries, so we do it manually
-	ar qf libtalloc.a bin/default/talloc_*.o
+	ar qf libtalloc.a bin/default/talloc.c*.o
 }
 
 check() {
@@ -48,16 +47,6 @@ package() {
 	install -Dm644 libtalloc.a "$pkgdir"/usr/lib/libtalloc.a
 }
 
-_py2() {
-	pkgdesc="Python 2 binding for libtalloc"
-	replaces="py-talloc"  # for backward compatibility
-	provides="py-talloc=$pkgver-r$pkgrel"  # for backward compatibility
-
-	mkdir -p "$subpkgdir"/usr/lib
-	mv "$pkgdir"/usr/lib/libpytalloc-util.so.* \
-		"$pkgdir"/usr/lib/python2* "$subpkgdir"/usr/lib/
-}
-
 _py3() {
 	pkgdesc="Python 3 binding for libtalloc"
 
@@ -66,5 +55,5 @@ _py3() {
 		"$pkgdir"/usr/lib/python3* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="1fcc70bf283a4d9fb61faf1c57f80a9c158efbe996452740db9755e879ad72ee7bff6f6c9bed358e085c5c7f97c78800bb903161143af2202952b702141cc130  talloc-2.1.14.tar.gz
-fa818d6291f6291d193b475af993de4fd34e6133ccacb55203f5c96973c51b2e932523f5f2a8cd38a4959e80d8378841b3b5efd5411b7828a240102b492c16e7  always-libs.patch"
+sha512sums="e762c6443ff2c0c35a9dbf7ac6e64a9182c04a218ad0f26fd67ac9620d9ae26d68b8dd2b21ff37e1df0e53748c84bece27890c5c4939eaeb61c502a698802388  talloc-2.2.0.tar.gz
+66d06f735fe591f3a888ced25c4c5a0068402001736ce52443d0670d42bf7144c7f69ff9c6299ecf4d9001f23c68403953c4bdc7325f4d094d304e4215ff90b1  always-libs.patch"

--- a/main/talloc/always-libs.patch
+++ b/main/talloc/always-libs.patch
@@ -4,7 +4,7 @@
              msg = "rpath library support"
          else:
              msg = "building library support"
-+	    return True
++            return True
  
      dir = find_config_dir(conf)
  

--- a/main/tdb/APKBUILD
+++ b/main/tdb/APKBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=tdb
-pkgver=1.3.16
-pkgrel=1
+pkgver=1.3.18
+pkgrel=0
 pkgdesc="The tdb library"
 url="https://tdb.samba.org"
 arch="all"
 license="LGPL-3.0-or-later"
-depends_dev="python2"
-makedepends="$depends_dev python2-dev python3-dev docbook-xsl"
-subpackages="$pkgname-dev py2-$pkgname:_py2 py3-$pkgname:_py3
+depends_dev="python3"
+makedepends="$depends_dev python3-dev docbook-xsl"
+subpackages="$pkgname-dev py3-$pkgname:_py3
 	$pkgname-libs $pkgname-doc"
 source="https://samba.org/ftp/tdb/tdb-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
@@ -25,8 +25,7 @@ build() {
 		--localstatedir=/var \
 		--disable-rpath \
 		--bundled-libraries=NONE \
-		--builtin-libraries=replace \
-		--extra-python=/usr/bin/python3
+		--builtin-libraries=replace
 	make
 }
 
@@ -38,15 +37,6 @@ check() {
 package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install
-}
-
-_py2() {
-	pkgdesc="Python 2 binding for the tdb library"
-	provides="py-tdb=$pkgver-r$pkgrel"  # for backward compatibility
-	replaces="py-tdb"  # for backward compatibility
-
-	mkdir -p "$subpkgdir"/usr/lib
-	mv "$pkgdir"/usr/lib/python2* "$subpkgdir"/usr/lib/
 }
 
 _py3() {
@@ -61,4 +51,4 @@ libs() {
 	replaces="tdb"
 }
 
-sha512sums="7b17852986e48a32f3f8f303dd2a26503a69fcf7849f22f51483334c9abda9f189b521679e51b4ee5a80197a8f304a084dde0f56d92cfe953d3a4ede557526d2  tdb-1.3.16.tar.gz"
+sha512sums="9b856b2a5b2d852ff0048ba7b1700ea46b8dad5d4e94027472fdce9f1db4b5afba9aec127b7a4c2a38d4722c8e0ea78c1734d102fa134ac802eace6b24358034  tdb-1.3.18.tar.gz"

--- a/main/tevent/APKBUILD
+++ b/main/tevent/APKBUILD
@@ -1,14 +1,14 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=tevent
-pkgver=0.9.37
-pkgrel=2
+pkgver=0.9.39
+pkgrel=0
 pkgdesc="The tevent library"
 url="https://tevent.samba.org"
 arch="all"
 license="LGPL-3.0-or-later"
-makedepends="libtirpc-dev python2-dev python3-dev talloc-dev"
+makedepends="libtirpc-dev python3-dev talloc-dev"
 replaces="samba"
-subpackages="$pkgname-dev py2-$pkgname:_py2 py3-$pkgname:_py3"
+subpackages="$pkgname-dev py3-$pkgname:_py3"
 source="https://samba.org/ftp/tevent/tevent-$pkgver.tar.gz
 	fix-public-header.patch"
 builddir="$srcdir/$pkgname-$pkgver"
@@ -25,8 +25,7 @@ build() {
 		--localstatedir=/var \
 		--disable-rpath \
 		--bundled-libraries=NONE \
-		--without-gettext \
-		--extra-python=/usr/bin/python3
+		--without-gettext
 	make
 }
 
@@ -40,15 +39,6 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-_py2() {
-	pkgdesc="Python 2 binding for the tevent library"
-	provides="py-$pkgname=$pkgver-r$pkgrel"  # for backward compatibility
-	replaces="py-$pkgname"  # for backward compatibility
-
-	mkdir -p "$subpkgdir"/usr/lib
-	mv "$pkgdir"/usr/lib/python2* "$subpkgdir"/usr/lib/
-}
-
 _py3() {
 	pkgdesc="Python 3 binding for the tevent library"
 
@@ -56,5 +46,5 @@ _py3() {
 	mv "$pkgdir"/usr/lib/python3* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="5d4833403e1c2f2749f00a389e4757261a4f22cd3a67c906001b36a8b622cc68a38e86d4eb475848a2121ebba054a7e7dac7f486d9f2906a401c3cc97fb447f4  tevent-0.9.37.tar.gz
+sha512sums="72f48493aa3ef2efb78fa4e8cbeca8a66871e6835b51307ce08864ed0a778ccfd5f62d6768099f06680915375ee78c3b889514e247bcfe797889f16388c321b0  tevent-0.9.39.tar.gz
 ee4cce8591dfe31288975596d8464b7cc160580715f88e4fd19b5ae7e1a831650b072954731f015f52d76600597faee894f0174b9e92d18dca9629f9d056230c  fix-public-header.patch"


### PR DESCRIPTION
Upgrade also talloc, tevent, cmocka, tdb and ldb to required/latest version.
Remove python2, as it will be EOL january next year.