### PR TITLE
community/drupal7: security upgrade to 7.66 (CVE-2019-11358)

### DIFF
--- a/community/drupal7/APKBUILD
+++ b/community/drupal7/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
 pkgname=drupal7
-pkgver=7.65
+pkgver=7.66
 pkgrel=0
 pkgdesc="An open source content management platform"
 url="https://www.drupal.org/"
@@ -36,6 +36,8 @@ builddir="$srcdir/drupal-$pkgver"
 options="!check" # This package not have testsuite
 
 # secfixes:
+#   7.66-r0:
+#     - CVE-2018-11358
 #   7.62-r0:
 #     - CVE-2018-1000888
 #   7.59-r0:
@@ -78,4 +80,4 @@ package() {
 		"$pkgdir"/var/lib/$pkgname/sites/default/files
 }
 
-sha512sums="a79ff93e13456b35160ee17f986dce9cffefa265d0034dab6223a3097eaf45c11ea3548904ff6c125be0817dc71a8ac7320aca91a11eefeaad03d45527725e79  drupal-7.65.tar.gz"
+sha512sums="c348eeeabfb5fef05b28aa87c9885231bd5e676b1ced64a2f51cc2aefa122b5ce142aae2ede5c1479608c893195450ae25168bae971b8e77cc741b18650f75c8  drupal-7.66.tar.gz"


### PR DESCRIPTION
Ref https://www.drupal.org/sa-core-2019-006