### PR TITLE
[3.9] community/shadow: fix broken chpasswd

### DIFF
--- a/community/shadow/APKBUILD
+++ b/community/shadow/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=shadow
 pkgver=4.5
-pkgrel=0
+pkgrel=1
 pkgdesc="PAM-using login and passwd utilities (usermod, useradd, ...)"
 url="http://pkg-shadow.alioth.debian.org/"
 arch="all"
@@ -12,6 +12,7 @@ depends=""
 makedepends="linux-pam-dev"
 subpackages="$pkgname-doc $pkgname-dbg $pkgname-uidmap"
 source="https://github.com/shadow-maint/shadow/releases/download/$pkgver/shadow-$pkgver.tar.xz
+	chpasswd.pamd
 	login.pamd
 	dots-in-usernames.patch
 	useradd-usergroups.patch
@@ -79,6 +80,9 @@ package() {
 	# However, install our own for login.
 	cp "$srcdir"/login.pamd "$pkgdir"/etc/pam.d/login || return 1
 
+	# Also install custom pam configuration for chpasswd (see bug #10209)
+	cp "$srcdir"/chpasswd.pamd "$pkgdir"/etc/pam.d/chpasswd || return 1
+
 	# /etc/login.defs is not very useful - replace it with an *almost* blank file.
 	rm "$pkgdir"/etc/login.defs
 	echo "USERGROUPS_ENAB yes" > "$pkgdir"/etc/login.defs
@@ -104,6 +108,7 @@ uidmap() {
 }
 
 sha512sums="e57f8db54df23301c229d4be30d4cbb67efa1d1809cffcff79adc480b6019fb2b5fd09e112e82a3f00ad5a6b2994592adac93f70a631cf666b6f4723b61c87b5  shadow-4.5.tar.xz
+38e78aade316350dc26000b35335a778f12f5deb0f54ea23f84000ad92a683c519c7814165b5ed7e63187d11677993082d35dc6c21f7f66c6aee8e3fd4b3694b  chpasswd.pamd
 46a6f83f3698e101b58b8682852da749619412f75dfa85cecad03d0847f6c3dc452d984510db7094220e4570a0565b83b0556e16198ad894a3ec84b3e513d58d  login.pamd
 745eea04c054226feba165b635dbb8570b8a04537d41e914400a4c54633c3a9cf350da0aabfec754fb8cf3e58fc1c8cf597b895506312f19469071760c11f31d  dots-in-usernames.patch
 49f1d5ded82d2d479805c77d7cc6274c30233596e375b28306b31a33f8fbfc3611dbc77d606081b8300247908c267297dbb6c5d1a30d56095dda53c6a636fb56  useradd-usergroups.patch

--- a/community/shadow/chpasswd.pamd
+++ b/community/shadow/chpasswd.pamd
@@ -1,0 +1,3 @@
+auth     sufficient pam_rootok.so
+account  include    base-account
+password include    base-password


### PR DESCRIPTION
It was found in bug #10209 (https://bugs.alpinelinux.org/issues/10209)
that the chpasswd command was broken due to a lack of a pam
configuration file.

This is a backport of PR #6980 by @bratkartoffel, targeting the
3.9 branch.