### PR TITLE
main/powertop: update to 2.10, adopt (again)

### DIFF
--- a/main/powertop/APKBUILD
+++ b/main/powertop/APKBUILD
@@ -1,18 +1,16 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
-# Maintainer:
+# Maintainer: Eivind Uggedal <eu@eju.no>
 pkgname=powertop
-pkgver=2.9
-pkgrel=1
+pkgver=2.10
+pkgrel=0
 pkgdesc="Power consumption monitor"
 url="https://01.org/powertop"
 arch="all"
 license="GPL-2.0"
-depends=
 makedepends="linux-headers ncurses-dev pciutils-dev zlib-dev libnl-dev
 	gettext-dev"
-install=""
 subpackages="$pkgname-doc"
-source="https://01.org/sites/default/files/downloads/$pkgname/$pkgname-v$pkgver.tar.gz
+source="https://01.org/sites/default/files/downloads/$pkgname-v$pkgver.tar.gz
 	musl-fix-headers.patch
 	strerror_r.patch
 	"
@@ -29,6 +27,6 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="783af538c44e3fae7215a5b4247eb32a72e02150b3f297e6b9777a450823dd30aca014601892c0e80937a366eed95b42b622c68161d53e905ad4fbcb574b26f5  powertop-v2.9.tar.gz
-d3bb0e8eaa56fe9ef5aed5d7bea4860be2135fc163ec0c669dc2d01f5ee46ee22ee58cac0835518dc1a4e2939748cf57f2ab37e8d0d879bbc0161d66db7d1919  musl-fix-headers.patch
+sha512sums="4219e7aadbeebdf6932c04f784434e4dd0f540bf4941d43c1830b1b5cad1f3928769b13897e24dd956b6bdee65fb1fbe902ee30685bca229b71e140d65367837  powertop-v2.10.tar.gz
+fe795996e9629735bf5c96222b7c431f9a43d57ad44d4d21b13321c423e7362ecf4fba0b41bb9945c58a0cc5a6a7ecdce4d1e5c7c557d577e7710ba8501d23b1  musl-fix-headers.patch
 0c3a67cae24ec675c71160bfb7222f32a01f59105726c6676b1a3c75ab91073782a593ec319d0e87e5391dbf455b900f6c18459f1fd58ac5789e82aa905c1046  strerror_r.patch"

--- a/main/powertop/musl-fix-headers.patch
+++ b/main/powertop/musl-fix-headers.patch
@@ -1,13 +1,3 @@
---- ./src/devices/devfreq.h.orig
-+++ ./src/devices/devfreq.h
-@@ -25,6 +25,7 @@
- #ifndef _INCLUDE_GUARD_DEVFREQ_H
- #define _INCLUDE_GUARD_DEVFREQ_H
- 
-+#include <sys/time.h>
- #include "device.h"
- #include "../parameters/parameters.h"
- 
 diff --git a/src/perf/perf.h b/src/perf/perf.h
 index ee072ae06d24..932588a684f9 100644
 --- a/src/perf/perf.h


### PR DESCRIPTION
Adopt the unmaintained aport I previously used to maintain.