### PR TITLE
community/libkeyfinder: modernize

### DIFF
--- a/community/libkeyfinder/APKBUILD
+++ b/community/libkeyfinder/APKBUILD
@@ -2,13 +2,13 @@
 # Maintainer: Jean-Louis Fuchs <ganwell@fangorn.ch>
 pkgname=libkeyfinder
 pkgver=2.2.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Musical key detection for digital audio"
 url="http://www.ibrahimshaath.co.uk/keyfinder/"
 arch="all"
-license="GPL"
+license="GPL-3.0-or-later"
 # Its just using qmake
-makedepends="qt-dev fftw-dev"
+makedepends="qt5-qtbase-dev fftw-dev"
 subpackages="$pkgname-dev $pkgname-doc"
 source="libkeyfinder-$pkgver.tar.gz::https://github.com/ibsh/libKeyFinder/archive/v$pkgver.tar.gz
 	alpine-settings-to-pro.patch
@@ -17,7 +17,7 @@ builddir="$srcdir/libKeyFinder-$pkgver"
 
 build() {
 	cd "$builddir"
-	qmake PREFIX=/usr
+	qmake-qt5 PREFIX=/usr
 	make
 }
 
@@ -31,7 +31,7 @@ package() {
 check() {
 	cd "$builddir/tests"
 	ln -s "$builddir" keyfinder
-	qmake
+	qmake-qt5
 	make
 	LD_LIBRARY_PATH="$builddir" ./tests
 }


### PR DESCRIPTION
- Switch to qt5, qt4 is EOL.
- Fix license