### PR TITLE
community/py3-pyrsistent: don't require net in abuild

### DIFF
--- a/community/py3-pyrsistent/APKBUILD
+++ b/community/py3-pyrsistent/APKBUILD
@@ -4,13 +4,12 @@ pkgname=py3-pyrsistent
 pkgver=0.15.1
 pkgrel=0
 pkgdesc="Persistent/Functional/Immutable data structures"
-options="net" # Needs to fetch pytest-runner
 url="https://github.com/tobgu/pyrsistent"
 arch="all"
 license="MIT"
 depends="py3-six"
 makedepends="py3-setuptools python3-dev"
-checkdepends="py3-hypothesis py3-pytest"
+checkdepends="py3-hypothesis py3-pytest py3-pytest-runner"
 source="$pkgname-$pkgver.tar.gz::https://github.com/tobgu/pyrsistent/archive/v${pkgver}.tar.gz"
 builddir="$srcdir/pyrsistent-$pkgver"
 

--- a/community/py3-pytest-runner/APKBUILD
+++ b/community/py3-pytest-runner/APKBUILD
@@ -1,0 +1,29 @@
+# Contributor: Leo <thinkabit.ukim@gmail.com>
+# Maintainer: Leo <thinkabit.ukim@gmail.com>
+pkgname=py3-pytest-runner
+_pkgname=pytest-runner
+pkgver=4.4
+pkgrel=0
+pkgdesc="Invoke py.test as distutils command"
+options="!check" # Requires unpackaged pytest-{checkdocs,flake8,virtualenv}
+url="https://github.com/pytest-dev/pytest-runner"
+arch="noarch"
+license="MIT"
+depends="py3-setuptools"
+makedepends="py3-setuptools_scm"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+build() {
+	python3 setup.py build
+}
+
+check() {
+	python3 setup.py test
+}
+
+package() {
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+sha512sums="3122e556bc7ad41f48a8044b6c8555aed41bbed1ccaafe39bbd0aff51c4b656c4de954ccd99b5122f95763dad7ad54a2ae78d4e9522364ea6bbafecb967b09f5  pytest-runner-4.4.tar.gz"


### PR DESCRIPTION
By using py3-pytest-runner, a network connection is no longer required for building