### PR TITLE
main/libcap: upgrade to 2.27

### DIFF
--- a/main/libcap/APKBUILD
+++ b/main/libcap/APKBUILD
@@ -1,29 +1,46 @@
+# Contributor: Leo <thinkabit.ukim@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libcap
-pkgver=2.26
+pkgver=2.27
 pkgrel=0
 pkgdesc="POSIX 1003.1e capabilities"
+options="checkroot"
 arch="all"
-license="GPL"
+license="BSD-3-Clause OR GPL-2.0-only"
 url="http://www.friedhoff.org/posixfilecaps.html"
-options="!check"
-depends=
 depends_dev="linux-headers"
 makedepends_build="linux-headers perl"
 makedepends_host="$depends_dev attr-dev"
 makedepends="$makedepends_build $makedepends_host"
+checkdepends="bash"
 source="https://kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-$pkgver.tar.xz"
-subpackages="$pkgname-doc $pkgname-dev"
+subpackages="$pkgname-doc $pkgname-static $pkgname-dev"
+builddir="$srcdir"/$pkgname-$pkgver
 
-_builddir="$srcdir"/$pkgname-$pkgver
-build ()
-{
-	cd "$_builddir"
+build() {
+	cd "$builddir"
 	make BUILD_CC=gcc CC="${CC:-gcc}" lib=lib prefix=/usr DESTDIR="$pkgdir"
 }
 
-package() {
-	cd "$_builddir"
-	make lib=/lib prefix=/usr RAISE_SETFCAP=no DESTDIR="$pkgdir" install
+check() {
+	cd "$builddir"
+	# Running make test runs the command below but with sudo
+	cd progs && ./quicktest.sh
 }
-sha512sums="1c2d59f007226405a924950b2c2090393527e06f0692a84e6463e33915a070df61a9070b8f30a624d5630ddd39290eac117e5d440577d1edd48510195b9d12f0  libcap-2.26.tar.xz"
+
+package() {
+	cd "$builddir"
+	make lib=lib prefix=/usr RAISE_SETFCAP=no DESTDIR="$pkgdir" install
+	# Fix perms
+	chmod -v 0755 "$pkgdir"/usr/lib/libcap.so.${pkgver}
+}
+
+static() {
+	depends=""
+	pkgdesc="$pkgdesc (static library)"
+
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib
+}
+
+sha512sums="e32335fd3e0d1564574acc73df7030b5b0fd98875217bffabd76f2765f1a7a6f1369f03df2ee22a1782776838784e342378c10613ea1163d53ae5055ab6a62b6  libcap-2.27.tar.xz"


### PR DESCRIPTION
- Fix license
- Enable check
- Fix permissions on the library
- Split -static package

@ncopa