### PR TITLE
testing/kde-frameworks-tier1: new aports

### DIFF
--- a/community/extra-cmake-modules/APKBUILD
+++ b/community/extra-cmake-modules/APKBUILD
@@ -1,5 +1,6 @@
 # Contributor: k0r10n <k0r10n.dev@gmail.com>
 # Contributor: Ivan Tham <pickfire@riseup.net>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=extra-cmake-modules
 pkgver=5.58.0
 pkgrel=1
@@ -11,29 +12,24 @@ depends="cmake"
 makedepends="py-sphinx"
 checkdepends="qt5-qtbase-dev qt5-qtquickcontrols2-dev"
 subpackages="$pkgname-doc"
-source="http://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz
-	disable-KDEFetchTranslations.patch
-	"
-
-prepare() {
-	default_prepare
-	mkdir -p build
-}
+source="http://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
 
 build() {
-	cd "$builddir"/build
-	cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTING=ON
+	cmake \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DBUILD_TESTING=OFF
 	make
 }
 
 check() {
-	cd "$builddir"/build
 	make test
 }
 
 package() {
-	cd "$builddir"/build
-	make DESTDIR="$pkgdir" install/fast
+	DESTDIR="$pkgdir" make install/fast
+
+	install -Dm644 COPYING-CMAKE-SCRIPTS \
+		"$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 
 sha512sums="edff7bcef7effad524743cf234ff6bb41ab59b7d8e4629ee11be9faea97985f32fff0d96cfaf25277acce9806abea3abe475c9dfe2f8c2dc1b61b7f52d2396bb  extra-cmake-modules-5.58.0.tar.xz

--- a/testing/bluez-qt/APKBUILD
+++ b/testing/bluez-qt/APKBUILD
@@ -1,0 +1,28 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=bluez-qt
+pkgver=5.58.0
+pkgrel=0
+arch="all"
+pkgdesc="Qt wrapper for Bluez 5 DBus API"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen graphviz qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Multiple tests either hang or fail completely
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="c6447bc8464876f91d8a9e2a0bd545791fa627ae94c47990ae58df7ac29ea9bf932482ca0ff94e84946950ddd95c9784d53ac6fd25e98901267d5267251d0d6f  bluez-qt-5.58.0.tar.xz"

--- a/testing/breeze-icons/APKBUILD
+++ b/testing/breeze-icons/APKBUILD
@@ -1,0 +1,28 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=breeze-icons
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Breeze icon themes"
+arch="noarch"
+url="https://community.kde.org/Frameworks"
+license="LGPL-3.0-or-later"
+makedepends="extra-cmake-modules qt5-qtbase-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DBINARY_ICONS_RESOURCE=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest -E dupe
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="3733fe1634dbfce4f5713689c334948f28f133936c7b069088b68b1c468fc0bdf6a95a6743c10ed3a0d13afd6814756e9ff32f1da34a33bebd579044507a92d5  breeze-icons-5.58.0.tar.xz"

--- a/testing/kapidox/APKBUILD
+++ b/testing/kapidox/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kapidox
+pkgver=5.58.0
+pkgrel=0
+arch="noarch"
+pkgdesc="Scripts and data for building API documentation (dox) in a standard format and style"
+url="https://community.kde.org/Frameworks"
+license="BSD-3-Clause"
+depends="python3 py3-yaml py3-jinja2 doxygen"
+makedepends="extra-cmake-modules python3-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="3ad73329f72fe78abb48a72a4caf06e09ef4237e2dd44732ec30b12af433f62bdc08501a4b00c37f390c71e79b90d1ca90de0d0d04854b30b647cde7e48f050d  kapidox-5.58.0.tar.xz"

--- a/testing/karchive/APKBUILD
+++ b/testing/karchive/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=karchive
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Qt 5 addon providing access to numerous types of archives"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.0-only AND LGPL-2.1-or-later"
+makedepends="extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="fd3e4f013a18a2e2876a010ba673c207a8cc05f3e41723daf46181f915259a06ba63e02d0d47cbf9da0445da94ce02cc62cee4fb90d0da2323c3e51a4d3e4d35  karchive-5.58.0.tar.xz"

--- a/testing/kcodecs/APKBUILD
+++ b/testing/kcodecs/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kcodecs
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Provide a collection of methods to manipulate strings using various encodings"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only AND LGPL-2.1-or-later"
+makedepends="extra-cmake-modules qt5-qttools-dev gperf doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="4e4f8083066972a9fc9565673b571d98316bb818646110768d5a68fe47e2db88dd453c22edbb307a65bfdb8a90eac5136507424a2fee5b85bdd77240d33b94f0  kcodecs-5.58.0.tar.xz"

--- a/testing/kconfig/APKBUILD
+++ b/testing/kconfig/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kconfig
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Configuration system"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.0-or-later AND LGPL-2.0-only AND LGPL-2.1-or-later"
+makedepends="extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="bdcd7b28734406ea5bc8e323659cae99754ca0da799a97d20a0e56ae74386cbec9bdaa447ab1b445bf137dfe928bece0c28a7630a1856eee9d822e6b01783c19  kconfig-5.58.0.tar.xz"

--- a/testing/kcoreaddons/APKBUILD
+++ b/testing/kcoreaddons/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kcoreaddons
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Addons to QtCore"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.0-or-later AND (LGPL-2.1-only OR LGPL-3.0-only)"
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen shared-mime-info"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+		make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="704985ec358804089267dc43efff0947dd56b74e627db900e38af5ca6c03be4c5f271a5e4ca8817f4ca67642b13c22bfdce57d77ea64266766e2d84a53d0238e  kcoreaddons-5.58.0.tar.xz"

--- a/testing/kdbusaddons/APKBUILD
+++ b/testing/kdbusaddons/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kdbusaddons
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Addons to QtDBus"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+makedepends="extra-cmake-modules qt5-qttools-dev doxygen shared-mime-info"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Requires running dbus-daemon
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="ddba1e9d535be578f68deea2e38919db691cdb25719b18197d13fd98a0d81ad537550b4b0f0243971741c30dc0fb1b9a242b56310fa52c756c1911b76b880002  kdbusaddons-5.58.0.tar.xz"

--- a/testing/kdnssd/APKBUILD
+++ b/testing/kdnssd/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kdnssd
+pkgver=5.58.0
+pkgrel=0
+arch="all"
+pkgdesc="Network service discovery using Zeroconf"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.0-or-later"
+depends="avahi"
+depends_dev="qt5-qtbase-dev avahi-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="af54e5c275f58b51a538dd5a0e50c53b78a9d421c142a3f812e63c4064b5ad5907bc668512b982a02accbe4fdeff3646eb85405e559514eea8c98368316a22b8  kdnssd-5.58.0.tar.xz"

--- a/testing/kguiaddons/APKBUILD
+++ b/testing/kguiaddons/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kguiaddons
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Addons to QtGui"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+makedepends="extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="a675fe76ef2d46c59d8d9ec5e949dbfca8d24cdb5ef4e5c3774dee45c82cafa0ff8e94c9508ac6cb875fc2188d564754081c5a1fe7b0cd096a128499a544c106  kguiaddons-5.58.0.tar.xz"

--- a/testing/kholidays/APKBUILD
+++ b/testing/kholidays/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kholidays
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Support for icon themes"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.0-or-later"
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="ef5a62331ee788d08913d4ebc68d6d420670d3bbb0823447e4ebfd1d0a7dec8cf44a5bda7453147160885a98900a081d60c5f175d4c6872688d394f8ea08180b  kholidays-5.58.0.tar.xz"

--- a/testing/ki18n/APKBUILD
+++ b/testing/ki18n/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=ki18n
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Advanced internationalization framework"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.0-or-later AND (LGPL-2.1-only OR LGPL-3.0-or-later)"
+depends_dev="qt5-qtdeclarative-dev qt5-qtscript-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="dae7dbfeb887db2f799619222702e2767a7a4f83e21a718af7f9376e735928846f4d792f9fa30dcf4d9010efdd5ffd926a89fb0fa9dd068e2573d2d47159a971  ki18n-5.58.0.tar.xz"

--- a/testing/kidletime/APKBUILD
+++ b/testing/kidletime/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kidletime
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Monitoring user activity"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.0-only"
+depends_dev="qt5-qtx11extras-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="73c81679d969a03e8e8aefb53896a463493cc6f252e2bd6d86219458761ef75df8b6795254544e4db33229a8775e6f6758183719ba21ec9eb21e5ac72b105886  kidletime-5.58.0.tar.xz"

--- a/testing/kirigami2/APKBUILD
+++ b/testing/kirigami2/APKBUILD
@@ -1,0 +1,38 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kirigami2
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="A QtQuick based components set"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.0-only"
+depends="qt5-qtgraphicaleffects"
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev qt5-qtsvg-dev qt5-qtquickcontrols2-dev kpackage-dev kcoreaddons-dev kservice-dev kconfig-dev kwindowsystem-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-libs $pkgname-lang"
+builddir="$srcdir/$pkgname-$pkgver/build"
+
+prepare() {
+	default_prepare
+	mkdir "$builddir" && cd "$builddir"
+}
+
+build() {
+	cmake .. \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DKDE_INSTALL_LIBDIR=lib \
+		-DBUILD_EXAMPLES=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="db7da93a1af3ba5216fd903667d75fc89e45197f7bdee713cfdf04b6bd1269d67c756369503561ff0c4766f088bd261b87a6fa7e5000d7533f9ccd088d710da3  kirigami2-5.58.0.tar.xz"

--- a/testing/kitemmodels/APKBUILD
+++ b/testing/kitemmodels/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kitemmodels
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Models for Qt Model/View system"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.0-only AND LGPL-2.0-or-later"
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="10f6af35a689a22106bc3df2eb7c069251c8ed61fc665cef224d861d8551805d0fdcf0c22a2b0d44fd5d2e4f7a94283d06a92dbb6b648bfa5a71bb63b873a87b  kitemmodels-5.58.0.tar.xz"

--- a/testing/kitemviews/APKBUILD
+++ b/testing/kitemviews/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kitemviews
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Widget addons for Qt Model/View"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="GPL-2.0-only AND LGPL-2.1-only"
+depends_dev="qt5-qtbase-dev"
+makedepends="extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="fe08b97c3b698ee4cad96cfff6907b88f6c77841619abff4caf2f949d4e9379860a0e5c0be6ace4b573b0efd9dfab2dda10ee4856b5ea99e8a8be836444f048f  kitemviews-5.58.0.tar.xz"

--- a/testing/kplotting/APKBUILD
+++ b/testing/kplotting/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kplotting
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Lightweight plotting framework"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="5c447f24d7dae28b75da8c2102d03f47757094dc41c79d21c474e0a19fb0c3ff96eda308b761bf8ca2f9a242cc611aaf496c3b67ee1ee587d64447413717f215  kplotting-5.58.0.tar.xz"

--- a/testing/kwayland/APKBUILD
+++ b/testing/kwayland/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kwayland
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Qt-style Client and Server library wrapper for the Wayland libraries"
+arch="all"
+url="https://www.kde.org"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+depends_dev="qt5-qtbase-dev wayland-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Fails due to requiring running Wayland compositor
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="5512621e69f354efccc52af1f571c6660ff72581ad00bc4766c4cc42d731baf1358107325af6a3b5685372c84f5c9f4b583d1bcf44ef81dbc252e15d6cede53a  kwayland-5.58.0.tar.xz"

--- a/testing/kwidgetsaddons/APKBUILD
+++ b/testing/kwidgetsaddons/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kwidgetsaddons
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Addons to QtWidgets"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="GPL-2.0-only AND LGPL-2.1-only AND Unicode-DFS-2016"
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="987512048c1ec90bed7252783fc82165a4e30dedfd2d2e3b3407febb624aef30a3969b5a0e78586b1ec0c811a1671620a2dc0f311f48946143c7c2d74322dcd1  kwidgetsaddons-5.58.0.tar.xz"

--- a/testing/kwindowsystem/APKBUILD
+++ b/testing/kwindowsystem/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kwindowsystem
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Access to the windowing system"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="MIT AND (LGPL-2.1-only OR LGPL-3.0-only"
+depends_dev="qt5-qtx11extras-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen libxrender-dev xcb-util-keysyms-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="7d54ee2629940d6dd80fefb673e7e0955cad5b76b17fa74f300bab8b13d97dc755b0562efa013ba05bf070339bb50f3a85b017797dd207d4c34bcb3315b656fd  kwindowsystem-5.58.0.tar.xz"

--- a/testing/modemmanager-qt/APKBUILD
+++ b/testing/modemmanager-qt/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=modemmanager-qt
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Qt wrapper for ModemManager DBus API"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+depends_dev="modemmanager-dev qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen graphviz-dev qt5-qttools-dev"
+subpackages="$pkgname-dev $pkgname-doc"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="96aa702c3b07bc48132aa9567a25de73cb820c1b3fa59b4532ec5f3f0a9b1528f6def51ca660d7d2ed9e4eec4c4401af6bbeecd7f2b7ef3f92eb40ba74ccac2e  modemmanager-qt-5.58.0.tar.xz"

--- a/testing/networkmanager-qt/APKBUILD
+++ b/testing/networkmanager-qt/APKBUILD
@@ -1,0 +1,40 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=networkmanager-qt
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Qt wrapper for NetworkManager API"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+depends="networkmanager"
+depends_dev="networkmanager-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+subpackages="$pkgname-dev $pkgname-doc"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+builddir="$srcdir/$pkgname-$pkgver/build"
+
+prepare() {
+	default_prepare
+
+	mkdir "$builddir" && cd "$builddir"
+}
+
+build() {
+	cmake .. \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="f10a898d7374a236f33766ec7a96ce349e1a11aaea28d9f728e8941f3ff6fc368b6d065a16ef3e18eae392199bbd669c63a1a6e64f9bc534960bb31b08b26856  networkmanager-qt-5.58.0.tar.xz"

--- a/testing/oxygen-icons/APKBUILD
+++ b/testing/oxygen-icons/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=oxygen-icons
+_pkgname=oxygen-icons5
+pkgver=5.58.0
+pkgrel=0
+arch="noarch"
+pkgdesc="Oxygen icon theme"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+makedepends="$depends_dev extra-cmake-modules fdupes qt5-qtbase-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$_pkgname-$pkgver.tar.xz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="a18c7f4433b89a12d5ee2a3e8666c5486927a93cc2d2fbef9b3107b72dc6fe2af42d9df5f4f16fafbd5b93d9e4ee0525a08883d82b5e4bf1c3f026fdd84a93fa  oxygen-icons5-5.58.0.tar.xz"

--- a/testing/prison/APKBUILD
+++ b/testing/prison/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=prison
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="A barcode API to produce QRCode barcodes and DataMatrix barcodes"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="MIT"
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev libqrencode-dev libdmtx-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="868ba1784043f1b77592f71810e37623309581f14a4d0348e8b673f466c258993d59dc1cd5920f30439083c48dc2f4e2cdb35c296eb9c7d9f7935a0ba6c9a9ab  prison-5.58.0.tar.xz"

--- a/testing/solid/APKBUILD
+++ b/testing/solid/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=solid
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Hardware integration and detection"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+depends_dev="qt5-qtdeclarative-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen eudev-dev flex-dev bison upower-dev udisks2-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-libs $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="f0b741be7702bae8cd80be83e41a2d328a85c04913e9a5cf745b81e22cacd493bf62931c6e1a0c283e1fb45000bf8e103436dae521a842f439f9cfcfa471781e  solid-5.58.0.tar.xz"

--- a/testing/sonnet/APKBUILD
+++ b/testing/sonnet/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=sonnet
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Spelling framework for Qt5"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only"
+depends_dev="qt5-qtbase"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen hunspell-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="c98d5d8fb19e0995b38ff414c54ea38e4d8303963b36fe140fddb53378c790adfbac3289045b147a6baa283d0a2db8112106808e09c068b180689a8f055719d0  sonnet-5.58.0.tar.xz"

--- a/testing/syntax-highlighting/APKBUILD
+++ b/testing/syntax-highlighting/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=syntax-highlighting
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Syntax highlighting engine for structured text and code"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="MIT"
+depends_dev="qt5-qtbase-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="a4b95a8ca9fcccf3fd5ea8d8a0d4a5b35712e69ce466bf28cf1f87831be6120c0bdb62b30fc14b1094cca7ad393fa8348ea1e0f13abc1a6cc742a521d4d7c350  syntax-highlighting-5.58.0.tar.xz"

--- a/testing/threadweaver/APKBUILD
+++ b/testing/threadweaver/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=threadweaver
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="High-level multithreading framework"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only"
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="75c43383995d053b9f65da1b62a2c52a91449a7eea6713b2363c90b87cfb0ea44d3fa81bb5c6964fd776d5c613ade0dcfb2c4b7a666e55b08fcc27d5c0a9ca54  threadweaver-5.58.0.tar.xz"


### PR DESCRIPTION
This PR introduces [KDE Frameworks tier 1](https://api.kde.org/frameworks/index.html).

This is basically a retry of #2495 :wink: 

Note that KDE Frameworks has no stable or unstable releases, but new releases are done every month. Once this is merged I'll introduce the other tiers.

The goal is to eventually fully package Plasma Desktop.