### PR TITLE
community/drupal7: security upgrade to 7.67

### DIFF
--- a/community/drupal7/APKBUILD
+++ b/community/drupal7/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
 pkgname=drupal7
-pkgver=7.66
+pkgver=7.67
 pkgrel=0
 pkgdesc="An open source content management platform"
 url="https://www.drupal.org/"
@@ -38,6 +38,8 @@ options="!check" # This package not have testsuite
 # secfixes:
 #   7.66-r0:
 #     - CVE-2018-11358
+#   7.65-r0:
+#     - CVE-2019-6341
 #   7.62-r0:
 #     - CVE-2018-1000888
 #   7.59-r0:
@@ -80,4 +82,4 @@ package() {
 		"$pkgdir"/var/lib/$pkgname/sites/default/files
 }
 
-sha512sums="c348eeeabfb5fef05b28aa87c9885231bd5e676b1ced64a2f51cc2aefa122b5ce142aae2ede5c1479608c893195450ae25168bae971b8e77cc741b18650f75c8  drupal-7.66.tar.gz"
+sha512sums="0e4f60010b1395183cea19424e8c2849f93fb7285a081bf7d0c774b8e82f403083533059f58c3831950cc06dfa8117d443db52b66a521301ceac10b1b333aa28  drupal-7.67.tar.gz"


### PR DESCRIPTION
No CVE yet, added published one for 7.65
Ref https://www.drupal.org/sa-core-2019-007