### PR TITLE
community/abcde: upgrade to 2.9.3 and fix dependency on py3-eyed3

### DIFF
--- a/community/abcde/APKBUILD
+++ b/community/abcde/APKBUILD
@@ -1,32 +1,27 @@
 # Maintainer:
 pkgname=abcde
-pkgver=2.9.2
+pkgver=2.9.3
 pkgrel=0
 pkgdesc="A command line CD encoder that reads your CD, downloads the track information from a CDDB provider, and rips your CD"
 url="http://abcde.einval.com/"
 arch="noarch"
-license="GPL-2.0"
-depends="bash cd-discid py-eyed3"
-depends_dev=""
-makedepends="$depends_dev"
-install=""
+license="GPL-2.0-or-later"
+depends="bash cd-discid py3-eyed3"
+options="!check"  # No test suite.
 subpackages="$pkgname-doc"
 source="http://abcde.einval.com/download/abcde-${pkgver}.tar.gz
 	busybox-wget.patch"
 
-builddir="$srcdir"/$pkgname-$pkgver
 prepare() {
 	default_prepare
 	sed -e "s:normalize-audio:normalize:g" -i ${pkgname}
 }
 
 build() {
-	cd "$builddir"
 	make
 }
 
 package() {
-	cd "$builddir"
 	make DESTDIR="${pkgdir}" \
 		prefix=/usr \
 		sysconfdir=/etc \
@@ -34,5 +29,5 @@ package() {
 		install
 }
 
-sha512sums="ef0048edf040ed5afee6fdd77377800ec02a3ba323647edd6d384679671b47eee63d8bd1c72ce6fe5ed3ab087a3d7f4024ab39e644be4ab8a92f5c5c0ddabfb5  abcde-2.9.2.tar.gz
+sha512sums="51a1dfa1f1d2dab6b8dad7d9f70d0139938151bc2dae0e9fc80da5385b4bba4d71c89a4d1b2dec5bd24787a542cb0caeacbef423cf32b8014cf6320c391b4236  abcde-2.9.3.tar.gz
 282eecc38064713e69705b2b5531822a44c74565fb2cea84f24c0210433d5cc4ec575f511d76b7f72d9af45c74e4722cd62e91c73145bfd06e1f5f0af2d44719  busybox-wget.patch"


### PR DESCRIPTION
Refs
- release https://git.einval.com/cgi-bin/gitweb.cgi?p=abcde.git;a=tag;h=e6400b13b5c4b8505eddd1e36e133757eddbd447
- changelog https://git.einval.com/cgi-bin/gitweb.cgi?p=abcde.git;a=blob;f=changelog;h=8f99618215bf7666911c3a291e52a58a54a76508;hb=5c6f9e4116d19e6ebabd543a2de0d87eb2f8cb58

PS Also it fix it for https://build.alpinelinux.org/buildlogs/build-3-10-armv7/community/abcde/abcde-2.9.2-r0.log