### PR TITLE
[3.9] community/flatpak: upgrade to 1.0.8, fixes CVE-2019-10063

### DIFF
--- a/community/flatpak/APKBUILD
+++ b/community/flatpak/APKBUILD
@@ -23,6 +23,8 @@ builddir="$srcdir/$pkgname-$pkgver"
 #     - CVE-2019-10063
 #   1.0.7-r0:
 #     - CVE-2019-5736
+#   1.0.8-r0:
+#     - CVE-2019-10063
 
 build() {
 	cd "$builddir"


### PR DESCRIPTION
Related to #7545