### PR TITLE
community/abiword: modify plugin function names to avoid ash conflict

### DIFF
--- a/community/abiword/APKBUILD
+++ b/community/abiword/APKBUILD
@@ -26,7 +26,7 @@ _plugins="applix babelfish bmp clarisworks collab docbook command eml epub \
 	xslfo"
 
 for _i in $_plugins; do
-	subpackages="$subpackages $pkgname-plugin-$_i:$_i"
+	subpackages="$subpackages $pkgname-plugin-$_i:plugin_${_i}"
 done
 
 source="http://www.abisource.com/downloads/$pkgname/$pkgver/source/$pkgname-$pkgver.tar.gz
@@ -60,7 +60,7 @@ _do_plugin() {
 }
 
 for _i in $_plugins; do
-	eval "$_i() { _do_plugin $_i; }"
+	eval "plugin_${_i}() { _do_plugin $_i; }"
 done
 
 plugins() {


### PR DESCRIPTION
APKBUILD includes instructions to build plugin routines,
for _i in $_plugins; do
        eval "plugin_${_i}() { _do_plugin $_i; }"
done

One of the plugin names is "command" which results in a script function being created:
command() { 
_do_plugin command; 
}

This command() created to support plugin handling conflicts with the builtin command() function supplied by the ash interpreter. This results in an error during build when abuild's default_doc() issues a
local gzip=$(command -v pigz || echo gzip)

This fix renames the plugin handling functions to add a prefix, avoiding the conflicts
