### PR TITLE
main/hexchat: fix intermittent bld err by forcing build dependency order

### DIFF
--- a/main/hexchat/APKBUILD
+++ b/main/hexchat/APKBUILD
@@ -11,7 +11,8 @@ makedepends="dbus-glib-dev gtk+2.0-dev iso-codes libnotify-dev libproxy-dev
 	openssl-dev libsexy-dev libxml2-dev lua5.3-dev meson python3-dev"
 install=""
 subpackages="$pkgname-doc $pkgname-lang $pkgname-python:_python"
-source="https://dl.hexchat.net/$pkgname/$pkgname-$pkgver.tar.xz"
+source="https://dl.hexchat.net/$pkgname/$pkgname-$pkgver.tar.xz
+	force-meson-build-order.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -41,4 +42,5 @@ _python() {
 		"$subpkgdir"/usr/lib/hexchat/plugins
 }
 
-sha512sums="488799700e439a137ad469f618cb1abf75d1f1ebf223c750d658004ef7b2c728543a5a9ae4e6317d6447428dc59e12dded619346a5d8bba12c92dab653512fca  hexchat-2.14.2.tar.xz"
+sha512sums="488799700e439a137ad469f618cb1abf75d1f1ebf223c750d658004ef7b2c728543a5a9ae4e6317d6447428dc59e12dded619346a5d8bba12c92dab653512fca  hexchat-2.14.2.tar.xz
+f579622330391fbce798bf9b0e5c1d07975a188b79f7160ab8c921b7df92b2d31444f30d6f62b7b08f7543a4ef40975ecf53705903374b73069bb369967491c5  force-meson-build-order.patch"

--- a/main/hexchat/force-meson-build-order.patch
+++ b/main/hexchat/force-meson-build-order.patch
@@ -1,0 +1,11 @@
+--- a/src/fe-gtk/meson.build
++++ b/src/fe-gtk/meson.build
+@@ -86,7 +86,7 @@
+ 
+ executable('hexchat',
+   sources:  resources + hexchat_gtk_sources,
+-  dependencies: hexchat_gtk_deps,
++  dependencies: [hexchat_gtk_deps,declare_dependency(sources: textevents)],
+   c_args: hexchat_gtk_cflags,
+   link_args: hexchat_gtk_ldflags,
+   install: true,


### PR DESCRIPTION
Building hexchat will fail intermittently with:
```
[17/81] Compiling C object 'src/fe-gtk/c4b29cb@@hexchat@exe/fkeys.c.o'.
FAILED: src/fe-gtk/c4b29cb@@hexchat@exe/fkeys.c.o
gcc -Isrc/fe-gtk/c4b29cb@@hexchat@exe -Isrc/fe-gtk -I../src/fe-gtk -I. -I../ -Isrc/common -I../src/common -Isrc/common/dbus -I../src/common/dbus -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/gtk-2.0 -I/usr/lib/gtk-2.0/include -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/uuid -I/usr/include/harfbuzz -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/atk-1.0 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu89 -O2 -g -fPIE -funsigned-char -Wno-conversion -Wno-pointer-sign -Wno-padded -Wno-unused-parameter -Wno-missing-prototypes -Winline -Wstrict-prototypes -Werror=implicit-function-declaration -Werror=pointer-arith -Werror=init-self -Werror=format-security -Werror=format=1 -Werror=missing-include-dirs -Werror=date-time -fstack-protector-strong -Os -fomit-frame-pointer -Os -fomit-frame-pointer -fPIE -pthread -DHAVE_CONFIG_H '-DHEXCHATLIBDIR="/usr/lib/hexchat/plugins"' -fPIE -MD -MQ 'src/fe-gtk/c4b29cb@@hexchat@exe/fkeys.c.o' -MF 'src/fe-gtk/c4b29cb@@hexchat@exe/fkeys.c.o.d' -o 'src/fe-gtk/c4b29cb@@hexchat@exe/fkeys.c.o' -c ../src/fe-gtk/fkeys.c
In file included from ../src/fe-gtk/fkeys.c:43:
../src/fe-gtk/../common/text.h:21:10: fatal error: textenums.h: No such file or directory
 #include "textenums.h"
          ^~~~~~~~~~~~~
```
This is because the fe-gtk component depends on the textevents component being built first which generates the textenums.h header files. This PR modifies fe-gtk's meson.build file to explicitly call out this ordering dependancy.

No changes to source level or binaries generated so pkgrel was not bumped.