### PR TITLE
community/chromium: drop dependency on libgnome-keyring

### DIFF
--- a/community/chromium/APKBUILD
+++ b/community/chromium/APKBUILD
@@ -40,7 +40,6 @@ makedepends="$depends_dev
 	libevent-dev
 	libexif-dev
 	libgcrypt-dev
-	libgnome-keyring-dev
 	libjpeg-turbo-dev
 	libpng-dev
 	libusb-dev


### PR DESCRIPTION
It can still be installed to use gnome keyring, we just don't link to
it which is good because it is deprecated