### PR TITLE
community/opentracker: fix build break by adding include prefix

### DIFF
--- a/community/opentracker/APKBUILD
+++ b/community/opentracker/APKBUILD
@@ -1,40 +1,31 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=opentracker
 pkgver=0_cvs20100625
-pkgrel=4
+pkgrel=5
 pkgdesc="an open and free bittorrent tracker"
 url="http://erdgeist.org/arts/software/opentracker/"
 arch="all"
 license="GPL"
-depends=
 makedepends="libowfat-dev zlib-dev"
 install="$pkgname.pre-install"
-subpackages=
 source="https://dev.alpinelinux.org/opentracker/opentracker-$pkgver.tar.gz
 	opentracker.initd"
 
-_builddir="$srcdir"/$pkgname
-prepare() {
-	cd "$_builddir"
-}
+builddir="$srcdir"/$pkgname
 
 build() {
-	cd "$_builddir"
-	make || return 1
+	cd "$builddir"
+	PREFIX=/usr/include make
 }
 
 package() {
-	cd "$_builddir"
+	cd "$builddir"
 	install -d "$pkgdir"/usr/bin
-	make BINDIR="$pkgdir"/usr/bin install || return 1
+	make BINDIR="$pkgdir"/usr/bin install
 	install -m644 -D opentracker.conf.sample \
 		"$pkgdir"/etc/opentracker/opentracker.conf
 	install -m755 -D "$srcdir"/$pkgname.initd "$pkgdir"/etc/init.d/$pkgname
 }
 
-md5sums="8d02a6f7a241c6b8c98e2dbde086cfcf  opentracker-0_cvs20100625.tar.gz
-bb3cfa7597cd86e2987aafb4081c6d78  opentracker.initd"
-sha256sums="c2be547353c55be95f7b29a1efd551d44ebbe7f7bc9835a29cf742ea2c21199e  opentracker-0_cvs20100625.tar.gz
-9058d2df337dc9259cd92e99350889dddcd86f14b3ced8577f69a348339bd15c  opentracker.initd"
 sha512sums="85686782d8f4469b3bbcd67851b86bb43fc258b6f347a695cef83b2d1354880eaeca475b85cce475646cec5e118a5dd3cb27c664166d0f5a8158a8662f633f01  opentracker-0_cvs20100625.tar.gz
 80ae2f4f5a485df7e3dab982068f3b79457721fd87e00e6a3450003f1a7685ade3e0edd4ab341a822abd51f002d3a8f7b897b38e76ac360fd6a0551c91a56d77  opentracker.initd"


### PR DESCRIPTION
build fails with errors of this type: 
trackerlogic.c:16:10: fatal error: byte.h: No such file or directory
 #include "byte.h"

header files are part of libowfat-dev package and have been installed at /usr/include/libowfat
Adding PREFIX=/usr/include in APKBUILD before "make" invocation will allow path search for header files to work correctly.