### PR TITLE
main/ninja: install ninja_syntax.py

### DIFF
--- a/main/ninja/APKBUILD
+++ b/main/ninja/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=ninja
 pkgver=1.9.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Small build system with a focus on speed"
 url="https://ninja-build.org/"
 arch="all"
@@ -15,6 +15,10 @@ source="
 	fix-musl.patch
 	"
 builddir="$srcdir"/${pkgname}-${pkgver}
+
+_py3_sitelib() {
+    python3 -c 'import sysconfig; print(sysconfig.get_path("platlib"))'
+}
 
 build() {
 	cd "$builddir"
@@ -39,6 +43,9 @@ package() {
 
 	install -m644 -D misc/bash-completion \
 		"$pkgdir/usr/share/bash-completion/completions/ninja"
+
+	install -m644 -D misc/ninja_syntax.py \
+		"${pkgdir}$(_py3_sitelib)/ninja_syntax.py"
 }
 
 sha512sums="a8b5ad00b60bddbdb8439a6092c91a65d093f9bcd6241f69088eb35bea2847efe673c3107a130dc754c747c7712b839d8f88e88d8389520cf7143668ee053feb  ninja-1.9.0.tar.gz


### PR DESCRIPTION
Some software that wants to use the Python API of the ninja build system requires the ninja_syntax.py be installed alongside ninja itself.