### PR TITLE
main/imagemagick: upgrade to 7.0.8.49

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
-pkgver=7.0.8.44
+pkgver=7.0.8.49
 pkgrel=0
 _pkgver=${pkgver%.*}-${pkgver##*.}
 _abiver=7
@@ -16,7 +16,7 @@ makedepends="zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev fontconfig-dev
 	libwebp-dev libxml2-dev librsvg-dev libx11-dev libxext-dev"
 checkdepends="freetype fontconfig ghostscript ghostscript-fonts lcms2 graphviz"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-c++:_cxx $pkgname-libs"
-source="https://www.imagemagick.org/download/releases/ImageMagick-$_pkgver.tar.xz"
+source="$pkgname-$_pkgver.tar.gz::https://github.com/ImageMagick/ImageMagick/archive/$_pkgver.tar.gz"
 builddir="$srcdir/ImageMagick-${_pkgver}"
 
 # secfixes:
@@ -85,4 +85,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="a18b9e78375ed1a8ab3526ead089dc39c4eed189d4aca0df87787c7ef6e4ee46cdc9a93a1fe1c2a65f0ac2f86c3651696ccd23eb82b6a96cad4c78cf8314bb96  ImageMagick-7.0.8-44.tar.xz"
+sha512sums="5deed9084cd28239733b54cd86a8ea81fac67847cef8b155bd41208f1a8fa4928551edcea2024b20d3f326be3f6204163ec0168e09ee5df907730d6212e0ca48  imagemagick-7.0.8-49.tar.gz"


### PR DESCRIPTION
Source url changed, because older releases are no longer available on imagemagick.org