### PR TITLE
community/libsoup: upgrade to 2.66.1

### DIFF
--- a/community/libsoup/APKBUILD
+++ b/community/libsoup/APKBUILD
@@ -1,17 +1,18 @@
+# Contributor: Leo <thinkabit.ukim@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libsoup
-pkgver=2.64.1
+pkgver=2.66.1
 pkgrel=0
 pkgdesc="Gnome HTTP Library"
 url="http://live.gnome.org/LibSoup"
 arch="all"
 options="!check"  # Requires a running Apache HTTPd.  not kidding...
 license="LGPL-2.0-or-later"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+subpackages="$pkgname-gnome:_gnome $pkgname-gnome-dev:_gnome_dev $pkgname-dev
+	$pkgname-doc $pkgname-lang"
 depends="glib-networking"
-depends_dev="gnutls-dev sqlite-dev"
-makedepends="$depends_dev libgcrypt-dev libgpg-error-dev zlib-dev
-	gobject-introspection-dev intltool vala libxml2-dev libpsl-dev"
+makedepends="meson libgpg-error-dev zlib-dev intltool vala gtk-doc libxml2-dev
+	gobject-introspection-dev libpsl-dev sqlite-dev"
 source="https://download.gnome.org/sources/$pkgname/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
 
 # secfixes:
@@ -19,23 +20,39 @@ source="https://download.gnome.org/sources/$pkgname/${pkgver%.*}/$pkgname-$pkgve
 #     - CVE-2017-2885
 
 build() {
-	cd "$builddir"
-	DATADIRNAME=share ./configure \
-		--build=$CBUILD \
-		--host=$CHOST \
+	meson \
 		--prefix=/usr \
-		--sysconfdir=/etc \
-		--localstatedir=/var \
-		--disable-more-warnings \
-		--disable-static \
-		--disable-tls-check \
-		--enable-introspection=yes \
-		--localedir=/usr/share/locale
-	make
+		-Dgssapi=false \
+		-Dintrospection=true \
+		-Dvapi=true \
+		-Dtls_check=false \
+		-Ddoc=true \
+		-Dtests=false \
+		build
+	ninja -C build
 }
 
 package() {
-	cd "$builddir"
-	make DESTDIR="$pkgdir" install
+	DESTDIR="$pkgdir" ninja -C build install
 }
-sha512sums="13d16457a443294020621df34205c570d25a6ff048ab68633cc504d70a8a1281a38dddb54110fd35a059bd69aebc3fd49b5ab0fc42abf4f4a19746a25050119d  libsoup-2.64.1.tar.xz"
+
+_gnome() {
+	pkgdesc="$pkgdesc (GNOME libraries)"
+	mkdir -p "$subpkgdir"/usr/lib/girepository-1.0
+	mv "$pkgdir"/usr/lib/libsoup-gnome*.so.* "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/girepository-1.0/SoupGNOME* "$subpkgdir"/usr/lib/girepository-1.0
+}
+
+_gnome_dev() {
+	pkgdesc="$pkgdesc (GNOME development files)"
+	mkdir -p "$subpkgdir"/usr/include \
+			 "$subpkgdir"/usr/lib/pkgconfig \
+			 "$subpkgdir"/usr/share/gir-1.0 \
+
+	mv "$pkgdir"/usr/include/libsoup-gnome* "$subpkgdir"/usr/include
+	mv "$pkgdir"/usr/lib/pkgconfig/*gnome* "$subpkgdir"/usr/lib/pkgconfig
+	mv "$pkgdir"/usr/share/gir-1.0/SoupGNOME* "$subpkgdir"/usr/share/gir-1.0
+	mv "$pkgdir"/usr/lib/libsoup-gnome*.so "$subpkgdir"/usr/lib
+}
+
+sha512sums="bb9c15cae965606d5f7c009fab9223445235982269d23ff20e89249b10d3423797427e7cff39c31a3f5db99b0c2d7a01eb911edb61309603cdeb8f2467fe6039  libsoup-2.66.1.tar.xz"


### PR DESCRIPTION
- Split libsoup-gnome and libsoup-gnome-dev
- Switch build system to meson
- Move sqlite-dev to makedepends as it is automatically found via pc:
- Don't build tests since it saves times and it is already !check
- Remove obsolete dependency on libgcrypt and gnutls