### PR TITLE
community/py-watchdog: split into py2- and py3- packages

### DIFF
--- a/community/py-watchdog/APKBUILD
+++ b/community/py-watchdog/APKBUILD
@@ -2,37 +2,46 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=py-watchdog
 pkgver=0.9.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Python API and shell utilities to monitor file system events."
 url="https://github.com/gorakhargosh/watchdog"
 arch="noarch"
 license="Apache-2.0"
 depends="py-pathtools py-yaml py-argh"
-depends_dev=""
-makedepends="$depends_dev py-setuptools python2-dev"
-install=""
-subpackages=""
+makedepends="py-setuptools py3-setuptools"
+subpackages="py2-watchdog:_py2 py3-watchdog:_py3"
 source="watchdog-$pkgver.tar.gz::https://github.com/gorakhargosh/watchdog/archive/v$pkgver.tar.gz"
 
-_builddir="$srcdir"/watchdog-$pkgver
-prepare() {
-	local i
-	cd "$_builddir"
-	for i in $source; do
-		case $i in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
+builddir="$srcdir"/watchdog-$pkgver
 
 build() {
-        cd "$_builddir"
-        python2 setup.py build || return 1
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
 }
 
 package() {
-        cd "$_builddir"
-        python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname"
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	local pyver="${python:6:1}"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="${depends//py-/py$pyver-} $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
 sha512sums="97fca2642209150a611d931d6f2049a9941a3494a6c566bc18eaa45a8fc2fbd02c712b37a85cc1375eeb65715706ba6b8ecf781b99951721988c318f81eff7c6  watchdog-0.9.0.tar.gz"


### PR DESCRIPTION
- py3- is required for testing py3-werkzeug