### PR TITLE
main/ncurses: Update to 6.1_p20190420

### DIFF
--- a/main/ncurses/APKBUILD
+++ b/main/ncurses/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=ncurses
-pkgver=6.1_p20190105
+pkgver=6.1_p20190420
 _ver=${pkgver/_p/-}
 pkgrel=0
 pkgdesc="Console display library"
@@ -103,4 +103,4 @@ static() {
 	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib/
 }
 
-sha512sums="98ccce35d315f278a732303fde974f5d3b5f8ee72e6d0948a8389f462a5991317b8d541981a022deba1223936b58fd36979418d51520507f42792dc411293d57  ncurses-6.1-20190105.tgz"
+sha512sums="5e87e0c7361f5695cffd04234971ce88ba8c991049b5355c707fae93537ba9f5b9c3eabcca3115b32c77f392efa36c94224896359dcc52742962bd5f69ae09a6  ncurses-6.1-20190420.tgz"


### PR DESCRIPTION
Previous version 404s upstream