### PR TITLE
community/chromium: fix sandbox crash with musl 1.1.22

### DIFF
--- a/community/chromium/APKBUILD
+++ b/community/chromium/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=chromium
 pkgver=73.0.3683.103
-pkgrel=0
+pkgrel=1
 pkgdesc="chromium web browser"
 url="http://www.chromium.org/"
 arch="x86_64 armv7 aarch64"
@@ -116,6 +116,7 @@ source="https://commondatastorage.googleapis.com/chromium-browser-official/$pkgn
 	musl-arm-limits.patch
 	chromium-71.0.3578.98-skia-aarch64-buildfix.patch
 	aarch64-fixes.patch
+	sandbox-membarrier.patch
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver
@@ -373,4 +374,5 @@ bb0f3dc1ade429a398d487ae190a278948533398c4a1085aeb35ff57fefb90a1e598008ba839423c
 ebfa795879130226d5d3601901df9c3a119b4f7342c12b7a24cb1697a4fa535c9a9cc4a11d30085df569a7337846c0e26b78928fd78f53c98e5773978621753d  gcc-arm.patch
 3bcffb36f28a01d8bb91f1c1ee1e327caebb1e139d4e8772ad15460ee69cb5ea3307a235dc83184a9e09b687882d9617f3a3ce1a7b07cbd6e11b0a5d6a6ace81  musl-arm-limits.patch
 d4d46ea95ed8d47cd4b09f27d99df61cc6b72b4cb92b865310f245259d5adf02cd136888cd44ad12aeba3fd4d638982437fdf230e817d0188cc5ea76fec82cd1  chromium-71.0.3578.98-skia-aarch64-buildfix.patch
-229a0c04ebd7465fabe3268959c386e63ac9e272a0506bb65785f6f9532a9f88bee436287fbcfc63e5fd9d85fb4f68f73a79475b6e6cc53dc58d715d40cd0ed2  aarch64-fixes.patch"
+229a0c04ebd7465fabe3268959c386e63ac9e272a0506bb65785f6f9532a9f88bee436287fbcfc63e5fd9d85fb4f68f73a79475b6e6cc53dc58d715d40cd0ed2  aarch64-fixes.patch
+9ce47ecd3c503d2099cbc65d61354a9ff3ab0330766bf997f6c4bb04e01da0e8751b5819811b4701b45062e55f6ad924ea5190a91a81157b249a6e20f84722ba  sandbox-membarrier.patch"

--- a/community/chromium/sandbox-membarrier.patch
+++ b/community/chromium/sandbox-membarrier.patch
@@ -1,0 +1,15 @@
+musl >= 1.1.22 uses the membarrier(2) syscall, allow it in the sandbox.
+
+See: https://bugs.alpinelinux.org/issues/10257
+
+diff -upr chromium-73.0.3683.103.orig/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+--- sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc.orig	2019-04-26 10:56:56.824506143 +0200
++++ sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc	2019-04-26 11:03:14.060482592 +0200
+@@ -386,6 +386,7 @@ bool SyscallSets::IsAllowedProcessStartO
+   switch (sysno) {
+     case __NR_exit:
+     case __NR_exit_group:
++    case __NR_membarrier:
+     case __NR_wait4:
+     case __NR_waitid:
+ #if defined(__i386__)


### PR DESCRIPTION
Fixes #10257

**Don't merge yet, I am still building this locally**