### PR TITLE
testing/i3status: add maintainer to i3status and set !check

### DIFF
--- a/testing/i3status/APKBUILD
+++ b/testing/i3status/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Brian Cole <git@brianecole.com>
 pkgname=i3status
 pkgver=2.12
-pkgrel=0
+pkgrel=1
 pkgdesc="Generates status bar for dzen2, xmobar or similar"
 url="https://i3.zekjur.net/i3status"
 arch="all"

--- a/testing/i3status/APKBUILD
+++ b/testing/i3status/APKBUILD
@@ -1,5 +1,5 @@
 # Contributor: k0r10n <k0r10n.dev@gmail.com>
-# Maintainer:
+# Maintainer: Brian Cole <git@brianecole.com>
 pkgname=i3status
 pkgver=2.12
 pkgrel=0
@@ -7,6 +7,7 @@ pkgdesc="Generates status bar for dzen2, xmobar or similar"
 url="https://i3.zekjur.net/i3status"
 arch="all"
 license="BSD-3-Clause"
+options="!check" # No test suite
 makedepends="alsa-lib-dev asciidoc confuse-dev libnl3-dev linux-headers yajl-dev"
 subpackages="$pkgname-doc"
 source="https://i3wm.org/i3status/$pkgname-$pkgver.tar.bz2


### PR DESCRIPTION
Add myself as maintainer on i3status, and explicitly specify that it has
no test suite (when testing to make sure I could build locally, it
complained, so I confirmed that upstream doesn't ship any tests in the
current stable version).