### PR TITLE
testing/elogind: fix missing macros on s390x

### DIFF
--- a/testing/elogind/APKBUILD
+++ b/testing/elogind/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Leo <thinkabit.ukim@gmail.com>
 pkgname=elogind
 pkgver=241.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Standalone fork of systemd's elogind"
 url="https://github.com/elogind/elogind"
 arch="all"
@@ -41,6 +41,7 @@ source="
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
+	[ "$CARCH" == "s390x" ] && export CFLAGS="$CFLAGS -D__IGNORE_pkey_mprotect -DSO_PEERSEC=31"
 	export LDFLAGS="$LDFLAGS -lintl"
 	meson \
 		--libdir=/usr/lib \


### PR DESCRIPTION
Temporarily add missing macros in musl. Patch for upstream is on the
way.