### PR TITLE
community/libsass: upgrade to 3.6.0 and clean-up

### DIFF
--- a/community/libsass/APKBUILD
+++ b/community/libsass/APKBUILD
@@ -1,16 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 # Contributor: Thomas Boerger <thomas@webhippie.de>
 pkgname=libsass
-pkgver=3.5.5
+pkgver=3.6.0
 pkgrel=0
 pkgdesc="C/C++ implementation of a Sass compiler"
-url="http://libsass.org"
+url="https://libsass.org"
 arch="all"
 license="MIT"
-depends=""
 makedepends="autoconf automake libtool"
 subpackages="$pkgname-dev"
-source="$pkgname-$pkgver.tar.gz::https://github.com/sass/$pkgname/archive/$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/sass/libsass/archive/$pkgver.tar.gz"
 
 prepare() {
 	default_prepare
@@ -18,7 +17,6 @@ prepare() {
 }
 
 build() {
-	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -28,10 +26,8 @@ build() {
 }
 
 package() {
-	cd "$builddir"
-
 	make install DESTDIR="$pkgdir"
 	rm -f "$pkgdir"/usr/lib/*.la
 }
 
-sha512sums="dcb73a5080c00023b60a19ea037ba5af481253a7b47492bd7114bf45ab78ed931c7b207fa8f12ed200a39760553d72ae92dbe4eb80b826b59a6201fb34008fe5  libsass-3.5.5.tar.gz"
+sha512sums="9665e50ee964ca3cc323f26c2b8322677102d26a7a102558ffbc5bef7a4c4ea44ca5096a967e4044dac1404bfa343a37d846f22d1e1adc27592023d5d4ac40c8  libsass-3.6.0.tar.gz"


### PR DESCRIPTION
Ref https://github.com/sass/libsass/releases/tag/3.6.0