### PR TITLE
main/samba: security upgrade to 4.10.3

### DIFF
--- a/main/samba/APKBUILD
+++ b/main/samba/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=samba
-pkgver=4.10.2
+pkgver=4.10.3
 pkgrel=0
 pkgdesc="Tools to access a server's filespace and printers via SMB"
 url="https://www.samba.org/"
@@ -89,6 +89,8 @@ pkggroups="winbind"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   4.10.3-r0:
+#     - CVE-2018-16860
 #   4.8.11-r0:
 #     - CVE-2018-14629
 #     - CVE-2019-3880
@@ -563,7 +565,7 @@ libs() {
 		"$pkgdir"/usr
 }
 
-sha512sums="3d146ea12567ebb02a7babcad779b82339ffbfb19f6f2be5cac33eb18af2c9b546dc1cd910072a5c9e152ba9c4a632ed6870c48a8f6ad9d04304b130f240a4bf  samba-4.10.2.tar.gz
+sha512sums="b247eaf4438b219ed0fdbc8dbdef94798cdb3eb5eb39831e89f2955842576ac90aa9201323ce6976f0e93dba69c6c6b7842d7bfc9e0a97ac9986d2f6a31882f8  samba-4.10.3.tar.gz
 188ed177d593906ac2ee532b40be20169f4379288480d71a79344702636208872fe50d54ec73f7c4477270f36c2c27308d1ae197b153b388ac4f3df9c8593347  domain.patch
 0d4fd9862191554dc9c724cec0b94fd19afbfd0c4ed619e4c620c075e849cb3f3d44db1e5f119d890da23a3dd0068d9873703f3d86c47b91310521f37356208b  getpwent_r.patch
 a99e771f28d787dc22e832b97aa48a1c5e13ddc0c030c501a3c12819ff6e62800ef084b62930abe88c6767d785d5c37e2e9f18a4f9a24f2ee1f5d9650320c556  musl_uintptr.patch


### PR DESCRIPTION
https://www.samba.org/samba/security/CVE-2018-16860.html