### PR TITLE
main/haproxy: upgrade to 1.9.7 and fix license

### DIFF
--- a/main/haproxy/APKBUILD
+++ b/main/haproxy/APKBUILD
@@ -1,20 +1,19 @@
 # Contributor: Jeff Bilyk <jbilyk@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=haproxy
-pkgver=1.9.6
+pkgver=1.9.7
 _pkgmajorver=${pkgver%.*}
 pkgrel=0
 pkgdesc="A TCP/HTTP reverse proxy for high availability environments"
-url="http://haproxy.1wt.eu"
+url="https://www.haproxy.org/"
 arch="all"
-license="GPL"
+license="GPL-2.0-or-later LGPL-2.1-or-later"
 _luaver="5.3"
 options="!check"  # FIXME: no idea how to run tests
-depends=""
 makedepends="pcre-dev openssl-dev linux-headers lua${_luaver}-dev zlib-dev"
 install="haproxy.pre-install haproxy.pre-upgrade"
-subpackages="$pkgname-doc"
-source="http://haproxy.1wt.eu/download/${_pkgmajorver}/src/$pkgname-$pkgver.tar.gz
+subpackages="$pkgname-doc $pkgname-openrc"
+source="https://www.haproxy.org/download/${_pkgmajorver}/src/$pkgname-$pkgver.tar.gz
 	haproxy.initd
 	haproxy.cfg"
 
@@ -50,6 +49,6 @@ package() {
 	        "$pkgdir"/etc/haproxy/haproxy.cfg
 }
 
-sha512sums="3b823005f02d035435838689ddbf50c4fd9fc14af20450c413526cda7a29eb01ee01f68d6867545ebf966235688eedeeb3d00f5e6011727486d53e881d8e73b6  haproxy-1.9.6.tar.gz
+sha512sums="3a901849fa4db15676e22dd11f8309a810fcfc38519d1e8488c1e3cd8341c82dccbfe3b083c37920a0d04d5c8b7fa7a2f0910e488693c2e8ffda1511a307bc09  haproxy-1.9.7.tar.gz
 3ab277bf77fe864ec6c927118dcd70bdec0eb3c54535812d1c3c0995fa66a3ea91a73c342edeb8944caeb097d2dd1a7761099182df44af5e3ef42de6e2176d26  haproxy.initd
 26bc8f8ac504fcbaec113ecbb9bb59b9da47dc8834779ebbb2870a8cadf2ee7561b3a811f01e619358a98c6c7768e8fdd90ab447098c05b82e788c8212c4c41f  haproxy.cfg"


### PR DESCRIPTION
Ref https://www.mail-archive.com/haproxy@formilux.org/msg33410.html

http://www.haproxy.org/download/1.9/src/CHANGELOG