### PR TITLE
testing/py-pyrsistent: new aport

### DIFF
--- a/testing/py-pyrsistent/APKBUILD
+++ b/testing/py-pyrsistent/APKBUILD
@@ -1,0 +1,56 @@
+# Maintainer: Adam Dobrawy <a.dobrawy@hyperone.com>
+pkgname=py-pyrsistent
+_pkgname=${pkgname#py-}
+pkgver=0.15.2
+pkgrel=0
+pkgdesc="Pyrsistent is a number of persistent collections. Persistent in the sense that they are immutable."
+url="https://github.com/tobgu/pyrsistent/"
+arch="noarch"
+license="MIT"
+depends="py-six"
+makedepends="$depends_dev python2-dev python3-dev py-setuptools"
+subpackages="py3-$_pkgname:_py3:all py2-$_pkgname:_py2:all"
+source="$pkgname-$pkgver.tar.gz::https://github.com/tobgu/pyrsistent/archive/v$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+check() {
+	cd "$builddir"
+	python2 setup.py check
+	python3 setup.py check
+	python2 -c 'import pyrsistent';
+	python3 -c 'import pyrsistent';
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr \
+		--root="$subpkgdir" --optimize=1
+}
+
+_py2() {
+	depends="${depends//py-/py2-}"
+	replaces="$pkgname"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+
+sha512sums="5333e706007f9d44b432f8bced12dd64c800e4128192b5e301b15d655470475ad234ebcb2a5b70498364dd7a467a2118944f7e6878a88a496aef89ce4edf3905  py-pyrsistent-0.15.2.tar.gz"


### PR DESCRIPTION
Required by py-jsonschema required by cloud-init. Console log running Alpine Edge:

```
Traceback (most recent call last):
  File "/usr/bin/cloud-init", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3191, in <module>
    @_call_aside
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3175, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3204,in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pyrsistent>=0.14.0' distribution was not found and is required by jsonschema
 [ ok ]
 * Setting hostname ... [ ok ]
 * Starting networking ...awk: /etc/network/interfaces: No such file or directory
 * ERROR: networking failed to start
 * Starting busybox syslog ... [ ok ]
 * Starting haveged ... * start-stop-daemon: /usr/sbin/haveged is already running
 * Failed to start haveged
 [ !! ]
 * ERROR: haveged failed to start
 * Starting networking ...awk: /etc/network/interfaces: No such file or directory
 * ERROR: networking failed to start
Traceback (most recent call last):
  File "/usr/bin/cloud-init", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3191, in <module>
    @_call_aside
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3175, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3204, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pyrsistent>=0.14.0' distribution was not found and is required by jsonschema
 [ ok ]
Traceback (most recent call last):
  File "/usr/bin/cloud-init", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3191, in <module>
    @_call_aside
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3175, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3204, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pyrsistent>=0.14.0' distribution was not found and is required by jsonschema
 [ ok ]
Traceback (most recent call last):
  File "/usr/bin/cloud-init", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3191, in <module>
    @_call_aside
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3175, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3204, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pyrsistent>=0.14.0' distribution was not found and is required by jsonschema
 [ ok ]
 * Starting busybox crond ... [ ok ]
ssh-keygen: generating new host keys: RSA DSA ECDSA ED25519 
 * Starting sshd ... [ ok ]
```