### PR TITLE
main/py-requests: upgrade support for urllib3 1.25

### DIFF
--- a/main/py-requests/APKBUILD
+++ b/main/py-requests/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=py-requests
 _pkgname=requests
 pkgver=2.21.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A HTTP request library for Python"
 url="http://www.python-requests.org/"
 arch="noarch"
@@ -17,7 +17,7 @@ makedepends="
 "
 subpackages="py3-${pkgname#py-}:_py3 py2-${pkgname#py-}:_py2"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz
-support-urllib3-1.26.patch"
+	support-urllib3-1.26.patch"
 builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
@@ -52,4 +52,4 @@ _py() {
 }
 
 sha512sums="385e1d80993a21c09e7c4682500ca8c24155962ba41ecd8e73612722b2ff6618b736e827fc48ad1683b0d2bc7a420cfe680f5107860aca52656ef777f1d60104  requests-2.21.0.tar.gz
-e2adfca523f7a35955d91e1fb3234d4ed7da01ab3bd3fa877db39957504e26991480300620c0da5996fae395a30bc9f216cbf98dd20bad7981b7c59250068920  support-urllib3-1.26.patch"
+7a52e88706e742f0973fec2f4784b6b51ed9adc8c82bccdb9bec3e7fe102f9794a512a53ccb08cb7460727357103c1dd8687c06bffd48aaf2f2811fd2e184a61  support-urllib3-1.26.patch"

--- a/main/py-requests/support-urllib3-1.26.patch
+++ b/main/py-requests/support-urllib3-1.26.patch
@@ -1,34 +1,12 @@
-From 44bf8223beb97a1e19c09c0d9c1b78db10c58bf2 Mon Sep 17 00:00:00 2001
-From: Ofek Lev <ofekmeister@gmail.com>
-Date: Sat, 20 Apr 2019 19:20:55 -0400
-Subject: [PATCH 1/3] Allow urllib3 1.25.x
-
----
- setup.py | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/setup.py b/setup.py
-index 10ce2c621..1bc64ca98 100755
---- a/setup.py
-+++ b/setup.py
-@@ -44,7 +44,7 @@ def run_tests(self):
- requires = [
-     'chardet>=3.0.2,<3.1.0',
-     'idna>=2.5,<2.9',
--    'urllib3>=1.21.1,<1.25',
-+    'urllib3>=1.21.1,<1.26',
-     'certifi>=2017.4.17'
- 
- ]
-
-From 9a7de14a2b9163e70dd1b3f2b12d9e0f922a0436 Mon Sep 17 00:00:00 2001
-From: Ofek Lev <ofekmeister@gmail.com>
-Date: Sat, 20 Apr 2019 19:22:50 -0400
-Subject: [PATCH 2/3] here too
+From d6b5b401e8d6141bcefa4a70ff1c836aa085120b Mon Sep 17 00:00:00 2001
+From: Nate Prewitt <Nate.Prewitt@gmail.com>
+Date: Thu, 25 Apr 2019 10:05:02 -0700
+Subject: [PATCH] upgrade support for urllib3 1.25
 
 ---
  requests/__init__.py | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ setup.py             | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/requests/__init__.py b/requests/__init__.py
 index bc168ee53..9a899df67 100644
@@ -47,26 +25,16 @@ index bc168ee53..9a899df67 100644
  
      # Check chardet for compatibility.
      major, minor, patch = chardet_version.split('.')[:3]
-
-From 5b42261365ecea4f7547660c2c27d046eecb30ca Mon Sep 17 00:00:00 2001
-From: Ofek Lev <ofekmeister@gmail.com>
-Date: Wed, 24 Apr 2019 13:57:47 -0400
-Subject: [PATCH 3/3] Update setup.py
-
----
- setup.py | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/setup.py b/setup.py
-index 1bc64ca98..0d5d0cc99 100755
+index 10ce2c621..50925533e 100755
 --- a/setup.py
 +++ b/setup.py
 @@ -44,7 +44,7 @@ def run_tests(self):
  requires = [
      'chardet>=3.0.2,<3.1.0',
      'idna>=2.5,<2.9',
--    'urllib3>=1.21.1,<1.26',
-+    'urllib3>=1.21.1,<1.26,!=1.25',
+-    'urllib3>=1.21.1,<1.25',
++    'urllib3>=1.21.1,<1.26,!=1.25.0',
      'certifi>=2017.4.17'
  
  ]


### PR DESCRIPTION
Fixes [#10378](https://bugs.alpinelinux.org/issues/10378)
Patch imported from [upstream](https://github.com/kennethreitz/requests/commit/d6b5b401e8d6141bcefa4a70ff1c836aa085120b).