### PR TITLE
testing/singularity: upgrade to 3.2.0

### DIFF
--- a/testing/singularity/APKBUILD
+++ b/testing/singularity/APKBUILD
@@ -1,13 +1,13 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=singularity
-pkgver=3.1.1
+pkgver=3.2.0
 pkgrel=0
 pkgdesc="Application containers focused on reproducibility for scientific computing and HPC world."
 url="https://www.sylabs.io/singularity/"
-arch="all"
+arch="all !aarch64 !armhf !armv7"
 license="BSD-3-Clause BSD-3-Clause-LBNL"
-options="suid"
+options="suid !check" # no test suite from upstream
 depends="squashfs-tools"
 makedepends="
 	go
@@ -18,7 +18,8 @@ makedepends="
 	libseccomp-dev
 	"
 subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch"
-source="$pkgname-$pkgver.tar.gz::https://github.com/sylabs/singularity/archive/v$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/sylabs/singularity/archive/v$pkgver.tar.gz
+	c0f9abf5d9877372bff12127fd7294c2e962e1ab.patch"
 builddir="$srcdir/src/github.com/sylabs/$pkgname"
 
 prepare() {
@@ -41,48 +42,28 @@ build() {
 		--infodir=/usr/share/infodir \
 		--localstatedir=/var
 
-	cd ./builddir
-	make
-}
-
-check() {
-	cd "$builddir"/builddir/
-
-	./singularity version
-
-	./singularity search alpine
-
-	./singularity key search Sylabs
-
-	./singularity pull alpine
-	printf 'Y\n' | ./singularity verify alpine_latest.sif 
-	./singularity key list
-
-	./singularity cache list
-	./singularity cache clean --name alpine_latest.sif
-	./singularity cache list
+	make -C builddir
 }
 
 package() {
-	cd "$builddir"/builddir/
-	make DESTDIR="$pkgdir" install
+	make -C builddir DESTDIR="$pkgdir" install
 
-	# bash completion has it's own package
-	rm -r "$pkgdir"/etc/bash_completion.d/
-
-	cd "$builddir"
 	install -m644 -D -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE.md
 	install -m644 -D -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE-LBNL.md
 	install -m644 -D -t "$pkgdir/usr/share/doc/$pkgname" README.md
-
 }
 
 bashcomp() {
 	depends=""
 	pkgdesc="Bash completion for $pkgname"
+
+
 	install_if="$pkgname=$pkgver-r$pkgrel bash-completion"
 
-	install -Dm 644 "$builddir"/builddir/etc/bash_completion.d/singularity \
-		"$subpkgdir"/usr/share/bash-completion/completions/$pkgname
+	mkdir -p "$subpkgdir"/usr/share/bash-completion/completions
+
+	mv "$pkgdir"/etc/bash_completion.d/singularity \
+		"$subpkgdir"/usr/share/bash-completion/completions/singularity
 }
-sha512sums="e3456b8629ea697f78f3260dc4f3ae3689a9dc274c49f7e8afb1c3f6f333f5e7402d4253eca767ae90b52e67ee006b58793338384cadda50191fba0e0e7bfd55  singularity-3.1.1.tar.gz"
+sha512sums="a9128a1da1e47858779a89d8af5807f7c1419863e78969be66d90fe635da225594c8051f570f25471ef393829ac8d7d1e854fc73773da3e49716da32a05aa15c  singularity-3.2.0.tar.gz
+0ac10ce764caae55d2850d32d4d9c428d5cea4b2a6b0eec3e95bf0e0e0240ec8eaca3394db62fa65e7f7b9ab202e0df54117104e08a8c1e0f185ceee5116bbc9  c0f9abf5d9877372bff12127fd7294c2e962e1ab.patch"

--- a/testing/singularity/c0f9abf5d9877372bff12127fd7294c2e962e1ab.patch
+++ b/testing/singularity/c0f9abf5d9877372bff12127fd7294c2e962e1ab.patch
@@ -1,0 +1,49 @@
+From c0f9abf5d9877372bff12127fd7294c2e962e1ab Mon Sep 17 00:00:00 2001
+From: Cedric Clerget <cedric.clerget@gmail.com>
+Date: Tue, 21 May 2019 12:22:01 +0200
+Subject: [PATCH] Fix instance join regression with root user
+
+---
+ .../runtime/engines/singularity/prepare_linux.go    | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/internal/pkg/runtime/engines/singularity/prepare_linux.go b/internal/pkg/runtime/engines/singularity/prepare_linux.go
+index 72f177a0fd..b639ff111b 100644
+--- a/internal/pkg/runtime/engines/singularity/prepare_linux.go
++++ b/internal/pkg/runtime/engines/singularity/prepare_linux.go
+@@ -375,14 +375,18 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
+ 		return err
+ 	}
+ 
++	uid := os.Getuid()
++	gid := os.Getgid()
++	suidRequired := uid != 0 && !file.UserNs
++
+ 	// basic checks:
+ 	// 1. a user must not use SUID workflow to join an instance
+ 	//    started with user namespace
+ 	// 2. a user must use SUID workflow to join an instance
+ 	//    started without user namespace
+-	if starterConfig.GetIsSUID() && file.UserNs {
++	if starterConfig.GetIsSUID() && !suidRequired {
+ 		return fmt.Errorf("joining user namespace with SUID workflow is not allowed")
+-	} else if !starterConfig.GetIsSUID() && !file.UserNs {
++	} else if !starterConfig.GetIsSUID() && suidRequired {
+ 		return fmt.Errorf("a setuid installation is required to join this instance")
+ 	}
+ 
+@@ -425,13 +429,10 @@ func (e *EngineOperations) prepareInstanceJoinConfig(starterConfig *starter.Conf
+ 		return err
+ 	}
+ 
+-	uid := os.Getuid()
+-	gid := os.Getgid()
+-
+ 	// enforce checks while joining an instance process with SUID workflow
+ 	// since instance file is stored in user home directory, we can't trust
+ 	// its content when using SUID workflow
+-	if !file.UserNs && uid != 0 {
++	if suidRequired {
+ 		// check if instance is running with user namespace enabled
+ 		// by reading /proc/pid/uid_map
+ 		_, hid, err := proc.ReadIDMap("uid_map")


### PR DESCRIPTION
- https://github.com/sylabs/singularity/releases 3.2.0
- Fixes high severity security issue CVE-2019-11328
- Modernize
- No test suite from upstream
- Disable aarch64, armhf, and armv7 due to build errors
- Add patch to fix instance join regression with root user,
  https://github.com/sylabs/singularity/pull/3586