### PR TITLE
[3.9] main/nginx add http-geoip2 module

### DIFF
--- a/main/nginx/APKBUILD
+++ b/main/nginx/APKBUILD
@@ -15,7 +15,7 @@ pkgname=nginx
 # NOTE: Upgrade only to even-numbered versions (e.g. 1.14.z, 1.16.z)!
 # Odd-numbered versions are mainline (development) versions.
 pkgver=1.14.2
-pkgrel=1
+pkgrel=2
 # Revision of nginx-tests to use for check().
 _tests_hgrev=d6daf03478ad
 _njs_ver=0.2.0
@@ -24,8 +24,8 @@ url="http://www.nginx.org/en"
 arch="all"
 license="BSD-2-Clause"
 depends=""
-makedepends="linux-headers gd-dev geoip-dev libxml2-dev libxslt-dev
-	openssl-dev paxmark pcre-dev perl-dev pkgconf zlib-dev"
+makedepends="linux-headers gd-dev geoip-dev libmaxminddb-dev libxml2-dev
+	libxslt-dev openssl-dev paxmark pcre-dev perl-dev pkgconf zlib-dev"
 checkdepends="gd perl perl-fcgi perl-io-socket-ssl perl-net-ssleay
 	perl-protocol-websocket tzdata uwsgi-python"
 pkgusers="nginx"
@@ -126,6 +126,9 @@ _add_module "rtmp" "v1.2.1" "https://github.com/arut/nginx-rtmp-module"
 _rtmp_provides="$pkgname-rtmp"  # for backward compatibility
 
 _add_module "http-vod" "1.24" "https://github.com/kaltura/nginx-vod-module"
