### PR TITLE
community/attica: fix url and drop obsolete dependency on automoc4

### DIFF
--- a/community/attica/APKBUILD
+++ b/community/attica/APKBUILD
@@ -1,16 +1,15 @@
-# Contributor: 
+# Contributor: Leo <thinkabit.ukim@gmail.com>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=attica
 pkgver=5.57.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Freedesktop OCS binding for Qt"
-url="http://www.kde.org/"
+url="https://api.kde.org/frameworks/attica/html/index.html"
 arch="all"
 license="LGPL-2.0-or-later"
-makedepends="qt5-qttools-dev extra-cmake-modules cmake automoc4"
+makedepends="qt5-qttools-dev extra-cmake-modules cmake"
 subpackages="$pkgname-dev"
 source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
-builddir="$srcdir"/$pkgname-$pkgver
 
 prepare() {
 	default_prepare
@@ -19,12 +18,11 @@ prepare() {
 
 build() {
 	cd "$builddir"/build
-	cmake \
+	cmake .. \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DCMAKE_BUILD_TYPE=Release \
-		-Wno-dev \
-	"$builddir"
+		-Wno-dev
 	make
 }
 


### PR DESCRIPTION
@fcolista

Part of my work on removing Qt4