### PR TITLE
community/cups-filters: depend on ghostscript

### DIFF
--- a/community/cups-filters/APKBUILD
+++ b/community/cups-filters/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cups-filters
 pkgver=1.22.5
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenPrinting CUPS filters and backends"
 url="https://wiki.linuxfoundation.org/openprinting/cups-filters"
 arch="all"
@@ -13,7 +13,7 @@ license="GPL-2.0-or-later LGPL-2.1-or-later MIT"
 # and busybox ash supports most of what bash does
 # texttops/textopdf need FreeMono from ttf-freefont
 # for text printing to work
-depends="poppler-utils bc ttf-freefont"
+depends="poppler-utils bc ttf-freefont ghostscript"
 makedepends="bash cups-dev libjpeg-turbo-dev poppler-dev zlib-dev
 	libpng-dev tiff-dev lcms2-dev freetype-dev ghostscript-dev
 	fontconfig-dev qpdf-dev avahi-dev dbus-dev linux-headers mupdf-tools


### PR DESCRIPTION
It's required for printing PDFs