### PR TITLE
community/libgnome-keyring: modernize

### DIFF
--- a/community/libgnome-keyring/APKBUILD
+++ b/community/libgnome-keyring/APKBUILD
@@ -1,54 +1,32 @@
-# Contributor: 
-# Maintainer: 
+# Contributor: Leo <thinkabit.ukim@gmail.com>
+# Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=libgnome-keyring
 pkgver=3.12.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNOME keyring"
 url="http://www.gnome.org"
 arch="all"
-license="GPL"
+license="GPL-2.0-or-later LGPL-2.0-or-later"
 depends="gnome-keyring"
-depends_dev="gtk+3.0-dev
-	     gconf-dev
-	     libx11-dev
-	     gnome-doc-utils
-	     libgnome-dev
-	     libwnck-dev
-
-	     libgcrypt-dev
-	     libtasn1-dev
-
-	     libxcursor-dev
-	     libxcomposite-dev
-	     libxi-dev
-	     libxau-dev
-	     libxdmcp-dev
-	     libxext-dev
-	     libxcb-dev"
-makedepends="$depends_dev intltool gobject-introspection-dev"
+makedepends="dbus-dev glib-dev libgcrypt-dev intltool gobject-introspection-dev"
 subpackages="$pkgname-dev $pkgname-lang"
 source="https://download.gnome.org/sources/$pkgname/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
 
-builddir="$srcdir/$pkgname-$pkgver"
-
 build() {
-	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
-		--sysconfdir=/etc
+		--sysconfdir=/etc \
+		--enable-introspection
 	make
 }
 
 check() {
-	cd "$builddir"
 	make check
 }
 
 package() {
-	cd "$builddir"
-
 	export GCONF_DISABLE_MAKEFILE_SCHEMA_INSTALL=1
 	make DESTDIR="$pkgdir" install
 }


### PR DESCRIPTION
- Fix license
- Remove unnecessary dependencies like gconf-dev and anything in
  depends_dev
- Use modern style