### PR TITLE
community/live-media: upgrade to 2019.05.12

### DIFF
--- a/community/live-media/APKBUILD
+++ b/community/live-media/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=live-media
-pkgver=2018.12.14
+pkgver=2019.05.12
 pkgrel=0
 pkgdesc="A set of C++ libraries for multimedia streaming"
 url="http://live555.com/liveMedia"
@@ -53,4 +53,4 @@ utils() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="8668f088e33c34a4a20a537e70c4f6678a93b275a77ce25697b95798f0b75d1d0f6a7f2d5284c0649330fa783d06946995e065241528169396460de548f5e44f  live.2018.12.14.tar.gz"
+sha512sums="5e9c136146906e483d1c57c93c3e134603fd4ddb0ab4d27f48ac8094029a1e3d9a396a5d1471ca6b5ac7f93f9267c5d8f9f2dd409c79559479ad53102a0216bd  live.2019.05.12.tar.gz"

--- a/community/vlc/APKBUILD
+++ b/community/vlc/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=vlc
 pkgver=3.0.6
-pkgrel=3
+pkgrel=4
 pkgdesc="A multi-platform MPEG, VCD/DVD, and DivX player"
 triggers="vlc-libs.trigger=/usr/lib/vlc/plugins"
 pkgusers="vlc"


### PR DESCRIPTION
There's no previous version https://build.alpinelinux.org/buildlogs/build-3-10-x86_64/community/live-media/live-media-2018.12.14-r0.log

The #5882 also bumps vlc 
```diff
usr/lib/libgroupsock.so.8
-usr/lib/libgroupsock.so.8.2.2
-usr/lib/libliveMedia.so.65
-usr/lib/libliveMedia.so.65.0.0
+usr/lib/libgroupsock.so.8.2.3
+usr/lib/libliveMedia.so.66
+usr/lib/libliveMedia.so.66.0.2 
```
so  yep
```
apk search -r so:libliveMedia.so.65
live-media-2018.12.14-r0 is required by:
live-media-dev-2018.12.14-r0
live-media-utils-2018.12.14-r0
vlc-plugins-access-3.0.6-r3
```
