### PR TITLE
testing/pass: modernize

### DIFF
--- a/testing/pass/APKBUILD
+++ b/testing/pass/APKBUILD
@@ -3,15 +3,13 @@
 # Maintainer: Johannes Matheis <jomat+alpinebuild@jmt.gr>
 pkgname=pass
 pkgver=1.7.3
-pkgrel=0
+pkgrel=1
 pkgdesc="Stores, retrieves, generates, and synchronizes passwords securely"
 url="https://www.passwordstore.org"
 arch="noarch"
 license="GPL-2.0-or-later"
-depends="bash tree"
-depends_dev=""
-makedepends="$depends_dev"
-options="!check"
+depends="bash tree cmd:gpg2"
+checkdepends="git"
 subpackages="$pkgname-doc
 	$pkgname-contrib
 	$pkgname-bash-completion:bashcomp
@@ -22,8 +20,11 @@ source="https://git.zx2c4.com/password-store/snapshot/password-store-$pkgver.tar
 	"
 builddir="$srcdir/password-store-$pkgver"
 
+check() {
+	make test
+}
+
 package() {
-	cd "$builddir"
 	make DESTDIR="$pkgdir" \
 		WITH_ALLCOMP=yes install
 	install -Dm 644 "$srcdir"/README.alpine "$pkgdir"/usr/share/doc/pass/README.alpine


### PR DESCRIPTION
- Add missing dependency on cmd:gpg
- Enable tests, add missing dep on git
- Use modern style