### PR TITLE
main/mariadb: after entropy

### DIFF
--- a/main/mariadb/APKBUILD
+++ b/main/mariadb/APKBUILD
@@ -7,7 +7,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mariadb
 pkgver=10.3.13
-pkgrel=4
+pkgrel=5
 pkgdesc="A fast SQL database server"
 url="https://www.mariadb.org"
 pkgusers="mysql"
@@ -422,7 +422,7 @@ _plugin_rocksdb() {
 }
 
 sha512sums="3cbd93291aa43b235e5b81d953ea69fb32df54fb518f922f69b5485952f01fae693c77b0efac37f414ed7ff132d3b58f899812bdb7be8a5b344c3640e2c3a0dd  mariadb-10.3.13.tar.gz
-c352969f6665b0ffa387f7b185a5dea7751f4b16c12c809627857b27321efa09159369d7dd5c852d6159a9f173cb895fb601f0c52a1fa6e3527899520030964c  mariadb.initd
+7744ce036e08fcbbc03d8b15efa525944c9e3f764c9dcb5a9fa3ec1db465a9471dc5f50989c7e75696ce74d34e5ef0983068d9e20ec9173b1101cc674be13172  mariadb.initd
 b4469f2f0299e71c09b65c91373f2d72b7fe9a9cd58ad24737a78a8097473b29c32b7267e173a2dfe1158f2f7d40a7fb02fb1b35caeda44d16ae3b9e2602a75f  fix-c11-atomics-check.patch
 e9ae4613f1d8c5f0a59b39a3548c46e50674ae78e7457d0e64c49f7e1573125c13634bbce7e29179bb8865a423171f852f43b96f7ef95619a95f02edcfc71efd  ppc-remove-glibc-dep.patch
 70da971aa78815495098205bcbd28428430aa83c3f1050fec0231ca86af9d9def2d2108a48ee08d86812c8dc5ad8ab1ef4e17a49b4936ed5187ae0f6a7ef8f63  pcre.cmake.patch"

--- a/main/mariadb/mariadb.initd
+++ b/main/mariadb/mariadb.initd
@@ -9,6 +9,7 @@ command_args="--syslog --nowatch --pid-file=$pidfile"
 depend() {
 	use net
 	need localmount
+	after entropy
 }
 
 start_pre() {


### PR DESCRIPTION
If mariadb is not started after an entropy provider it will take too long to start resulting in:
```
 * Starting mariadb ...190515 22:15:31 mysqld_safe Logging to syslog.
190515 22:15:31 mysqld_safe Starting mysqld daemon with databases from /var/lib/mysql
 [ ok ]
 * ERROR: mariadb failed to start
```