### PR TITLE
community/virt-manager: depend on py3-libvirt, use HTTPS for url

### DIFF
--- a/community/virt-manager/APKBUILD
+++ b/community/virt-manager/APKBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=virt-manager
 pkgver=2.1.0
-pkgrel=0
+pkgrel=1
 pkgdesc="GUI for managing virtual machines"
-url="http://virt-manager.org/"
+url="https://virt-manager.org/"
 arch="noarch"
 license="GPL-2.0-or-later"
-depends="python3 $pkgname-common py3-configparser py3-libxml2"
+depends="python3 $pkgname-common py3-configparser py3-libxml2 py3-libvirt"
 _common_deps="libvirt-glib py3-gobject3 py3-requests spice-gtk vte3 libosinfo py3-cairo gtk-vnc>=0.5.2-r2"
 makedepends="intltool grep glib"
 subpackages="$pkgname-doc $pkgname-lang


### PR DESCRIPTION
py3-libvirt is required for launch, otherwise one gets the following
error upon launching virt-manager

ImportError: no module named libvirt^