### PR TITLE
main/haveged: remove net dependency

### DIFF
--- a/main/haveged/APKBUILD
+++ b/main/haveged/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=haveged
 pkgver=1.9.4
-pkgrel=3
+pkgrel=4
 pkgdesc="Entropy harvesting daemon using CPU timings"
 url="http://www.issihosts.com/haveged/"
 arch="all"
@@ -54,5 +54,5 @@ package() {
 sha512sums="20017c7637779c0cfa414233bb67efb2976f92c08e4eb1b7ea41ccd483dad755629d8e05fb8560a2db811fc2ded7d05fa081ab10c59341cb4c206595a964641d  haveged-1.9.4.tar.gz
 6279296b057f19daf25020ac14997268230af4b11510d6e5c4a86989c119d6b081d2501069af198772302d5cce1464514c749033a4928fb95671268825a84ba8  fix-cpu-cache-size-detection.patch
 e977a6487df29a0e7de07ef3ef6546776ee9671cc8ac02868800351c6461be4d0d2e05cf40c5bc54742c00d5fe1878027959ab598d96be4f81a9eb4969fce08d  double-the-sample-size-used-in-the-entest.patch
-b721ad2d14a358b663a7a161c94963a152c99c69434eeb6fd012e6d6af18b3b88372da9603e2485675ce5c092424795e03953a3a0033fa6501252c25a86ea491  haveged.initd
+ede46769216bfbd2847b9405121d3baa78d50c263fef1762465491af708361702d2948ab58b6f7f677a95d7b329dd4630caa422339612505fee8a158bae4620b  haveged.initd
 57201472fc659aaab919562a00d474d3823d5becea62e8b13ef93eda05e1fd667721c968f224fcae871d13cfcd16d1924403d9181e0899fa214fa00bf4fefc75  haveged.confd"

--- a/main/haveged/haveged.initd
+++ b/main/haveged/haveged.initd
@@ -7,6 +7,7 @@ command_background="yes"
 pidfile="/run/$RC_SVCNAME.pid"
 
 depend() {
-	need net
+	need localmount
+	after urandom
 	provide entropy
 }


### PR DESCRIPTION
haveged does not require any network connectivity to function, and this
errant dependency can cause the daemon to not start properly at boot.