### PR TITLE
community/qt5-qtwebengine: fix with musl-1.22

### DIFF
--- a/community/qt5-qtwebengine/APKBUILD
+++ b/community/qt5-qtwebengine/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=qt5-qtwebengine
 pkgver=5.12.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Qt5 - QtWebEngine components"
 url="http://qt-project.org/"
 # ppc64le, s390x: not supported
@@ -78,6 +78,7 @@ source="http://download.qt-project.org/$_rel/qt/${pkgver%.*}/$_ver/submodules/qt
 	qt-musl-thread-stacksize.patch
 	musl-sandbox.patch
 	yasm-nls.patch
+	sandbox-membarrier.patch
 	"
 builddir="$srcdir"/qtwebengine-everywhere-src-$_V
 
@@ -112,4 +113,5 @@ b1f7823d0bdd14dbcb4dbd72ab2d16460d343722d2601921a50f8912ce580a632e0d7b01d7fea6f2
 7dc3e9995596adef65cd96f650eb7ee13d52cabfe6353f04eeb5b8a5776e7e0585ffc2a0a31deea6924352ee9a5a8e03ac37432b558c6a46f3dc457b4283392a  qt-musl-stackstart.patch
 b37fbc4df03c82123f94982039defa12d9bb8c885c9dcf8fff556b5f9cc58182fa471f970cc3a5e2d5dbe964855f591b474366b6a8926d94ae6a78e883811c1a  qt-musl-thread-stacksize.patch
 635d77109b5ce9bc9697d621f1bf98193903e2ac69fc4079fb92f175daa80147fed8ae15544d239ef680e120474d8f811002935ef1a078836ba01695f9ddfcb9  musl-sandbox.patch
-f6b1941e40f44b675ab554166e3cd8d3272b23f48571b4949b3af7b8e1c642ee84fe0ee26dd2457fc3bf20e9924cddb411e293b7a8a103029ee196587371a1e2  yasm-nls.patch"
+f6b1941e40f44b675ab554166e3cd8d3272b23f48571b4949b3af7b8e1c642ee84fe0ee26dd2457fc3bf20e9924cddb411e293b7a8a103029ee196587371a1e2  yasm-nls.patch
+ac7f58f21b626db0d75d6fd985e1696488551924c9a4a27c2e1efb79638a5dfb55f71f35a7a05890b849c49c81d9ad009c821d32b27d5e2e96bf403113e7348d  sandbox-membarrier.patch"

--- a/community/qt5-qtwebengine/sandbox-membarrier.patch
+++ b/community/qt5-qtwebengine/sandbox-membarrier.patch
@@ -1,0 +1,60 @@
+--- a/src/3rdparty/chromium/sandbox/linux/system_headers/arm64_linux_syscalls.h
++++ b/src/3rdparty/chromium/sandbox/linux/system_headers/arm64_linux_syscalls.h
+@@ -1063,4 +1063,8 @@
+ #define __NR_memfd_create 279
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 283
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_ARM64_LINUX_SYSCALLS_H_
+
+--- a/src/3rdparty/chromium/sandbox/linux/system_headers/arm_linux_syscalls.h
++++ b/src/3rdparty/chromium/sandbox/linux/system_headers/arm_linux_syscalls.h
+@@ -1385,6 +1385,10 @@
+ #define __NR_memfd_create (__NR_SYSCALL_BASE+385)
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier (__NR_SYSCALL_BASE+389)
++#endif
++
+ // ARM private syscalls.
+ #if !defined(__ARM_NR_BASE)
+ #define __ARM_NR_BASE (__NR_SYSCALL_BASE + 0xF0000)
+
+--- a/src/3rdparty/chromium/sandbox/linux/system_headers/x86_32_linux_syscalls.h
++++ b/src/3rdparty/chromium/sandbox/linux/system_headers/x86_32_linux_syscalls.h
+@@ -1422,5 +1422,9 @@
+ #define __NR_memfd_create 356
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 375
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_X86_32_LINUX_SYSCALLS_H_
+ 
+--- a/src/3rdparty/chromium/sandbox/linux/system_headers/x86_64_linux_syscalls.h
++++ b/src/3rdparty/chromium/sandbox/linux/system_headers/x86_64_linux_syscalls.h
+@@ -1290,5 +1290,9 @@
+ #define __NR_memfd_create 319
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 324
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_X86_64_LINUX_SYSCALLS_H_
+ 
+--- a/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
++++ b/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+@@ -370,6 +370,7 @@
+   switch (sysno) {
+     case __NR_exit:
+     case __NR_exit_group:
++    case __NR_membarrier:
+     case __NR_wait4:
+     case __NR_waitid:
+ #if defined(__i386__)


### PR DESCRIPTION
musl-1.22 introduced SYS_membarrier, which breaks the sandbox of chromium
(and as such also qt5-qtwebengine)