### PR TITLE
community/caddy: upgrade to 1.0.0

### DIFF
--- a/community/caddy/APKBUILD
+++ b/community/caddy/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
-# Maintainer: Carlo Landmeter <clandmeter@gmail.com>
+# Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=caddy
-pkgver=0.11.5
+pkgver=1.0.0
 pkgrel=0
 pkgdesc="Fast, cross-platform HTTP/2 web server with automatic HTTPS"
 url="https://caddyserver.com/"
@@ -10,7 +10,6 @@ license="Apache-2.0"
 depends="ca-certificates"
 makedepends="go libcap bash"
 subpackages="$pkgname-openrc"
-options="!check" # tests fail
 install="$pkgname.pre-install"
 pkgusers="$pkgname"
 pkggroups="$pkgname"
@@ -29,22 +28,18 @@ prepare() {
 }
 
 build() {
-	cd "$builddir"
 	export GOPATH="$srcdir"
-	go build -v -o bin/caddy -ldflags \
+	GO111MODULE=on go build -v -o bin/caddy -ldflags \
 		"-X github.com/mholt/caddy/caddy/caddymain.gitTag=$pkgver" \
 		./caddy
 }
 
 check() {
-	cd "$builddir"
 	export GOPATH="$srcdir"
-	go test ./...
+	GO111MODULE=on go test ./...
 }
 
 package() {
-	cd "$builddir"
-
 	install -Dm755 bin/caddy "$pkgdir"/usr/sbin/caddy
 
 	# caddy currently does not support dropping privileges so we
@@ -66,7 +61,12 @@ package() {
 		"$pkgdir"/etc/$pkgname/$pkgname.conf
 }
 
-sha512sums="09a28da82c53f088c4d76cf5f1218ee70c53d5ffaaf6ed1fe25fcda68ff3b75834d3d8dfaa5459e83f48f8fdd028c313b16fca9fe6ede0353c49a1360c98d471  caddy-0.11.5.tar.gz
+cleanup_srcdir() {
+	go clean -modcache
+	default_cleanup_srcdir
+}
+
+sha512sums="3b77b99634609f9216f51481011b11159b5a7bdb96254783011d9a7e76209853e2eb5eeffdf5243687f4b64eeb36fc18a2f9c7a410ea5ce409608ff6784eaf93  caddy-1.0.0.tar.gz
 00fe095efd8d801f0c2c69832c7240858080407ea3696ca07f6b53d3304f7e2784566d8a6b447cb83d7dc4542db551f1b4fa48ff031da7e4a1d4a26e59fc05c5  caddy.initd
 7808688e92ab9950403a9b8ad29777f5bd0f75aa8cccc1d49958bb1e5af1b972dfba0c6d31931354f702a3a13933d0a1b8f28b82eed263773d71b79ec95cc15c  caddy.confd
 c24805d17234e6cf40fe1dd102c03f05cf6129d43f58f5567d540a0e4400ce89994820bb0e317f611c65459ae26bcf7110e23a8fecaae11ca78a561892b45d75  caddy.conf"


### PR DESCRIPTION
Superseeds #7880 (there was too much to change for a review).

1. Caddy now uses the Go Modules system:
    -> builds and tests require a new environment variable
    -> it now requires a custom cleanup step
2. Tests now pass (on my builder)

Note: I would be willing to adopt this package if it's too much of a bother to upkeep otherwise.