+
+_add_module "http-geoip2" "3.2" "https://github.com/leev/ngx_http_geoip2_module"
+_http_geoip2_so="ngx_http_geoip2_module.so ngx_stream_geoip2_module.so"
 
 prepare() {
 	local file; for file in $source; do
@@ -273,20 +276,22 @@ vim() {
 _module() {
 	local name="${subpkgname#$pkgname-mod-}"
 	name="${name//-/_}"
-	local soname="$(eval "echo \$_${name}_so")";
-	soname="${soname:-"ngx_${name}_module.so"}"
+	local sonames="$(eval "echo \$_${name}_so")";
+	sonames="${sonames:-"ngx_${name}_module.so"}"
 
 	pkgdesc="$pkgdesc (module $name)"
 	depends="$pkgname $(eval "echo \$_${name}_depends")"
 	provides="$(eval "echo \$_${name}_provides")"
 
 	mkdir -p "$subpkgdir"/$_modules_dir
+	mkdir -p "$subpkgdir"/etc/nginx/modules
+
 	cd "$subpkgdir"
 
-	mv "$pkgdir"/$_modules_dir/$soname ./$_modules_dir/$soname
-
-	mkdir -p "$subpkgdir"/etc/nginx/modules
-	echo "load_module \"modules/$soname\";" > ./etc/nginx/modules/$name.conf
+	local soname; for soname in $sonames; do
+		mv "$pkgdir"/$_modules_dir/$soname ./$_modules_dir/$soname
+		echo "load_module \"modules/$soname\";" > ./etc/nginx/modules/$name.conf
+	done
 }
 
 sha512sums="d8362dbd86435657d6b13156bd6ad1b251d2ab10bc11cdda959b142dd6120b087e4b314f0025d9bbcc88529cb4b9407fb4df1cfae5d081b7ea1db51ccfc2dbe7  nginx-1.14.2.tar.gz
@@ -302,7 +307,7 @@ eb183860cd511361346e4079c1fcf470985e1c3b2a034a57f8b2a92ba851fed99256261f9b779770
 c90b81a4e85a8e9beeb5ff591dc91adb25fa4e0b6cb47086b577e5fa36db2368442dd011187675e358781956c364b949bc4d920ca2b534481b21c9987d2a9a3b  echo-nginx-module-0.61.tar.gz
 fe5f6afc29c99f66151c1a06e27b5749b0a16227638583d9c961adc94b2942b981184382f95e70d927f00b09b43f597b963a85a41bde5903b10e42f86bc321f1  ngx-fancyindex-0.4.3.tar.gz
 13165b1b8d4be281b8bd2404fa48d456013d560bace094c81da08a35dc6a4f025a809a3ae3a42be6bbf67abbcbe41e0730aba06f905220f3baeb01e1192a7d37  headers-more-nginx-module-0.33.tar.gz
-7555d3d256f169a4473f9be80e70e5bf53df5289167c9f70ecc943720bc783f92f54adcb69f15cd5fe2174436875f92f0b17d8198e3a86e27c4f0cf1e0536308  lua-nginx-module-0.10.15.tar.gz
+1feea538464275e6e571860592628ad639b2259c8aab7f38575b81c0b355f1ade32a91643267bc9ec16519e3bcf3d132511513dc8c949f74a3bff975c85d8ff7  lua-nginx-module-0.10.15.tar.gz
 72887c4490854b099cb26bb3f840073a36b0d812bde4486f04dc1be182ca74f0d1e3fd709e77c240c2dcf37665f74cf04e188ea9efe8e127c6789b27b487d0cd  lua-upstream-nginx-module-0.07.tar.gz
 e2f23ec82669af4be77cb4d6ee24347fc8438b658a0d16d42d6a8e81b074685f5cd1d2060ccf314e610f9d3aee3720181243133af3e450d2c0d7105a1873f13f  nchan-1.2.3.tar.gz
 1730845ea2e52be8c2f6cfceb2894304c5a07959a96940bb1617ee0e7cf81d22283304f411d9a219ddb71e4d9a66012bba0f6f5574d101aeb3c406f26c5d6a4e  nginx-http-shibboleth-2.0.1.tar.gz
@@ -311,4 +316,5 @@ d6ca250db8de93edbd7875afca35e73cecdaf82132d1a7ee933cf94c6b8afa8e629e9e647a9321f2
 c31c46344d49704389722325a041b9cd170fa290acefe92cfc572c07f711cd3039de78f28df48ca7dcb79b2e4bbe442580aaaf4d92883fd3a14bf41d66dd9d8c  nginx-upload-progress-module-0.9.2.tar.gz
 8adb7453c27748f4e685e3352e9b318b408da818754dc5b6244e908423941a8ba337561104f6e481f2553cbc0e334dcea73b57f8e810a9d6e974bb69ff8859e5  nginx-upstream-fair-0.1.3.tar.gz
 4a0af5e9afa4deb0b53de8de7ddb2cfa6430d372e1ef9e421f01b509548bd134d427345442ac1ce667338cc2a1484dc2ab732e316e878ac7d3537dc527d5f922  nginx-rtmp-module-1.2.1.tar.gz
-daa9b23858937e57f1bcd5f4400b33155ab4e0e455eea01d80eec5285fc85bd10db63d80a1560f1fea51914a4eb4c59cc54110b7e4de208adbf52ea691cfd6d9  nginx-vod-module-1.24.tar.gz"
+daa9b23858937e57f1bcd5f4400b33155ab4e0e455eea01d80eec5285fc85bd10db63d80a1560f1fea51914a4eb4c59cc54110b7e4de208adbf52ea691cfd6d9  nginx-vod-module-1.24.tar.gz
+84b26955234e29dbfbf2431b652fcc453c5e86b95f837296df4f3d6c730e3e0773223dae890eebfc9b5763f46082bde6f38d6505b8bf78133b89e7297016cc5d  ngx_http_geoip2_module-3.2.tar.gz"


### PR DESCRIPTION
Backport of https://github.com/alpinelinux/aports/commit/ff3a47ccfe8ed9d0b87359b176019114b7158807 and https://github.com/alpinelinux/aports/commit/156e80641c20ed961a9232774b5a37b1941eb085

Also fixes the sha512sum of `lua-nginx-module-0.10.15.tar.gz`