### PR TITLE
testing/libtickit: upgrade to 0.3.2

### DIFF
--- a/testing/libtickit/APKBUILD
+++ b/testing/libtickit/APKBUILD
@@ -1,39 +1,40 @@
 # Contributor: Roberto Oliveira <robertoguimaraes8@gmail.com>
 # Maintainer: Roberto Oliveira <robertoguimaraes8@gmail.com>
 pkgname=libtickit
-pkgver=0.2
+pkgver=0.3.2
 pkgrel=0
 pkgdesc="A library that provides an abstracted mechanism for building interactive full-screen terminal programs"
 url="http://www.leonerd.org.uk/code/libtickit/"
 arch="all"
 license="MIT"
-depends=""
 makedepends="libtermkey-dev"
 checkdepends="perl-test-harness-utils"
-# See https://bugs.launchpad.net/libtickit/+bug/1756523
-options="!check" #FIXME: some tests are failing
-subpackages="$pkgname-dev $pkgname-doc"
+# options="!check" #FIXME: some tests are failing
+subpackages="$pkgname-static $pkgname-dev $pkgname-doc"
 source="http://www.leonerd.org.uk/code/$pkgname/$pkgname-$pkgver.tar.gz"
-builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
 	default_prepare
-	cd "$builddir"
 	sed -i -e "s/PREFIX=\/usr\/local/PREFIX=\/usr/g" Makefile
 }
+
 build() {
-	cd "$builddir"
 	make PREFIX=/usr
 }
 
 check() {
-	cd "$builddir"
-	make test
+	TERM=linux make test
 }
 
 package() {
-	cd "$builddir"
 	make install DESTDIR="$pkgdir"
 }
 
-sha512sums="5ba8581dfc17d0f56fc9e543aa452980ce864a5079a34d60db3a15b49c82c894ce082598865aeaa28c32c32549c40582fb40d1209ea893c8c6993604cae9437b  libtickit-0.2.tar.gz"
+static() {
+	depends=""
+	pkgdesc="$pkgdesc (static library)"
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib
+}
+
+sha512sums="94d1da49783a4215617d129f07e2729282fabebf9555a70f565c59b26bf5ca5a1e0e7643ead3e25398238af2818edfe9bd56d41986ddf93b087ea1eeaea503a9  libtickit-0.3.2.tar.gz"


### PR DESCRIPTION
- Use modern style
- Enable check again
- Split $pkganme-static