### PR TITLE
community/namecoin: upgrade to 0.18.0

### DIFF
--- a/community/namecoin/APKBUILD
+++ b/community/namecoin/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=namecoin
-pkgver=0.17.0
+pkgver=0.18.0
 _ver=${pkgver/_/}
-pkgrel=1
+pkgrel=0
 pkgdesc="Namecoin is a peer to peer DNS based on bitcoin"
 url="https://www.namecoin.org/"
 arch="all !s390x"
@@ -22,7 +22,6 @@ source="$pkgname-$_ver.tar.gz::https://github.com/$pkgname/$pkgname-core/archive
 builddir="$srcdir/$pkgname-core-nc$_ver"
 
 build() {
-	cd "$builddir"
 	./autogen.sh
 	./configure \
 		--build=$CBUILD \
@@ -39,12 +38,10 @@ build() {
 }
 
 check() {
-	cd "$builddir"
 	make check
 }
 
 package() {
-	cd "$builddir"
 	make install DESTDIR="$pkgdir"
 	install -m755 -D "$srcdir"/$pkgname.initd "$pkgdir"/etc/init.d/$pkgname
 	install -m600 -D "$srcdir"/$pkgname.conf "$pkgdir"/etc/$pkgname.conf
@@ -89,7 +86,7 @@ dev() {
 	mv "$pkgdir"/usr/include "$subpkgdir"/usr/
 }
 
-sha512sums="d130f055298dfd54b7c8dcc9070a01af5a209ebf80166434187512be683993ed7b3379d9367d725200851ab148c80bfa480b77822aea59cfdae260cdfbd6e471  namecoin-0.17.0.tar.gz
+sha512sums="ae1b0bf58ecd57546d1e23b943cd565ced39452f560c6afdbdae511224ead8cd134b8a22efe2a89287c616be2d16a5c044b0a84477019589e65fc61fd449cfd8  namecoin-0.18.0.tar.gz
 98aa5ad81bdb4ae961b791bc978c39117cdf2d83c2181f92bebbb0db107d9b6e86eda265fb3f93ff8a5ca8a7754d7148818b98095d57201dff9363d60b97e7dd  ssize_t.patch
 1753132f349e02cc248a622eb17f2f98a180d561d46f2e8916b84cc26c98d546214ca305bb1ea378ae14090c0abf8d6ac257c98c6776bbe4dabd68c108f595a3  namecoin.initd
 3f92cb9a5f66d0e9e3792691b2e62b929c092030273bb87ebd9564e0c02196a5a9f69c458162f1b35099ac28e9b79b1c4035144b9d2dae4ad3e87d05a40d7ed4  namecoin.conf"


### PR DESCRIPTION
Ref https://github.com/namecoin/namecoin-core/releases/tag/nc0.18.0