### PR TITLE
community/mate-power-manager: drop libgnome-keyring dependency

### DIFF
--- a/community/mate-power-manager/APKBUILD
+++ b/community/mate-power-manager/APKBUILD
@@ -2,14 +2,15 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=mate-power-manager
 pkgver=1.22.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A Power Manager for MATE"
 url="https://github.com/mate-desktop/mate-power-manager"
 arch="all"
 license="GPL-2.0-or-later"
-makedepends="$depends_dev intltool gettext-dev itstool glib-dev libcanberra-dev
+depends="dconf upower"
+makedepends="intltool gettext-dev itstool glib-dev libcanberra-dev
 	dbus-glib-dev mate-desktop-dev dconf-dev libnotify-dev libunique-dev
-	upower-dev libgnome-keyring-dev mate-panel-dev libcanberra-dev harfbuzz-dev"
+	upower-dev mate-panel-dev libcanberra-dev harfbuzz-dev"
 subpackages="$pkgname-doc $pkgname-lang"
 source="https://pub.mate-desktop.org/releases/${pkgver%.*}/$pkgname-$pkgver.tar.xz
 	0001-execinfo-patch.patch
@@ -17,26 +18,23 @@ source="https://pub.mate-desktop.org/releases/${pkgver%.*}/$pkgname-$pkgver.tar.
 	0001-get_nprocs-patch.patch
 	install-sh.patch
 	"
-builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--sysconfdir=/etc \
 		--prefix=/usr \
-		--enable-static=no
+		--enable-static=no \
+		--without-keyring
 	make
 }
 
 check() {
-	cd "$builddir"
 	make check
 }
 
 package() {
-	cd "$builddir"
 	make DESTDIR="${pkgdir}" install
 }
 


### PR DESCRIPTION
It is deprecated and libsecret is encouraged instead.