### PR TITLE
community/rethinkdb: fix tribool errs with explicit cast and re=enable ppc64le

### DIFF
--- a/community/rethinkdb/APKBUILD
+++ b/community/rethinkdb/APKBUILD
@@ -2,10 +2,10 @@
 # Maintainer: Daniel Treadwell <daniel@djt.id.au>
 pkgname=rethinkdb
 pkgver=2.3.6
-pkgrel=9
+pkgrel=10
 pkgdesc="Distributed powerful and scalable NoSQL database"
 url="https://www.rethinkdb.com"
-arch="x86_64 s390x"
+arch="x86_64 ppc64le s390x"
 license="Apache-2.0"
 options="!check" # needs coffeescript
 makedepends="bash python2 linux-headers bsd-compat-headers m4 paxmark
@@ -52,7 +52,7 @@ build() {
 	esac
 
 	export LDFLAGS="$LDFLAGS -lexecinfo"
-	make CXXFLAGS="$CXXFLAGS -fno-delete-null-pointer-checks"
+	make CXXFLAGS="$CXXFLAGS -DBOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS -fno-delete-null-pointer-checks"
 }
 
 check() {


### PR DESCRIPTION
build breaking across all architectures with errors like:
````
src/clustering/administration/auth/user.cc: In member function 'bool auth::user_t::has_read_permission(const database_id_t&, const namespace_id_t&) const':
src/clustering/administration/auth/user.cc:199:20: error: cannot convert 'boost::logic::tribool' to 'bool' in return
             return table_permission;
                    ^~~~~~~~~~~~~~~~
```
add compiler flag -DBOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS to force compiler compatible behavior for tribool