### PR TITLE
[3.6] main/mariadb: security upgrade to 10.1.40

### DIFF
--- a/main/mariadb/APKBUILD
+++ b/main/mariadb/APKBUILD
@@ -4,10 +4,10 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mariadb
-pkgver=10.1.38
+pkgver=10.1.40
 pkgrel=0
 pkgdesc="A fast SQL database server"
-url="https://www.mariadb.org"
+url="https://www.mariadb.org/"
 pkgusers="mysql"
 pkggroups="mysql"
 arch="all"
@@ -23,6 +23,9 @@ source="https://downloads.mariadb.org/interstitial/mariadb-$pkgver/source/mariad
 	"
 
 # secfixes:
+#   10.1.40-r0:
+#     - CVE-2019-2614
+#     - CVE-2019-2627
 #   10.1.38-r0:
 #     - CVE-2019-2537
 #     - CVE-2019-2529
@@ -256,6 +259,6 @@ mysql() { _compat mysql mariadb; }
 _compat_client() { _compat mysql-client mariadb-client; }
 _compat_bench() { _compat mysql-bench mariadb-client; }
 
-sha512sums="184582f3a902a989ba3d9c4d21288c014c8b469adbbb4cbabc621c5006022cef29baed8c1140ed4476b124da83b76dfa414295ed0c3374be826e75aca953a77b  mariadb-10.1.38.tar.gz
+sha512sums="6b946189c69905f1a23a96d34720f1592353e0095455bf452bba31d53c90143d088f0fd997cac3da0a779840bb6ae6cc30b45144cba474463a8e3a6978a8a8f3  mariadb-10.1.40.tar.gz
 06751768cb00d2e433655635c38d267ef25084a5830ff40e719ac579223c7192dc34b43f919ab6faf480094632327511cbd22456064dde2d04dc15648b9e3b9f  mariadb.initd
 a352661d19becae717c16ac67a0e47ed93787653851a75d27e7764133b31dc02e18c38dbbce6d3138e4db08da616dfc75a0141865cd042cef669d6afe4463127  ppc-remove-glibc-dep.patch"


### PR DESCRIPTION
https://mariadb.com/kb/en/library/mariadb-10139-release-notes/