### PR TITLE
testing/openresty: new aport

### DIFF
--- a/testing/openresty/APKBUILD
+++ b/testing/openresty/APKBUILD
@@ -1,0 +1,159 @@
+# Contributor: tcely <openresty+aports@tcely.33mail.com>
+# Maintainer: tcely <openresty+aports@tcely.33mail.com>
+pkgname=openresty
+pkgver=1.13.6.2
+pkgrel=0
+pkgdesc="Scalable Web Platform by Extending NGINX with Lua"
+url="https://openresty.org/"
+arch="all"
+license="BSD-2-Clause"
+options="!check" # tests environment not available
+provides="cmd:nginx"
+depends="!nginx"
+depends_dev="gd-dev geoip-dev openssl-dev libxml2-dev libxslt-dev pcre-dev perl-dev pkgconf readline-dev zlib-dev"
+makedepends="$depends_dev linux-headers"
+install=""
+subpackages="$pkgname-doc"
+source="https://openresty.org/download/$pkgname-$pkgver.tar.gz"
+
+_modules_dir="/usr/lib/nginx/modules"
+_add_module() {
+	local name="http-${1}"
+	local _soname="${2-$1}"
+	local soname="ngx_http_${_soname//-/_}_module.so"
+
+	subpackages="$subpackages ${pkgname}-mod-${name}:_module"
+	eval "_module_${name//-/_}_so='${soname//\'}'"
+
+	[ -z "$3" ] || { shift; shift; eval "_module_${name//-/_}_deps='${*//\'}'"; }
+}
+
+_add_module echo
+_add_module headers-more headers_more_filter
+_add_module lua lua nginx-mod-devel-kit
+_add_module lua-upstream lua_upstream "${pkgname}-mod-http-lua"
+_add_module redis2
+_add_module set-misc set_misc nginx-mod-devel-kit
+
+prepare() {
+	default_prepare
+	cd "$builddir"
+
+	sed -i.orig -e '/--add-module=$dir/s/module/dynamic-&/' configure
+}
+
+_configure() {
+	local _pkgname=nginx
+
+	./configure -j$(nproc) \
+	--prefix=/var/lib/$_pkgname \
+	--sbin-path=/usr/sbin/$_pkgname \
+	--modules-path="$_modules_dir" \
+	--conf-path=/etc/$_pkgname/${_pkgname}.conf \
+	--pid-path=/var/run/$_pkgname/${_pkgname}.pid \
+	--lock-path=/var/run/$_pkgname/${_pkgname}.lock \
+	--error-log-path=/var/log/$_pkgname/error.log \
+	--http-log-path=/var/log/$_pkgname/access.log \
+	\
+	--http-client-body-temp-path=/var/tmp/$_pkgname/client_body \
+	--http-proxy-temp-path=/var/tmp/$_pkgname/proxy \
+	--http-fastcgi-temp-path=/var/tmp/$_pkgname/fastcgi \
+	--http-uwsgi-temp-path=/var/tmp/$_pkgname/uwsgi \
+	--http-scgi-temp-path=/var/tmp/$_pkgname/scgi \
+	--with-perl_modules_path=/usr/lib/perl5/vendor_perl \
+	\
+	--user=$_pkgname \
+	--group=$_pkgname \
+	--with-threads \
+	--with-file-aio \
+	\
+	--with-http_ssl_module \
+	--with-http_v2_module \
+	--with-http_realip_module \
+	--with-http_addition_module \
+	--with-http_xslt_module=dynamic \
+	--with-http_image_filter_module=dynamic \
+	--with-http_geoip_module=dynamic \
+	--with-http_sub_module \
+	--with-http_dav_module \
+	--with-http_flv_module \
+	--with-http_mp4_module \
+	--with-http_gunzip_module \
+	--with-http_gzip_static_module \
+	--with-http_auth_request_module \
+	--with-http_random_index_module \
+	--with-http_secure_link_module \
+	--with-http_degradation_module \
+	--with-http_slice_module \
+	--with-http_stub_status_module \
+	--with-http_perl_module=dynamic \
+	--with-mail=dynamic \
+	--with-mail_ssl_module \
+	--with-stream=dynamic \
+	--with-stream_ssl_module \
+	--with-stream_realip_module \
+	--with-stream_geoip_module=dynamic \
+	--with-stream_ssl_preread_module \
+	--with-pcre-jit \
+
+}
+
+build() {
+	cd "$builddir"
+
+	_configure
+	make
+	mv build built
+
+	mv configure.orig configure
+	_configure
+	make
+}
+
+package() {
+	cd "$builddir"
+
+	make DESTDIR="$pkgdir" install
+}
+
+_module() {
+	local name="${subpkgname#${pkgname}-mod-}"
+	local soname="$(eval echo "\$_module_${name//-/_}_so")"
+	local _deps="$(eval echo "\$_module_${name//-/_}_deps")"
+
+	pkgdesc="$pkgdesc (module $soname)"
+	depends="cmd:nginx${_deps:+ }${_deps}"
+	provides=""
+
+	mkdir -p "${subpkgdir}${_modules_dir}"
+	cd "${subpkgdir}${_modules_dir}"
+	mv "$builddir"/built/nginx-*/objs/"$soname" .
+
+	mkdir -p "${subpkgdir}/etc/nginx/modules"
+	cd "${subpkgdir}/etc/nginx/modules"
+	echo "load_module \"modules/${soname}\";" > "./${name}.conf"
+}
+
+doc() {
+	default_doc
+	local _prefix='/var/lib/nginx'
+
+	mkdir -p "$subpkgdir$_prefix"
+	mkdir -p "$subpkgdir$_prefix/bin"
+	mkdir -p "$subpkgdir$_prefix/luajit/share"
+	mkdir -p "$subpkgdir$_prefix/site"
+
+	mv "$pkgdir$_prefix/pod" "$subpkgdir$_prefix/"
+	mv "$pkgdir$_prefix/site/pod" "$subpkgdir$_prefix/site/"
+	mv "$pkgdir$_prefix/luajit/share/man" "$subpkgdir$_prefix/luajit/share/"
+
+	mv "$pkgdir$_prefix/bin/md2pod.pl" "$subpkgdir$_prefix/bin/"
+	mv "$pkgdir$_prefix/bin/nginx-xml2pod" "$subpkgdir$_prefix/bin/"
+	mv "$pkgdir$_prefix/bin/restydoc" "$subpkgdir$_prefix/bin/"
+	mv "$pkgdir$_prefix/bin/restydoc-index" "$subpkgdir$_prefix/bin/"
+
+	mkdir -p "$subpkgdir/usr/lib/perl5/vendor_perl"
+	mv "$pkgdir/usr/lib/perl5/vendor_perl/man3" "$subpkgdir/usr/lib/perl5/vendor_perl/"
+}
+
+sha512sums="c0584566c06e95b12c5827f7b3185e859cb79a8d4754257246644c19888bfabfcec3577953b1a5a9aa7c0c5627b3e45bd0befacea4e3c64d21f895869ee302d5  openresty-1.13.6.2.tar.gz"


### PR DESCRIPTION
https://openresty.org/
A Fast and Scalable Web Platform by Extending NGINX with LuaJIT

* upgrade to 1.13.6.2
* add subpkgs for modules
* build bundled nginx normally
* -doc subpkg
* fix license
* switch from `libressl-dev` to `openssl-dev`

Updates #4264
Replaces #3246