### PR TITLE
community/libdwarf: upgrade to 20190505

### DIFF
--- a/community/libdwarf/APKBUILD
+++ b/community/libdwarf/APKBUILD
@@ -1,20 +1,18 @@
 # Contributor: David Huffman <storedbox@outlook.com>
-# Maintainer: David Huffman <storedbox@outlook.com>
+# Maintainer: Leo <thinkabit.ukim@gmail.com>
 pkgname=libdwarf
-pkgver=20180527
+pkgver=20190505
 pkgrel=0
 pkgdesc="Parsing library for DWARF2 and later debugging file format"
 url="http://www.prevanders.net/dwarf.html"
 arch="all"
-license="LGPL-2.0-or-later"
+license="LGPL-2.1-or-later"
 makedepends="elfutils-dev"
-subpackages="$pkgname-dev dwarf-tools dwarf-tools-doc"
+subpackages="$pkgname-static $pkgname-dev dwarf-tools::noarch dwarf-tools-doc"
 source="http://www.prevanders.net/$pkgname-$pkgver.tar.gz"
 options="!check"
-builddir="$srcdir/dwarf-$pkgver"
 
 build() {
-	cd "$builddir"
 	./configure --prefix=/usr --enable-shared
 	make && make -C dwarfgen
 }
@@ -29,6 +27,7 @@ package() {
 
 	cd "$builddir/libdwarf"
 	cp dwarf.h libdwarf.h "$incdir"
+	cd "$builddir/libdwarf/.libs"
 	cp libdwarf.a libdwarf.so libdwarf.so.1 "$libdir"
 
 	cd "$builddir/dwarfdump"
@@ -45,7 +44,7 @@ package() {
 }
 
 tools() {
-	license="GPL2 BSD"
+	license="GPL-2.0-only AND BSD-3-Clause"
 	pkgdesc="Tools for interacting with DWARF2 and later debugging files"
 
 	local bin="usr/bin"
@@ -56,4 +55,11 @@ tools() {
 	mv "$pkgdir/$lib/dwarfdump.conf" "$subpkgdir/$lib"
 }
 
-sha512sums="f8f285373d03498e0bcf607d61cc0fb17b555ca48bbeda7c133a9c620e34b727973aceecfa5402b53189211e3a0f15dbe49951c2cf3e63e43775fbc8e9fbfa5d  libdwarf-20180527.tar.gz"
+static() {
+	depends=""
+	pkgdesc="$pkgdesc (static library)"
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib
+}
+
+sha512sums="0bd22bc62c72819198917a7fd25859052913e38bd2b09a73ccaa8e57c9ed072b8f14763c5b34b6dcb91e9f904535ced1122cfd9d5e036d07508c478b30522726  libdwarf-20190505.tar.gz"


### PR DESCRIPTION
- Fix license
- Fix subpkg license
- Split $pkgname-static
- Make dwarf-tools noarch
- Use modern style