### PR TITLE
scripts/mkimg.*.sh: add haveged & rng-tools

### DIFF
--- a/scripts/mkimg.base.sh
+++ b/scripts/mkimg.base.sh
@@ -297,7 +297,7 @@ profile_base() {
 	case "$ARCH" in
 	x86*) grub_mod="$grub_mod multiboot2 efi_uga";;
 	esac
-	apks="alpine-base alpine-mirrors busybox kbd-bkeymaps chrony e2fsprogs network-extras openssl openssh tzdata"
+	apks="alpine-base alpine-mirrors busybox kbd-bkeymaps chrony e2fsprogs haveged network-extras openssl openssh tzdata"
 	apkovl=
 	hostname="alpine"
 }

--- a/scripts/mkimg.standard.sh
+++ b/scripts/mkimg.standard.sh
@@ -44,7 +44,7 @@ profile_extended() {
 		iptables iputils irssi ldns-tools links
 		ncurses-terminfo net-snmp net-snmp-tools nrpe nsd
 		opennhrp openvpn openvswitch pingu ppp quagga
-		quagga-nhrp rpcbind sntpc socat ssmtp strongswan
+		quagga-nhrp rng-tools rpcbind sntpc socat ssmtp strongswan
 		sysklogd tcpdump tinyproxy unbound
 		wireless-tools wpa_supplicant zonenotify
 

--- a/scripts/mkimg.xen.sh
+++ b/scripts/mkimg.xen.sh
@@ -17,6 +17,6 @@ profile_xen() {
 	arch="x86_64"
 	kernel_cmdline="nomodeset"
 	xen_params=""
-	apks="$apks ethtool lvm2 mdadm multipath-tools openvswitch sfdisk xen xen-bridge"
+	apks="$apks ethtool lvm2 mdadm multipath-tools openvswitch rng-tools sfdisk xen xen-bridge"
 #	apkovl="genapkovl-xen.sh"
 }


### PR DESCRIPTION
We need a way to generate entropy already at installation.

If not, things like https downloads or starting sshd for a remote
shell to the installer can block for a few minutes.