### PR TITLE
main/gphoto2: upgrade to 2.5.20

### DIFF
--- a/main/gphoto2/APKBUILD
+++ b/main/gphoto2/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: 
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gphoto2
-pkgver=2.5.15
+pkgver=2.5.20
 pkgrel=0
 pkgdesc="Commandline utilities for accessing cameras"
 url="http://www.gphoto.org/"
@@ -31,4 +31,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="46058a12a81379f3311911e103cf934b6eb616d7f81180615b385d01e855bf6ce998eb12811b9d032328ebed6acfc4456f3a383cfedb93c6967c9699654d4f40  gphoto2-2.5.15.tar.bz2"
+sha512sums="0350c38c264e5ba858ee14952fbf6ad271e7fef05e3f5f8eb3d45102099ae435fec63b09881efa99af60d4e086a9c2f69be92a7e49617643ab13146a5e4655f3  gphoto2-2.5.20.tar.bz2"


### PR DESCRIPTION
Requires libgphoto2 2.5.17+ (see #7790 for libgphoto2 upgrade)