### PR TITLE
community/hugo: upgrade to 0.55.5 and fix up failing test

### DIFF
--- a/community/hugo/0001-Remove-git-tests.patch
+++ b/community/hugo/0001-Remove-git-tests.patch
@@ -1,32 +1,32 @@
-From a77897023bc3379f9ed15080d88dd944f3f51f94 Mon Sep 17 00:00:00 2001
-From: Drew DeVault <sir@cmpwn.com>
-Date: Fri, 8 Mar 2019 19:46:32 -0500
-Subject: [PATCH] Remove git tests
-
----
- hugolib/page_test.go | 60 -----------------------------------
- releaser/git_test.go | 75 --------------------------------------------
- 2 files changed, 135 deletions(-)
- delete mode 100644 releaser/git_test.go
-
-diff --git a/hugolib/page_test.go b/hugolib/page_test.go
-index 1db1d352..07c17e6d 100644
 --- a/hugolib/page_test.go
 +++ b/hugolib/page_test.go
-@@ -26,9 +26,6 @@ import (
+@@ -16,7 +16,6 @@
+ import (
+ 	"fmt"
+ 	"html/template"
+-	"os"
+ 
+ 	"github.com/gohugoio/hugo/common/loggers"
+ 
+@@ -25,12 +24,9 @@
  	"testing"
  	"time"
  
 -	"github.com/gohugoio/hugo/hugofs"
--	"github.com/spf13/afero"
 -
+ 	"github.com/gohugoio/hugo/resources/page"
+ 	"github.com/gohugoio/hugo/resources/resource"
+ 
+-	"github.com/spf13/afero"
  	"github.com/spf13/viper"
  
  	"github.com/gohugoio/hugo/deps"
-@@ -861,63 +858,6 @@ func TestPageWithDate(t *testing.T) {
- 	checkPageDate(t, p, d)
- }
+@@ -760,63 +756,6 @@
+ 	d, _ := time.Parse(time.RFC3339, "2013-05-17T16:59:30Z")
  
+ 	checkPageDate(t, p, d)
+-}
+-
 -func TestPageWithLastmodFromGitInfo(t *testing.T) {
 -	assrt := require.New(t)
 -
@@ -71,22 +71,20 @@ index 1db1d352..07c17e6d 100644
 -	require.NoError(t, h.Build(BuildCfg{SkipRender: true}))
 -
 -	enSite := h.Sites[0]
--	assrt.Len(enSite.RegularPages, 1)
+-	assrt.Len(enSite.RegularPages(), 1)
 -
 -	// 2018-03-11 is the Git author date for testsite/content/first-post.md
--	assrt.Equal("2018-03-11", enSite.RegularPages[0].Lastmod.Format("2006-01-02"))
+-	assrt.Equal("2018-03-11", enSite.RegularPages()[0].Lastmod().Format("2006-01-02"))
 -
 -	nnSite := h.Sites[1]
--	assrt.Len(nnSite.RegularPages, 1)
+-	assrt.Len(nnSite.RegularPages(), 1)
 -
 -	// 2018-08-11 is the Git author date for testsite/content_nn/first-post.md
--	assrt.Equal("2018-08-11", nnSite.RegularPages[0].Lastmod.Format("2006-01-02"))
+-	assrt.Equal("2018-08-11", nnSite.RegularPages()[0].Lastmod().Format("2006-01-02"))
 -
--}
--
- func TestPageWithFrontMatterConfig(t *testing.T) {
- 	t.Parallel()
+ }
  
+ func TestPageWithFrontMatterConfig(t *testing.T) {
 diff --git a/releaser/git_test.go b/releaser/git_test.go
 deleted file mode 100644
 index f0d6fd24..00000000

--- a/community/hugo/APKBUILD
+++ b/community/hugo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Thomas Boerger <thomas@webhippie.de>
 # Maintainer: Thomas Boerger <thomas@webhippie.de>
 pkgname=hugo
-pkgver=0.54.0
+pkgver=0.55.5
 pkgrel=0
 pkgdesc="A Fast and Flexible Static Site Generator built with love in GoLang"
 url="http://gohugo.io/"
@@ -28,5 +28,5 @@ package() {
 	install -Dm755 "$builddir"/bin/$pkgname "$pkgdir"/usr/bin/$pkgname
 }
 
-sha512sums="904b9ae9e3db91195e9e768faca8867d6534d20f64b19dec4d1788ca5f19863e9fac284821855ffef9bee6280d77cc72816c42b6e28b5f3a4f45d12daf6b9d0d  hugo-0.54.0.tar.gz
-be2cd72475db35465bc6a0b091640ba65d4c41c686ed218d715b29b9b36d128e37579c719a203ccaa1d2563faac7307934485f30fef913d05b8c85251d086572  0001-Remove-git-tests.patch"
+sha512sums="1558b334a3443428ab29d4ac923b0023f0aaf3457e45248200c7ee258cb9ab101086d996392a53168269b1edb0bf7ea0d3e1374a4711cfaef165d136abb8e506  hugo-0.55.5.tar.gz
+66ffa51fa50209542c5ef6af2daeccb0be9fa20812f1b83c81623859fd652d047eb5d6e57b967d705d23e8760218d7c9973897d0a05d5cf2c2f33ff2bd0615d1  0001-Remove-git-tests.patch"


### PR DESCRIPTION
Upgrade to fix failing hugolib test.
FAIL	github.com/gohugoio/hugo/hugolib	9.259s