### PR TITLE
community/biber: fix sortinihash values to match perl-unicode-collate

### DIFF
--- a/community/biber/APKBUILD
+++ b/community/biber/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=biber
 # This version should be compatible with Biblatex in testing
 pkgver=2.12
-pkgrel=0
+pkgrel=1
 pkgdesc="Backend processor for BibLaTeX"
 url="https://github.com/plk/biber"
 arch="noarch"
@@ -23,7 +23,8 @@ depends="perl perl-module-build perl-config-autoconf
 checkdepends="perl-test-simple"
 makedepends="perl-dev"
 subpackages="$pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/plk/biber/archive/v${pkgver}.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/plk/biber/archive/v${pkgver}.tar.gz
+	fix-sortinithash-unicode-collate.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
@@ -65,4 +66,5 @@ package() {
 	find "$pkgdir" \( -name perllocal.pod -o -name .packlist \) -delete
 }
 
-sha512sums="72f1a05224dc2735b32e92ac376d392fb631bf788a15de449471fdc5a94182ad4434ce71f95281e4cfc3a06cd275d2ff98e526d540c2979cd3e0dfa15b5c75ff  biber-2.12.tar.gz"
+sha512sums="72f1a05224dc2735b32e92ac376d392fb631bf788a15de449471fdc5a94182ad4434ce71f95281e4cfc3a06cd275d2ff98e526d540c2979cd3e0dfa15b5c75ff  biber-2.12.tar.gz
+fb09766b549605868bc972d4cce30748c1364cb8780fd97f2c000d8148197877642d9b7546e8e88837b95ec2fb80b4dcd9567500d12016b92c8254504387ada2  fix-sortinithash-unicode-collate.patch"

