### PR TITLE
community/mpv: Use lua5.2

### DIFF
--- a/community/mpv/APKBUILD
+++ b/community/mpv/APKBUILD
@@ -1,3 +1,4 @@
+# Contributor: Chloe Kudryavtsev <toast@toastin.space>
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
@@ -31,7 +32,7 @@ makedepends="
 	libxv-dev
 	libxvmc-dev
 	libxxf86dga-dev
-	lua5.3-dev
+	lua5.2-dev
 	mesa-dev
 	perl
 	py-docutils


### PR DESCRIPTION
mpv does not currently support detecting lua5.3, which results in lua support being
disabled.
fixes [bugs.a.o#10461](https://bugs.alpinelinux.org/issues/10461)