### PR TITLE
main/pinentry: add pinentry-gnome, use libsecret

### DIFF
--- a/main/pinentry/APKBUILD
+++ b/main/pinentry/APKBUILD
@@ -2,15 +2,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=pinentry
 pkgver=1.1.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Collection of simple PIN or passphrase entry dialogs which utilize the Assuan protocol"
 url="http://www.gnupg.org/aegypten2"
 arch="all"
 license="GPL-2.0-or-later"
-depends=""
 install="pinentry.post-install pinentry.post-deinstall"
-makedepends="ncurses-dev libcap-dev gtk+-dev libgpg-error-dev libassuan-dev"
-subpackages="$pkgname-doc $pkgname-gtk"
+makedepends="ncurses-dev libcap-dev gtk+-dev libgpg-error-dev libassuan-dev
+	gcr-dev libsecret-dev"
+subpackages="$pkgname-doc $pkgname-gtk $pkgname-gnome"
 source="ftp://ftp.gnupg.org/gcrypt/$pkgname/$pkgname-$pkgver.tar.bz2"
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -24,7 +24,9 @@ build () {
 		--enable-pinentry-gtk2 \
 		--disable-pinentry-qt \
 		--enable-pinentry-curses \
-		--enable-fallback-curses
+		--enable-fallback-curses \
+		--enable-pinentry-gnome3 \
+		--enable-libsecret
 	make
 }
 
@@ -44,6 +46,13 @@ gtk() {
 	install="pinentry-gtk.post-install pinentry-gtk.post-deinstall"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/pinentry-gtk* \
+		"$subpkgdir"/usr/bin/
+}
+
+gnome() {
+	install="pinentry-gnome.post-install pinentry-gnome.post-deinstall"
+	mkdir -p "$subpkgdir"/usr/bin
+	mv "$pkgdir"/usr/bin/pinentry-gnome3 \
 		"$subpkgdir"/usr/bin/
 }
 

--- a/main/pinentry/pinentry-gnome.post-deinstall
+++ b/main/pinentry/pinentry-gnome.post-deinstall
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ -f /usr/bin/pinentry-curses ]; then
+	ln -sf pinentry-curses /usr/bin/pinentry
+else
+	rm -f /usr/bin/pinentry
+fi
+

--- a/main/pinentry/pinentry-gnome.post-install
+++ b/main/pinentry/pinentry-gnome.post-install
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+ln -sf pinentry-gnome3 /usr/bin/pinentry
+


### PR DESCRIPTION
pinentry-gnome is useful when used in GNOME environments for better integration.
Use libsecret to save secrets in the keychain.