### PR TITLE
Readd contrib comments

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -6,3 +6,4 @@ Kevin Daudt <kdaudt@alpinelinux.org> <ops@ikke.info>
 Lucas Ramage <ramage.lucas@protonmail.com> <oxr463@gmx.us>
 Lucas Ramage <ramage.lucas@protonmail.com> <ramage.lucas@openmailbox.org>
 Lucas Ramage <ramage.lucas@protonmail.com> <lramage@star2star.com>
+<eu@eju.no> <eivind@uggedal.com>

--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -1,6 +1,6 @@
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Contributor: Jake Buchholz <tomalok@gmail.com>
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
-
 pkgname=docker
 pkgver=18.09.6
 _gitcommit=481bc7715621adba10752357e0d537c8dc86507d	# https://github.com/docker/docker-ce/commits/v$pkgver

--- a/community/go-bootstrap/APKBUILD
+++ b/community/go-bootstrap/APKBUILD
@@ -1,5 +1,5 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
-# Contributor: Eivind Uggedal <eivind@uggedal.com>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: Sören Tempel <soeren+alpine@soeren-tempel.net>
 pkgname=go-bootstrap
 _realname="${pkgname%-*}"

--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -1,4 +1,5 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=go
 pkgver=1.12.5

--- a/community/sxiv/APKBUILD
+++ b/community/sxiv/APKBUILD
@@ -1,4 +1,5 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: Sören Tempel <soeren+alpine@soeren-tempel.net>
 pkgname=sxiv
 pkgver=25

--- a/main/dmenu/APKBUILD
+++ b/main/dmenu/APKBUILD
@@ -1,4 +1,4 @@
-# Contributor: Eivind Uggedal <eivind@uggedal.com>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: Sören Tempel <soeren+alpine@soeren-tempel.net>
 pkgname=dmenu
 pkgver=4.9

--- a/main/fcgiwrap/APKBUILD
+++ b/main/fcgiwrap/APKBUILD
@@ -1,3 +1,4 @@
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=fcgiwrap
 pkgver=1.1.0

--- a/main/ghi/APKBUILD
+++ b/main/ghi/APKBUILD
@@ -1,3 +1,4 @@
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: Roberto Oliveira <robertoguimaraes8@gmail.com>
 pkgname=ghi
 pkgver=1.2.0

--- a/main/herbstluftwm/APKBUILD
+++ b/main/herbstluftwm/APKBUILD
@@ -1,4 +1,5 @@
 # Contributor: Łukasz Jendrysik
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: prspkt <prspkt@protonmail.com>
 pkgname=herbstluftwm
 pkgver=0.7.1

--- a/main/mksh/APKBUILD
+++ b/main/mksh/APKBUILD
@@ -1,4 +1,4 @@
-# Contributor: Eivind Uggedal <eivind@uggedal.com>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: Sören Tempel <soeren+alpinelinux@soeren-tempel.net>
 pkgname=mksh
 pkgver=57

--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -1,8 +1,8 @@
-# Contributor: 
 # Contributor: Jose-Luis Rivas <ghostbar@riseup.net>
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Contributor: Dave Esaias <dave@containership.io>
 # Contributor: Tadahisa Kamijo <kamijin@live.jp>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 #
 # secfixes:

--- a/main/py-jwt/APKBUILD
+++ b/main/py-jwt/APKBUILD
@@ -1,3 +1,4 @@
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer:
 pkgname=py-jwt
 _pkgname=PyJWT

--- a/main/py-nose/APKBUILD
+++ b/main/py-nose/APKBUILD
@@ -1,4 +1,5 @@
 # Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer:
 pkgname=py-nose
 _pkgname=nose

--- a/main/py-oauthlib/APKBUILD
+++ b/main/py-oauthlib/APKBUILD
@@ -1,3 +1,4 @@
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer:
 pkgname=py-oauthlib
 _pkgname=${pkgname#py-}

--- a/main/py3-hoedown/APKBUILD
+++ b/main/py3-hoedown/APKBUILD
@@ -1,4 +1,5 @@
 # Contributor: Leo <thinkabit.ukim@gmail.com>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer:
 pkgname=py3-hoedown
 _pkgname=hoedown

--- a/main/redis/APKBUILD
+++ b/main/redis/APKBUILD
@@ -1,4 +1,5 @@
 # Contributor: V.Krishn <vkrishn4@gmail.com>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: TBK <alpine@jjtc.eu>
 pkgname=redis
 pkgver=5.0.4

--- a/main/s6-rc/APKBUILD
+++ b/main/s6-rc/APKBUILD
@@ -1,5 +1,5 @@
 # Maintainer: Laurent Bercot <ska-devel@skarnet.org>
-# Contributor: Eivind Uggedal <eivind@uggedal.com>
+# Contributor: Eivind Uggedal <eu@eju.no>
 pkgname=s6-rc
 pkgver=0.5.0.0
 pkgrel=0

--- a/main/spawn-fcgi/APKBUILD
+++ b/main/spawn-fcgi/APKBUILD
@@ -1,5 +1,5 @@
 # Maintainer:
-# Contributor: Valery Kartel <valery.kartel@gmail.com>
+# Contributor: Eivind Uggedal <eu@eju.no>
 pkgname=spawn-fcgi
 pkgver=1.6.4
 pkgrel=3

--- a/main/tarsnap/APKBUILD
+++ b/main/tarsnap/APKBUILD
@@ -1,4 +1,5 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer:
 pkgname=tarsnap
 pkgver=1.0.39

--- a/main/xbanish/APKBUILD
+++ b/main/xbanish/APKBUILD
@@ -1,4 +1,4 @@
-# Contributor: Eivind Uggedal <eivind@uggedal.com>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=xbanish
 pkgver=1.6

--- a/testing/hub/APKBUILD
+++ b/testing/hub/APKBUILD
@@ -1,6 +1,6 @@
 # Contributor: Leo <thinkabit.ukim@gmail.com>
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
-# Contributor: Eivind Uggedal <eivind@uggedal.com>
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Maintainer: Roberto Oliveira <robertoguimaraes8@gmail.com>
 pkgname=hub
 pkgver=2.11.2


### PR DESCRIPTION
Since I left the project almost all my Maintainer/Contributor tags were stripped. Ideally I'd like them back so that I can keep tabs on packages I can continue to contribute to in the future.

Also some email address fixes for still-existing contrib tags. Same for a `.mailmap` entry.

CC @ncopa 