### PR TITLE
community/php7: split static and add dbg packages

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -27,7 +27,7 @@
 pkgname=php7
 _pkgreal=php
 pkgver=7.3.8
-pkgrel=0
+pkgrel=1
 _apiver=20180731
 _suffix=${pkgname#php}
 # Is this package the default (latest) PHP version?
@@ -86,7 +86,8 @@ makedepends="
 	"
 provides="$pkgname-cli php-cli php"  # for backward compatibility
 provider_priority=100
-subpackages="$pkgname-dev $pkgname-doc $pkgname-apache2 $pkgname-phpdbg
+subpackages="$pkgname-static $pkgname-dev $pkgname-dbg $pkgname-doc
+	$pkgname-phpdbg $pkgname-apache2
 	$pkgname-embed $pkgname-litespeed $pkgname-cgi $pkgname-fpm
 	$pkgname-pear::noarch
 	"
@@ -438,6 +439,7 @@ package() {
 dev() {
 	default_dev
 	replaces="php-dev"
+	depends="$depends $pkgname-static"
 
 	cd "$pkgdir"
 


### PR DESCRIPTION
The main reason is to have dbg symbols also abuild complains about `-dev` is polluted by missing `-static` (meantime "static" should go before "dev"