### PR TITLE
testing/light: new aport

### DIFF
--- a/testing/light/APKBUILD
+++ b/testing/light/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Eivind Uggedal <eu@eju.no>
+# Maintainer: Eivind Uggedal <eu@eju.no>
+pkgname=light
+pkgver=1.2
+pkgrel=0
+pkgdesc="A program to control backlights and other hardware lights"
+url="http://haikarainen.github.io/light/"
+arch="all"
+license="GPL-3.0-or-later"
+options="!check"  # no test suite
+subpackages="$pkgname-doc"
+source="https://github.com/haikarainen/light/releases/download/v$pkgver/light-$pkgver.tar.gz"
+
+build() {
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var \
+		--with-udev=/lib/udev/rules.d
+	make
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="d35e1fd097ccaf062a5da02ff769a3f916bf49d307f7db03522ad733bec499378585d5b62e4628a3e73db475060ebe4660be82efbc68709ef3ca3342af7cf252  light-1.2.tar.gz"


### PR DESCRIPTION
Built in non-SUID mode where udev rules sets up the correct permissions
for the video group.