### PR TITLE
community/cargo-static: split off from community/rust

### DIFF
--- a/testing/drone-cli/APKBUILD
+++ b/testing/drone-cli/APKBUILD
@@ -1,13 +1,13 @@
 # Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
-# Maintainer:
+# Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=drone-cli
-pkgver=1.0.6
+pkgver=1.1.0
 pkgrel=0
-pkgdesc="Drone CLI" 
+pkgdesc="Drone CLI"
 url="https://github.com/drone/drone-cli"
 arch="all"
 license="Apache-2.0"
-options="!check"
+options="!check" # No tests to run
 makedepends="go"
 source="drone-cli-$pkgver.tar.gz::https://github.com/drone/drone-cli/archive/v$pkgver.tar.gz"
 builddir="$srcdir/src/github.com/drone/$pkgname"
@@ -20,7 +20,6 @@ prepare() {
 }
 
 build() {
-	cd "$builddir"
 	export GOPATH="$srcdir"
 	go build -ldflags "-X main.version=${pkgver}" -o bin/drone ./drone
 }
@@ -29,4 +28,4 @@ package() {
 	install -Dm755 "$builddir"/bin/drone "$pkgdir"/usr/bin/drone
 }
 
-sha512sums="cf4f78eb4d16cb52c81a049485b6341ee0b6b400f1219f232408dcb39f6b783f647d44f50cc0def9996787d06dc4c458f29d9bf8c44ba1f9b9e101104863374c  drone-cli-1.0.6.tar.gz"
+sha512sums="ba059250cf73982b662e5fb9f4570381ca4ff2618a759dc497f793e7bba7d7094cc28fb90390c61b642caab0ee5d33ddc1c5a25cea13c6aaea8e50ac24868927  drone-cli-1.1.0.tar.gz"


### PR DESCRIPTION
This allows us to have a static cargo version for bootstrapping (e.g. to not
break when libgit is upgraded) while still offering the users a shared one.