### PR TITLE
main/snort: enable lzma support

### DIFF
--- a/main/snort/APKBUILD
+++ b/main/snort/APKBUILD
@@ -1,15 +1,16 @@
+# Contributor: Karim Kanso <kaz.kanso@gmail.com>
 # Contributor: Michael Mason <ms13sp@gmail.com>
 # Contributor: Leonardo Arena <rnalrd@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=snort
 pkgver=2.9.13
-pkgrel=0
+pkgrel=1
 pkgdesc="An open source network intrusion prevention and detection system"
 url="https://www.snort.org/"
 arch="all"
 license="GPL-2.0-only"
 makedepends="pcre-dev libpcap-dev libnet-dev libdnet-dev daq-dev
-	bison flex zlib-dev libtirpc-dev"
+	bison flex zlib-dev libtirpc-dev xz-dev"
 install="$pkgname.pre-install"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-openrc"
 source="https://www.snort.org/downloads/snort/snort-$pkgver.tar.gz


### PR DESCRIPTION
Fix error when using current/up to date  rulesets from snort.org:

```
ERROR: etc/snort.conf(327) => Invalid keyword '}' for server configuration.
```

Issue is caused by `snort` not being compiled with lzma support. Added `xz-dev` to `makedepends` as if its not present, build script will fail silently and not support lzma.

To reproduce the error using latest available rule set, follow below on `edge`:
```bash
$ apk add snort
$ cd /var/lib/snort/
$ wget https://www.snort.org/rules/snortrules-snapshot-29130.tar.gz?oinkcode=${OINKCODE} -O - |  tar xzf -
$ sed -e 's|/usr/local|/usr|' -e 's|\.\./|/var/lib/snort/|' etc/snort.conf > etc/snort.conf.patched
$ snort -i eth0 -c etc/snort.conf.patched  -T
<snip>
ERROR: etc/snort.conf.patched(327) => Invalid keyword '}' for server configuration.
```

More information: https://seclists.org/snort/2016/q4/232