### PR TITLE
community/nbd: fix segfault during tests

### DIFF
--- a/community/nbd/APKBUILD
+++ b/community/nbd/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=nbd
 pkgver=3.18
-pkgrel=0
+pkgrel=1
 pkgdesc="Tools for network block devices"
 url="http://nbd.sourceforge.net"
 arch="all"
@@ -11,6 +11,7 @@ makedepends="glib-dev linux-headers zlib-dev gnutls-dev libnl3-dev bash"
 subpackages="$pkgname-doc $pkgname-client $pkgname-openrc"
 source="https://downloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.xz
 	nbd-server.initd
+	fix-segfault-freeaddrinfo.patch
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver
@@ -52,4 +53,5 @@ client() {
 }
 
 sha512sums="f9fe221b585c126efa3fb65e2344477a38f2ce42164b04d0dc4681c5a3bfd34d5d3e227454fff24eee9039853eb38a8707ea0aab0337f44906cccf379c185ce8  nbd-3.18.tar.xz
-3e71f0cd79d378abb1901038952748b548d18540aa7ebe94bcda65bc331021c1eef942c26283dbbd39471ecfa33c2c5b6165acfcf0abd7d17aed1bdcd47fea31  nbd-server.initd"
+3e71f0cd79d378abb1901038952748b548d18540aa7ebe94bcda65bc331021c1eef942c26283dbbd39471ecfa33c2c5b6165acfcf0abd7d17aed1bdcd47fea31  nbd-server.initd
+fb83a0a1f2863b147f462e27edc713134a5a4541b5807dbb320cae67f96314ceca86c40b4cc344a6f0fd42e73a8807bf238edb3ebaeb2855eb98359b905855a3  fix-segfault-freeaddrinfo.patch"

--- a/community/nbd/fix-segfault-freeaddrinfo.patch
+++ b/community/nbd/fix-segfault-freeaddrinfo.patch
@@ -1,0 +1,15 @@
+diff --git a/nbd-server.c b/nbd-server.c
+index b0720ea140..cf3df0462a 100644
+--- a/nbd-server.c
++++ b/nbd-server.c
+@@ -1700,7 +1700,9 @@ int set_peername(int net, CLIENT *client) {
+ 			break;
+ 	}
+ 
+-	freeaddrinfo(ai);
++	if(ai) {
++		freeaddrinfo(ai);
++	}
+         msg(LOG_INFO, "connect from %s, assigned file is %s",
+             peername, client->exportname);
+ 	client->clientname=g_strdup(peername);


### PR DESCRIPTION
nbd calls freeaddrinfo on a variable that might not have been initialized. This causes segfaults for inetd and unix mode. 

This was caught by the test suite.