### PR TITLE
main/meson: depend on py3-setuptools

### DIFF
--- a/main/meson/APKBUILD
+++ b/main/meson/APKBUILD
@@ -2,13 +2,12 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=meson
 pkgver=0.50.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Fast and user friendly build system"
 url="https://mesonbuild.com"
 arch="noarch"
 license="Apache-2.0"
-depends="ninja python3"
-makedepends="python3-dev"
+depends="ninja py3-setuptools python3"
 subpackages="$pkgname-doc"
 source="https://github.com/mesonbuild/meson/releases/download/$pkgver/$pkgname-$pkgver.tar.gz"
 


### PR DESCRIPTION
>>> elogind: Unpacking /var/cache/distfiles/elogind-241.2.tar.gz...
Traceback (most recent call last):
  File "/usr/bin/meson", line 6, in <module>
    from pkg_resources import load_entry_point
ImportError: cannot import name 'load_entry_point' from 'pkg_resources' (unknown location)