### PR TITLE
community/dnscrypt-proxy: upgrade to 2.0.23

### DIFF
--- a/community/dnscrypt-proxy/APKBUILD
+++ b/community/dnscrypt-proxy/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Ian Bashford <ianbashford@gmail.com>
 # Maintainer: Ian Bashford <ianbashford@gmail.com>
 pkgname=dnscrypt-proxy
-pkgver=2.0.22
+pkgver=2.0.23
 pkgrel=0
 pkgdesc="A tool for securing communications between a client and a DNS resolver"
 url="https://dnscrypt.info"
@@ -12,7 +12,7 @@ makedepends="libcap go"
 install="$pkgname.pre-install"
 pkgusers=dnscrypt
 pkggroups=dnscrypt
-subpackages="$pkgname-setup::noarch $pkgname-openrc::noarch"
+subpackages="$pkgname-setup::noarch $pkgname-openrc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/jedisct1/$pkgname/archive/$pkgver.tar.gz
 	$pkgname.initd
 	$pkgname.confd
@@ -54,7 +54,7 @@ setup() {
 	install -m755 -D "$srcdir"/$pkgname.setup "$subpkgdir"/usr/sbin/setup-dnscrypt
 }
 
-sha512sums="ea2641e79739e75e8a7e6bc24a788488537ffa823e18a3585f95ca1ae90bef9890c65eaf7feb80cc5ad09165cef9513d4025e96367ca87fc59333534f8856102  dnscrypt-proxy-2.0.22.tar.gz
+sha512sums="d4eeaf20a397c8aed08a7a91a720637bb49395488eb1f7ab4a52ca8832d3e0b98fb320b86ca30ad19e1e3504e226379e5d325891a68624532493fc4796959462  dnscrypt-proxy-2.0.23.tar.gz
 e0a72d39d47dc24b889d08beedbd9fdf21615f42fbab79980debdfd2c3feaa83dc3f776351f7dd13533cc85905ce4e01812e4ff8a80a9ccc0b21e9db7d6cb232  dnscrypt-proxy.initd
 c001ae39da1b2db71764cab568f9ed18e4de0cea3d1a4e7bd6dd01a5668b81a888ea9eef99de6beac08857ad7f8eb1a32d730e946ac3563e4dcfa27147e35052  dnscrypt-proxy.confd
 66dd43d84117a0151ae41f34d82b716760382a5a491424bf6418228ffd21f0dfbc88e34cc5074e11f97f006335d97b85367bb9ab1d96747a48e893c022ad52d0  dnscrypt-proxy.setup


### PR DESCRIPTION
.onion servers are now automatically ignored if Tor routing is not enabled
caching of server addresses has been improved, especially when using proxies.
DNSCrypt communications are now automatically forced to using TCP when a SOCKS proxy has been set up.