### PR TITLE
community/py-msgpack: use C extension and modernize

### DIFF
--- a/community/py-msgpack/APKBUILD
+++ b/community/py-msgpack/APKBUILD
@@ -3,30 +3,36 @@
 pkgname=py-msgpack
 _pkgname=msgpack-python
 pkgver=0.6.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A Python module for MessagePack serialization/deserialization"
 url="https://msgpack.org/"
 arch="all"
 license="Apache-2.0"
 # Dependency (pluggy) to run test is not available
-options="!check"
 depends=""
-makedepends="python2-dev python3-dev py-setuptools pytest py3-pytest"
+makedepends="python2-dev python3-dev py-setuptools py3-setuptools py-cython py3-cython"
+checkdepends="pytest py3-pytest"
 subpackages="py3-${pkgname/py-/}:_py3 py2-${pkgname/py-/}:_py2"
 source="$_pkgname-$pkgver.tar.gz::https://github.com/msgpack/msgpack-python/archive/v$pkgver.tar.gz"
 builddir="$srcdir/msgpack-python-$pkgver"
 
 build() {
-	cd "$builddir"
 	python2 setup.py build
 	python3 setup.py build
 }
 
-check() {                                                                                                                                      
-        cd "$builddir"                                                                                                                         
-        pytest test
-	pytest-3 test
-} 
+check() {
+	local _pyarch
+
+	case "$CARCH" in
+		x86_64|aarch64) _pyarch="$CARCH" ;;
+		x86) _pyarch=i686 ;;
+		armhf|armv7) _pyarch=armv8l ;;
+	esac
+
+	env PYTHONPATH="${PWD}/build/lib.linux-$_pyarch-2.7" pytest test
+	env PYTHONPATH="${PWD}/build/lib.linux-$_pyarch-3.7" pytest-3 test
+}
 
 package() {
 	mkdir -p "$pkgdir"


### PR DESCRIPTION
- Use C extension with Cython
- Fix check
- separate makedepends and checkdepends