### PR TITLE
main/libvirt: modernize

### DIFF
--- a/main/libvirt/APKBUILD
+++ b/main/libvirt/APKBUILD
@@ -2,11 +2,11 @@
 pkgname=libvirt
 pkgver=5.2.0
 _ver="${pkgver/_rc/-rc}"
-pkgrel=0
+pkgrel=1
 pkgdesc="A virtualization API for several hypervisor and container systems"
 url="http://libvirt.org/"
 arch="all"
-license="LGPL"
+license="LGPL-2.1-or-later"
 _daemon_deps="bridge-utils dmidecode dnsmasq ebtables ip6tables iptables"
 _client_deps="pm-utils gnutls-utils netcat-openbsd"
 depends="lvm2"
@@ -23,7 +23,7 @@ makedepends="augeas-dev bridge-utils cyrus-sasl-dev device-mapper
 install="$pkgname.post-install"
 subpackages="$pkgname-static $pkgname-libs $pkgname-dev $pkgname-doc $pkgname-client $pkgname-daemon
 	$pkgname-lang $pkgname-lxc $pkgname-qemu $pkgname-uml::noarch $pkgname-vbox
-	$pkgname-bash-completion:bashcomp:noarch"
+	$pkgname-bash-completion:bashcomp:noarch $pkgname-daemon-openrc"
 source="https://libvirt.org/sources/$pkgname-$pkgver.tar.xz
 	libvirt.confd
 	libvirt.initd
@@ -93,13 +93,17 @@ daemon() {
 	replaces="libvirt"
 	mkdir -p "$subpkgdir"/etc/$pkgname \
 	 "$subpkgdir"/etc/logrotate.d \
-	 "$subpkgdir"/usr/sbin
-	mv "$pkgdir"/etc/init.d "$subpkgdir"/etc
-	mv "$pkgdir"/etc/conf.d "$subpkgdir"/etc
+	 "$subpkgdir"/usr/sbin \
+	 "$subpkgdir"/usr/share
 	mv "$pkgdir"/etc/modules-load.d "$subpkgdir"/etc
 	mv "$pkgdir"/etc/$pkgname/libvirtd.conf "$subpkgdir"/etc/libvirt/
-	mv "$pkgdir"/usr/sbin/libvirtd "$subpkgdir"/usr/sbin/
+	mv "$pkgdir"/etc/$pkgname/virtlogd.conf "$subpkgdir"/etc/libvirt/
+	mv "$pkgdir"/etc/$pkgname/virtlockd.conf "$subpkgdir"/etc/libvirt/
+	mv "$pkgdir"/usr/sbin/* "$subpkgdir"/usr/sbin/
 	mv "$pkgdir"/etc/logrotate.d/libvirtd "$subpkgdir"/etc/logrotate.d/
+	mv "$pkgdir"/etc/sasl2 "$subpkgdir"/etc
+	mv "$pkgdir"/usr/share/polkit-1 "$subpkgdir"/usr/share
+	mv "$pkgdir"/usr/share/augeas "$subpkgdir"/usr/share
 }
 
 client() {


### PR DESCRIPTION
- Split libvirt-daemon-openrc from libvirt-daemon
- move virtlogd and virtlockd binaries to libvirt-daemon
- move virtlogd and virtlockd configuration files to libvirt-daemon
- move augeas configuration to libvirt-daemon
- move sasl2 and polkit-1 configuration to libvirt-daemon
- Fix license to use SPDX