### PR TITLE
community/orage: fix bld break by migrating is_utc calls if libical is v3 or later

### DIFF
--- a/community/orage/APKBUILD
+++ b/community/orage/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=orage
 pkgver=4.12.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A simple calendar application with reminders for Xfce"
 url="https://xfce.org/projects/"
 arch="all"
@@ -10,13 +10,10 @@ subpackages="$pkgname-doc $pkgname-lang"
 depends="hicolor-icon-theme"
 makedepends="xfce4-panel-dev libnotify-dev libxfce4ui-dev libical-dev popt-dev"
 install=
-source="https://archive.xfce.org/src/apps/orage/${pkgver%.*}/orage-$pkgver.tar.bz2"
+source="https://archive.xfce.org/src/apps/orage/${pkgver%.*}/orage-$pkgver.tar.bz2
+	migrate-libical-is_utc-calls.patch"
 
 _builddir="$srcdir/$pkgname-$pkgver"
-
-prepare() {
-	cd "$_builddir"
-}
 
 build() {
 	cd "$_builddir"
@@ -37,6 +34,5 @@ package() {
 	make DESTDIR="$pkgdir" install || return 1
 }
 
-md5sums="2b7f5d38cb5c6edbcc65d0f52a742e46  orage-4.12.1.tar.bz2"
-sha256sums="3cf9aa441ae83c8688865f82217025cdf3ebaa152cce4571777b8c2aa8dd9062  orage-4.12.1.tar.bz2"
-sha512sums="3fec0201171140586cdc9bcf151450a7086515e18b5815afe4fe4c4726ba554c50582b0479e52985b330140c51b7233ef81f678f986f848afbeee74c66b2d196  orage-4.12.1.tar.bz2"
+sha512sums="3fec0201171140586cdc9bcf151450a7086515e18b5815afe4fe4c4726ba554c50582b0479e52985b330140c51b7233ef81f678f986f848afbeee74c66b2d196  orage-4.12.1.tar.bz2
+c67c106560fd0420083d77ca3d3c54bc1c6f9e2b5a7631d6f32ced04ecb78bfe485064935b1fb2480badee8c9dbfe13750ff35fd0ab7891eb9c55b8220b3dfc4  migrate-libical-is_utc-calls.patch"

--- a/community/orage/migrate-libical-is_utc-calls.patch
+++ b/community/orage/migrate-libical-is_utc-calls.patch
@@ -1,0 +1,72 @@
+--- a/src/ical-code.c
++++ b/src/ical-code.c
+@@ -129,7 +129,9 @@
+         &&   (strcmp(g_par.local_timezone, "floating") != 0))
+         ctime = icaltime_current_time_with_zone(local_icaltimezone);
+     else { / * use floating time * /
++#if ICAL_MAJOR_VERSION < 3
+         ctime.is_utc      = 0;
++#endif
+         ctime.is_date     = 0;
+         ctime.is_daylight = 0;
+         ctime.zone        = NULL;
+@@ -2579,7 +2581,9 @@
+  * when counting alarm time. */
+         if (rel == ICAL_RELATED_START) {
+             per.stime.is_date       = 0;
++#if ICAL_MAJOR_VERSION < 3
+             per.stime.is_utc        = 1;
++#endif
+             per.stime.is_daylight   = 0;
+             per.stime.zone          = utc_icaltimezone;
+             per.stime.hour          = 0;
+@@ -2588,7 +2592,9 @@
+         }
+         else {
+             per.etime.is_date       = 0;
++#if ICAL_MAJOR_VERSION < 3
+             per.etime.is_utc        = 1;
++#endif
+             per.etime.is_daylight   = 0;
+             per.etime.zone          = utc_icaltimezone;
+             per.etime.hour          = 0;
+@@ -2613,7 +2619,9 @@
+ /* HACK: convert to UTC time so that we can use time arithmetic
+  * when counting alarm time. */
+         start_time.is_date       = 0;
++#if ICAL_MAJOR_VERSION < 3
+         start_time.is_utc        = 1;
++#endif
+         start_time.is_daylight   = 0;
+         start_time.zone          = utc_icaltimezone;
+         start_time.hour          = 0;
+@@ -2768,7 +2776,9 @@
+      */
+     if (icaltime_is_date(per.stime)) {
+         if (local_icaltimezone != utc_icaltimezone) {
++#if ICAL_MAJOR_VERSION < 3
+             next_alarm_time.is_utc        = 0;
++#endif
+             next_alarm_time.is_daylight   = 0;
+             next_alarm_time.zone          = local_icaltimezone;
+         }
+@@ -2850,7 +2860,9 @@
+          */
+         if (icaltime_is_date(per.stime)) {
+             if (local_icaltimezone != utc_icaltimezone) {
++#if ICAL_MAJOR_VERSION < 3
+                 next_alarm_time.is_utc        = 0;
++#endif
+                 next_alarm_time.is_daylight   = 0;
+                 next_alarm_time.zone          = local_icaltimezone;
+             }
+@@ -2944,7 +2956,9 @@
+          */
+         if (icaltime_is_date(per.stime)) {
+             if (local_icaltimezone != utc_icaltimezone) {
++#if ICAL_MAJOR_VERSION < 3
+                 next_alarm_time.is_utc        = 0;
++#endif
+                 next_alarm_time.is_daylight   = 0;
+                 next_alarm_time.zone          = local_icaltimezone;
+             }


### PR DESCRIPTION
After version 2 of libical the is_utc member no longer exists. This results in build breaks with errors like:
```
ical-code.c:2582:23: error: 'struct icaltimetype' has no member named 'is_utc'; did you mean 'is_date'?
```
Suggested patch is this PR is modeled on debian like changes available here:
https://sources.debian.org/patches/orage/4.12.1-6/02_libical3.patch/
