### PR TITLE
testing/frei0r-plugins: upgrade to 1.6.1

### DIFF
--- a/testing/frei0r-plugins/APKBUILD
+++ b/testing/frei0r-plugins/APKBUILD
@@ -1,29 +1,18 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer:
 pkgname=frei0r-plugins
-pkgver=1.5.0
-pkgrel=2
+pkgver=1.6.1
+pkgrel=0
 pkgdesc="A minimalistic plugin API for video sources and filters"
-url="http://www.piksel.org/frei0r"
+url="https://frei0r.dyne.org/"
 arch="all"
 options="!check"  # No test suite.
-license="GPL-2.0+"
-depends=""
-makedepends="opencv-dev gavl-dev file cairo-dev doxygen
-	automake autoconf libtool"
-install=""
+license="GPL-2.0-or-later"
+makedepends="gavl-dev file cairo-dev doxygen"
 subpackages="$pkgname-dev $pkgname-doc"
 source="https://files.dyne.org/frei0r/releases/frei0r-plugins-$pkgver.tar.gz"
 
-prepare() {
-	default_prepare
-	cd "$builddir"
-	touch README AUTHORS ChangeLog TODO
-	autoreconf -i
-}
-
 build() {
-	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -32,8 +21,7 @@ build() {
 }
 
 package() {
-	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="9be0384421ff5ac9000dcda9acefb5cb2b6dc05ea72d9771fae990cb5fad4424dcef8dd15c1e5031a89169f914af8c7a30e47934ad007a3bc0150f3c005bc6bf  frei0r-plugins-1.5.0.tar.gz"
+sha512sums="843790389e6de83817d1c3744a91d3365864bb0c22cf6598707ccba5ec8933f6209434011cde1303e16edd89f6cde2f22aa1fb6eca3548d892a2c77332c44aac  frei0r-plugins-1.6.1.tar.gz"


### PR DESCRIPTION
- Stop using opencv since it is unmaintained
- Fix license
- Use modern style