### PR TITLE
community/docker: don't install docker-fish-completion on newer fish

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -5,7 +5,7 @@ pkgname=docker
 pkgver=18.09.5
 _gitcommit=e8ff056dbcfadaeca12a5f508b0cec281126c01d	# https://github.com/docker/docker-ce/commits/v$pkgver
 _ver=${pkgver/_/-}-ce
-pkgrel=0
+pkgrel=1
 pkgdesc="Pack, ship and run any application as a lightweight container"
 url="http://www.docker.io/"
 arch="all"
@@ -160,7 +160,7 @@ bashcomp() {
 fishcomp() {
 	pkgdesc="Fish shell completion for Docker"
 	depends=""
-	install_if="$pkgname=$pkgver-r$pkgrel fish"
+	install_if="$pkgname=$pkgver-r$pkgrel fish<3" # fish above version 3 has docker completion
 
 	install -Dm644 "$_cli_builddir"/contrib/completion/fish/$pkgname.fish \
 		"$subpkgdir"/usr/share/fish/completions/$pkgname.fish


### PR DESCRIPTION
The newer fish has docker completion upstream, installing
docker-fish-completion will just lead to a file conflict