### PR TITLE
main/uriparser: upgrade to 0.9.3

### DIFF
--- a/main/uriparser/APKBUILD
+++ b/main/uriparser/APKBUILD
@@ -1,38 +1,47 @@
-# Contributor:
+# Contributor: Leo <thinkabit.ukim@gmail.com>
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=uriparser
-pkgver=0.9.1
+pkgver=0.9.3
 pkgrel=0
 pkgdesc="A strictly RFC 3986 compliant URI parsing and handling library"
 url="https://uriparser.github.io/"
 arch="all"
-license="BSD"
-depends=""
-makedepends=""
-# libcpptest is missing to run tests
-options="!check"
-subpackages="$pkgname-dev"
-source="https://github.com/uriparser/uriparser/releases/download/$pkgname-$pkgver/$pkgname-$pkgver.tar.bz2"
+license="BSD-3-Clause"
+makedepends="cmake gtest-dev"
+subpackages="$pkgname-dev lib$pkgname:libs"
+source="https://github.com/uriparser/uriparser/releases/download/$pkgname-$pkgver/$pkgname-$pkgver.tar.bz2
+	disable-test.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
-	./configure \
-		--prefix=/usr \
-		--disable-test \
-		--disable-doc \
-		--disable-static || return 1
-	make || return 1
+	if [ "$CBUILD" != "$CHOST" ]; then
+		CMAKE_CROSSOPTS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
+	fi
+	cmake \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_SHARED_LIBS=True \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+		-DCMAKE_C_FLAGS="$CFLAGS" \
+		-DURIPARSER_BUILD_DOCS=OFF \
+		-DURIPARSER_BUILD_TOOLS=ON \
+		-DURIPARSER_BUILD_TESTS=ON \
+		-DBUILD_SHARED_LIBS=ON \
+		${CMAKE_CROSSOPTS}
+	make
 }
 
 check() {
-	cd "builddir"
-	make test
+	cd "$builddir"
+	make test ARGS=--verbose
 }
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="c6a4f3b737d4c53ba14148a5be363d93947c8c32755b369726ccdd6e01e8a2293d2c94d448700fc97bb56092696b67965646ae07c9ef31be253e2279d0bc3821  uriparser-0.9.1.tar.bz2"
+sha512sums="424419ea7b5f945b37ea06091d59e731c6a7ee76e7998f8a4e598036b3de8b593d62d1af6c6ddc7c31b43fc6795d4a5fa8d50da2508ca19de100a2222106fa3e  uriparser-0.9.3.tar.bz2
+d4fb8786cf5580713ec5f8babfe6e4c91482e00e20c46bc700b05e8f01739ce692834b9bc7d76eabb9263afea2655a27f69cec4215ba39204a8476729fcf67f1  disable-test.patch"

--- a/main/uriparser/disable-test.patch
+++ b/main/uriparser/disable-test.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 749fea1..b112f9b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -245,7 +245,6 @@ if(URIPARSER_BUILD_TESTS)
+ 
+     add_executable(testrunner
+         test/FourSuite.cpp
+-        test/MemoryManagerSuite.cpp
+         test/test.cpp
+         test/VersionSuite.cpp
+ 
+


### PR DESCRIPTION
- Switch build system to cmake
- Fix license identifier
- enable tests but disable a failing test that causes segfaults
- split library into lib$pkgname