### PR TITLE
community/ceph: upgrade to 14.2.1

### DIFF
--- a/community/ceph/APKBUILD
+++ b/community/ceph/APKBUILD
@@ -1,14 +1,15 @@
 # Contributor: John Coyle <dx9err@gmail.com>
 # Maintainer: John Coyle <dx9err@gmail.com>
 pkgname=ceph
-pkgver=14.2.0
-pkgrel=3
+pkgver=14.2.1
+pkgrel=0
 pkgdesc="Ceph is a distributed object store and file system"
 pkgusers="ceph"
 pkggroups="ceph"
 url="http://ceph.com"
 arch="x86_64"
-license="LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and GPL-2.0-with-autoconf-exception and BSD-3-Clause and MIT"
+# https://github.com/ceph/ceph/blob/master/COPYING
+license="LGPL-2.1-only AND LGPL-2.0-or-later AND GPL-2.0-only AND GPL-3.0-only AND CC-BY-SA-1.0 AND BSL-1.0 AND GPL-2.0 WITH Autoconf-exception-2.0 AND BSD-3-Clause AND MIT AND custom"
 depends="ceph-osd ceph-mds ceph-mon"
 options="!checkroot"
 _base_deps="
@@ -443,6 +444,6 @@ _pkg() {
 	done
 }
 
-sha512sums="c86a335714fd5678988133ec0e60cb10cd948250a133c073d1ed055c5bba232fa6f1e102dd7fcb0c70b37a07c9c2d1220d4a1713720e4dcab9659152ee577480  ceph_14.2.0.orig.tar.gz
+sha512sums="fccde341344c721fbfc7f7cb73db4f65933d7fcacc9495398b55b37d1e208f0bad0cd78a4da08a3b5e26cca3175e7707f7dfb76fae5aa094f58afaed8603c866  ceph_14.2.1.orig.tar.gz
 e1becd813ed3f28e2e4a6bef78b3b5117c1c0bb9cabe0ba9c912e0a20b551b6b2667495cddb94acd64192e287144911ff1c11e0d636fe04cc458146cfb0daca8  allperms.patch
 35722b11ad52a3145153635b6a96abda2a23ae9c7e63e2eac006c1e5b8014452c4a1a11bbe0292fd731e4c43aa38e27dd75d2ff9d25bcf52290278f71e868570  musl-fixes.patch"


### PR DESCRIPTION
Bump version to latest and update checksum. No other functional changes
for now.