### PR TITLE
community/mpd: update to 0.21.7

### DIFF
--- a/community/mpd/APKBUILD
+++ b/community/mpd/APKBUILD
@@ -1,28 +1,28 @@
+# Contributor: Leo <thinkabit.ukim@gmail.com>
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Contributor: Sebastian Wicki <gandro@gmx.net>
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Carlo Landmeter <clandmeter@alpinelinux.org>
 pkgname=mpd
-pkgver=0.21.5
+pkgver=0.21.7
 case $pkgver in
 *.*.*) _branch=${pkgver%.*};;
 *.*) _branch=$pkgver;;
 esac
-pkgrel=5
+pkgrel=0
 pkgdesc="Music daemon that plays MP3, FLAC, and Ogg Vorbis files"
 url="https://musicpd.org"
 pkgusers="mpd"
 pkggroups="mpd audio"
 arch="all"
-license="GPL-2.0"
-depends=""
+license="GPL-2.0-or-later"
 makedepends="py-sphinx lame-dev glib-dev curl-dev libao-dev libmad-dev flac-dev
 	libogg-dev faad2-dev libid3tag-dev libvorbis-dev alsa-lib-dev
 	libsamplerate-dev libshout-dev libmodplug-dev boost-dev icu-dev
 	libnfs-dev samba-dev opus-dev ffmpeg-dev meson libmpdclient-dev"
 checkdepends="gtest-dev gtest"
 install="$pkgname.pre-install"
-subpackages="$pkgname-doc $pkgname-dbg"
+subpackages="$pkgname-doc $pkgname-dbg $pkgname-openrc"
 source="https://www.musicpd.org/download/$pkgname/$_branch/$pkgname-$pkgver.tar.xz
 	stacksize.patch
 	mpd.initd
@@ -30,7 +30,6 @@ source="https://www.musicpd.org/download/$pkgname/$_branch/$pkgname-$pkgver.tar.
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-	cd "$builddir"
 	meson \
 		--prefix=/usr \
 		--sysconfdir=/etc \
@@ -51,11 +50,10 @@ build() {
 }
 
 check() {
-	ninja -C "$builddir/output" -v test
+	ninja -C output -v test
 }
 
 package() {
-	cd "$builddir"
 	DESTDIR="$pkgdir" ninja -C output install
 
 	# provide a config that works by default
@@ -76,7 +74,7 @@ package() {
 		"$pkgdir"/var/lib/mpd/music
 }
 
-sha512sums="b3a938f43cd554e0e761890ca7ea910e21b8f98f54f5bfceb0efcbef4df46db0d110d1bbc24a233021b463e3424d6246c1013f5a6ebdfc85a418008d49ced7a4  mpd-0.21.5.tar.xz
+sha512sums="a6e8848c851ca464cfd26284d6479d561f127bc102128e8a41274bc1d62d87a3720843ff1922b5b64b33280217a6036b512f7aa0ce7d7f6b90cbed9fe787c5ca  mpd-0.21.7.tar.xz
 f60f6f3e921d20732c1a4c31a97f28660b43fd649e767d6c39661b6a90145231a79ad3f740ae0d706380b245ad040e98b661a513463c54cea161d1f64fc261e0  stacksize.patch
 3725a528a45edf60e6a9ebd75c880aa63d0e71ab40c20dbc538af2d7c83ca657833b6853d9b488d635883fb7871bb76fada129b3bf8acff4bb060f98a5ad8774  mpd.initd
 41b2467f5b03f5c4dd7003cd5f56f6cfc1f67af7a9aa2538d70360f839625222bdd0c4b04c33e8cd52eeecfc354da3ca22f5aaab8aee357a5774aaf3503594e7  mpd.confd"


### PR DESCRIPTION
- Split openrc files into mpd-openrc
- Fix SPDX license
- remove superfluous usage of 'cd "$builddir"'