### PR TITLE
testing/zerofree: new aport

### DIFF
--- a/testing/zerofree/APKBUILD
+++ b/testing/zerofree/APKBUILD
@@ -1,0 +1,24 @@
+# Contributor: Oleg Titov <oleg.titov@gmail.com>
+# Maintainer: Oleg Titov <oleg.titov@gmail.com>
+pkgname=zerofree
+pkgver=1.1.1
+pkgrel=0
+pkgdesc="Zero free blocks from ext2, ext3 and ext4 file-systems"
+url="https://frippery.org/uml/"
+arch="all"
+license="GPL-2.0-only"
+options="!check" # No test suite from upstream
+makedepends="e2fsprogs-dev"
+source="https://frippery.org/uml/zerofree-${pkgver}.tgz
+	types.patch"
+
+build() {
+	make
+}
+
+package() {
+	install -Dm 755 -t "$pkgdir/usr/bin/" zerofree
+}
+
+sha512sums="2d7ee57a877bff2491c48054338a26d624ae75c238ac2b0568a75de88b6621c16cc1e7d65500879825d14d8ba44a5173587a061459072769c165bee47c3f9f1c  zerofree-1.1.1.tgz
+0cf3833271195c2f1da591af625928d8207d6bb39702cdc9f8ade0e7e773096e4f55860438863f06639f205283c0cccbaaf8b4d9ee98e3850a5075e38d06a187  types.patch"

--- a/testing/zerofree/types.patch
+++ b/testing/zerofree/types.patch
@@ -1,0 +1,10 @@
+--- zerofree-1.1.1/zerofree.c.orig	2019-05-05 19:22:49.000000000 -0500
++++ zerofree-1.1.1/zerofree.c	2019-05-05 19:21:50.000000000 -0500
+@@ -17,6 +17,7 @@
+  *             Jan Krämer.
+  */
+ 
++#include <sys/types.h>
+ #include <ext2fs/ext2fs.h>
+ #include <stdio.h>
+ #include <unistd.h>


### PR DESCRIPTION
https://frippery.org/uml/
Zero free blocks from ext2, ext3 and ext4 file-systems

Closes https://bugs.alpinelinux.org/issues/10403