### PR TITLE
community/nextcloud: Fix broken dependencies for default-apps

### DIFF
--- a/community/nextcloud/APKBUILD
+++ b/community/nextcloud/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=nextcloud
 pkgver=16.0.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A safe home for all your data"
 url="http://nextcloud.com"
 arch="noarch"
@@ -59,6 +59,7 @@ _apps="accessibility
 	federation
 	files_external
 	files_pdfviewer
+	files_rightclick
 	files_sharing
 	files_texteditor
 	files_trashbin
@@ -70,6 +71,8 @@ _apps="accessibility
 	nextcloud_announcements
 	notifications
 	password_policy
+	privacy
+	recommendations
 	serverinfo
 	support
 	sharebymail
@@ -77,6 +80,7 @@ _apps="accessibility
 	systemtags
 	theming
 	user_ldap
+	viewer
 	"
 for _i in $_apps; do
 	subpackages="$subpackages $pkgname-$_i:_package_app"


### PR DESCRIPTION
This fixes the broken dependencies for the default-apps package.

Closes https://bugs.alpinelinux.org/issues/10442