### PR TITLE
testing/acme.sh: add missing openssl dependency

### DIFF
--- a/testing/acme.sh/APKBUILD
+++ b/testing/acme.sh/APKBUILD
@@ -2,27 +2,17 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=acme.sh
 pkgver=2.8.0
-pkgrel=0
+pkgrel=1
 pkgdesc="An ACME Shell script, an acme client alternative to certbot"
+options="!check" # No testsuite
 url="https://github.com/Neilpang/acme.sh"
 arch="noarch"
 license="GPL-3.0"
-depends="curl"
+depends="curl cmd:openssl"
 source="$pkgname-$pkgver.tar.gz::https://github.com/Neilpang/acme.sh/archive/$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
-build() {
-	cd "$builddir"
-	return 0
-}
-
-check() {
-	cd "$builddir"
-	return 0
-}
-
 package() {
-	cd "$builddir"
 	install -dm755 "$pkgdir"/usr/share/acme.sh/deploy
 	install -dm755 "$pkgdir"/usr/share/acme.sh/dnsapi
 	install -dm755 "$pkgdir"/usr/bin


### PR DESCRIPTION
- Also removed superfluous return 0 statements

fixes #10355