### PR TITLE
testing/assimp: new aport

### DIFF
--- a/testing/assimp/01-rm-revision-test.patch
+++ b/testing/assimp/01-rm-revision-test.patch
@@ -1,0 +1,12 @@
+--- src/test/unit/utVersion.cpp.orig
++++ src/test/unit/utVersion.cpp
+@@ -65,7 +65,6 @@
+     EXPECT_NE( aiGetCompileFlags(), 0U );
+ }
+
+-TEST_F( utVersion, aiGetVersionRevisionTest ) {
++/*TEST_F( utVersion, aiGetVersionRevisionTest ) {
+     EXPECT_NE( aiGetVersionRevision(), 0U );
+-}
+-
++}*/

--- a/testing/assimp/APKBUILD
+++ b/testing/assimp/APKBUILD
@@ -1,0 +1,42 @@
+# Contributor: Russ Webber <russ@rw.id.au>
+# Maintainer: Russ Webber <russ@rw.id.au>
+pkgname=assimp
+pkgver=4.1.0
+pkgrel=0
+pkgdesc="Open Asset Import Library imports and exports 3D model formats."
+url="http://www.assimp.org/"
+arch="all"
+license="BSD-3-Clause"
+makedepends="cmake zlib-dev minizip-dev"
+subpackages="$pkgname-dev"
+source="assimp-$pkgver.tar.gz::https://github.com/assimp/assimp/archive/v$pkgver.tar.gz
+        01-rm-revision-test.patch"
+
+build() {
+  if [ "$CBUILD" != "$CHOST" ]; then
+    CMAKE_CROSSOPTS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
+  fi
+
+  cmake \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DBUILD_SHARED_LIBS=True \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+    -DCMAKE_C_FLAGS="$CFLAGS" \
+    -DASSIMP_BUILD_TESTS=True \
+    ${CMAKE_CROSSOPTS} .
+  make
+}
+
+check() {
+  cd "$builddir"/bin
+  ./unit
+}
+
+package() {
+  make DESTDIR="$pkgdir" install
+}
+
+sha512sums="5f1292de873ae16c9921d1d44f2871474d74c0ddfd76cc928a7d9b3e03aa6eca4cc72af0513da20a86d09c55d48646e610fd4a4f2b05364f08ad09cf27cbc67a  assimp-4.1.0.tar.gz
+4cbcf0d8c91a5d727de25af2444f9a997e111b8cc3cfb951ec7f1ad4f4d0a1bce5300a853a3788a3da787245fd373bfbf9a0f767ec902343e47c366c070b28f3  01-rm-revision-test.patch"


### PR DESCRIPTION
http://www.assimp.org/
Open Asset Import Library imports and exports 3D model formats.

I need some guidance on what to do with this package where it builds a static library called irrXML from external source they seem to have included in their tree. Do I create an official package for the irrXML package (https://www.ambiera.com/irrxml/downloads.html) and then force assimp to use this version of irrXML?