### PR TITLE
testing/knot-resolver4: dnstap generated header meson fix

### DIFF
--- a/testing/knot-resolver4/APKBUILD
+++ b/testing/knot-resolver4/APKBUILD
@@ -20,6 +20,7 @@ install="$pkgname.pre-install"
 subpackages="$pkgname-mod-http:http:noarch $pkgname-mod-dnstap:dnstap $pkgname-dev $pkgname-doc $pkgname-openrc"
 source="
 	https://secure.nic.cz/files/${_pkgname}/${_pkgname}-$pkgver.tar.xz
+	meson-dnstap-generated-sources.patch
 	knot-resolver4.logrotate
 	knot-resolver4.confd
 	knot-resolver4.initd
@@ -81,10 +82,12 @@ dnstap() {
 }
 
 sha256sums="37161d931e64535ce38c33b9635f06a43cd1541945bf2c79a55e37f230de1631  knot-resolver-4.0.0.tar.xz
+630e9e22fc6c343e3f864ab6a83ab57071c1dbf8a55cad24628c30c536c45e4f  meson-dnstap-generated-sources.patch
 23a9fff29fae658e669553a385cf5563311a3451bb8f77889a8d8501e8c98c5a  knot-resolver4.logrotate
 bb3e4c1f666c3e1d995aad8fa0af98960298d91b0222fc7f423692493ffbb3a5  knot-resolver4.confd
 41acd36d8f84805d851865daf993cb5f6697190662edf7f95d0e92ab1ff58b80  knot-resolver4.initd"
 sha512sums="e4c7e21ec36b5a733adf9f8e3751bbc347ce9ce7af8d71e8d5f3a7a87da673db753490c5257466e8433cd5fff1651046c8500ee59e91be8e55b1a16614eaf53a  knot-resolver-4.0.0.tar.xz
+d51fb4eacc2b86fe7ee6d39a9f34d9eaf874204ab4c965cb5c053b3a5b5920f90e0cee388c2707d0ff3eb705f5764221e0823813baa9c1ccf247b185436adb6a  meson-dnstap-generated-sources.patch
 86fcd63264a21b83850d42328c89f051055bbd81c95bb96b298fb74a0826fa453b05fd34ae247e176635466d678ea740912047d05cacaea96c67fd2ded6b5bb5  knot-resolver4.logrotate
 0379745f15175aa9a740c7e58b7279b2e1520effb465dd168ea2165118fdb79291082b914dce34d7967068568c35ad381950845e2b03802a1c88fe99b55a7211  knot-resolver4.confd
 2f192e5c66455a211f113ae92a8001711d4b174490bd95617eb66cc2072804ba3881508754c2841dd12bcae15a50d85d32f53b026a04a7f4134942ce4a15edb2  knot-resolver4.initd"

--- a/testing/knot-resolver4/meson-dnstap-generated-sources.patch
+++ b/testing/knot-resolver4/meson-dnstap-generated-sources.patch
@@ -1,0 +1,12 @@
+--- a/modules/dnstap/meson.build
++++ b/modules/dnstap/meson.build
+@@ -40,8 +40,8 @@
+   dnstap_mod = shared_module(
+     'dnstap',
+     dnstap_src,
+-    dnstap_pb[1],
+     dependencies: [
++      declare_dependency(sources: dnstap_pb),
+       libfstrm,
+       libprotobuf_c,
+     ],


### PR DESCRIPTION
The dependencies were not explicity declared for meson/ninja.

This resulted in build failure on ppc64le.