### PR TITLE
community/vdr: use libdvbcsa on all arches except x86

### DIFF
--- a/community/vdr/APKBUILD
+++ b/community/vdr/APKBUILD
@@ -3,10 +3,10 @@
 # Maintainer: Taner Tas <taner76@gmail.com>
 pkgname=vdr
 pkgver=2.4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Video Disk Recorder"
 url="http://www.tvdr.de/"
-arch="all !ppc64le" # build errors
+arch="all"
 license="GPL-2.0-or-later"
 depends_dev="libexecinfo-dev fontconfig-dev freetype-dev gettext-dev libjpeg-turbo-dev fribidi-dev
 	libcap-dev alsa-lib-dev libvdpau-dev libva-dev libx11-dev xcb-util-dev xcb-util-wm-dev
@@ -122,8 +122,8 @@ build() {
 	cd "$builddir"
 	cp $srcdir/Make.config $builddir
 	case "$CARCH" in
-		arm*|aarch64) make LIBDVBCSA=1 ;;
-		*) make ;;
+		x86*) make ;;
+		*) make LIBDVBCSA=1 ;;
 	esac
 }
 
@@ -175,8 +175,8 @@ skincurses() {
 package() {
 	cd "$builddir"
 	case "$CARCH" in
-		arm*|aarch64) make -j1 LIBDVBCSA=1 DESTDIR="$pkgdir" install ;;
-		*) make -j1 DESTDIR="$pkgdir" install ;;
+		x86*) make -j1 DESTDIR="$pkgdir" install ;;
+		*) make -j1 LIBDVBCSA=1 DESTDIR="$pkgdir" install ;;
 	esac
 	install -D -m755 "$srcdir"/$pkgname.initd \
 		${pkgdir}/etc/init.d/$pkgname


### PR DESCRIPTION
FFdecsa uses x86-specific flags. We use libdvbcsa for other arches.

See vdr-plugin-dvbapi/INSTALL.