### PR TITLE
community/firefox-esr: fix sandbox crash with musl 1.1.22

### DIFF
--- a/community/firefox-esr/APKBUILD
+++ b/community/firefox-esr/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox-esr
 pkgver=60.6.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Firefox web browser - Extended Support Release"
 url="https://www.mozilla.org/en-US/firefox/organizations/"
 # limited by rust and cargo
@@ -67,6 +67,7 @@ source="https://ftp.mozilla.org/pub/firefox/releases/${pkgver}esr/source/firefox
 	fix-bug-1261392.patch
 	rust-unitialized-field.patch
 	fix-webrtc-glibcisms.patch
+	sandbox-membarrier.patch
 
 	firefox.desktop
 	firefox-safe.desktop"
@@ -260,5 +261,6 @@ e61664bc93eadce5016a06a4d0684b34a05074f1815e88ef2613380d7b369c6fd305fb34f83b5eb1
 a50b412edf9573a0bd04a43578b1c927967a616b73a5995eefb15bfa78fd2bd14e36ec05315a0703f6370ecd524e6bcb012e7285beb1245e9add9b8553acb79e  fix-bug-1261392.patch
 01b48a708cc6bc6e3cd7cc7b16f5137ec344566ac891d699b65e322bc992726072fa14a54cef1a7775799fcbbcf90a6c170107c8524caba3bc311b42d93b7581  rust-unitialized-field.patch
 75b97d59e81e5f1debe6a459b535da704d5a2ac4a57c446d16058fd18db81e22317fcc3ec11b89f569f4de87e8e80ced027c0e72e7f1dd16f6fd0feb6b263919  fix-webrtc-glibcisms.patch
+e725a6e9b2361cd566ae2f90861dbce9f2231f16721ec02f4b9f9986b7dc82cc006ea6a500ae7f30c095ce746132a5bd1d9532c4cf0d1541dcc672a20aef8807  sandbox-membarrier.patch
 f3b7c3e804ce04731012a46cb9e9a6b0769e3772aef9c0a4a8c7520b030fdf6cd703d5e9ff49275f14b7d738fe82a0a4fde3bc3219dff7225d5db0e274987454  firefox.desktop
 5dcb6288d0444a8a471d669bbaf61cdb1433663eff38b72ee5e980843f5fc07d0d60c91627a2c1159215d0ad77ae3f115dcc5fdfe87e64ca704b641aceaa44ed  firefox-safe.desktop"

--- a/community/firefox-esr/sandbox-membarrier.patch
+++ b/community/firefox-esr/sandbox-membarrier.patch
@@ -1,0 +1,54 @@
+allow usage of SYS_membarrier, needed since musl-1.1.22
+
+Taken from voidlinux: https://github.com/void-linux/void-packages/commit/4198411ac3b9e2620e171c662df82008da0faebb
+
+--- a/security/sandbox/linux/SandboxFilter.cpp
++++ b/security/sandbox/linux/SandboxFilter.cpp
+@@ -283,6 +283,8 @@
+       case __NR_set_tid_address:
+         return Allow();
+ #endif
++      case __NR_membarrier:
++        return Allow();
+ 
+         // prctl
+       case __NR_prctl: {
+
+--- a/security/sandbox/chromium/sandbox/linux/system_headers/arm_linux_syscalls.h
++++ b/security/sandbox/chromium/sandbox/linux/system_headers/arm_linux_syscalls.h
+@@ -1385,6 +1385,10 @@
+ #define __NR_memfd_create (__NR_SYSCALL_BASE+385)
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier (__NR_SYSCALL_BASE+389)
++#endif
++
+ // ARM private syscalls.
+ #if !defined(__ARM_NR_BASE)
+ #define __ARM_NR_BASE (__NR_SYSCALL_BASE + 0xF0000)
+
+--- a/security/sandbox/chromium/sandbox/linux/system_headers/x86_64_linux_syscalls.h
++++ b/security/sandbox/chromium/sandbox/linux/system_headers/x86_64_linux_syscalls.h
+@@ -1290,5 +1290,9 @@
+ #define __NR_memfd_create 319
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 324
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_X86_64_LINUX_SYSCALLS_H_
+ 
+--- a/security/sandbox/chromium/sandbox/linux/system_headers/x86_32_linux_syscalls.h
++++ b/security/sandbox/chromium/sandbox/linux/system_headers/x86_32_linux_syscalls.h
+@@ -1490,5 +1490,9 @@
+ #define __NR_shutdown 373
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 375
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_X86_32_LINUX_SYSCALLS_H_
+ 


### PR DESCRIPTION
See https://bugs.alpinelinux.org/issues/10257

**Don't merge yet, I am still building this locally**