### PR TITLE
community/mpv: Enable lua explicitly and fix makedepends

### DIFF
--- a/community/mpv/APKBUILD
+++ b/community/mpv/APKBUILD
@@ -5,7 +5,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mpv
 pkgver=0.29.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Video player based on MPlayer/mplayer2"
 url="https://mpv.io/"
 arch="all"
@@ -31,7 +31,7 @@ makedepends="
 	libxv-dev
 	libxvmc-dev
 	libxxf86dga-dev
-	lua5.3-dev
+	lua5.2-dev
 	mesa-dev
 	perl
 	py-docutils
@@ -58,14 +58,10 @@ builddir="$srcdir/$pkgname-$pkgver"
 
 prepare() {
 	default_prepare
-
-	cd "$builddir"
 	./bootstrap.py
 }
 
 build() {
-	cd "$builddir"
-
 	./waf configure --prefix=/usr \
 		--mandir=/usr/share/man \
 		--confdir=/etc/mpv \
@@ -73,19 +69,17 @@ build() {
 		--enable-libass \
 		--enable-libmpv-shared \
 		--enable-wayland \
+		--enable-lua \
 		--enable-zsh-comp \
 		--enable-test
 	./waf build
 }
 
 check() {
-	cd "$builddir"
 	find build/test/ -perm -111 -exec '{}' ';'
 }
 
 package() {
-	cd "$builddir"
-
 	./waf install --destdir="$pkgdir"
 
 	mkdir -p "$pkgdir"/usr/share/doc/$pkgname


### PR DESCRIPTION
Enable lua support explicitly, because it got disabled without
anyone noticing instead of throwing an error during build.
Commit cdf8852d1e5ef6c766b94eec7f31fb38410dad8f changed lua5.2-dev
in makedepends to lua5.3-dev, but mpv needs either lua5.2 or luajit.