### PR TITLE
community/py-execnet: enabled tests

### DIFF
--- a/community/py-execnet/APKBUILD
+++ b/community/py-execnet/APKBUILD
@@ -3,14 +3,13 @@
 pkgname=py-execnet
 _pkgname=execnet
 pkgver=1.6.0
-pkgrel=0
+pkgrel=1
 pkgdesc="execnet: rapid multi-Python deployment"
 url="https://github.com/pytest-dev/execnet"
 arch="noarch"
 license="MIT"
 depends="py-apipkg"
-options="!check" # Tests are broken https://github.com/pytest-dev/execnet/issues/89
-checkdepends="pytest"
+checkdepends="pytest py-py"  # tests for py-gevent are broken, jython is missing in repo, eventlet is part of testing
 makedepends="python2-dev python3-dev py-setuptools py-setuptools_scm"
 subpackages="py3-$_pkgname:_py3 py2-$_pkgname:_py2"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"


### PR DESCRIPTION
Enabled most of tests, but not all of them. The ones that are not enabled are "optional" and skipped automatically.

Reasons for skip are next:
1. py-gevent - cries with errors mentioned in https://github.com/pytest-dev/execnet/issues/45
2. jython - doesn't exist in aports
3. py-eventlet - currently part of "testing", not community.