### PR TITLE
community/qt5-qtwebscript: upgrade to 5.12.3

### DIFF
--- a/community/qt5-qtscript/APKBUILD
+++ b/community/qt5-qtscript/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=qt5-qtscript
 _pkgname=${pkgname/qt5-//}-everywhere-src
-pkgver=5.12.1
+pkgver=5.12.3
 _ver=${pkgver/_/-}
 _ver=${_ver/beta0/beta}
 _ver=${_ver/rc0/rc}
@@ -40,6 +40,6 @@ package() {
 	make INSTALL_ROOT="$pkgdir" install
 }
 
-sha512sums="1fe7d0582e6c61fd146d66080bc91b40a6a2bda9b6bdb983339276b1aebb6f3c24070fc5acb2fd90556c11d51708c7bc75542532097b7f4f381b13dadaec5c9e  qtscript-everywhere-src-5.12.1.tar.xz
+sha512sums="4c4498acb39536bdc03643fb1717c7a47c82b1734cf67d17d40bc216084f01e837648d261f7f69e317387f9c6efa9aaa6b0df8f5532f55615252c95b1089ca1a  qtscript-everywhere-src-5.12.3.tar.xz
 c89124fc940ceaa5cfc52c8f48b8eef17bba575a080fad3f27d61e3da98ab5cfd4bb6ffaae09ccae81f6f7644719fa28d38d4b7a7fe4cdb4268673c39627eb22  qtscript-everywhere-src-5.10.1-sgidefs.patch
 a0a22824954d35495d9d08c2b82d6eeeec26765760d417b8bc72c51e1753d4bb9f5e55d5289001d2d6071669a0bfd4f856fc3d0cf58b509bcbcd5211df35e482  qtscript-s390x.patch"


### PR DESCRIPTION
Version 5.12.1 used code that is no longer accepted in GCC 8.3. Upstream
fixed that issue in 5.12.2.

See [this commit][0] for more information.

[0]: https://code.qt.io/cgit/qt/qtscript.git/commit/?id=97ec1d1882a83c23c91f0f7daea48e05858d8c32