### PR TITLE
community/libetonyek: fix bld break configure error by adding with-mdds flag

### DIFF
--- a/community/libetonyek/APKBUILD
+++ b/community/libetonyek/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=libetonyek
 pkgver=0.1.9
-pkgrel=0
+pkgrel=1
 pkgdesc="Import filter and tools for Apple Keynote presentations"
 url="https://wiki.documentfoundation.org/DLP/Libraries/libetonyek"
 arch="all"
@@ -25,6 +25,7 @@ build() {
 		--infodir=/usr/share/info \
 		--localstatedir=/var \
 		--disable-werror \
+		--with-mdds=1.4 \
 		--disable-static
 	make
 }


### PR DESCRIPTION
Build fails with error:
```
configure: error: Package requirements (mdds-1.2) were not met:
Package 'mdds-1.2', required by 'virtual:world', not found
```
the mdds-dev package is installed as a dependancy. Adding the with-mdds=1.4 flag to .configure in APKBUILD will fix the error