### PR TITLE
testing/geoclue: upgrade to 2.5.2

### DIFF
--- a/testing/geoclue/APKBUILD
+++ b/testing/geoclue/APKBUILD
@@ -1,34 +1,43 @@
+# Contributor: Leo <thinkabit.ukim@gmail.com>
 # Maintainer: 
 pkgname=geoclue
-pkgver=2.4.7
-pkgrel=2
+pkgver=2.5.2
+pkgrel=0
 pkgdesc="dbus geolocation service"
 url="https://www.freedesktop.org/wiki/Software/GeoClue/"
 arch="all"
-license="LGPL"
-depends=""
-depends_dev=""
-makedepends="libsoup-dev json-glib-dev modemmanager-dev avahi-dev intltool gobject-introspection-dev"
-install=""
+license="LGPL-2.1-or-later"
+makedepends="
+	meson
+	libsoup-dev
+	json-glib-dev
+	modemmanager-dev
+	avahi-dev
+	intltool
+	gobject-introspection-dev
+	libnotify-dev
+	"
 subpackages="$pkgname-dev"
-source="https://freedesktop.org/software/geoclue/releases/2.4/geoclue-$pkgver.tar.xz"
-builddir="$srcdir/geoclue-$pkgver"
+install="$pkgname.pre-install"
+source="https://gitlab.freedesktop.org/geoclue/geoclue/-/archive/${pkgver}/geoclue-${pkgver}.tar.bz2"
 
 build() {
-	cd "$builddir"
-	./configure \
-		--build=$CBUILD \
-		--host=$CHOST \
+	meson \
 		--prefix=/usr \
-		--sysconfdir=/etc \
-		--mandir=/usr/share/man \
-		--localstatedir=/var
-	make
+		-Ddbus-srv-user=geoclue \
+		-Ddbus-sys-dir=/usr/share/dbus-1/system.d \
+		-Dgtk-doc=false \
+		-Dintrospection=true \
+		build
+	ninja -C build
+}
+
+check() {
+	ninja -C build test
 }
 
 package() {
-	cd "$builddir"
-	make DESTDIR="$pkgdir" install
+	DESTDIR="$pkgdir" ninja -C build install
 }
 
-sha512sums="472cf923abfd40dee296eee2e6888c47f273ad709e1bdcce534bd794cf9f7073ceabd6addf918277e10498e094af5a6e9539b5cf24171577e78bc3b0b2d17b72  geoclue-2.4.7.tar.xz"
+sha512sums="be876ca096b7ed1e1756fed6da655f7f9398cf5e024a6e82d61641ae57af332d917b40e2240d9517a1a9e585580beced95bd7f8cbe4340c9c385a74a8b07fdf1  geoclue-2.5.2.tar.bz2"

--- a/testing/geoclue/geoclue.pre-install
+++ b/testing/geoclue/geoclue.pre-install
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Alpine Linux pre-install script for geoclue
+# Copyright 2019 Leo (thinkabit.ukim@gmail.com)
+# Distributed under the terms of the GNU General Public License, v2 or later
+
+addgroup -S geoclue 2>/dev/null
+adduser -S -D -h /var/lib/geoclue -s /sbin/nologin -G geoclue geoclue 2>/dev/null
+
+exit 0


### PR DESCRIPTION
- Create user and group geoclue
- Create /var/lib/geoclue with proper permissions
- Switch to meson build system
- Fix license into LGPL-2.1-or-later
- Remove superfluous builddir= assignment and cd "$builddir" statements