### PR TITLE
[3.9] main/bind: bump pkgrel

### DIFF
--- a/main/bind/APKBUILD
+++ b/main/bind/APKBUILD
@@ -8,7 +8,7 @@ _ver=${pkgver%_p*}
 _p=${pkgver#*_p}
 _major=${pkgver%%.*}
 [ "$_p" != "$pkgver" ] && _ver="${_ver}-P$_p"
-pkgrel=1
+pkgrel=2
 pkgdesc="The ISC DNS server"
 url="http://www.isc.org"
 arch="all"


### PR DESCRIPTION
missing in last change