### PR TITLE
community/sigar: modernize and enable all arches

### DIFF
--- a/community/sigar/0004-make-the-package-compile-on-MIPS.patch
+++ b/community/sigar/0004-make-the-package-compile-on-MIPS.patch
@@ -1,0 +1,39 @@
+From: Hilko Bengen <bengen@debian.org>
+Date: Tue, 29 Jul 2014 16:41:18 +0200
+Subject: make the package compile on MIPS
+
+---
+ src/sigar_getline.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/sigar_getline.c b/src/sigar_getline.c
+index 0a8946b..fd36fef 100644
+--- a/src/sigar_getline.c
++++ b/src/sigar_getline.c
+@@ -362,7 +362,7 @@ static void     search_forw(int s);     /* look forw for current string */
+ #endif
+ 
+ #if defined(TIOCGETP) && !defined(__sgi) && !defined(R__MKLINUX) && \
+-   !defined(R__ALPHALINUX)  /* use BSD interface if possible */
++   !defined(R__ALPHALINUX) && !defined(__mips__)  /* use BSD interface if possible */
+ #include <sgtty.h>
+ static struct sgttyb   new_tty, old_tty;
+ static struct tchars   tch;
+@@ -371,7 +371,7 @@ static struct ltchars  ltch;
+ #ifdef SIGTSTP          /* need POSIX interface to handle SUSP */
+ #include <termios.h>
+ #if defined(__sun) || defined(__sgi) || defined(R__MKLINUX) || \
+-    defined(R__ALPHALINUX)
++    defined(R__ALPHALINUX) || defined(__mips__)
+ #undef TIOCGETP         /* Solaris and SGI define TIOCGETP in <termios.h> */
+ #undef TIOCSETP
+ #endif
+@@ -412,7 +412,7 @@ gl_char_init()                  /* turn off input echo */
+ {
+     if (gl_notty) return;
+ #ifdef unix
+-#ifdef TIOCGETP                 /* BSD */
++#if defined(TIOCGETP) && !defined(__mips__)  /* BSD */
+     ioctl(0, TIOCGETC, &tch);
+     ioctl(0, TIOCGLTC, &ltch);
+     gl_intrc = tch.t_intrc;

--- a/community/sigar/0005-no-m64-mips-arm.patch
+++ b/community/sigar/0005-no-m64-mips-arm.patch
@@ -1,0 +1,14 @@
+Index: hyperic-sigar-1.6.4+dfsg/bindings/java/hyperic_jni/src/org/hyperic/jni/ArchNameTask.java
+===================================================================
+--- hyperic-sigar-1.6.4+dfsg.orig/bindings/java/hyperic_jni/src/org/hyperic/jni/ArchNameTask.java	2014-11-03 13:25:30.620030459 +0800
++++ hyperic-sigar-1.6.4+dfsg/bindings/java/hyperic_jni/src/org/hyperic/jni/ArchNameTask.java	2014-11-03 13:25:30.608030459 +0800
+@@ -75,7 +75,8 @@
+         if (ArchName.is64()) {
+             getProject().setProperty("jni.arch64", "true");
+             if (ArchLoader.IS_LINUX) {
+-                if (!osArch.equals("ia64")) {
++                if (!osArch.equals("ia64") && !osArch.equals("mips64el")
++                      && !osArch.equals("mips64") && !osArch.equals("aarch64")) {
+                     getProject().setProperty("jni.gccm", "-m64");
+                 }
+             }

--- a/community/sigar/0006-fix-undefined-symbols.patch
+++ b/community/sigar/0006-fix-undefined-symbols.patch
@@ -1,0 +1,13 @@
+Description: fix 'undefined symbol: sigar_skip_token' problem as suggested
+ in upstream's issue tracker: https://github.com/hyperic/sigar/issues/60
+Author: Andrius Merkys <merkys@debian.org>
+--- a/bindings/java/hyperic_jni/jni-build.xml
++++ b/bindings/java/hyperic_jni/jni-build.xml
+@@ -305,6 +305,7 @@
+         <compilerarg value="-Wall"/>
+         <compilerarg value="-Werror" if="jni.werror"/>
+         <compilerarg value="${jni.gccm}" if="jni.gccm"/>
++        <compilerarg value="-fgnu89-inline"/>
+         <defineset>
+           <define name="${jni.define.name}_LINUX"/>
+           <define name="_REENTRANT"/>

--- a/community/sigar/APKBUILD
+++ b/community/sigar/APKBUILD
@@ -1,23 +1,23 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=sigar
 pkgver=1.6.4
-pkgrel=0
+pkgrel=1
 pkgdesc="System Information Gatherer And Reporter"
 url="http://sigar.hyperic.com/"
-arch="x86_64 x86 ppc64le"
+arch="all"
 license="Apache-2.0"
-depends=""
-depends_dev=""
-makedepends="$depends_dev libtirpc-dev perl apache-ant openjdk8"
-install=""
-subpackages=""
+makedepends="libtirpc-dev perl apache-ant openjdk8"
 source="https://github.com/hyperic/sigar/archive/sigar-$pkgver.tar.gz
 	0001-fix-compilation-with-musl-libc.patch
 	0002-only-enable-the-GNU-libc-strerror_r-on-GNU-libc.patch
 	0003-build-with-libtirpc-and-gcc5.patch
+	0004-make-the-package-compile-on-MIPS.patch
+	0005-no-m64-mips-arm.patch
+	0006-fix-undefined-symbols.patch
 	"
 
 builddir="$srcdir"/sigar-sigar-$pkgver
+
 build() {
 	cd "$builddir"/bindings/java
 	ant
@@ -29,15 +29,10 @@ package() {
 	install ./sigar-bin/lib/libsigar-*.so "$pkgdir"/usr/lib/
 }
 
-md5sums="b4a5e195755fa084feec3cdadcd964d1  sigar-1.6.4.tar.gz
-6e519321a995126f66995d5d961b5463  0001-fix-compilation-with-musl-libc.patch
-9c739f71c0f9bd0cba16e7d85fc49271  0002-only-enable-the-GNU-libc-strerror_r-on-GNU-libc.patch
-ec4b6b987330d01fdfa94f7f3e62c8f6  0003-build-with-libtirpc-and-gcc5.patch"
-sha256sums="179b04c1eb7e10e50632e1f8c8d25c1bc4d35259f2976bc72686ecfa79a0052e  sigar-1.6.4.tar.gz
-be24452bf5960adbe6d7b422ca101d015d52ac0dfabcf0ca973883cab56b6d18  0001-fix-compilation-with-musl-libc.patch
-234551e9b9dd03345bacd589c3b9e66f90d6730db9ddca4d692cf8d779c83009  0002-only-enable-the-GNU-libc-strerror_r-on-GNU-libc.patch
-8d68f10a9a14c54c17276e7d48fb6cf82919ad473f2fdf475cfcab6ca9678a96  0003-build-with-libtirpc-and-gcc5.patch"
 sha512sums="0515f3501a51357d6ac01dc5e3ecffae10995f347b98c66928adff247b86e52112d2bf9cf78b2633941eb9c7fb23f019f4885c41348fe461239e4eebd147253e  sigar-1.6.4.tar.gz
 577f10add8dfe3f1e97375aba06fdecb4ae9d64d75246107cde2183a9efee5eeb8f2c00c072397e2ac4bba2dc49e67c5efef141c609f84a6128d03f3f5187d05  0001-fix-compilation-with-musl-libc.patch
 12f68a3c3449b98a45458aa189a633d32ccc9adab83e04e84c8e496c1e0545a58ecc86fdcb68d55b162f5717244f69a48f0a13241b672c909993dc13643c8c64  0002-only-enable-the-GNU-libc-strerror_r-on-GNU-libc.patch
-1896f8deb1945dd18283cb391528791b7554b2a4d56c0bc02a58d36a6af2a333782486a508e4d756b558d522d9a759bb3eefe12f0fd1720a9b83426d2b9bf469  0003-build-with-libtirpc-and-gcc5.patch"
+1896f8deb1945dd18283cb391528791b7554b2a4d56c0bc02a58d36a6af2a333782486a508e4d756b558d522d9a759bb3eefe12f0fd1720a9b83426d2b9bf469  0003-build-with-libtirpc-and-gcc5.patch
+2999ac33ee0346ebb2d390bb4e315e340eb0c5c3e78c078f7687ddfa83b9817d13d46d4e1f7d208c75a49a279d035efb1a50af56c021d068ea313813e013c851  0004-make-the-package-compile-on-MIPS.patch
+c77796ce9d34a42ea8663bf47b119ec1e3b8a4daf938dad7a15a4c11239cd58ee9797725da4c7defa846479db4d8eb190220beafc969c9dac5fa6d5adebf55b6  0005-no-m64-mips-arm.patch
+b85593c1b07c2c7ac3cd66df70e2ab75e615547c14c797c4e6ce0508fc3a02988e5c9055f0dada14bdf0cb060c35129872239f01e9cf0e0481d0038578f93908  0006-fix-undefined-symbols.patch"


### PR DESCRIPTION
Fix https://bugs.alpinelinux.org/issues/7011
aarch64/mips patches are borrowed from Debian.