### PR TITLE
testing/fzy acceptance tests

### DIFF
--- a/testing/fzy/APKBUILD
+++ b/testing/fzy/APKBUILD
@@ -1,32 +1,29 @@
 # Contributor: Jonathan Neuschäfer <j.neuschaefer@gmx.net>
+# Maintainer: Eivind Uggedal <eu@eju.no>
 pkgname=fzy
 pkgver=1.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A better fuzzy finder"
 url="https://github.com/jhawthorn/$pkgname"
 arch="all"
 license="MIT"
-depends=""
-makedepends=""
-install=""
+checkdepends="ruby-minitest ruby-ttytest"
 subpackages="$pkgname-doc"
 source="https://github.com/jhawthorn/fzy/releases/download/$pkgver/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-	cd "$builddir"
 	make PREFIX="/usr"
 }
 
 check() {
-	cd "$builddir"
 	make check
 
-	# In addition, we could also require ruby here, and run "make acceptance".
+	cd test/acceptance
+	ruby acceptance_test.rb
 }
 
 package() {
-	cd "$builddir"
 	make install PREFIX="/usr" DESTDIR="$pkgdir"
 }
 

--- a/testing/ruby-ttytest/APKBUILD
+++ b/testing/ruby-ttytest/APKBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Eivind Uggedal <eu@eju.no>
+pkgname=ruby-ttytest
+_gemname=ttytest
+pkgver=0.5.0
+pkgrel=0
+pkgdesc="Acceptance test framework for interactive console applications"
+url="https://github.com/jhawthorn/ttytest"
+arch="noarch"
+license="MIT"
+depends="ruby tmux"
+checkdepends="ruby-minitest ruby-rake ruby-bundler"
+source="$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz
+	skip-yard.patch
+	fix-flaky-test.patch
+	gemspec.patch"
+builddir="$srcdir/$_gemname-$pkgver"
+
+build() {
+	gem build $_gemname.gemspec
+}
+
+check() {
+	rake test
+}
+
+package() {
+	local gemdir="$pkgdir/$(ruby -e 'puts Gem.default_dir')"
+
+	gem install --local \
+		--install-dir "$gemdir" \
+		--ignore-dependencies \
+		--no-document \
+		--verbose \
+		$_gemname
+
+	# Cleanup:
+	cd "$gemdir"
+	rm -r cache build_info doc
+}
+sha512sums="30b9f41c8da691178dc9cee66e6fe75c57b3536408d75a6667c1436772103a296e0ec01b2d819592241601e2deae8ebb098a52267fe0e740a35bc039af626fe7  ruby-ttytest-0.5.0.tar.gz
+9986cc16c5c30a11cdb92f8d93159bb06dbbc125e1e839d3438b60baabb15b062326116e7e42b9f289a671d91d3f67b90b4f149e0fd86c56b59365b0b36ac4e6  skip-yard.patch
+6f1e61c958b754fa2d292c486a366122402a20769156d6a251be47f5cc830ac62d88b70e6dd9984d467dbd87ab103625cec1b7e1f369fc60f7263de887250d60  fix-flaky-test.patch
+23dbf425ba8733c6ee91a3809ffab97ec934d1c8c9269105b04bb8b1c3e942cfef417a9ce303e4d5d607d01cb52c83098d0a6c5ddd79aa83274406bbd188704a  gemspec.patch"

--- a/testing/ruby-ttytest/fix-flaky-test.patch
+++ b/testing/ruby-ttytest/fix-flaky-test.patch
@@ -1,0 +1,12 @@
+--- ttytest-0.5.0/test/ttytest/terminal_test.rb
++++ ttytest-0.5.0_p/test/ttytest/terminal_test.rb
+@@ -4,6 +4,9 @@
+   class TerminalTest < Minitest::Test
+     def test_shell_hello_world
+       @tty = TTYtest.new_terminal(%{PS1='$ ' /bin/sh})
++      # Give tmux some time to settle
++      # (see https://github.com/jhawthorn/ttytest/issues/2):
++      sleep(0.5)
+       @tty.assert_row(0, '$')
+       @tty.send_keys('echo "Hello, world"')
+       @tty.assert_row(0, '$ echo "Hello, world"')

--- a/testing/ruby-ttytest/gemspec.patch
+++ b/testing/ruby-ttytest/gemspec.patch
@@ -1,0 +1,13 @@
+--- ttytest-0.5.0/ttytest.gemspec
++++ ttytest-0.5.0_p/ttytest.gemspec
+@@ -14,9 +14,7 @@
+   spec.homepage      = "https://github.com/jhawthorn/ttytest"
+   spec.license       = "MIT"
+ 
+-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+-    f.match(%r{^(test|spec|features)/})
+-  end
++  spec.files         = Dir["lib/**/*"]
+   spec.bindir        = "exe"
+   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+   spec.require_paths = ["lib"]

--- a/testing/ruby-ttytest/skip-yard.patch
+++ b/testing/ruby-ttytest/skip-yard.patch
@@ -1,0 +1,26 @@
+--- ttytest-0.5.0/Rakefile
++++ ttytest-0.5.0_p/Rakefile
+@@ -1,15 +1,10 @@
+ require "bundler/gem_tasks"
+ require "rake/testtask"
+-require "yard"
+ 
+ Rake::TestTask.new(:test) do |t|
+   t.libs << "test"
+   t.libs << "lib"
+   t.test_files = FileList['test/**/*_test.rb']
+-end
+-
+-YARD::Rake::YardocTask.new do |t|
+-  t.files   = ['lib/**/*.rb']
+ end
+ 
+ task :console do
+--- ttytest-0.5.0/ttytest.gemspec
++++ ttytest-0.5.0_p/ttytest.gemspec
+@@ -26,5 +26,4 @@
+   spec.add_development_dependency "bundler", "~> 1.7"
+   spec.add_development_dependency "rake", "~> 10.0"
+   spec.add_development_dependency "minitest", "~> 5.0"
+-  spec.add_development_dependency "yard"
+ end


### PR DESCRIPTION
This brings in a new aport: `ruby-ttycheck`.

I intend to open a new PR to move `fzy`  (and `ruby-ttycheck`) to community once the latter hits testing.