### PR TITLE
main/python3: -dev depends on py3-setuptools

### DIFF
--- a/main/py-setuptools/APKBUILD
+++ b/main/py-setuptools/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=py-setuptools
 _pkgname=${pkgname#py-}
 pkgver=40.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A collection of enhancements to the Python distutils"
 url="https://pypi.python.org/pypi/setuptools"
 arch="noarch"

--- a/main/python3/APKBUILD
+++ b/main/python3/APKBUILD
@@ -5,7 +5,7 @@ pkgname=python3
 # the python2-tkinter's pkgver needs to be synchronized with this.
 pkgver=3.7.3
 _basever="${pkgver%.*}"
-pkgrel=0
+pkgrel=1
 pkgdesc="A high-level scripting language"
 url="https://www.python.org"
 arch="all"
@@ -13,7 +13,9 @@ license="custom"
 provides="py3-pip"
 subpackages="$pkgname-dbg $pkgname-dev $pkgname-doc $pkgname-tests::noarch
 	$pkgname-wininst"
-makedepends="expat-dev openssl-dev zlib-dev ncurses-dev bzip2-dev xz-dev
+depends_dev="py3-setuptools"
+makedepends="$depends_dev
+	expat-dev openssl-dev zlib-dev ncurses-dev bzip2-dev xz-dev
 	sqlite-dev libffi-dev tcl-dev linux-headers gdbm-dev readline-dev
 	!gettext-dev"
 source="https://www.python.org/ftp/python/$pkgver/Python-$pkgver.tar.xz


### PR DESCRIPTION
A package using -dev will likely have setup.py that should be used.