### PR TITLE
testing/linux-tools: streamline bash-completion package

### DIFF
--- a/testing/linux-tools/APKBUILD
+++ b/testing/linux-tools/APKBUILD
@@ -1,9 +1,10 @@
+# Contributor: Leo <thinkabit.ukim@gmail.com>
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=linux-tools
 pkgver=4.18.13
 _kernver=${pkgver%.*}
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux kernel tools meta package"
 url="https://www.kernel.org/"
 arch="all !aarch64 !armhf !armv7"
@@ -12,10 +13,9 @@ depends="cpupower perf"
 depends_dev="pciutils-dev readline-dev gettext-dev"
 makedepends="$depends_dev elfutils-dev bash linux-headers flex bison diffutils
 	zlib-dev findutils"
-install=""
-subpackages="perf perf-bash-completions:perf_completions cpupower $pkgname-doc $pkgname-dev"
+subpackages="perf perf-bash-completion:bashcomp:noarch cpupower $pkgname-doc $pkgname-dev"
 source="https://kernel.org/pub/linux/kernel/v4.x/linux-$_kernver.tar.xz
-        https://kernel.org/pub/linux/kernel/v4.x/patch-$pkgver.xz
+	https://kernel.org/pub/linux/kernel/v4.x/patch-$pkgver.xz
 	cpupower-libs.patch
 	disable-Werror.patch
 	"
@@ -40,12 +40,10 @@ _make_tools() {
 }
 
 build() {
-        cd "$builddir"
 	_make_tools perf cpupower
 }
 
 package() {
-	cd "$builddir"
 	mkdir -p "$pkgdir"
 	_make_tools DESTDIR="$pkgdir" \
 		perf_install cpupower_install
@@ -75,11 +73,12 @@ perf() {
 	mv "$pkgdir"/usr/libexec "$subpkgdir"/usr/
 }
 
-perf_completions() {
-	pkgdesc="bash autocompletion for perf"
-	install_if="perf=$pkgver-r$pkgrel bash"
-	mkdir -p "$subpkgdir"/etc
-	mv "$pkgdir"/etc/bash_completion.d "$subpkgdir"/etc/
+bashcomp() {
+	replaces="$pkgname-bash-completion" # Backward compatibility
+	pkgdesc="Bash autocompletion for $pkgname"
+	install_if="perf=$pkgver-r$pkgrel bash-completion"
+	mkdir -p "$subpkgdir"/usr/share/bash-completion/completions
+	mv "$pkgdir"/etc/bash_completion.d "$subpkgdir"/usr/share/bash-completion/completions
 }
 
 sha512sums="950eb85ac743b291afe9f21cd174d823e25f11883ee62cecfbfff8fe8c5672aae707654b1b8f29a133b1f2e3529e63b9f7fba4c45d6dacccc8000b3a9a9ae038  linux-4.18.tar.xz


### PR DESCRIPTION
- Use modern style
- Create perf-bash-completion and replace perf-bash-completions
- Install completions to /usr/share/bash-completion/completions
- perf-bash-completion noarch
- Install completions when bash-completion is installed not when bash is