### PR TITLE
main/grub: fix initramfs detection for xen

### DIFF
--- a/main/grub/APKBUILD
+++ b/main/grub/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=grub
 pkgver=2.02
-pkgrel=15
+pkgrel=16
 pkgdesc="Bootloader with support for Linux, Multiboot and more"
 url="https://www.gnu.org/software/grub/"
 arch="all !s390x"
@@ -42,6 +42,7 @@ source="https://ftp.gnu.org/gnu/grub/grub-$pkgver.tar.xz
 	x86-64-Treat-R_X86_64_PLT32-as-R_X86_64_PC32.patch
 	alpine-use-uuid.patch
 	f2fs-support.patch
+	alpine-xen-initramfs.patch
 
 	0001-xen-Add-some-Xen-headers.patch
 	0002-loader-linux-Support-passing-RSDP-address-via-boot-p.patch
@@ -239,6 +240,7 @@ f2a7d9ab6c445f4e402e790db56378cecd6631b5c367451aa6ce5c01cd95b95c83c3dd24d6d4b857
 e11f62b5012ecc8abf9d4912db12a263470887671b05ccb4de54981fb3b32a52d4557439a160e69e0654e35a57fdb0afd5fe801709b8037a6ea4a50d8b8455ec  x86-64-Treat-R_X86_64_PLT32-as-R_X86_64_PC32.patch
 ce788fa909bb89a3ccabbc144bb46226373cf846ffe1f315b0bf8b02403220d95c8fe67baf3c37c4e12cb36f22d70f62bbd2d0c5ff6b7230f05e5964b5c548ac  alpine-use-uuid.patch
 e4e7716cef9f183810eade57751617595c5d5fac740223a5ac3ed13e2215bbb38781328a3f8da3d4c71dd39ffec55d27d3e55b55c189dce55748e9a8512d4b41  f2fs-support.patch
+e683a647757956349c25e3c4e0be8d2e4f78287ba588c497f21942677b207f33a33fa4293cbe71665760dd31b752af02e1353896858cdb2f8d4368116878d5b1  alpine-xen-initramfs.patch
 9daf00b36108852a7443ce4b5b1114d2e87cbfc72148b7847508965ff0dfab14b3f56980a0110c82170f5c2b75ef7a337a15398f59a4cb7e6404227499bffd9a  0001-xen-Add-some-Xen-headers.patch
 33505273a8525aa4b44acba69f1b7f0dbee144809fb86626879895d44ce7eed889abf442644fc96536b4ebf86ab7c84a982749fc1181976e89e59a5cf7f7944e  0002-loader-linux-Support-passing-RSDP-address-via-boot-p.patch
 1e446051930a96078e2b22831f53e939affdcee371e35e45d87efb8bdf02e2eea03247b7636525daf7d9306ec47cd4351e4d74abe357d19658b0b3fc884f9343  0003-xen-Carve-out-grant-tab-initialization-into-dedicate.patch

--- a/main/grub/alpine-xen-initramfs.patch
+++ b/main/grub/alpine-xen-initramfs.patch
@@ -1,0 +1,10 @@
+--- a/util/grub.d/20_linux_xen.in
++++ b/util/grub.d/20_linux_xen.in
+@@ -221,6 +221,7 @@
+ 	   "initrd-${version}" "initramfs-${version}.img" \
+ 	   "initrd.img-${alt_version}" "initrd-${alt_version}.img" \
+ 	   "initrd-${alt_version}" "initramfs-${alt_version}.img" \
++	   "initramfs-${version}" \
+ 	   "initramfs-genkernel-${version}" \
+ 	   "initramfs-genkernel-${alt_version}" \
+ 	   "initramfs-genkernel-${GENKERNEL_ARCH}-${version}" \


### PR DESCRIPTION
/etc/grub.d/20_linux_xen fails to find the initramfs image on Alpine Linux, this patch fixes that.