### PR TITLE
community/gitea: upgrade to 1.8.0

### DIFF
--- a/community/gitea/APKBUILD
+++ b/community/gitea/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=gitea
-pkgver=1.7.6
+pkgver=1.8.0
 pkgrel=0
 pkgdesc="A self-hosted Git service written in Go"
 url="https://gitea.io"
@@ -68,7 +68,7 @@ check() {
 	"$builddir"/$pkgname help > /dev/null
 }
 
-sha512sums="ad39969b5f1246875c006c72f2ea711772f29bfb9c687510efbd2089c9f88e9d218d14b03111715179b2e0f72f85731f22dd46fc022e224be73b7e73e798236b  gitea-1.7.6.tar.gz
+sha512sums="eebbe2f77ed2e4c3562f48a6fa647e6f2a0492c5b6ea4f13542a5ef82e94a357a8d53897aa013107b5f735d2aff9d719893b5724de44831c43998c2e9c6e78d7  gitea-1.8.0.tar.gz
 a7c70a144dc0582d6230e59ff717023fddcac001a6a9c895b46a0df1fbd9639453b2f5027d47dad21f442869c145dbc801eda61b6c50a2dd8103f562b8569009  gitea.initd
 27a202006d6e8d4146659f6356eaa99437f9f596dd369e9430d64b859bc6a1ad16091eef09232aa385fe1bf8ca94bbdf31b94975068220ad10338cded384f726  gitea.ini
-05272f3733dffeb75881579ff6553d32515e4de32113ff9395e521e93946a45101d04d4e435d7d8e7bfe49a512e5e4ac300576d2e79d7bcf314fc0ce526a07f9  allow-to-set-version.patch"
+4eee3ab54c6e44327a1f7e68a5de320204dd46852a7eee7d6652397f03f9af72fb28455dcaec9b6498439360c6c9699ce5a7c17b9e9b0b568c6840bf1e4d13e6  allow-to-set-version.patch"

--- a/community/gitea/allow-to-set-version.patch
+++ b/community/gitea/allow-to-set-version.patch
@@ -1,6 +1,6 @@
---- ./Makefile.orig
+--- ./Makefile
 +++ ./Makefile
-@@ -30,7 +30,7 @@
+@@ -33,7 +33,7 @@
  	else
  		VERSION ?= master
  	endif


### PR DESCRIPTION
SECURITY
- Prevent remote code execution vulnerability with mirror repo URL settings (#6593) (#6594)
-  Resolve 2FA bypass on API (#6676) (#6674)
-  Prevent the creation of empty sessions for non-logged in users (#6690) (#6677)

BREAKING
- Add "ghost" and "notifications" to list of reserved user names. (#6208)
- Change sqlite DB path default to data directory (#6198)
- Adds MustChangePassword to user create/edit API (#6193)
- Disable redirect for i18n (#5910)
- Releases API paging (#5831)
- Allow Macaron to be set to log through to gitea.log (#5667)
- Don't close issues via commits on non-default branch (#5622)

FEATURE, ENHANCEMENT, BUGFIXES...
.... Tons of stuff, see the changelog.

https://github.com/go-gitea/gitea/releases/tag/v1.8.0