### PR TITLE
main/libcroco: upgrade to 0.6.13

### DIFF
--- a/main/libcroco/APKBUILD
+++ b/main/libcroco/APKBUILD
@@ -1,13 +1,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libcroco
-pkgver=0.6.12
-pkgrel=1
+pkgver=0.6.13
+pkgrel=0
 pkgdesc="GNOME CSS2 parsing and manipulation toolkit"
 url="http://www.gnome.org"
 arch="all"
 license="LGPL-2.1-only"
-subpackages="$pkgname-dev"
-depends=
+subpackages="$pkgname-dev $pkgname-doc"
 makedepends="glib-dev libxml2-dev"
 source="https://download.gnome.org/sources/$pkgname/0.6/$pkgname-$pkgver.tar.xz"
 
@@ -30,4 +29,4 @@ package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
-sha512sums="af9a171d5ccded255b57f170576e67155f12fa0f61ab3e379e907975f77afc37e82e22772c6019b2897cffc15b2425faf3ccfda92b1a45b23eda2519debabeb6  libcroco-0.6.12.tar.xz"
+sha512sums="038a3ac9d160a8cf86a8a88c34367e154ef26ede289c93349332b7bc449a5199b51ea3611cebf3a2416ae23b9e45ecf8f9c6b24ea6d16a5519b796d3c7e272d4  libcroco-0.6.13.tar.xz"


### PR DESCRIPTION
- Split gtk-doc into $pkgname-doc