### PR TITLE
community/flatpak-builder: build docs, enable YAML support

### DIFF
--- a/community/flatpak-builder/APKBUILD
+++ b/community/flatpak-builder/APKBUILD
@@ -2,21 +2,18 @@
 # Maintainer: André Klitzing <aklitzing@gmail.com>
 pkgname=flatpak-builder
 pkgver=1.0.6
-pkgrel=0
+pkgrel=1
 pkgdesc="Tool to build flatpaks from source"
 url="http://flatpak.org"
 arch="all !aarch64"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 makedepends="flatpak-dev glib-dev libsoup-dev json-glib-dev
-             elfutils-dev libdwarf-dev libcap-dev curl-dev"
+		elfutils-dev libdwarf-dev libcap-dev curl-dev
+		yaml-dev libxslt docbook-xsl docbook-xml xmlto"
 subpackages="$pkgname-doc"
 source="https://github.com/flatpak/$pkgname/releases/download/$pkgver/$pkgname-$pkgver.tar.xz
 		musl-fixes.patch"
-builddir="$srcdir/$pkgname-$pkgver"
-
 build() {
-	cd "$builddir"
-
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -26,22 +23,18 @@ build() {
 		--sbindir=/usr/bin \
 		--libexecdir=/usr/lib/$pkgname \
 		--disable-static \
-		--disable-documentation \
 		--with-dwarf-header=/usr/include/libdwarf
 
 	make
 }
 
 check() {
-	cd "$builddir"
 	#make -k check
 	./flatpak-builder --version
 }
 
 package() {
-	cd "$builddir"
 	make DESTDIR="$pkgdir" install
-	install -D -m644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 
 sha512sums="b0a832d3220737b8572b2c47f95b61477f01e0d887b2c30e5ef910bfa80ee5c9b2129763805e72552975a23ac7d1fc965d2d84928f3ca63238929e1abcbbc439  flatpak-builder-1.0.6.tar.xz


### PR DESCRIPTION
Most of the new Flatpak templates are written in YAML now, so it makes
sense to enable support for it.