### PR TITLE
testing/py3-catkin-pkg-modules: new aport

### DIFF
--- a/testing/py3-catkin-pkg-modules/APKBUILD
+++ b/testing/py3-catkin-pkg-modules/APKBUILD
@@ -1,0 +1,26 @@
+# Contributor: Russ Webber <russ@rw.id.au>
+# Maintainer: Russ Webber <russ@rw.id.au>
+pkgname=py3-catkin-pkg-modules
+_pkgname=catkin_pkg_modules
+pkgver=0.4.12
+pkgrel=0
+pkgdesc="Standalone Python library for the catkin build system."
+url="http://wiki.ros.org/catkin_pkg"
+arch="noarch"
+license="BSD-3-Clause"
+options="!check" # python deps not packaged: flake8-blind-except flake8-builtins
+		 # flake8-class-newline flake8-comprehensions flake8-deprecated
+		 # flake8-docstrings flake8-import-order flake8-quotes
+depends="py3-docutils py3-dateutil py3-parsing"
+makedepends="python3"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+build() {
+	python3 setup.py build
+}
+
+package() {
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+sha512sums="ce04475b9d974cf08e1bd9f1cce9e476975d6d8162d00d856c3fa0e3155b95b1a5d68f1992d5be2ccd8cb7b9c5eba7a62b85062537e30368708ee4f2c8d7fe5f  catkin_pkg_modules-0.4.12.tar.gz"


### PR DESCRIPTION
http://wiki.ros.org/catkin_pkg
Standalone Python library for the catkin build system.