### PR TITLE
testing/rustup: new aport

### DIFF
--- a/testing/rustup/APKBUILD
+++ b/testing/rustup/APKBUILD
@@ -1,0 +1,64 @@
+# Contributor: Rasmus Thomsen <oss@cogitri.dev>
+# Maintainer: Rasmus Thomsen <oss@cogitri.dev>
+pkgname=rustup
+pkgver=1.16.0
+pkgrel=0
+pkgdesc="The Rust toolchain installer"
+url="rustup.rs"
+arch="x86_64" # limited by cargo
+license="Apache-2.0"
+makedepends="cargo perl openssl-dev zlib-dev curl-dev"
+options="!check" # Doesn't recognise x86_64-unknown-linux-musl yet, so it tries
+		 # to test with nonexistent x86_64-unknown-linux
+subpackages="
+	$pkgname-bash-completion:bashcomp:noarch
+	$pkgname-fish-completion:fishcomp:noarch
+	$pkgname-zsh-completion:zshcomp:noarch"
+source="
+	$pkgname-$pkgver.tar.gz::https://github.com/rust-lang/rustup.rs/archive/${pkgver}.tar.gz"
+builddir="$srcdir/rustup.rs-${pkgver}"
+
+build() {
+	cargo build --release --features no-self-update --bin rustup-init
+}
+
+check() {
+	cargo test --release
+}
+
+package() {
+	install -d "$pkgdir"/usr/bin
+	install -m755 target/release/rustup-init "$pkgdir"/usr/bin/
+
+	ln -s target/release/rustup-init rustup
+	./rustup completions zsh > rustup.zsh
+	./rustup completions bash > rustup.bash
+	./rustup completions fish > rustup.fish
+}
+
+bashcomp() {
+        pkgdesc="$pkgdesc - bash completion"
+        install_if="$pkgname=$pkgver-r$pkgrel bash-completion"
+
+        install -Dm644 "$builddir"/rustup.bash \
+                "$subpkgdir"/usr/share/bash-completion/completions/$pkgname
+}
+
+fishcomp() {
+        pkgdesc="$pkgdesc - fish shell completion"
+        depends=""
+        install_if="$pkgname=$pkgver-r$pkgrel fish"
+
+        install -Dm644 "$builddir"/rustup.fish \
+                "$subpkgdir"/usr/share/fish/completions/$pkgname.fish
+}
+
+zshcomp() {
+        pkgdesc="$pkgdesc -zsh completion"
+        depends=""
+        install_if="$pkgname=$pkgver-r$pkgrel zsh"
+
+        install -Dm644 "$builddir"/rustup.zsh \
+                "$subpkgdir"/usr/share/zsh/site-functions/_$pkgname
+}
+sha512sums="413aada75d90b7c8946edd62e05c526f65e7b34899ac4afe711ba79ab2a1e3e6366c84a3b5996df7de804ef6db98d571ad4aa4bc3f46faed30ebf6eb2ac7e58c  rustup-1.16.0.tar.gz"


### PR DESCRIPTION
This can install beta/nightly toolchains now, once Rust 1.35.0 is released it'll also be possible to install stable toolchains. Can't use a more recent version due to our old rustc.