### PR TITLE
main/fish: don't install docker completion, -tools needs man-db

### DIFF
--- a/main/fish/APKBUILD
+++ b/main/fish/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Leo <thinkabit.ukim@gmail.com>
 pkgname=fish
 pkgver=3.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Modern interactive commandline shell"
 url="http://www.fishshell.com"
 arch="all"
@@ -69,7 +69,7 @@ doc() {
 
 tools() {
 	pkgdesc="$pkgdesc (tools)"
-	depends="$pkgname python"
+	depends="$pkgname python man-db"
 
 	mkdir -p "$subpkgdir"/usr/share/$pkgname
 	mv "$pkgdir"/usr/share/$pkgname/tools "$subpkgdir"/usr/share/$pkgname


### PR DESCRIPTION
The docker completion is installed by docker-fish-completion already, which
causes conflicts upon install. fish-tools needs man-db for generating completions.

@maxice8