### PR TITLE
community/network-manager-applet: modernize

### DIFF
--- a/community/network-manager-applet/APKBUILD
+++ b/community/network-manager-applet/APKBUILD
@@ -1,19 +1,18 @@
 # Maintainer: 
 pkgname=network-manager-applet
 pkgver=1.8.18
-pkgrel=1
+pkgrel=2
 pkgdesc="GTK network manager applet"
 url="https://wiki.gnome.org/Projects/NetworkManager"
 arch="all"
-license="GPL"
-depends="libgnome-keyring"
-depends_dev=""
-makedepends="$depends_dev
+license="GPL-2.0-or-later"
+makedepends="
+	intltool
 	gcr-dev
 	gtk+3.0-dev
 	iso-codes-dev
 	jansson-dev
-	libgnome-keyring-dev
+	libsecret-dev
 	libgudev-dev
 	libnotify-dev
 	libsecret-dev
@@ -26,10 +25,8 @@ makedepends="$depends_dev
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 source="https://download.gnome.org/sources/network-manager-applet/${pkgver%.*}/network-manager-applet-$pkgver.tar.xz
 	"
-builddir="$srcdir/network-manager-applet-$pkgver"
 
 build() {
-	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -45,7 +42,6 @@ build() {
 }
 
 package() {
-	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
 


### PR DESCRIPTION
- Switch from deprecated libgnome-keyring to libsecret
- Fix license
- Add missing dep on intltool
- Use modern style