### PR TITLE
community/runc: upgrade to 1.0.0_rc8

### DIFF
--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -34,11 +34,6 @@ build() {
 	make man
 }
 
-check() {
-	cd "$builddir"
-	./runc --version
-}
-
 package() {
 	cd "$builddir"
 	install -Dsm755 "$builddir"/runc "$pkgdir"/usr/bin/runc

--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -5,13 +5,13 @@ pkgname=runc
 pkgdesc="CLI tool for spawning and running containers according to the OCI specification"
 url="https://www.opencontainers.org"
 
-_commit=029124da7af7360afa781a0234d1b083550f797c
-pkgver=1.0.0_rc7
-pkgrel=1
+_commit=425e105d5a03fabd737a126ad93d62a9eeede87f
+pkgver=1.0.0_rc8
+pkgrel=0
 
-#_ver=v${pkgver/_rc/-rc}
+_ver=v${pkgver/_rc/-rc}
 # if we're building against an explicit commit beyond pkgver, use this instead:
-_ver=${_commit}
+#_ver=${_commit}
 
 arch="all"
 license="Apache-2.0"
@@ -46,4 +46,4 @@ package() {
 	install -Dm644 "$builddir"/man/man8/* "$pkgdir"/usr/share/man/man8/
 }
 
-sha512sums="54eccc1ece8f58e90655538938c64289bc4a6180d3abd074d9f5f48f0dd1e2c0139e603e26235ec3efc104f98efbc987207db42490d29a523c52f3526a01e163  runc-029124da7af7360afa781a0234d1b083550f797c.tar.gz"
+sha512sums="4bf464acc87b6d687010f0c070d96e171d91e46c45b84b5570c6f607e7d06777d2d83b2ead87ac4aa761e34afc68a3d9be9ab25107d499e8f41cb68647e23541  runc-v1.0.0-rc8.tar.gz"


### PR DESCRIPTION
Fixes regression in 1.0.0_rc7, see https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc8