### PR TITLE
[3.9] main/samba: security upgrade to 4.8.12

### DIFF
--- a/main/samba/APKBUILD
+++ b/main/samba/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=samba
-pkgver=4.8.11
-pkgrel=1
+pkgver=4.8.12
+pkgrel=0
 pkgdesc="Tools to access a server's filespace and printers via SMB"
 url="https://www.samba.org/"
 arch="all"
@@ -86,6 +86,8 @@ pkggroups="winbind"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   4.8.12-r0:
+#     - CVE-2018-16860
 #   4.8.11-r0:
 #     - CVE-2018-14629
 #     - CVE-2019-3880
@@ -560,7 +562,7 @@ libs() {
 		"$pkgdir"/usr
 }
 
-sha512sums="65f3791ca3300f0e9760730962978bffc4ae22bf3bb3e58e7f2249bab6db9758dfcde9487ae0c8bc862fe7a507252cad131f8ea5dec826aceac214227d8e75cd  samba-4.8.11.tar.gz
+sha512sums="f29595f6390d01860cb6acd750d2e36b4d207dd1da16465c21c8d6d732ce27bd0582a0f34296081e2659638d839c8b12f28deccc31982afa94650da8bce8df8b  samba-4.8.12.tar.gz
 62d373dbaee75121a1d73f2c09cdca7239705808ff807b171d1d5a28fd4ffc66bdb52494b62786d7aaba8aeece5c08433b532ca96a28d712452fe9daac8d8d2e  domain.patch
 0d4fd9862191554dc9c724cec0b94fd19afbfd0c4ed619e4c620c075e849cb3f3d44db1e5f119d890da23a3dd0068d9873703f3d86c47b91310521f37356208b  getpwent_r.patch
 a99e771f28d787dc22e832b97aa48a1c5e13ddc0c030c501a3c12819ff6e62800ef084b62930abe88c6767d785d5c37e2e9f18a4f9a24f2ee1f5d9650320c556  musl_uintptr.patch


### PR DESCRIPTION
https://www.samba.org/samba/security/CVE-2018-16860.html