### PR TITLE
main/py-urllib3: upgrade to 1.25.1

### DIFF
--- a/main/py-urllib3/APKBUILD
+++ b/main/py-urllib3/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=py-urllib3
 _pkgname=${pkgname/py-/}
-pkgver=1.24.2
+pkgver=1.25.1
 pkgrel=0
 pkgdesc="HTTP library with thread-safe connection pooling, file post, and more"
 url="https://github.com/shazow/urllib3"
@@ -50,4 +50,4 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="08e8d896f57eb9af5511d07002859f87f2a7bddbd5e66468908188dfe13d2e3985a8cdd2da12d06d0b337945ca8314c1f026d4e82badf23a09bf686fa121e863  py-urllib3-1.24.2.tar.gz"
+sha512sums="52231e6120140e444d5255a53fd8719441f88d34f810c2a561ae0a480fe19f210eb6f941404974dfc7e90ee7326e50139557421df037abd4a4387912d49dac35  py-urllib3-1.25.1.tar.gz"


### PR DESCRIPTION
1.25.1 (2019-04-24)
-------------------

* Add support for Google's ``Brotli`` package.

* Upgrade bundled rfc3986 to v1.3.1

1.25 (2019-04-22)
-----------------

* Require and validate certificates by default when using HTTPS

* Upgraded ``urllib3.utils.parse_url()`` to be RFC 3986 compliant.

* Added support for ``key_password`` for ``HTTPSConnectionPool`` to use
  encrypted ``key_file`` without creating your own ``SSLContext`` object.

* Add TLSv1.3 support to CPython, pyOpenSSL, and SecureTransport ``SSLContext``
  implementations.

* Switched the default multipart header encoder from RFC 2231 to HTML 5 working draft.

* Fixed issue where OpenSSL would block if an encrypted client private key was
  given and no password was given. Instead an ``SSLError`` is raised.

* Added support for Brotli content encoding. It is enabled automatically if
  ``brotlipy`` package is installed which can be requested with
  ``urllib3[brotli]`` extra.

* Drop ciphers using DSS key exchange from default TLS cipher suites.
  Improve default ciphers when using SecureTransport.

* Implemented a more efficient ``HTTPResponse.__iter__()`` method.