### PR TITLE
main/vte3: fix bld break by adding dummy struct member

### DIFF
--- a/main/vte3/APKBUILD
+++ b/main/vte3/APKBUILD
@@ -13,6 +13,7 @@ makedepends="pango-dev gtk+3.0-dev intltool python2-dev
 	autoconf automake libtool"
 source="https://download.gnome.org/sources/vte/${pkgver%.*}/vte-$pkgver.tar.xz
 	allow_alt_in_terminal.patch
+	fix-empty-options-struct.patch
 	werror.patch"
 builddir="$srcdir/vte-$pkgver"
 
@@ -49,4 +50,5 @@ package() {
 
 sha512sums="fc760973efa1eb1f100447cdf0d9b944b74f5ba7e3ae1ae1d0acadaebd540fff19f7edc741685ba944147c151223942a80f8f3dad3602469f1aff5c44f6cc846  vte-0.52.2.tar.xz
 a4786a97a5caa42db3b29808c3542777684fcf7d931a116d4e3d847e859a64fb59a2d5b60927dc8e5c2733efc55c29aa4d30aeb02597aff5f034c172cc528833  allow_alt_in_terminal.patch
+61dcd0ee6202bba6140cecc191f328f65ccdb3ce396680a276f0a10c68f433eddfd911e390e3d3dd6089e287c4cca873b6690d1dfaab03fb3c78dbf6658e18c3  fix-empty-options-struct.patch
 ff199ede8e415d141d897e9c922db84d33c2c28d07958a5ec44b3688809809885f45275cc1aeed56fa2d8de46e9cc2527f5e9682a8ea28af7e39b275340c85c4  werror.patch"

--- a/main/vte3/fix-empty-options-struct.patch
+++ b/main/vte3/fix-empty-options-struct.patch
@@ -1,0 +1,11 @@
+--- a/bindings/vala/app.vala
++++ b/bindings/vala/app.vala
+@@ -819,6 +819,8 @@
+ 
+   public struct Options
+   {
++    //FIXME Merge this struct into App class
++    public int dummy;
+     public static bool audible = false;
+     public static string? command = null;
+     private static string? cjk_ambiguous_width_string = null;


### PR DESCRIPTION
As described in https://stackoverflow.com/questions/55175072/vala-code-with-static-struct-dont-works-after-update-to-0-44 vala doesn't allow empty struct class members. Since static struct variables are not considered instance members nothing is left in the Options struct causing the compile error:
```
./app.vala:820.3-820.23: error: struct `Test.App.Options' cannot be empty
  public struct Options
  ^^^^^^^^^^^^^^^^^^^^^
```

The vte project added commit https://github.com/GNOME/vte/commit/53690d5cee51bdb7c3f7680d3c22b316b1086f2c#diff-09af37e3a14d365cf086df3ead32aa7f to work around this issue.

This patch pulls this commit to allow this version of vte to compile properly with vala version 0.44.3