### PR TITLE
main/curl: disable SSH support via libssh2

### DIFF
--- a/main/curl/APKBUILD
+++ b/main/curl/APKBUILD
@@ -4,13 +4,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=curl
 pkgver=7.64.1
-pkgrel=1
+pkgrel=2
 pkgdesc="URL retrival utility and library"
 url="https://curl.haxx.se/"
 arch="all"
 license="MIT"
 depends="ca-certificates"
-depends_dev="openssl-dev libssh2-dev nghttp2-dev zlib-dev"
+depends_dev="openssl-dev nghttp2-dev zlib-dev"
 checkdepends="python2"
 makedepends="$depends_dev autoconf automake groff libtool perl"
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev libcurl"
@@ -90,10 +90,10 @@ build() {
 		--enable-unix-sockets \
 		--without-libidn \
 		--without-libidn2 \
-		--with-libssh2 \
 		--with-nghttp2 \
 		--disable-ldap \
-		--with-pic
+		--with-pic \
+		--without-libssh2 # https://bugs.alpinelinux.org/issues/10222
 	make
 }
 


### PR DESCRIPTION
fixes #10222

See: https://bugs.alpinelinux.org/issues/10222 for more info