### PR TITLE
community/libfilezilla: add note about ABI instability of libfilezilla

### DIFF
--- a/community/libfilezilla/APKBUILD
+++ b/community/libfilezilla/APKBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
+# filezilla needs to be rebuilt when libfilezilla version changes, ABI is not stable
 pkgname=libfilezilla
 pkgver=0.15.1
 pkgrel=0


### PR DESCRIPTION
Taken from Void Linux

https://github.com/void-linux/void-packages/commit/3f4da6f802ab1bcb5f20403ed668becb0a560578
https://www.reddit.com/r/voidlinux/comments/bhcxl4/filezilla_does_not_start_symbol_lookup_error/?st=juyzetv8&sh=07347122