--- a/community/biber/fix-sortinithash-unicode-collate.patch
+++ b/community/biber/fix-sortinithash-unicode-collate.patch
@@ -1,0 +1,1630 @@
+diff --git a/t/annotations.t b/t/annotations.t
+index b4f641eb..c6f86c7f 100644
+--- a/t/annotations.t
++++ b/t/annotations.t
+@@ -73,7 +73,7 @@ my $ann1 = q|    \entry{ann1}{misc}{}
+       \strng{authorfullhash}{90ae96c82de92e36949bc64254bbde0c}
+       \field{extraname}{1}
+       \field{sortinit}{L}
+-      \field{sortinithash}{2c7981aaabc885868aba60f0c09ee20f}
++      \field{sortinithash}{dad3efd0836470093a7b4a7bb756eb8c}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+       \field{title}{The Title}
+@@ -116,7 +116,7 @@ my $ann2 = q|    \entry{ann2}{misc}{}
+       \strng{authorfullhash}{90ae96c82de92e36949bc64254bbde0c}
+       \field{extraname}{2}
+       \field{sortinit}{L}
+-      \field{sortinithash}{2c7981aaabc885868aba60f0c09ee20f}
++      \field{sortinithash}{dad3efd0836470093a7b4a7bb756eb8c}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+       \field{title}{The Title}
+diff --git a/t/basic-misc.t b/t/basic-misc.t
+index 3da513a1..c9622693 100644
+--- a/t/basic-misc.t
++++ b/t/basic-misc.t
+@@ -97,7 +97,7 @@ my $u1 = q|    \entry{u1}{misc}{}
+       \strng{authorfullhash}{b78abdc838d79b6576f2ed0021642766}
+       \field{labelalpha}{AAA\textbf{+}00}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \true{singletitle}
+       \true{uniquework}
+       \field{labelnamesource}{author}
+@@ -231,7 +231,7 @@ my $murray1 = q|    \entry{murray}{article}{}
+       \strng{authorfullhash}{1572cc3fd324f560e5e71d041a6bd764}
+       \field{labelalpha}{Hos\textbf{+}98}
+       \field{sortinit}{H}
+-      \field{sortinithash}{5f15a7bc777ad49ff15aa4d2831b1681}
++      \field{sortinithash}{6db6145dae8dc9e1271a8d556090b50a}
+       \true{singletitle}
+       \true{uniquework}
+       \field{labelnamesource}{author}
+@@ -348,7 +348,7 @@ my $murray2 = q|    \entry{murray}{article}{}
+       \strng{authorfullhash}{1572cc3fd324f560e5e71d041a6bd764}
+       \field{labelalpha}{Hos98}
+       \field{sortinit}{H}
+-      \field{sortinithash}{5f15a7bc777ad49ff15aa4d2831b1681}
++      \field{sortinithash}{6db6145dae8dc9e1271a8d556090b50a}
+       \true{singletitle}
+       \true{uniquework}
+       \field{labelnamesource}{author}
+@@ -389,7 +389,7 @@ my $t1 = q+    \entry{t1}{misc}{}
+       \field{extraname}{1}
+       \field{labelalpha}{Bro92}
+       \field{sortinit}{B}
+-      \field{sortinithash}{276475738cc058478c1677046f857703}
++      \field{sortinithash}{8de16967003c7207dae369d874f1456e}
+       \true{uniquework}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -419,7 +419,7 @@ my $t2 = q|    \entry{t2}{misc}{}
+       \field{extraname}{2}
+       \field{labelalpha}{Bro94}
+       \field{sortinit}{B}
+-      \field{sortinithash}{276475738cc058478c1677046f857703}
++      \field{sortinithash}{8de16967003c7207dae369d874f1456e}
+       \true{uniquework}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -452,7 +452,7 @@ my $anon1 = q|    \entry{anon1}{unpublished}{}
+       \strng{shortauthorfullhash}{9873a6cc65c553faa2b21aaad626fe4b}
+       \field{labelalpha}{XAn35}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \true{singletitle}
+       \true{uniquework}
+       \field{labelnamesource}{shortauthor}
+@@ -491,7 +491,7 @@ my $anon2 = q|    \entry{anon2}{unpublished}{}
+       \strng{shortauthorfullhash}{f64c29e89ea49402b997956610b58ef6}
+       \field{labelalpha}{YAn39}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \true{singletitle}
+       \true{uniquework}
+       \field{labelnamesource}{shortauthor}
+@@ -526,7 +526,7 @@ my $url1 = q|    \entry{url1}{misc}{}
+       \field{extraname}{4}
+       \field{labelalpha}{Ali05}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \field{extraalpha}{4}
+       \field{labelnamesource}{author}
+       \field{year}{2005}
+@@ -710,7 +710,7 @@ my $isbn1 = q|    \entry{isbn1}{misc}{}
+       \field{extraname}{1}
+       \field{labelalpha}{Flu}
+       \field{sortinit}{F}
+-      \field{sortinithash}{669c706c6f1fbf3b5a83d26f1d9e9e72}
++      \field{sortinithash}{fb0c0faa89eb6abae8213bf60e6799ea}
+       \field{extraalpha}{1}
+       \field{labelnamesource}{author}
+       \field{isbn}{978-0-8165-2066-4}
+@@ -735,7 +735,7 @@ my $isbn2 = q|    \entry{isbn2}{misc}{}
+       \field{extraname}{2}
+       \field{labelalpha}{Flu}
+       \field{sortinit}{F}
+-      \field{sortinithash}{669c706c6f1fbf3b5a83d26f1d9e9e72}
++      \field{sortinithash}{fb0c0faa89eb6abae8213bf60e6799ea}
+       \field{extraalpha}{2}
+       \field{labelnamesource}{author}
+       \field{isbn}{978-0-8165-2066-4}
+@@ -778,7 +778,7 @@ my $clone1 = q|    \entry{snk1}{book}{}
+       \field{extraname}{2}
+       \field{labelalpha}{vDoe}
+       \field{sortinit}{v}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \field{extraalpha}{2}
+       \field{labelnamesource}{author}
+     \endentry
+@@ -807,7 +807,7 @@ my $clone2 = q|    \entry{clone-snk1}{book}{}
+       \field{extraname}{1}
+       \field{labelalpha}{vDoe}
+       \field{sortinit}{v}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \field{extraalpha}{1}
+       \field{labelnamesource}{author}
+       \field{addendum}{add}
+@@ -839,7 +839,7 @@ my $ent1 = q|    \entry{ent1}{book}{}
+       \strng{authorfullhash}{b2536a425d549b46de5f21c4d468050a}
+       \field{labelalpha}{SdB}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+     \endentry
+@@ -862,7 +862,7 @@ my $verb1 = q|    \entry{verb1}{book}{}
+       \strng{authorfullhash}{cac5a25f503e71f5ef28f474e14007b6}
+       \field{labelalpha}{All}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+       \verb{verba}
+diff --git a/t/biblatexml.t b/t/biblatexml.t
+index ad9ad259..0959bfa5 100644
+--- a/t/biblatexml.t
++++ b/t/biblatexml.t
+@@ -111,7 +111,7 @@ my $l1 = q|    \entry{bltx1}{misc}{useprefix=false}
+       \strng{translatornamehash}{b44eba830fe9817fbe8e53c82f1cbe04}
+       \strng{translatorfullhash}{b44eba830fe9817fbe8e53c82f1cbe04}
+       \field{sortinit}{v}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -158,7 +158,7 @@ my $l1 = q|    \entry{bltx1}{misc}{useprefix=false}
+ 
+ my $l2 = q|    \entry{loopkey:a}{book}{}
+       \field{sortinit}{0}
+-      \field{sortinithash}{168ad0c7c5ed09f1d28c6675717b5b03}
++      \field{sortinithash}{bcf7a1f4afb88b7299f988caccb80d1c}
+     \endentry
+ |;
+ 
+diff --git a/t/crossrefs.t b/t/crossrefs.t
+index 915b52b2..b6191c62 100644
+--- a/t/crossrefs.t
++++ b/t/crossrefs.t
+@@ -82,7 +82,7 @@ my $cr1 = q|    \entry{cr1}{inbook}{}
+       \strng{editornamehash}{c129df5593fdaa7475548811bfbb227d}
+       \strng{editorfullhash}{c129df5593fdaa7475548811bfbb227d}
+       \field{sortinit}{G}
+-      \field{sortinithash}{5e8d2bf9d38de41b1528bd307546008f}
++      \field{sortinithash}{62eb2aa29549e4fdbd3cb154ec5711cb}
+       \true{singletitle}
+       \true{uniquetitle}
+       \true{uniquework}
+@@ -131,7 +131,7 @@ my $cr2 = q|    \entry{cr2}{inbook}{}
+       \strng{editornamehash}{c129df5593fdaa7475548811bfbb227d}
+       \strng{editorfullhash}{c129df5593fdaa7475548811bfbb227d}
+       \field{sortinit}{F}
+-      \field{sortinithash}{669c706c6f1fbf3b5a83d26f1d9e9e72}
++      \field{sortinithash}{fb0c0faa89eb6abae8213bf60e6799ea}
+       \true{singletitle}
+       \true{uniquetitle}
+       \true{uniquework}
+@@ -165,7 +165,7 @@ my $cr_m = q|    \entry{cr_m}{book}{}
+       \strng{editornamehash}{c129df5593fdaa7475548811bfbb227d}
+       \strng{editorfullhash}{c129df5593fdaa7475548811bfbb227d}
+       \field{sortinit}{G}
+-      \field{sortinithash}{5e8d2bf9d38de41b1528bd307546008f}
++      \field{sortinithash}{62eb2aa29549e4fdbd3cb154ec5711cb}
+       \true{crossrefsource}
+       \true{uniquetitle}
+       \field{labeltitlesource}{title}
+@@ -203,7 +203,7 @@ my $cr3 = q|    \entry{cr3}{inbook}{}
+       \strng{editornamehash}{a1f5c22413396d599ec766725b226735}
+       \strng{editorfullhash}{a1f5c22413396d599ec766725b226735}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \true{singletitle}
+       \true{uniquetitle}
+       \true{uniquework}
+@@ -248,7 +248,7 @@ my $cr4 = q|    \entry{cr4}{inbook}{}
+       \strng{editornamehash}{6ea89bd4958743a20b70fe17647d6af5}
+       \strng{editorfullhash}{6ea89bd4958743a20b70fe17647d6af5}
+       \field{sortinit}{M}
+-      \field{sortinithash}{cfd219b90152c06204fab207bc6c7cab}
++      \field{sortinithash}{2e5c2f51f7fa2d957f3206819bf86dc3}
+       \true{singletitle}
+       \true{uniquetitle}
+       \true{uniquework}
+@@ -279,7 +279,7 @@ my $crt = q|    \entry{crt}{book}{}
+       \strng{editornamehash}{a1f5c22413396d599ec766725b226735}
+       \strng{editorfullhash}{a1f5c22413396d599ec766725b226735}
+       \field{sortinit}{B}
+-      \field{sortinithash}{276475738cc058478c1677046f857703}
++      \field{sortinithash}{8de16967003c7207dae369d874f1456e}
+       \true{uniquetitle}
+       \field{labeltitlesource}{title}
+       \field{title}{Beasts of the Burbling Burns}
+@@ -315,7 +315,7 @@ my $cr6 = q|    \entry{cr6}{inproceedings}{}
+       \strng{editorfullhash}{344a7f427fb765610ef96eb7bce95257}
+       \field{extraname}{2}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \true{uniquetitle}
+       \true{uniquework}
+       \field{labelnamesource}{author}
+@@ -366,7 +366,7 @@ my $cr7 = q|    \entry{cr7}{inbook}{}
+       \strng{bookauthorfullhash}{91a1dd4aeed3c4ec29ca74c4e778be5f}
+       \field{extraname}{1}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \true{uniquetitle}
+       \true{uniquework}
+       \field{labelnamesource}{author}
+@@ -401,7 +401,7 @@ my $cr8 = q|    \entry{cr8}{incollection}{}
+       \strng{authorfullhash}{3d449e56eb3ca1ae80dc99a18d689795}
+       \field{extraname}{4}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \true{singletitle}
+       \true{uniquetitle}
+       \true{uniquework}
+@@ -431,7 +431,7 @@ my $xr1 = q|    \entry{xr1}{inbook}{}
+       \strng{authornamehash}{e0ecc4fc668ee499d1afba44e1ac064d}
+       \strng{authorfullhash}{e0ecc4fc668ee499d1afba44e1ac064d}
+       \field{sortinit}{Z}
+-      \field{sortinithash}{156173bd08b075d7295bc3e0f4735a04}
++      \field{sortinithash}{8f7b480688e809b50b6f6577b16f3db5}
+       \true{singletitle}
+       \true{uniquetitle}
+       \true{uniquework}
+@@ -460,7 +460,7 @@ my $xr2 = q|    \entry{xr2}{inbook}{}
+       \strng{authornamehash}{6afa09374ecfd6b394ce714d2d9709c7}
+       \strng{authorfullhash}{6afa09374ecfd6b394ce714d2d9709c7}
+       \field{sortinit}{I}
+-      \field{sortinithash}{320bc8fe8101b9376f9f21cd507de0e8}
++      \field{sortinithash}{9417e9a1288a9371e2691d999083ed39}
+       \true{singletitle}
+       \true{uniquetitle}
+       \true{uniquework}
+@@ -491,7 +491,7 @@ my $xrm = q|    \entry{xrm}{book}{}
+       \strng{editornamehash}{809950f9b59ae207092b909a19dcb27b}
+       \strng{editorfullhash}{809950f9b59ae207092b909a19dcb27b}
+       \field{sortinit}{C}
+-      \field{sortinithash}{963e9d84a3da2344e8833203de5aed05}
++      \field{sortinithash}{4c244ceae61406cdc0cc2ce1cb1ff703}
+       \true{xrefsource}
+       \true{uniquetitle}
+       \field{labeltitlesource}{title}
+@@ -516,7 +516,7 @@ my $xr3 = q|    \entry{xr3}{inbook}{}
+       \strng{authornamehash}{9788055665b9bb4b37c776c3f6b74f16}
+       \strng{authorfullhash}{9788055665b9bb4b37c776c3f6b74f16}
+       \field{sortinit}{N}
+-      \field{sortinithash}{f7242c3ed3dc50029fca1be76c497c7c}
++      \field{sortinithash}{98cf339a479c0454fe09153a08675a15}
+       \true{singletitle}
+       \true{uniquetitle}
+       \true{uniquework}
+@@ -546,7 +546,7 @@ my $xrt = q|    \entry{xrt}{book}{}
+       \strng{editornamehash}{bf7d6b02f3e073913e5bfe5059508dd5}
+       \strng{editorfullhash}{bf7d6b02f3e073913e5bfe5059508dd5}
+       \field{sortinit}{K}
+-      \field{sortinithash}{9fd838a31ba64d981e8f44562bd33f89}
++      \field{sortinithash}{d3edc18d54b9438a72c24c925bfb38f4}
+       \true{uniquetitle}
+       \field{labeltitlesource}{title}
+       \field{title}{Kings, Cork and Calculation}
+@@ -572,7 +572,7 @@ my $xr4 = q|    \entry{xr4}{inbook}{}
+       \strng{authorfullhash}{7804ffef086c0c4686c235807f5cb502}
+       \field{extraname}{1}
+       \field{sortinit}{M}
+-      \field{sortinithash}{cfd219b90152c06204fab207bc6c7cab}
++      \field{sortinithash}{2e5c2f51f7fa2d957f3206819bf86dc3}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+       \field{origyear}{1933}
+@@ -600,7 +600,7 @@ my $mxr = q|    \entry{mxr}{inbook}{}
+       \strng{authorfullhash}{7804ffef086c0c4686c235807f5cb502}
+       \field{extraname}{2}
+       \field{sortinit}{M}
+-      \field{sortinithash}{cfd219b90152c06204fab207bc6c7cab}
++      \field{sortinithash}{2e5c2f51f7fa2d957f3206819bf86dc3}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+       \field{origyear}{1933}
+@@ -625,7 +625,7 @@ my $mcr = q|    \entry{mcr}{inbook}{}
+       \strng{authorfullhash}{7804ffef086c0c4686c235807f5cb502}
+       \field{extraname}{3}
+       \field{sortinit}{M}
+-      \field{sortinithash}{cfd219b90152c06204fab207bc6c7cab}
++      \field{sortinithash}{2e5c2f51f7fa2d957f3206819bf86dc3}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+       \field{origyear}{1933}
+@@ -660,7 +660,7 @@ my $ccr1 = q|    \entry{ccr2}{book}{}
+       \strng{editorfullhash}{cfee758a1c82df2e26af1985e061bb0a}
+       \field{extraname}{1}
+       \field{sortinit}{V}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \true{uniquetitle}
+       \true{uniquework}
+       \field{labelnamesource}{author}
+@@ -694,7 +694,7 @@ my $ccr2 = q|    \entry{ccr3}{inbook}{}
+       \strng{editornamehash}{cfee758a1c82df2e26af1985e061bb0a}
+       \strng{editorfullhash}{cfee758a1c82df2e26af1985e061bb0a}
+       \field{sortinit}{P}
+-      \field{sortinithash}{8d51b3d5b78d75b54308d706b9bbe285}
++      \field{sortinithash}{bb5b15f2db90f7aef79bb9e83defefcb}
+       \true{uniquetitle}
+       \field{labeltitlesource}{title}
+       \field{booktitle}{Misc etc.}
+@@ -726,7 +726,7 @@ my $ccr3 = q|    \entry{ccr4}{inbook}{}
+ 
+ my $s1 = q|    \entry{s1}{inbook}{}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \true{uniquetitle}
+       \field{labeltitlesource}{title}
+       \strng{crossref}{s2}
+@@ -760,7 +760,7 @@ my $xc2 = q|    \entry{xc2}{inbook}{}
+       \strng{bookauthorfullhash}{1a0f7d518cccdad859a74412ef956474}
+       \field{extraname}{2}
+       \field{sortinit}{C}
+-      \field{sortinithash}{963e9d84a3da2344e8833203de5aed05}
++      \field{sortinithash}{4c244ceae61406cdc0cc2ce1cb1ff703}
+       \true{xrefsource}
+       \field{labelnamesource}{author}
+       \field{booktitle}{Title}
+@@ -769,7 +769,7 @@ my $xc2 = q|    \entry{xc2}{inbook}{}
+ 
+ my $b1 = q|    \entry{b1}{inbook}{}
+       \field{sortinit}{2}
+-      \field{sortinithash}{cbff857e587bcb4635511624d773949e}
++      \field{sortinithash}{ed39bb39cf854d5250e95b1c1f94f4ed}
+       \strng{crossref}{b2}
+       \field{day}{3}
+       \field{month}{3}
+@@ -803,7 +803,7 @@ my $sup1 = q|    \entry{sup1}{mvbook}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{3}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \true{crossrefsource}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+@@ -828,7 +828,7 @@ my $sup2 = q|    \entry{sup2}{book}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{1}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+diff --git a/t/datalists.t b/t/datalists.t
+index 3081cc49..4855e3d9 100644
+--- a/t/datalists.t
++++ b/t/datalists.t
+@@ -187,7 +187,7 @@ my $K11 = q|    \entry{K11}{book}{}
+       \strng{authornamehash}{4edc280a0ef229f9c061e3b121b17482}
+       \strng{authorfullhash}{4edc280a0ef229f9c061e3b121b17482}
+       \field{sortinit}{a}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -219,7 +219,7 @@ my $K12 = q|    \entry{K12}{book}{}
+       \strng{authornamehash}{a846a485fc9cbb59b0ebeedd6ac637e4}
+       \strng{authorfullhash}{a846a485fc9cbb59b0ebeedd6ac637e4}
+       \field{sortinit}{Z}
+-      \field{sortinithash}{156173bd08b075d7295bc3e0f4735a04}
++      \field{sortinithash}{8f7b480688e809b50b6f6577b16f3db5}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+diff --git a/t/dateformats.t b/t/dateformats.t
+index f941cde8..2c01de8d 100644
+--- a/t/dateformats.t
++++ b/t/dateformats.t
+@@ -88,7 +88,7 @@ my $l13c = q|    \entry{L13}{book}{}
+       \strng{authorfullhash}{8c77336299b25bdada7bf8038f46722f}
+       \field{extraname}{3}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -126,7 +126,7 @@ my $l14 = q|    \entry{L14}{book}{}
+       \strng{authorfullhash}{8c77336299b25bdada7bf8038f46722f}
+       \field{extraname}{4}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extradate}{3}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+@@ -168,7 +168,7 @@ my $l15 = q|    \entry{L15}{book}{}
+       \strng{authorfullhash}{8c77336299b25bdada7bf8038f46722f}
+       \field{extraname}{12}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extradate}{4}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -201,7 +201,7 @@ my $l16 = q|    \entry{L16}{proceedings}{}
+       \strng{editorfullhash}{8c77336299b25bdada7bf8038f46722f}
+       \field{extraname}{13}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extradate}{7}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{event}
+@@ -240,7 +240,7 @@ my $l17 = q|    \entry{L17}{proceedings}{}
+       \strng{editorfullhash}{8c77336299b25bdada7bf8038f46722f}
+       \field{extraname}{5}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extradate}{4}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+@@ -299,7 +299,7 @@ my $l17c = q|    \entry{L17}{proceedings}{}
+       \strng{editorfullhash}{8c77336299b25bdada7bf8038f46722f}
+       \field{extraname}{5}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{orig}
+       \field{labelnamesource}{editor}
+@@ -357,7 +357,7 @@ my $l17e = q|    \entry{L17}{proceedings}{}
+       \strng{editorfullhash}{8c77336299b25bdada7bf8038f46722f}
+       \field{extraname}{5}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{event}
+       \field{labelnamesource}{editor}
+@@ -479,7 +479,7 @@ my $era1 = q|    \entry{era1}{article}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{9}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -512,7 +512,7 @@ my $era2 = q|    \entry{era2}{inproceedings}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{10}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -546,7 +546,7 @@ my $era3 = q|    \entry{era3}{inproceedings}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{11}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -580,7 +580,7 @@ my $era4 = q|    \entry{era4}{inproceedings}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{6}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -622,7 +622,7 @@ my $time1 = q|    \entry{time1}{article}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{2}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -671,7 +671,7 @@ my $range1 = q|    \entry{range1}{inproceedings}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{7}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradate}{1}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+@@ -712,7 +712,7 @@ my $range2 = q|    \entry{range2}{inproceedings}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{8}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradate}{2}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+@@ -753,7 +753,7 @@ my $season1 = q|    \entry{season1}{inproceedings}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{1}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -785,7 +785,7 @@ my $unspec1 = q|    \entry{unspec1}{inproceedings}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{4}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -838,7 +838,7 @@ my $unspec2 = q|    \entry{unspec2}{article}{}
+       \strng{authorfullhash}{556c8dba145b472e6a8598d506f7cbe2}
+       \field{extraname}{3}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+diff --git a/t/encoding.t b/t/encoding.t
+index a150b4f5..36d99558 100644
+--- a/t/encoding.t
++++ b/t/encoding.t
+@@ -52,7 +52,7 @@ my $encode1 = q|    \entry{testŠ}{book}{}
+       \strng{authorfullhash}{06a47edae2e847800cfd78323a0e6be8}
+       \field{labelalpha}{Enc99}
+       \field{sortinit}{E}
+-      \field{sortinithash}{f615fb9c6fba11c6f962fb3fd599810e}
++      \field{sortinithash}{c554bd1a0b76ea92b9f105fe36d9c7b0}
+       \field{labeldatesource}{year}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+@@ -82,7 +82,7 @@ my $encode2 = q|    \entry{test1}{book}{}
+       \strng{authorfullhash}{06a47edae2e847800cfd78323a0e6be8}
+       \field{labelalpha}{Enc99}
+       \field{sortinit}{E}
+-      \field{sortinithash}{f615fb9c6fba11c6f962fb3fd599810e}
++      \field{sortinithash}{c554bd1a0b76ea92b9f105fe36d9c7b0}
+       \field{labeldatesource}{year}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+@@ -112,7 +112,7 @@ my $encode3 = q|    \entry{test1}{book}{}
+       \strng{authorfullhash}{06a47edae2e847800cfd78323a0e6be8}
+       \field{labelalpha}{Enc99}
+       \field{sortinit}{E}
+-      \field{sortinithash}{f615fb9c6fba11c6f962fb3fd599810e}
++      \field{sortinithash}{c554bd1a0b76ea92b9f105fe36d9c7b0}
+       \field{labeldatesource}{year}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+@@ -142,7 +142,7 @@ my $encode5 = q|    \entry{test}{book}{}
+       \strng{authorfullhash}{06a47edae2e847800cfd78323a0e6be8}
+       \field{labelalpha}{Enc99}
+       \field{sortinit}{E}
+-      \field{sortinithash}{f615fb9c6fba11c6f962fb3fd599810e}
++      \field{sortinithash}{c554bd1a0b76ea92b9f105fe36d9c7b0}
+       \field{labeldatesource}{year}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+@@ -172,7 +172,7 @@ my $encode6 = q|    \entry{test}{book}{}
+       \strng{authorfullhash}{06a47edae2e847800cfd78323a0e6be8}
+       \field{labelalpha}{Enc99}
+       \field{sortinit}{E}
+-      \field{sortinithash}{f615fb9c6fba11c6f962fb3fd599810e}
++      \field{sortinithash}{c554bd1a0b76ea92b9f105fe36d9c7b0}
+       \field{labeldatesource}{year}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+@@ -202,7 +202,7 @@ my $encode7 = q|    \entry{test}{book}{}
+       \strng{authorfullhash}{06a47edae2e847800cfd78323a0e6be8}
+       \field{labelalpha}{Enc99}
+       \field{sortinit}{E}
+-      \field{sortinithash}{f615fb9c6fba11c6f962fb3fd599810e}
++      \field{sortinithash}{c554bd1a0b76ea92b9f105fe36d9c7b0}
+       \field{labeldatesource}{year}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+diff --git a/t/names.t b/t/names.t
+index 7b9a59a3..4908bea1 100644
+--- a/t/names.t
++++ b/t/names.t
+@@ -188,7 +188,7 @@ my $l1 = q|    \entry{L1}{book}{}
+       \strng{authornamehash}{72287a68c1714cb1b9f4ab9e03a88b96}
+       \strng{authorfullhash}{72287a68c1714cb1b9f4ab9e03a88b96}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -208,7 +208,7 @@ my $l2 = q|    \entry{L2}{book}{}
+       \strng{authornamehash}{2098d59d0f19a2e003ee06c1aa750d57}
+       \strng{authorfullhash}{2098d59d0f19a2e003ee06c1aa750d57}
+       \field{sortinit}{B}
+-      \field{sortinithash}{276475738cc058478c1677046f857703}
++      \field{sortinithash}{8de16967003c7207dae369d874f1456e}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -228,7 +228,7 @@ my $l3 = q|    \entry{L3}{book}{}
+       \strng{authornamehash}{c8b06fe88bde128b25eb0b3b1cc5837c}
+       \strng{authorfullhash}{c8b06fe88bde128b25eb0b3b1cc5837c}
+       \field{sortinit}{C}
+-      \field{sortinithash}{963e9d84a3da2344e8833203de5aed05}
++      \field{sortinithash}{4c244ceae61406cdc0cc2ce1cb1ff703}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -248,7 +248,7 @@ my $l4 = q|    \entry{L4}{book}{}
+       \strng{authornamehash}{5ec958b850c0c2de7de7c42c84b9c419}
+       \strng{authorfullhash}{5ec958b850c0c2de7de7c42c84b9c419}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -270,7 +270,7 @@ my $l5 = q|    \entry{L5}{book}{}
+       \strng{authornamehash}{c6b9d281cc1ff3f35570f76f463d4244}
+       \strng{authorfullhash}{c6b9d281cc1ff3f35570f76f463d4244}
+       \field{sortinit}{v}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -292,7 +292,7 @@ my $l6 = q|    \entry{L6}{book}{}
+       \strng{authornamehash}{5fd24d3d1608a310ec205a6b201a5495}
+       \strng{authorfullhash}{5fd24d3d1608a310ec205a6b201a5495}
+       \field{sortinit}{v}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -314,7 +314,7 @@ my $l7 = q|    \entry{L7}{book}{}
+       \strng{authornamehash}{98edb0b90251df22b74328d9227eceb7}
+       \strng{authorfullhash}{98edb0b90251df22b74328d9227eceb7}
+       \field{sortinit}{v}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -336,7 +336,7 @@ my $l8 = q|    \entry{L8}{book}{}
+       \strng{authornamehash}{1211dc8dbbc191cbcab4da3c3c1fc48a}
+       \strng{authorfullhash}{1211dc8dbbc191cbcab4da3c3c1fc48a}
+       \field{sortinit}{v}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -356,7 +356,7 @@ my $l9 = q|    \entry{L9}{book}{}
+       \strng{authornamehash}{bae61a889ab149a6deafe45333204cf0}
+       \strng{authorfullhash}{bae61a889ab149a6deafe45333204cf0}
+       \field{sortinit}{I}
+-      \field{sortinithash}{320bc8fe8101b9376f9f21cd507de0e8}
++      \field{sortinithash}{9417e9a1288a9371e2691d999083ed39}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -379,7 +379,7 @@ my $l10 = q|    \entry{L10}{book}{}
+       \strng{authornamehash}{37b4325752e394ddfb2fc810f6c88e27}
+       \strng{authorfullhash}{37b4325752e394ddfb2fc810f6c88e27}
+       \field{sortinit}{J}
+-      \field{sortinithash}{fce5f8d0bd05e8d93f3dbe21c78897ca}
++      \field{sortinithash}{c45040a764d616897e7f5b30174d7b92}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -402,7 +402,7 @@ my $l10a = q|    \entry{L10a}{book}{}
+       \strng{authornamehash}{7bf2c9d8b89a1930ee91bfddcaf20c9c}
+       \strng{authorfullhash}{7bf2c9d8b89a1930ee91bfddcaf20c9c}
+       \field{sortinit}{P}
+-      \field{sortinithash}{8d51b3d5b78d75b54308d706b9bbe285}
++      \field{sortinithash}{bb5b15f2db90f7aef79bb9e83defefcb}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -427,7 +427,7 @@ my $l11 = q|    \entry{L11}{book}{}
+       \strng{authornamehash}{9f48d231be68c9435fab4faca55a5caf}
+       \strng{authorfullhash}{9f48d231be68c9435fab4faca55a5caf}
+       \field{sortinit}{v}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -449,7 +449,7 @@ my $l12 = q|    \entry{L12}{book}{}
+       \strng{authornamehash}{d7ca88c13a8f7ce1c23e920010a31f83}
+       \strng{authorfullhash}{d7ca88c13a8f7ce1c23e920010a31f83}
+       \field{sortinit}{d}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \true{uniqueprimaryauthor}
+       \field{labelnamesource}{author}
+     \endentry
+@@ -470,7 +470,7 @@ my $l13 = q|    \entry{L13}{book}{}
+       \strng{authornamehash}{227ac48bb788a658cfaa4eefc71ff0cc}
+       \strng{authorfullhash}{227ac48bb788a658cfaa4eefc71ff0cc}
+       \field{sortinit}{V}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -490,7 +490,7 @@ my $l14 = q|    \entry{L14}{book}{}
+       \strng{authornamehash}{779475052c17ed56dc3be900d0dfdf87}
+       \strng{authorfullhash}{779475052c17ed56dc3be900d0dfdf87}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -513,7 +513,7 @@ my $l15 = q|    \entry{L15}{book}{}
+       \strng{authorfullhash}{783c636e853e47a854ae034ebe9dde62}
+       \field{extraname}{1}
+       \field{sortinit}{v}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -536,7 +536,7 @@ my $l16 = q|    \entry{L16}{book}{}
+       \strng{authorfullhash}{783c636e853e47a854ae034ebe9dde62}
+       \field{extraname}{2}
+       \field{sortinit}{v}
+-      \field{sortinithash}{75dd7385c90b2252c3ae853a80ca853b}
++      \field{sortinithash}{02432525618c08e2b03cac47c19764af}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -557,7 +557,7 @@ my $l17 = q|    \entry{L17}{book}{}
+       \strng{authorfullhash}{b51f667a3384d92ea5458ba80716bff7}
+       \field{extraname}{1}
+       \field{sortinit}{L}
+-      \field{sortinithash}{2c7981aaabc885868aba60f0c09ee20f}
++      \field{sortinithash}{dad3efd0836470093a7b4a7bb756eb8c}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -578,7 +578,7 @@ my $l18 = q|    \entry{L18}{book}{}
+       \strng{authorfullhash}{b51f667a3384d92ea5458ba80716bff7}
+       \field{extraname}{2}
+       \field{sortinit}{L}
+-      \field{sortinithash}{2c7981aaabc885868aba60f0c09ee20f}
++      \field{sortinithash}{dad3efd0836470093a7b4a7bb756eb8c}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -598,7 +598,7 @@ my $l19 = q|    \entry{L19}{book}{}
+       \strng{authornamehash}{83caa52f21f97e572dd3267bdf62978a}
+       \strng{authorfullhash}{83caa52f21f97e572dd3267bdf62978a}
+       \field{sortinit}{M}
+-      \field{sortinithash}{cfd219b90152c06204fab207bc6c7cab}
++      \field{sortinithash}{2e5c2f51f7fa2d957f3206819bf86dc3}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -618,7 +618,7 @@ my $l19a = q|    \entry{L19a}{book}{}
+       \strng{authornamehash}{0963f6904ccfeaac2770c5882a587001}
+       \strng{authorfullhash}{0963f6904ccfeaac2770c5882a587001}
+       \field{sortinit}{L}
+-      \field{sortinithash}{2c7981aaabc885868aba60f0c09ee20f}
++      \field{sortinithash}{dad3efd0836470093a7b4a7bb756eb8c}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -639,7 +639,7 @@ my $l20 = q|    \entry{L20}{book}{}
+       \strng{authornamehash}{5f26c2f3b33095d5b005714893f4d698}
+       \strng{authorfullhash}{5f26c2f3b33095d5b005714893f4d698}
+       \field{sortinit}{F}
+-      \field{sortinithash}{669c706c6f1fbf3b5a83d26f1d9e9e72}
++      \field{sortinithash}{fb0c0faa89eb6abae8213bf60e6799ea}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -660,7 +660,7 @@ my $l21 = q|    \entry{L21}{book}{}
+       \strng{authorfullhash}{4389a3c0dc7da74487b50808ba9436ad}
+       \field{extraname}{1}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -681,7 +681,7 @@ my $l22u = q|    \entry{L22}{book}{}
+       \strng{authorfullhash}{e58b861545799d0eaf883402a882126e}
+       \field{extraname}{1}
+       \field{sortinit}{Š}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -703,7 +703,7 @@ my $l22 = q|    \entry{L22}{book}{}
+       \strng{authorfullhash}{e58b861545799d0eaf883402a882126e}
+       \field{extraname}{1}
+       \field{sortinit}{\v{S}}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \true{uniqueprimaryauthor}
+       \field{labelnamesource}{author}
+     \endentry
+@@ -726,7 +726,7 @@ my $l23 = q|    \entry{L23}{book}{}
+       \strng{authorfullhash}{4389a3c0dc7da74487b50808ba9436ad}
+       \field{extraname}{3}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -747,7 +747,7 @@ my $l24 = q|    \entry{L24}{book}{}
+       \strng{authorfullhash}{e58b861545799d0eaf883402a882126e}
+       \field{extraname}{2}
+       \field{sortinit}{Š}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -765,7 +765,7 @@ my $l25 = q|    \entry{L25}{book}{}
+       \strng{authornamehash}{d7cd2c5ea0848abc3e90609558b84a45}
+       \strng{authorfullhash}{d7cd2c5ea0848abc3e90609558b84a45}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -783,7 +783,7 @@ my $l26 = q|    \entry{L26}{book}{}
+       \strng{authornamehash}{8eee1dbafdbd0a4b73157e60f18b4784}
+       \strng{authorfullhash}{8eee1dbafdbd0a4b73157e60f18b4784}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -791,7 +791,7 @@ my $l26 = q|    \entry{L26}{book}{}
+ # Malformed anyway but a decent test
+ my $l28 = q|    \entry{L28}{book}{}
+       \field{sortinit}{0}
+-      \field{sortinithash}{168ad0c7c5ed09f1d28c6675717b5b03}
++      \field{sortinithash}{bcf7a1f4afb88b7299f988caccb80d1c}
+       \warn{\item Name "Deux et al.,, O." is malformed (consecutive commas): skipping name}
+     \endentry
+ |;
+@@ -810,7 +810,7 @@ my $l29 = q|    \entry{L29}{book}{}
+       \strng{authornamehash}{27ad192a3a715aa89152b2a4ee392e8c}
+       \strng{authorfullhash}{27ad192a3a715aa89152b2a4ee392e8c}
+       \field{sortinit}{U}
+-      \field{sortinithash}{36a2444f5238e0dcf4bb59704df6624d}
++      \field{sortinithash}{77a6935510e008adcf5b555e7b4f0711}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -850,7 +850,7 @@ my $l31 = q|    \entry{L31}{book}{}
+       \strng{translatornamehash}{29c3ff92fff79d09a8b44d2f775de0b1}
+       \strng{translatorfullhash}{29c3ff92fff79d09a8b44d2f775de0b1}
+       \field{sortinit}{\~{Z}}
+-      \field{sortinithash}{156173bd08b075d7295bc3e0f4735a04}
++      \field{sortinithash}{8f7b480688e809b50b6f6577b16f3db5}
+       \true{uniqueprimaryauthor}
+       \field{labelnamesource}{author}
+     \endentry
+diff --git a/t/options.t b/t/options.t
+index 8cb3b612..7e4c1f20 100644
+--- a/t/options.t
++++ b/t/options.t
+@@ -100,7 +100,7 @@ my $l1 = q|    \entry{L1}{book}{}
+       \strng{authornamehash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \strng{authorfullhash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -137,7 +137,7 @@ my $l2 = q|    \entry{L2}{book}{maxcitenames=3,maxbibnames=3,maxsortnames=3,maxi
+       \strng{authornamehash}{19eec87c959944d6d9c72434a42856ba}
+       \strng{authorfullhash}{19eec87c959944d6d9c72434a42856ba}
+       \field{sortinit}{E}
+-      \field{sortinithash}{f615fb9c6fba11c6f962fb3fd599810e}
++      \field{sortinithash}{c554bd1a0b76ea92b9f105fe36d9c7b0}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -169,7 +169,7 @@ my $l3 = q|    \entry{L3}{book}{blah=10}
+       \strng{authornamehash}{490250da1f3b92580d97563dc96c6c84}
+       \strng{authorfullhash}{490250da1f3b92580d97563dc96c6c84}
+       \field{sortinit}{B}
+-      \field{sortinithash}{276475738cc058478c1677046f857703}
++      \field{sortinithash}{8de16967003c7207dae369d874f1456e}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+diff --git a/t/related-entries.t b/t/related-entries.t
+index 53dce64b..b38ac79f 100644
+--- a/t/related-entries.t
++++ b/t/related-entries.t
+@@ -56,7 +56,7 @@ my $k1 = q|    \entry{key1}{article}{}
+       \strng{authorfullhash}{a517747c3d12f99244ae598910d979c5}
+       \field{extraname}{1}
+       \field{sortinit}{1}
+-      \field{sortinithash}{2174f786c6195e7fe2ee1c229b416e29}
++      \field{sortinithash}{50c6687d7fc80f50136d75228e3c59ba}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -95,7 +95,7 @@ my $k2 = q|    \entry{key2}{inbook}{}
+       \strng{authorfullhash}{a517747c3d12f99244ae598910d979c5}
+       \field{extraname}{2}
+       \field{sortinit}{2}
+-      \field{sortinithash}{cbff857e587bcb4635511624d773949e}
++      \field{sortinithash}{ed39bb39cf854d5250e95b1c1f94f4ed}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -243,7 +243,7 @@ my $kck4 = q|    \entry{caf8e34be07426ae7127c1b4829983c1}{inbook}{dataonly,useed
+ 
+ my $c1 = q|    \entry{c1}{book}{}
+       \field{sortinit}{3}
+-      \field{sortinithash}{a4b52e5432884761f50fb9571273b93e}
++      \field{sortinithash}{a37a8ef248a93c322189792c34fc68c9}
+       \field{related}{9ab62b5ef34a985438bfdf7ee0102229}
+     \endentry
+ |;
+@@ -330,7 +330,7 @@ my $un1 = q|    \entry{kullback}{book}{}
+       \strng{authorfullhash}{34c5bbf9876c37127c3abe4e7d7a7198}
+       \field{extraname}{1}
+       \field{sortinit}{5}
+-      \field{sortinithash}{3c19c3776b658b3558e9e2e4840c01e2}
++      \field{sortinithash}{5dd416adbafacc8226114bc0202d5fdd}
+       \field{extradatescope}{year}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -364,7 +364,7 @@ my $un2 = q|    \entry{kullback:related}{book}{}
+       \strng{authorfullhash}{34c5bbf9876c37127c3abe4e7d7a7198}
+       \field{extraname}{2}
+       \field{sortinit}{6}
+-      \field{sortinithash}{57e57fb8451e7fcfa45d1e069f6d3136}
++      \field{sortinithash}{7851c86048328b027313775d8fbd2131}
+       \field{extradatescope}{year}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+diff --git a/t/set-legacy.t b/t/set-legacy.t
+index 4e56991e..9d40acb7 100644
+--- a/t/set-legacy.t
++++ b/t/set-legacy.t
+@@ -45,7 +45,7 @@ my $out = $biber->get_output_obj;
+ my $string1 = q|    \entry{Elias1955}{set}{}
+       \set{Elias1955a,Elias1955b}
+       \field{sortinit}{1}
+-      \field{sortinithash}{2174f786c6195e7fe2ee1c229b416e29}
++      \field{sortinithash}{50c6687d7fc80f50136d75228e3c59ba}
+     \endentry
+ |;
+ 
+diff --git a/t/skips.t b/t/skips.t
+index 7c80d391..caa835fb 100644
+--- a/t/skips.t
++++ b/t/skips.t
+@@ -50,7 +50,7 @@ my $set1 = q|    \entry{seta}{set}{}
+       \field{labelalpha}{Doe10}
+       \field{extraalpha}{1}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+     \endentry
+ |;
+ 
+@@ -70,7 +70,7 @@ my $set2 = q|    \entry{set:membera}{book}{}
+       \strng{authornamehash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \strng{authorfullhash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -97,7 +97,7 @@ my $set3 = q|    \entry{set:memberb}{book}{}
+       \strng{authornamehash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \strng{authorfullhash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -123,7 +123,7 @@ my $set4 = q|    \entry{set:memberc}{book}{}
+       \strng{authornamehash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \strng{authorfullhash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -150,7 +150,7 @@ my $noset1 = q|    \entry{noseta}{book}{}
+       \field{extraname}{3}
+       \field{labelalpha}{Doe10}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extradate}{2}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+@@ -180,7 +180,7 @@ my $noset2 = q|    \entry{nosetb}{book}{}
+       \field{extraname}{4}
+       \field{labelalpha}{Doe10}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extradate}{3}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+@@ -210,7 +210,7 @@ my $noset3 = q|    \entry{nosetc}{book}{}
+       \field{extraname}{5}
+       \field{labelalpha}{Doe10}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extradate}{4}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+@@ -244,7 +244,7 @@ my $sk4 = q|    \entry{skip4}{article}{dataonly}
+       \strng{authornamehash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \strng{authorfullhash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{labeldatesource}{year}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+diff --git a/t/sort-complex.t b/t/sort-complex.t
+index 75061f1c..8c1fabea 100644
+--- a/t/sort-complex.t
++++ b/t/sort-complex.t
+@@ -123,7 +123,7 @@ my $l4 = q|    \entry{L4}{book}{}
+       \field{extraname}{2}
+       \field{labelalpha}{Doe\textbf{+}95}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extraalpha}{2}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -155,7 +155,7 @@ my $l1 = q|    \entry{L1}{book}{}
+       \field{extraname}{1}
+       \field{labelalpha}{Doe95}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extraalpha}{1}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -187,7 +187,7 @@ my $l2 = q|    \entry{L2}{book}{}
+       \field{extraname}{3}
+       \field{labelalpha}{Doe95}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extraalpha}{3}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -219,7 +219,7 @@ my $l3 = q|    \entry{L3}{book}{}
+       \field{extraname}{2}
+       \field{labelalpha}{Doe95}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extraalpha}{2}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -253,7 +253,7 @@ my $l5 = q|    \entry{L5}{book}{}
+       \field{extraname}{1}
+       \field{labelalpha}{Doe\textbf{+}95}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{extraalpha}{1}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+diff --git a/t/tdata/full-bbl.bbl b/t/tdata/full-bbl.bbl
+index 4f168de8..07c2fab4 100644
+--- a/t/tdata/full-bbl.bbl
++++ b/t/tdata/full-bbl.bbl
+@@ -36,7 +36,7 @@
+       \strng{authorfullhash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \field{labelalpha}{\emph{A}}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -63,7 +63,7 @@
+       \strng{authorfullhash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \field{labelalpha}{\emph{A}}
+       \field{sortinit}{A}
+-      \field{sortinithash}{d77c7cdd82ff690d4c3ef13216f92f0b}
++      \field{sortinithash}{a3dcedd53b04d1adfd5ac303ecd5e6fa}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -90,7 +90,7 @@
+       \strng{authorfullhash}{bd051a2f7a5f377e3a62581b0e0f8577}
+       \field{labelalpha}{\emph{A}}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \true{singletitle}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+diff --git a/t/tdata/full-bblxml.bblxml b/t/tdata/full-bblxml.bblxml
+index 9eea7d18..a39a7872 100644
+--- a/t/tdata/full-bblxml.bblxml
++++ b/t/tdata/full-bblxml.bblxml
+@@ -47,7 +47,7 @@
+         <bbl:field name="authorbibnamehash">860705eb8ffac6e40507746c7ede79ca</bbl:field>
+         <bbl:field name="labelalpha">Aks\textbf{+}06</bbl:field>
+         <bbl:field name="sortinit">A</bbl:field>
+-        <bbl:field name="sortinithash">d77c7cdd82ff690d4c3ef13216f92f0b</bbl:field>
++        <bbl:field name="sortinithash">a3dcedd53b04d1adfd5ac303ecd5e6fa</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="indextitle">Effect of immobilization on catalytic characteristics</bbl:field>
+@@ -79,7 +79,7 @@
+         <bbl:field name="authorbibnamehash">9717d2d959a4b18727868ca7928c34b4</bbl:field>
+         <bbl:field name="labelalpha">Ang02</bbl:field>
+         <bbl:field name="sortinit">A</bbl:field>
+-        <bbl:field name="sortinithash">d77c7cdd82ff690d4c3ef13216f92f0b</bbl:field>
++        <bbl:field name="sortinithash">a3dcedd53b04d1adfd5ac303ecd5e6fa</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">shorttitle</bbl:field>
+         <bbl:field name="annotation">A German article in a French journal. Apart from that, a typical article entry. Note the indextitle field</bbl:field>
+@@ -109,7 +109,7 @@
+         </bbl:set>
+         <bbl:field name="labelalpha">Gla61</bbl:field>
+         <bbl:field name="sortinit">G</bbl:field>
+-        <bbl:field name="sortinithash">5e8d2bf9d38de41b1528bd307546008f</bbl:field>
++        <bbl:field name="sortinithash">62eb2aa29549e4fdbd3cb154ec5711cb</bbl:field>
+         <bbl:field name="annotation">A set entry with three members discussing the standard model of particle physics.</bbl:field>
+       </bbl:entry>
+       <bbl:entry key="stdmodel:glashow" type="article">
+@@ -129,7 +129,7 @@
+         <bbl:field name="authorfullhash">eb3f242602109f5bdbeb41fdd990fcc0</bbl:field>
+         <bbl:field name="authorbibnamehash">eb3f242602109f5bdbeb41fdd990fcc0</bbl:field>
+         <bbl:field name="sortinit">G</bbl:field>
+-        <bbl:field name="sortinithash">5e8d2bf9d38de41b1528bd307546008f</bbl:field>
++        <bbl:field name="sortinithash">62eb2aa29549e4fdbd3cb154ec5711cb</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="journaltitle">Nucl. Phys.</bbl:field>
+@@ -168,7 +168,7 @@
+         <bbl:field name="extraname">1</bbl:field>
+         <bbl:field name="labelalpha">Knu86</bbl:field>
+         <bbl:field name="sortinit">K</bbl:field>
+-        <bbl:field name="sortinithash">9fd838a31ba64d981e8f44562bd33f89</bbl:field>
++        <bbl:field name="sortinithash">d3edc18d54b9438a72c24c925bfb38f4</bbl:field>
+         <bbl:field name="extraalpha">1</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">shorttitle</bbl:field>
+@@ -207,7 +207,7 @@
+         <bbl:field name="extraname">2</bbl:field>
+         <bbl:field name="labelalpha">Knu86</bbl:field>
+         <bbl:field name="sortinit">K</bbl:field>
+-        <bbl:field name="sortinithash">9fd838a31ba64d981e8f44562bd33f89</bbl:field>
++        <bbl:field name="sortinithash">d3edc18d54b9438a72c24c925bfb38f4</bbl:field>
+         <bbl:field name="extraalpha">2</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">shorttitle</bbl:field>
+@@ -236,7 +236,7 @@
+         <bbl:field name="authorbibnamehash">d52f05e0199eae563725b4165f4b2520</bbl:field>
+         <bbl:field name="labelalpha">Ree58</bbl:field>
+         <bbl:field name="sortinit">R</bbl:field>
+-        <bbl:field name="sortinithash">da6b42bd3ab22fee61abed031ee405f7</bbl:field>
++        <bbl:field name="sortinithash">b9c68a358aea118dfa887b6e902414a7</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="annotation">An article entry with a series and a volume field. Note the format of the series. If the value of the series field is an integer, this number is printed as an ordinal and the string *series is appended automatically</bbl:field>
+@@ -286,7 +286,7 @@
+         <bbl:field name="editorfullhash">d0ec890e59163c24c111a08d2a4be982</bbl:field>
+         <bbl:field name="editorbibnamehash">d0ec890e59163c24c111a08d2a4be982</bbl:field>
+         <bbl:field name="sortinit">S</bbl:field>
+-        <bbl:field name="sortinithash">322b1d5276f2f6c1bccdcd15920dbee6</bbl:field>
++        <bbl:field name="sortinithash">c319cff79d99c853d775f88277d4e45f</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="booksubtitle">Relativistic groups and analyticity</bbl:field>
+@@ -317,7 +317,7 @@
+         <bbl:field name="authorbibnamehash">93f17724cbd884231ef39a73755ef5bb</bbl:field>
+         <bbl:field name="labelalpha">Sho91</bbl:field>
+         <bbl:field name="sortinit">S</bbl:field>
+-        <bbl:field name="sortinithash">322b1d5276f2f6c1bccdcd15920dbee6</bbl:field>
++        <bbl:field name="sortinithash">c319cff79d99c853d775f88277d4e45f</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="annotation">An article entry with series, volume, and number fields. Note the format of the series which is a localization key</bbl:field>
+@@ -353,7 +353,7 @@
+         <bbl:field name="authorfullhash">15e144c72b0b9d10db00ddc6d37a19e6</bbl:field>
+         <bbl:field name="authorbibnamehash">15e144c72b0b9d10db00ddc6d37a19e6</bbl:field>
+         <bbl:field name="sortinit">W</bbl:field>
+-        <bbl:field name="sortinithash">ecb89ff85896a47dc313960773ac311d</bbl:field>
++        <bbl:field name="sortinithash">1af34bd8c148ffb32de1494636b49713</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="journaltitle">Phys. Rev. Lett.</bbl:field>
+@@ -411,7 +411,7 @@
+         <bbl:field name="authorbibnamehash">860705eb8ffac6e40507746c7ede79ca</bbl:field>
+         <bbl:field name="labelalpha">Aks\textbf{+}06</bbl:field>
+         <bbl:field name="sortinit">A</bbl:field>
+-        <bbl:field name="sortinithash">d77c7cdd82ff690d4c3ef13216f92f0b</bbl:field>
++        <bbl:field name="sortinithash">a3dcedd53b04d1adfd5ac303ecd5e6fa</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="indextitle">Effect of immobilization on catalytic characteristics</bbl:field>
+@@ -443,7 +443,7 @@
+         <bbl:field name="authorbibnamehash">9717d2d959a4b18727868ca7928c34b4</bbl:field>
+         <bbl:field name="labelalpha">Ang02</bbl:field>
+         <bbl:field name="sortinit">A</bbl:field>
+-        <bbl:field name="sortinithash">d77c7cdd82ff690d4c3ef13216f92f0b</bbl:field>
++        <bbl:field name="sortinithash">a3dcedd53b04d1adfd5ac303ecd5e6fa</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">shorttitle</bbl:field>
+         <bbl:field name="annotation">A German article in a French journal. Apart from that, a typical article entry. Note the indextitle field</bbl:field>
+@@ -473,7 +473,7 @@
+         </bbl:set>
+         <bbl:field name="labelalpha">Gla61</bbl:field>
+         <bbl:field name="sortinit">G</bbl:field>
+-        <bbl:field name="sortinithash">5e8d2bf9d38de41b1528bd307546008f</bbl:field>
++        <bbl:field name="sortinithash">62eb2aa29549e4fdbd3cb154ec5711cb</bbl:field>
+         <bbl:field name="annotation">A set entry with three members discussing the standard model of particle physics.</bbl:field>
+       </bbl:entry>
+       <bbl:entry key="stdmodel:glashow" type="article">
+@@ -493,7 +493,7 @@
+         <bbl:field name="authorfullhash">eb3f242602109f5bdbeb41fdd990fcc0</bbl:field>
+         <bbl:field name="authorbibnamehash">eb3f242602109f5bdbeb41fdd990fcc0</bbl:field>
+         <bbl:field name="sortinit">G</bbl:field>
+-        <bbl:field name="sortinithash">5e8d2bf9d38de41b1528bd307546008f</bbl:field>
++        <bbl:field name="sortinithash">62eb2aa29549e4fdbd3cb154ec5711cb</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="journaltitle">Nucl. Phys.</bbl:field>
+@@ -532,7 +532,7 @@
+         <bbl:field name="extraname">1</bbl:field>
+         <bbl:field name="labelalpha">Knu86</bbl:field>
+         <bbl:field name="sortinit">K</bbl:field>
+-        <bbl:field name="sortinithash">9fd838a31ba64d981e8f44562bd33f89</bbl:field>
++        <bbl:field name="sortinithash">d3edc18d54b9438a72c24c925bfb38f4</bbl:field>
+         <bbl:field name="extraalpha">1</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">shorttitle</bbl:field>
+@@ -571,7 +571,7 @@
+         <bbl:field name="extraname">2</bbl:field>
+         <bbl:field name="labelalpha">Knu86</bbl:field>
+         <bbl:field name="sortinit">K</bbl:field>
+-        <bbl:field name="sortinithash">9fd838a31ba64d981e8f44562bd33f89</bbl:field>
++        <bbl:field name="sortinithash">d3edc18d54b9438a72c24c925bfb38f4</bbl:field>
+         <bbl:field name="extraalpha">2</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">shorttitle</bbl:field>
+@@ -600,7 +600,7 @@
+         <bbl:field name="authorbibnamehash">d52f05e0199eae563725b4165f4b2520</bbl:field>
+         <bbl:field name="labelalpha">Ree58</bbl:field>
+         <bbl:field name="sortinit">R</bbl:field>
+-        <bbl:field name="sortinithash">da6b42bd3ab22fee61abed031ee405f7</bbl:field>
++        <bbl:field name="sortinithash">b9c68a358aea118dfa887b6e902414a7</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="annotation">An article entry with a series and a volume field. Note the format of the series. If the value of the series field is an integer, this number is printed as an ordinal and the string *series is appended automatically</bbl:field>
+@@ -650,7 +650,7 @@
+         <bbl:field name="editorfullhash">d0ec890e59163c24c111a08d2a4be982</bbl:field>
+         <bbl:field name="editorbibnamehash">d0ec890e59163c24c111a08d2a4be982</bbl:field>
+         <bbl:field name="sortinit">S</bbl:field>
+-        <bbl:field name="sortinithash">322b1d5276f2f6c1bccdcd15920dbee6</bbl:field>
++        <bbl:field name="sortinithash">c319cff79d99c853d775f88277d4e45f</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="booksubtitle">Relativistic groups and analyticity</bbl:field>
+@@ -681,7 +681,7 @@
+         <bbl:field name="authorbibnamehash">93f17724cbd884231ef39a73755ef5bb</bbl:field>
+         <bbl:field name="labelalpha">Sho91</bbl:field>
+         <bbl:field name="sortinit">S</bbl:field>
+-        <bbl:field name="sortinithash">322b1d5276f2f6c1bccdcd15920dbee6</bbl:field>
++        <bbl:field name="sortinithash">c319cff79d99c853d775f88277d4e45f</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="annotation">An article entry with series, volume, and number fields. Note the format of the series which is a localization key</bbl:field>
+@@ -717,7 +717,7 @@
+         <bbl:field name="authorfullhash">15e144c72b0b9d10db00ddc6d37a19e6</bbl:field>
+         <bbl:field name="authorbibnamehash">15e144c72b0b9d10db00ddc6d37a19e6</bbl:field>
+         <bbl:field name="sortinit">W</bbl:field>
+-        <bbl:field name="sortinithash">ecb89ff85896a47dc313960773ac311d</bbl:field>
++        <bbl:field name="sortinithash">1af34bd8c148ffb32de1494636b49713</bbl:field>
+         <bbl:field name="labelnamesource">author</bbl:field>
+         <bbl:field name="labeltitlesource">title</bbl:field>
+         <bbl:field name="journaltitle">Phys. Rev. Lett.</bbl:field>
+diff --git a/t/tdata/remote-files.bcf b/t/tdata/remote-files.bcf
+index c2d784b6..a2a1842b 100644
+--- a/t/tdata/remote-files.bcf
++++ b/t/tdata/remote-files.bcf
+@@ -1853,12 +1853,12 @@
+     <bcf:datasource type="file" datatype="bibtex">http://www.citeulike.org/bibtex/group/8082</bcf:datasource>
+     <bcf:datasource type="file" datatype="bibtex">http://people.cs.uu.nl/hansb/graphs-bib/definitions.bib</bcf:datasource>
+     <bcf:datasource type="file" datatype="bibtex">http://people.cs.uu.nl/hansb/graphs-bib/papers.bib</bcf:datasource>
+-    <bcf:datasource type="file" datatype="bibtex">https://api.zotero.org/groups/9097/items/II22KQ7D?format=bibtex&amp;limit=1</bcf:datasource>
++    <bcf:datasource type="file" datatype="bibtex">https://api.zotero.org/groups/9097/items/8VITAT46?format=bibtex&amp;limit=1</bcf:datasource>
+   </bcf:bibdata>
+   <bcf:section number="0">
+     <bcf:citekey order="1">citeulike:8283461</bcf:citekey>
+     <bcf:citekey order="2">AbdelbarH98</bcf:citekey>
+-    <bcf:citekey order="3">merleau-ponty_philosophe_2010</bcf:citekey>
++    <bcf:citekey order="3">crossley_politics_1994</bcf:citekey>
+   </bcf:section>
+   <!-- SORTING TEMPLATES -->
+   <bcf:sortingtemplate name="nty">
+diff --git a/t/uniqueness-nameparts.t b/t/uniqueness-nameparts.t
+index 08d8d97c..09e18a8b 100644
+--- a/t/uniqueness-nameparts.t
++++ b/t/uniqueness-nameparts.t
+@@ -81,7 +81,7 @@ my $un1 = q|    \entry{un1}{article}{}
+       \strng{authorfullhash}{329d8f9192ea3349d700160c9ddb505d}
+       \field{labelalpha}{SmiJohSim}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -106,7 +106,7 @@ my $un2 = q|    \entry{un2}{article}{}
+       \strng{authorfullhash}{7551114aede4ef69e4b3683039801706}
+       \field{labelalpha}{SmiJohAla}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -131,7 +131,7 @@ my $un3 = q|    \entry{un3}{article}{}
+       \strng{authorfullhash}{401aebda288799a7c757526242d8c9fc}
+       \field{labelalpha}{SmiJohArt}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -156,7 +156,7 @@ my $un4 = q|    \entry{un4}{article}{}
+       \strng{authorfullhash}{f6038a264619efefd49c7daac56424ca}
+       \field{labelalpha}{SmiAlaSim}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -181,7 +181,7 @@ my $un1a = q|    \entry{un1}{article}{}
+       \strng{authorfullhash}{329d8f9192ea3349d700160c9ddb505d}
+       \field{labelalpha}{SmiJohSim}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -206,7 +206,7 @@ my $un2a = q|    \entry{un2}{article}{}
+       \strng{authorfullhash}{7551114aede4ef69e4b3683039801706}
+       \field{labelalpha}{SmiJohAla}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -231,7 +231,7 @@ my $un3a = q|    \entry{un3}{article}{}
+       \strng{authorfullhash}{401aebda288799a7c757526242d8c9fc}
+       \field{labelalpha}{SmiJohArt}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -257,7 +257,7 @@ my $un4a = q|    \entry{un4}{article}{}
+       \strng{authorfullhash}{f6038a264619efefd49c7daac56424ca}
+       \field{labelalpha}{SmiAlaSim}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -285,7 +285,7 @@ my $un1b = q|    \entry{un1}{article}{}
+       \field{extraname}{5}
+       \field{labelalpha}{SmiJohSim}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradate}{5}
+       \field{labelnamesource}{author}
+     \endentry
+@@ -311,7 +311,7 @@ my $un2b = q|    \entry{un2}{article}{}
+       \strng{authorfullhash}{7551114aede4ef69e4b3683039801706}
+       \field{labelalpha}{SmiJohAla}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -336,7 +336,7 @@ my $un3b = q|    \entry{un3}{article}{}
+       \strng{authorfullhash}{401aebda288799a7c757526242d8c9fc}
+       \field{labelalpha}{SmiJohArt}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{labelnamesource}{author}
+     \endentry
+ |;
+@@ -364,7 +364,7 @@ my $un4b = q|    \entry{un4}{article}{}
+       \field{extraname}{1}
+       \field{labelalpha}{SmiAlaSim}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradate}{1}
+       \field{labelnamesource}{author}
+     \endentry
+@@ -393,7 +393,7 @@ my $un5 = q|    \entry{un5}{article}{uniquenametemplatename=test3}
+       \field{extraname}{2}
+       \field{labelalpha}{SmiArtSim}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradate}{2}
+       \field{labelnamesource}{author}
+     \endentry
+@@ -422,7 +422,7 @@ my $un6 = q|    \entry{un6}{article}{}
+       \field{extraname}{3}
+       \field{labelalpha}{SmiArtSmy}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradate}{3}
+       \field{labelnamesource}{author}
+     \\endentry
+@@ -451,7 +451,7 @@ my $un7 = q|    \entry{un7}{article}{}
+       \field{extraname}{4}
+       \field{labelalpha}{SmiArtSme}
+       \field{sortinit}{S}
+-      \field{sortinithash}{322b1d5276f2f6c1bccdcd15920dbee6}
++      \field{sortinithash}{c319cff79d99c853d775f88277d4e45f}
+       \field{extradate}{4}
+       \field{labelnamesource}{author}
+     \endentry
+diff --git a/t/xdata.t b/t/xdata.t
+index 7411b1dd..73dcb8b1 100644
+--- a/t/xdata.t
++++ b/t/xdata.t
+@@ -75,7 +75,7 @@ my $xd1 = q|    \entry{xd1}{book}{}
+       \strng{authorfullhash}{51db4bfd331cba22959ce2d224c517cd}
+       \field{extraname}{2}
+       \field{sortinit}{E}
+-      \field{sortinithash}{f615fb9c6fba11c6f962fb3fd599810e}
++      \field{sortinithash}{c554bd1a0b76ea92b9f105fe36d9c7b0}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+@@ -107,7 +107,7 @@ my $xd2 = q|    \entry{xd2}{book}{}
+       \strng{authornamehash}{68539e0ce4922cc4957c6cabf35e6fc8}
+       \strng{authorfullhash}{68539e0ce4922cc4957c6cabf35e6fc8}
+       \field{sortinit}{P}
+-      \field{sortinithash}{8d51b3d5b78d75b54308d706b9bbe285}
++      \field{sortinithash}{bb5b15f2db90f7aef79bb9e83defefcb}
+       \field{extradatescope}{labelyear}
+       \field{labeldatesource}{}
+       \field{labelnamesource}{author}
+--- a/t/set-static.t.orig
++++ b/t/set-static.t
+@@ -47,7 +47,7 @@
+ my $string1 = q|    \entry{Static1}{set}{}
+       \set{Static2,Static4,Static3}
+       \field{sortinit}{B}
+-      \field{sortinithash}{276475738cc058478c1677046f857703}
++      \field{sortinithash}{8de16967003c7207dae369d874f1456e}
+       \field{annotation}{Some notes}
+     \endentry
+ |;
+@@ -68,7 +68,7 @@
+       \strng{authornamehash}{43874d80d7ce68027102819f16c47df1}
+       \strng{authorfullhash}{43874d80d7ce68027102819f16c47df1}
+       \field{sortinit}{B}
+-      \field{sortinithash}{276475738cc058478c1677046f857703}
++      \field{sortinithash}{8de16967003c7207dae369d874f1456e}
+       \field{labeldatesource}{year}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -94,7 +94,7 @@
+       \strng{authornamehash}{22dafa5cd57bb5dd7f3e3bab98fd539c}
+       \strng{authorfullhash}{22dafa5cd57bb5dd7f3e3bab98fd539c}
+       \field{sortinit}{D}
+-      \field{sortinithash}{2ef1bd9a78cc71eb74d7231c635177b8}
++      \field{sortinithash}{c438b3d5d027251ba63f5ed538d98af5}
+       \field{labeldatesource}{year}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -119,7 +119,7 @@
+       \strng{authornamehash}{da80091c8cd89e5269bd55af1bd5d2fa}
+       \strng{authorfullhash}{da80091c8cd89e5269bd55af1bd5d2fa}
+       \field{sortinit}{C}
+-      \field{sortinithash}{963e9d84a3da2344e8833203de5aed05}
++      \field{sortinithash}{4c244ceae61406cdc0cc2ce1cb1ff703}
+       \field{labeldatesource}{year}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -145,7 +145,7 @@
+       \strng{authornamehash}{43874d80d7ce68027102819f16c47df1}
+       \strng{authorfullhash}{43874d80d7ce68027102819f16c47df1}
+       \field{sortinit}{1}
+-      \field{sortinithash}{2174f786c6195e7fe2ee1c229b416e29}
++      \field{sortinithash}{50c6687d7fc80f50136d75228e3c59ba}
+       \field{labeldatesource}{year}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+--- a/t/set-dynamic.t
++++ b/t/set-dynamic.t
+@@ -51,7 +51,7 @@
+ my $string1 = q|    \entry{DynSet}{set}{}
+       \set{Dynamic1,Dynamic2,Dynamic3}
+       \field{sortinit}{1}
+-      \field{sortinithash}{2174f786c6195e7fe2ee1c229b416e29}
++      \field{sortinithash}{50c6687d7fc80f50136d75228e3c59ba}
+     \endentry
+ |;
+ 
+@@ -71,7 +71,7 @@
+       \strng{authornamehash}{252caa7921a061ca92087a1a52f15b78}
+       \strng{authorfullhash}{252caa7921a061ca92087a1a52f15b78}
+       \field{sortinit}{8}
+-      \field{sortinithash}{07edf88d4ea82509b9c4b4d13f41c452}
++      \field{sortinithash}{1b24cab5087933ef0826a7cd3b99e994}
+       \field{labeldatesource}{year}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -98,7 +98,7 @@
+       \strng{authornamehash}{894a5fe6de820f5dcce84a65581667f4}
+       \strng{authorfullhash}{894a5fe6de820f5dcce84a65581667f4}
+       \field{sortinit}{9}
+-      \field{sortinithash}{1dd72ab054147731c9d824b49aba0534}
++      \field{sortinithash}{54047ffb55bdefa0694bbd554c1b11a0}
+       \field{labeldatesource}{year}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -124,7 +124,7 @@
+       \strng{authornamehash}{fc3cc97631ceaecdde2aee6cc60ab42b}
+       \strng{authorfullhash}{fc3cc97631ceaecdde2aee6cc60ab42b}
+       \field{sortinit}{1}
+-      \field{sortinithash}{2174f786c6195e7fe2ee1c229b416e29}
++      \field{sortinithash}{50c6687d7fc80f50136d75228e3c59ba}
+       \field{labeldatesource}{year}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}
+@@ -151,7 +151,7 @@
+       \strng{authornamehash}{fc3cc97631ceaecdde2aee6cc60ab42b}
+       \strng{authorfullhash}{fc3cc97631ceaecdde2aee6cc60ab42b}
+       \field{sortinit}{1}
+-      \field{sortinithash}{2174f786c6195e7fe2ee1c229b416e29}
++      \field{sortinithash}{50c6687d7fc80f50136d75228e3c59ba}
+       \field{labeldatesource}{year}
+       \field{labelnamesource}{author}
+       \field{labeltitlesource}{title}


### PR DESCRIPTION
Multiple test fails with incorrect sorthashinit values like:
```
#   Failed test 'xdata test - 2'
#   at t/xdata.t line 125.
# --- Got
# +++ Expected
# @@ -1,34 +1,34 @@
#  '    \\entry{xd2}{book}{}
#        \\name{author}{1}{}{%
#          {{hash=68539e0ce4922cc4957c6cabf35e6fc8}{%
#             family={Pillington},
#             familyi={P\\bibinitperiod},
#             given={Peter},
#             giveni={P\\bibinitperiod}}}%
#        }
#        \\list{location}{2}{%
#          {New York}%
#          {London}%
#        }
#        \\list{publisher}{1}{%
#          {Routledge}%
#        }
#        \\strng{namehash}{68539e0ce4922cc4957c6cabf35e6fc8}
#        \\strng{fullhash}{68539e0ce4922cc4957c6cabf35e6fc8}
#        \\strng{bibnamehash}{68539e0ce4922cc4957c6cabf35e6fc8}
#        \\strng{authorbibnamehash}{68539e0ce4922cc4957c6cabf35e6fc8}
#        \\strng{authornamehash}{68539e0ce4922cc4957c6cabf35e6fc8}
#        \\strng{authorfullhash}{68539e0ce4922cc4957c6cabf35e6fc8}
#        \\field{sortinit}{P}
# -      \\field{sortinithash}{bb5b15f2db90f7aef79bb9e83defefcb}
# +      \\field{sortinithash}{8d51b3d5b78d75b54308d706b9bbe285}
#        \\field{extradatescope}{labelyear}
#        \\field{labeldatesource}{}
#        \\field{labelnamesource}{author}
#        \\field{abstract}{An abstract}
#        \\field{addendum}{ÐœÐ¾ÑÐºÐ²Ð°}
#        \\field{note}{A Note}
#        \\field{venue}{venue}
#        \\field{year}{2003}
#        \\field{dateera}{ce}
#      \\endentry
```
This appears to be due to a mismatch in the perl unicode collate levels. Backing out biber commit
https://github.com/plk/biber/commit/6b61b4c13778cf638f82569ab9e413f09f111ba5 will fix.