### PR TITLE
main/py-pillow: disable tests on s390x

### DIFF
--- a/main/py-pillow/APKBUILD
+++ b/main/py-pillow/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=py-pillow
 _pkgname=Pillow
 pkgver=6.0.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Python Imaging Library"
 url="https://python-pillow.org"
 arch="all"
@@ -14,6 +14,7 @@ makedepends="python2-dev python3-dev py-setuptools freetype-dev jpeg-dev libwebp
 subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$_pkgname-$pkgver"
+[ "$CARCH" = "s390x" ] && options="!check"
 
 build() {
 	cd "$builddir"


### PR DESCRIPTION
Testsuites fail on big endian arch

Upstream report:
https://github.com/python-pillow/Pillow/issues/3798
https://github.com/python-pillow/Pillow/issues/1204