### PR TITLE
main/py-redis: update to 3.2.1, adopt

### DIFF
--- a/main/py-redis/APKBUILD
+++ b/main/py-redis/APKBUILD
@@ -1,16 +1,14 @@
-# Maintainer:
+# Maintainer: Eivind Uggedal <eu@eju.no>
 pkgname=py-redis
 _pkgname=${pkgname#py-}
-pkgver=2.10.6
-pkgrel=1
+pkgver=3.2.1
+pkgrel=0
 pkgdesc="Python client for Redis key-value store"
 url="https://github.com/andymccurdy/redis-py"
 arch="noarch"
 license="MIT"
-depends=""
-depends_dev=""
-makedepends="python2-dev python3-dev py-setuptools"
-install=""
+makedepends="py-setuptools py3-setuptools"
+checkdepends="pytest py-mock redis"
 subpackages="py2-redis:py2 py3-redis:py3"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 
@@ -22,13 +20,22 @@ build() {
 	python3 setup.py build
 }
 
+check() {
+	cd "$builddir"
+	redis-server --dir "$builddir"&
+	local _redispid=$!
+
+	python2 setup.py test || (kill $_redispid && false)
+	python3 setup.py test || (kill $_redispid && false)
+	kill $_redispid
+}
+
 _py() {
         local python="$1"
         pkgdesc="$pkgdesc ${python#python}"
         depends="$depends $python"
         install_if="$pkgname=$pkgver-r$pkgrel $python"
 
-        cd "$builddir"
         $python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
@@ -46,4 +53,4 @@ py3() {
 	_py python3
 }
 
-sha512sums="e7df464bc3b26e23f6a0d2d2896306c1e4792b9a2a4ecaea6dd8690ffa17853cc85345f063307295dd3c2da399f7f203f4b21d785f7e073c0501732257419dad  redis-2.10.6.tar.gz"
+sha512sums="be51642a8895325c3c61993dd83c3299a9e2cefc1010e04f182833f720ff161bea43d3a57d28afba991949fcf6e967c4f778002967641bffe651d5db384f2e08  redis-3.2.1.tar.gz"


### PR DESCRIPTION
Update to latest version, add testing (needs running redis server)
and adopt the package (again).