### PR TITLE
community/docker: upgrade to 18.09.6, separate engine & cli

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -160,7 +160,7 @@ cli_doc() {
 	depends=""
 	install_if="docs $pkgname-cli=$pkgver-r$pkgrel"
 
-	mkdir -p "$subpkgdir"/usr/share/man/man1 || return 1
+	mkdir -p "$subpkgdir"/usr/share/man/man1
 	gzip -9 "$_cli_builddir"/man/man1/*
 	install -Dm644 "$_cli_builddir"/man/man1/* \
 		"$subpkgdir"/usr/share/man/man1

--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -116,13 +116,6 @@ build() {
 	./man/md2man-all.sh -q
 }
 
-check() {
-	cd "$_cli_builddir"/build
-        ./docker --version
-	cd "$_daemon_builddir"/bundles/dynbinary-daemon
-	./dockerd --version
-}
-
 # docker itself is a meta package
 package() {
 	mkdir -p "$pkgdir"

--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -2,29 +2,31 @@
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 
 pkgname=docker
-pkgver=18.09.5
-_gitcommit=e8ff056dbcfadaeca12a5f508b0cec281126c01d	# https://github.com/docker/docker-ce/commits/v$pkgver
+pkgver=18.09.6
+_gitcommit=481bc7715621adba10752357e0d537c8dc86507d	# https://github.com/docker/docker-ce/commits/v$pkgver
 _ver=${pkgver/_/-}-ce
-pkgrel=1
+pkgrel=0
 pkgdesc="Pack, ship and run any application as a lightweight container"
 url="http://www.docker.io/"
 arch="all"
 license="Apache-2.0"
-depends="ca-certificates containerd iptables tini-static"
+depends="docker-engine docker-cli"
 makedepends="go go-md2man btrfs-progs-dev bash linux-headers coreutils lvm2-dev libtool"
 install="$pkgname.pre-install"
 
 # from https://github.com/docker/docker-ce/blob/v$pkgver/components/engine/vendor.conf
-_libnetwork_ver=c9029898e32f7c89bbb81511fbb721df252ce61a
+_libnetwork_ver=872f0a83c98add6cae255c8859e29532febc0039
 _cobra_ver="0.0.3"
 
 subpackages="
-	$pkgname-bash-completion:bashcomp:noarch
-	$pkgname-fish-completion:fishcomp:noarch
-	$pkgname-zsh-completion:zshcomp:noarch
-	$pkgname-vim:vim:noarch
-	$pkgname-doc
-	$pkgname-openrc
+	$pkgname-engine:engine
+	$pkgname-openrc:engine_openrc:noarch
+	$pkgname-cli:cli
+	$pkgname-doc:cli_doc:noarch
+	$pkgname-bash-completion:cli_bashcomp:noarch
+	$pkgname-fish-completion:cli_fishcomp:noarch
+	$pkgname-zsh-completion:cli_zshcomp:noarch
+	$pkgname-vim:cli_vim:noarch
 	"
 
 source="
@@ -121,64 +123,87 @@ check() {
 	./dockerd --version
 }
 
+# docker itself is a meta package
 package() {
-	cd "$_dockerdir"
-	local ver=$(cat VERSION)
+	mkdir -p "$pkgdir"
+}
+
+engine() {
+	pkgdesc="Docker Engine (dockerd)"
+	depends="ca-certificates containerd iptables tini-static"
+
+	install -Dm755 "$_daemon_builddir"/bundles/dynbinary-daemon/dockerd \
+		"$subpkgdir"/usr/bin/dockerd
+
+	install -Dm755 "$_libnetwork_builddir"/docker-proxy \
+		"$subpkgdir"/usr/bin/docker-proxy
+
+	# symlink externally provided tini-static binary
+	ln -s /sbin/tini-static "$subpkgdir"/usr/bin/docker-init
+}
+
+engine_openrc() {
+	pkgdesc="OpenRC init scripts for Docker"
+	depends=""
+	install_if="openrc $pkgname-engine=$pkgver-r$pkgrel"
+
+	install -Dm755 "$_daemon_builddir"/contrib/init/openrc/docker.initd \
+		"$subpkgdir"/etc/init.d/docker
+	install -Dm644 "$_daemon_builddir"/contrib/init/openrc/docker.confd \
+		"$subpkgdir"/etc/conf.d/docker
+}
+
+cli() {
+	pkgdesc="Docker CLI"
+	depends="ca-certificates"
 
 	# 'build/docker' is a symlink to 'docker-linux-$arch' e.g. 'docker-linux-amd64'
 	install -Dm755 "$_cli_builddir"/build/docker \
-		"$pkgdir"/usr/bin/docker
-
-	install -Dm755 "$_daemon_builddir"/bundles/dynbinary-daemon/dockerd \
-		"$pkgdir"/usr/bin/dockerd
-
-	install -Dm755 "$_libnetwork_builddir"/docker-proxy \
-		"$pkgdir"/usr/bin/docker-proxy
-
-	# symlink externally provided tini-static binary
-	ln -s /sbin/tini-static "$pkgdir"/usr/bin/docker-init
-
-	install -Dm755 "$_daemon_builddir"/contrib/init/openrc/docker.initd \
-		"$pkgdir"/etc/init.d/docker
-	install -Dm644 "$_daemon_builddir"/contrib/init/openrc/docker.confd \
-		"$pkgdir"/etc/conf.d/docker
-
-	mkdir -p "$pkgdir"/usr/share/man/man1
-	install -Dm644 "$_cli_builddir"/man/man1/* \
-		"$pkgdir"/usr/share/man/man1
+		"$subpkgdir"/usr/bin/docker
 }
 
-bashcomp() {
+cli_doc() {
+	pkgdesc="Documentation for Docker"
+	depends=""
+	install_if="docs $pkgname-cli=$pkgver-r$pkgrel"
+
+	mkdir -p "$subpkgdir"/usr/share/man/man1 || return 1
+	gzip -9 "$_cli_builddir"/man/man1/*
+	install -Dm644 "$_cli_builddir"/man/man1/* \
+		"$subpkgdir"/usr/share/man/man1
+}
+
+cli_bashcomp() {
 	pkgdesc="Bash completion for Docker"
 	depends=""
-	install_if="$pkgname=$pkgver-r$pkgrel bash-completion"
+	install_if="bash-completion $pkgname-cli=$pkgver-r$pkgrel"
 
 	install -Dm644 "$_cli_builddir"/contrib/completion/bash/$pkgname \
 		"$subpkgdir"/usr/share/bash-completion/completions/$pkgname
 }
 
-fishcomp() {
+cli_fishcomp() {
 	pkgdesc="Fish shell completion for Docker"
 	depends=""
-	install_if="$pkgname=$pkgver-r$pkgrel fish<3" # fish above version 3 has docker completion
+	install_if="fish<3 $pkgname-cli=$pkgver-r$pkgrel" # fish above version 3 has docker completion
 
 	install -Dm644 "$_cli_builddir"/contrib/completion/fish/$pkgname.fish \
 		"$subpkgdir"/usr/share/fish/completions/$pkgname.fish
 }
 
-zshcomp() {
-	pkgdesc="Zsh completion for $pkgname"
+cli_zshcomp() {
+	pkgdesc="Zsh completion for Docker"
 	depends=""
-	install_if="$pkgname=$pkgver-r$pkgrel zsh"
+	install_if="zsh $pkgname-cli=$pkgver-r$pkgrel"
 
 	install -Dm644 "$_cli_builddir"/contrib/completion/zsh/_$pkgname \
 		"$subpkgdir"/usr/share/zsh/site-functions/_$pkgname
 }
 
-vim() {
+cli_vim() {
+	pkgdesc="Vim syntax for Docker"
 	depends=""
-	pkgdesc="Vim syntax for $pkgname"
-	install_if="vim $pkgname=$pkgver-r$pkgrel"
+	install_if="vim $pkgname-cli=$pkgver-r$pkgrel"
 
 	local f=
 	for f in ftdetect/dockerfile.vim syntax/dockerfile.vim; do
@@ -187,8 +212,8 @@ vim() {
 	done
 }
 
-sha512sums="a6012d202761d6449e347b03759d92f5f45309e72562fd4a619b2a21c62b3f50b1256d2e4820317aa6b412f1eecda66dbd960d322293699433417a5f7ee73486  docker-18.09.5.tar.gz
-a24061cd29c3c9852a435f742e6653da48edd419205be18a37d065b50c2fbf005bfe62a1f909b91781f521b70cb3a9639a4a67e8563e2e39e6dd22f1c7bf82b2  libnetwork-c9029898e32f7c89bbb81511fbb721df252ce61a.tar.gz
+sha512sums="f05fc78f5891fa0308878690576e245eebb1e72f306f5b629b0e82dc96a04812202a2393ee6fd352bc59a1c5d29d398f0d6cddf545d57b483a051d14d7a0ee28  docker-18.09.6.tar.gz
+c8e8544a3d8d44dc0f309aa3520a2cf62cee374a06d40473542078de94d88cb484c0dca1cee7ad89fb312c969af1694c848f464d04d61df5a9888058e21a485e  libnetwork-872f0a83c98add6cae255c8859e29532febc0039.tar.gz
 c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 33155a79799cc6c0520a030e1a9bdba60441776d612e5e255574b23bbce1c7a8e5d868284b05a8a92704be6bbb7db905388564e867986a705acbe4884ac58584  docker-openrc-fixes.patch
 9b24dc0c50904c3d12bb04c1a7df169651043ddbc258018647010a5aa01d8a19ad54d10ca79dce6d6283c81f4fa0cc8de417f6180dd824c5a588b22b23546cb5  docker-openrc-busybox-ash.patch"


### PR DESCRIPTION
Separates Docker's standalone engine and CLI components into separate packages, `docker-engine` and `docker-cli`; the  container now exists as a 'meta' package, pulling in both the engine and cli packages, to maintain backward compatibility.

See https://github.com/docker/docker-ce/releases/tag/v18.09.6 for more information about what's new in 18.09.6.