### PR TITLE
community/py-setuptools_scm: upgrade to 3.3.3

### DIFF
--- a/community/py-setuptools_scm/APKBUILD
+++ b/community/py-setuptools_scm/APKBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Dmitry Romanenko <dmitry@romanenko.in>
 pkgname=py-setuptools_scm
 _pkgname=setuptools_scm
-pkgver=3.2.0
-pkgrel=1
+pkgver=3.3.3
+pkgrel=0
 pkgdesc="the blessed package to manage your versions by scm tags"
 url="https://github.com/pypa/setuptools_scm"
 arch="noarch"
@@ -50,4 +50,4 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="1995754654f8bf509ec7f2186857ba0005dbaea0b1c734f521becb9d022c127e7b36f21da8defd5ec9883de5d0d4afe006f9d152c4cefe6beadf8b878e949eb2  setuptools_scm-3.2.0.tar.gz"
+sha512sums="196d4785a1802875d89b9e54ae788e791a9c5cb685109784059955b691242984e42b96d77075116790935f56be82259bc2588d95d65ecbb101261d76daddb83c  setuptools_scm-3.3.3.tar.gz"


### PR DESCRIPTION
https://github.com/pypa/setuptools_scm/blob/master/CHANGELOG.rst

v3.3.2
======


* fix 335 - fix python3.8 support and add builds for up to python3.8

v3.3.1
======

* fix 333 (regression from 198) - use a specific fallback root when calling fallbacks. Remove old
  hack that resets the root when fallback entrypoints are present.

v3.3.0
======

* fix 198 by adding the ``fallback_version`` option, which sets the version to be used when everything else fails.