### PR TITLE
community/libdwarf: dont build dwarfgen on s390x

### DIFF
--- a/community/libdwarf/APKBUILD
+++ b/community/libdwarf/APKBUILD
@@ -2,19 +2,20 @@
 # Maintainer: Leo <thinkabit.ukim@gmail.com>
 pkgname=libdwarf
 pkgver=20190505
-pkgrel=0
+pkgrel=1
 pkgdesc="Parsing library for DWARF2 and later debugging file format"
 url="http://www.prevanders.net/dwarf.html"
 arch="all"
 license="LGPL-2.1-or-later"
-makedepends="elfutils-dev"
+makedepends="elfutils-dev zlib-dev"
 subpackages="$pkgname-static $pkgname-dev dwarf-tools::noarch dwarf-tools-doc"
 source="http://www.prevanders.net/$pkgname-$pkgver.tar.gz"
 options="!check"
 
 build() {
-	./configure --prefix=/usr --enable-shared
-	make && make -C dwarfgen
+	[ "$CARCH" != "s390x" ] && _enable_dwarfgen="--enable-dwarfgen"
+	./configure --prefix=/usr --enable-shared $_enable_dwarfgen
+	make
 }
 
 package() {
@@ -37,10 +38,15 @@ package() {
 	cp dwarfdump.conf "$libdir"
 	cp dwarfdump.1 "$man1dir"
 
-	cd "$builddir/dwarfgen"
-	cp dwarfgen "$bindir"
-	cp COPYING "$docdir/dwarfgen.COPYING"
-	cp dwarfgen.1 "$man1dir"
+	case "$CARCH" in
+		s390x) ;;
+		*)
+		cd "$builddir/dwarfgen"
+		cp dwarfgen "$bindir"
+		cp COPYING "$docdir/dwarfgen.COPYING"
+		cp dwarfgen.1 "$man1dir"
+		;;
+	esac
 }
 
 tools() {


### PR DESCRIPTION
There is no upstream support of dwarfgen on s390x yet.
Explicitly include zlib-dev for build time dependencies.

https://sourceforge.net/p/libdwarf/bugs/7/