### PR TITLE
testing/minio: modernize init.d

### DIFF
--- a/testing/minio/APKBUILD
+++ b/testing/minio/APKBUILD
@@ -5,7 +5,7 @@ _pkgver='RELEASE.2019-05-02T19-07-09Z'
 pkgver=${_pkgver#*.}
 pkgver=${pkgver%T*}
 pkgver=0.${pkgver//-}
-pkgrel=0
+pkgrel=1
 pkgdesc="An open source object storage server compatible with Amazon S3"
 pkgusers="minio"
 pkggroups="minio"
@@ -58,6 +58,6 @@ cleanup_srcdir() {
 	default_cleanup_srcdir
 }
 
-sha512sums="18e55dc143c0d71afa8ba758de2efde40946704de65d7a53bfb5f2162fedc736a3f596d0fa75e514cb615e3bbf65809a60bd4b1c2fa22be39d18613d7ab42395  minio.initd
+sha512sums="ee2881200295cb638a55eb58b27c10752f1c0eec8fd1b60c1d4457b494c1b5b4b43de9953de4f92d54cdf41d3ec86158e8ae9ad2dffbc590dfda30332b02e2a9  minio.initd
 ed9790fbadfb38e4d660eb1befd87e803d70dec04d936e8cd26def4a9c21240bb7cae8750ae3395aa4761e6738b9e346c86ba57761cfde30efe46d2cb459a7e4  minio.confd
 34560333c90cbb037562a957ac764500c5bc38355fb99ed9c590c20f40acad9ca98026f3923f90bfdd57dfe8f04b7ecd6951ccc43fc242e68fbdd88ffab01c79  RELEASE.2019-05-02T19-07-09Z.tar.gz"

--- a/testing/minio/minio.initd
+++ b/testing/minio/minio.initd
@@ -1,4 +1,6 @@
 #!/sbin/openrc-run
+supervisor=supervise-daemon
+healthcheck_timer=30
 
 name='Minio Block Storage Server'
 command=/usr/bin/minio
@@ -6,13 +8,16 @@ command_args="server \
     ${address:+--address=$address} \
     $MINIO_OPTS \
     $MINIO_VOLUMES"
-command_background=true
 command_user="minio:minio"
-pidfile="/run/${RC_SVCNAME}.pid"
 
 start_pre() {
     # the conf.d file might contain secrets!
     [ -f "/etc/conf.d/${RC_SVCNAME}" ] && checkpath --file --mode 0600 --owner root:root "/etc/conf.d/${RC_SVCNAME}"
     # make sure the default volume exists
     checkpath --directory --mode 0700 --owner minio:minio "/srv/${RC_SVCNAME}"
+}
+
+healthcheck() {
+    [ -x /usr/bin/curl ] || return 0
+    /usr/bin/curl -q "$address"/minio/health/ready
 }


### PR DESCRIPTION
Now that we have openrc 0.41.2, supervise-daemon is actually usable.
Minio also behaves much nicer with it.