### PR TITLE
testing/crosstool-ng: upgrade to 1.24.0

### DIFF
--- a/testing/crosstool-ng/APKBUILD
+++ b/testing/crosstool-ng/APKBUILD
@@ -1,15 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=crosstool-ng
-pkgver=1.23.0
-pkgrel=1
+pkgver=1.24.0
+pkgrel=0
 pkgdesc="tool for building toolchains"
 url="http://crosstool-ng.org/"
-license="GPL"
+license="LGPL-2.1-or-later GPL-2.0-or-later CC-BY-SA-2.5"
 arch="x86 x86_64 ppc64le"
 depends="bash gawk bison flex automake autoconf libtool cvs sed texinfo gperf"
-makedepends="ncurses-dev help2man xz"
-subpackages="$pkgname-doc"
-source="http://ymorin.is-a-geek.org/download/crosstool-ng/crosstool-ng-$pkgver.tar.bz2"
+makedepends="ncurses-dev help2man xz gettext-dev"
+subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch"
+source="http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-$pkgver.tar.xz"
 
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -27,4 +27,15 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="1842d140b1c4f76783751eab60722e8077f356dfc9e9cc941d3c991a7e9bb23cb19e6bd7cd5c630cc87967853c55e0c16e415b222e546b5baaffb264ca799b69  crosstool-ng-1.23.0.tar.bz2"
+bashcomp() {
+	depends=""
+	pkgdesc="Bash completion for $pkgname"
+	install_if="$pkgname=$pkgver-r$pkgrel bash-completion"
+
+	# bash completion has it's own package
+	mkdir -p "$subpkgdir"/usr/share/bash-completion/completions/
+	mv "$pkgdir"/usr/share/bash-completion/completions/ct-ng \
+		"$subpkgdir"/usr/share/bash-completion/completions/$pkgname
+}
+
+sha512sums="89b8794a4184ad4928750e29712ed4f194aa1d0b93768d67ff64f30c30f1b1e165647cafc6de94d68d3ef70e50446e544dad65aa36137511a32ee7a667dddfb4  crosstool-ng-1.24.0.tar.xz"


### PR DESCRIPTION
- http://crosstool-ng.github.io/2019/04/13/release-1.24.0.html 1.24.0
- Added new dependency to makedepends: gettext-dev
- Updated licenses info
- Added bash completion as separate package
- Source URL updated to official one