### PR TITLE
community/py3-openzwave: fix build break on ppc64le by disabling Werror

### DIFF
--- a/community/py3-openzwave/APKBUILD
+++ b/community/py3-openzwave/APKBUILD
@@ -3,7 +3,7 @@
 _name=python-openzwave
 pkgname=py3-openzwave
 pkgver=0.4.19
-pkgrel=1
+pkgrel=2
 pkgdesc="Python wrapper for openzwave"
 url="http://www.openzwave.com/"
 arch="all"
@@ -23,6 +23,9 @@ builddir="$srcdir/python-openzwave-$pkgver"
 build() {
 	cd "$builddir"
 	unset CFLAGS CPPFLAGS
+	case "$CARCH" in
+		ppc64le) export CPPFLAGS="-Wno-error";;
+	esac
 	make build PYTHON_EXEC=python3
 	python3 setup-lib.py build
 	python3 setup-api.py build


### PR DESCRIPTION
On ppc64le build fails with error:
```./community/py3-openzwave/src/python-openzwave-0.4.19/openzwave/cpp/src/command_classes/DoorLockLogging.cpp: In member function 'virtual bool OpenZWave::DoorLockLogging::HandleMsg(const uint8*, uint32, uint32)':
./community/py3-openzwave/src/python-openzwave-0.4.19/openzwave/cpp/src/command_classes/DoorLockLogging.cpp:313:48: error: 'char* strncat(char*, const char*, size_t)' output may be truncated copying between 0 and 253 bytes from a string of length 253 [-Werror=stringop-truncation]
                                         strncat(usercode, tmpusercode, sizeof(usercode) - strlen(usercode) - 1 );
                                         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

This error is difficult to patch directly since the openzwave code is being downloaded dynamically during the build process. A PR to fix has been submitted to the openzwave project,  https://github.com/OpenZWave/open-zwave/pull/1782

Until this PR can be integrated into the openzwave source this Alpine PR disables -Werror for ppc64le.
pkgrel has been bumped to force rebuild since openzwave source is downloaded dynamically using git and that source is likely to have changed.

