### PR TITLE
testing/totem-pl-parser: upgrade to 3.26.3

### DIFF
--- a/testing/totem-pl-parser/APKBUILD
+++ b/testing/totem-pl-parser/APKBUILD
@@ -1,33 +1,36 @@
-# Maintainer: 
+# Contributor: Leo <thinkabit.ukim@gmail.com>
+# Maintainer: Leo <thinkabit.ukim@gmail.com> 
 pkgname=totem-pl-parser
-pkgver=3.26.0
-pkgrel=1
+pkgver=3.26.3
+pkgrel=0
 pkgdesc="GNOME playlist parser library"
 url="https://www.gnome.org/"
 arch="all"
-license="LGPL"
+license="LGPL-2.0-or-later"
 makedepends="meson gnome-desktop-dev libsoup-dev libxml2-dev json-glib-dev
-	gmime-dev libxml2-utils libxslt itstool ninja"
-install=""
+	gmime-dev libxml2-utils libxslt itstool libarchive-dev libgcrypt-dev"
 subpackages="$pkgname-dev $pkgname-lang"
 source="https://download.gnome.org/sources/totem-pl-parser/${pkgver%.*}/totem-pl-parser-$pkgver.tar.xz"
-builddir="$srcdir/totem-pl-parser-$pkgver"
 
 build() {
-	mkdir "$builddir"/build
-	cd "$builddir"/build
 	meson \
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
-		..
-	ninja
+		-Denable-libarchive=yes \
+		-Denable-libgcrypt=yes \
+		-Dintrospection=true \
+		build
+	ninja -C build
+}
+
+check() {
+	ninja -C build test
 }
 
 package() {
-	cd "$builddir"/build
-	DESTDIR="$pkgdir" ninja install
+	DESTDIR="$pkgdir" ninja -C build install
 }
 
-sha512sums="30fad1f96bb0f16b39afc7f0d9632ea1e97f5c96e8aecbf0a6c19b9474c5683adc90786ac27d64d68130914fdf073b575921d54d0bced6cd5bdd23631252e8d8  totem-pl-parser-3.26.0.tar.xz"
+sha512sums="f059fd9447627268ce5029ed48551b0a2b6c30ba28c50a360d37808ad63fa8423824eef29c7f4d7a752f24861d4c7a7139f321fa2e19085085446e7ed15130cd  totem-pl-parser-3.26.3.tar.xz"


### PR DESCRIPTION
- Adopt
- Modernize
- Enable libarchive and libgcrypt support
- Enable tests