### PR TITLE
community/networkmanager: fix and re-enable ppc64le build by forcing header generation order

### DIFF
--- a/community/networkmanager/APKBUILD
+++ b/community/networkmanager/APKBUILD
@@ -5,7 +5,7 @@ pkgver=1.18.1
 pkgrel=1
 pkgdesc="Network Management daemon"
 url="https://wiki.gnome.org/Projects/NetworkManager"
-arch="all !s390x !armhf !armv7 !ppc64le" # Missing polkit, build errors on ppc64le
+arch="all !s390x !armhf !armv7" # Missing polkit
 license="GPL-2.0-or-later"
 depends="dhcpcd iptables dbus"
 install="$pkgname.pre-install $pkgname.pre-upgrade"
@@ -78,6 +78,7 @@ build() {
 		-Dsession_tracking=no \
 		-Dqt=false \
 		. output
+	ninja -C output introspection/libnmdbus.a
 	ninja -C output
 }
 


### PR DESCRIPTION
ppc64le builds intermittently fail with errors like:
```
../libnm/nm-remote-connection.c:34:10: fatal error: introspection/org.freedesktop.NetworkManager.Settings.Connection.h: No such file or directory
 #include "introspection/org.freedesktop.NetworkManager.Settings.Connection.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This is because there is a race to generate required header files before using them. Changes to APKBUILD build() invocations of ninja will force all headers to be generated before use. With this fix ppc64le can be re-enabled again.