### PR TITLE
main/libuv: upgrade to 1.29.1

### DIFF
--- a/main/libuv/APKBUILD
+++ b/main/libuv/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libuv
-pkgver=1.28.0
+pkgver=1.29.1
 pkgrel=0
 pkgdesc="Cross-platform asychronous I/O"
 url="https://libuv.org"
@@ -10,7 +10,7 @@ arch="all"
 license="MIT BSD ISC"
 makedepends_build="automake autoconf libtool"
 makedepends_host="linux-headers"
-subpackages="$pkgname-dev $pkgname-dbg"
+subpackages="$pkgname-static $pkgname-dev $pkgname-dbg"
 source="https://dist.libuv.org/dist/v$pkgver/$pkgname-v$pkgver.tar.gz
 	disable-setuid-test.patch
 	"
@@ -46,5 +46,5 @@ package() {
 		"$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 
-sha512sums="d7f635ab99569e96db9ae97d29a302f5eec1fd75c71b035ec597a6b978a3fc797a37c7406fed81a27d4d706fe21cbfe919d829d6dae67399cd5cddd107ad6949  libuv-v1.28.0.tar.gz
+sha512sums="0813a57d7da28c1665824be69321f133050656171d294bb0cb5a83bab7b7c8eef2d6690bdcff2f44727a6f6d6b9b977a66586efb5d59ed280f78be72c71110d3  libuv-v1.29.1.tar.gz
 ba85b0be3905be6d5ff2bf825f99420d979eb2db9c665d2de1cea8366470de718670f71addb9611e468befe1f1e9fcdcf8886ae1d4784485abf0beae2ccc8ee3  disable-setuid-test.patch"


### PR DESCRIPTION
- https://github.com/libuv/libuv/releases 1.29.1
- Add $pkgname-static to subpackages