### PR TITLE
main/curl: security upgrade to 7.65.0

### DIFF
--- a/main/curl/APKBUILD
+++ b/main/curl/APKBUILD
@@ -3,8 +3,8 @@
 # Contributor: Łukasz Jendrysik <scadu@yandex.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=curl
-pkgver=7.64.1
-pkgrel=3
+pkgver=7.65.0
+pkgrel=0
 pkgdesc="URL retrival utility and library"
 url="https://curl.haxx.se/"
 arch="all"
@@ -15,9 +15,11 @@ checkdepends="python2"
 makedepends="$depends_dev autoconf automake groff libtool perl"
 subpackages="$pkgname-dbg $pkgname-static $pkgname-doc $pkgname-dev libcurl"
 source="https://curl.haxx.se/download/$pkgname-$pkgver.tar.xz"
-builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   7.65.0-r0:
+#     - CVE-2019-5435
+#     - CVE-2019-5436
 #   7.64.0-r0:
 #     - CVE-2018-16890
 #     - CVE-2019-3822
@@ -115,4 +117,4 @@ libcurl() {
 	mv "$pkgdir"/usr/lib "$subpkgdir"/usr
 }
 
-sha512sums="1629ba154691bf9d936e0bce69ec8fb54991a40d34bc16ffdfb117f91e3faa93164154fc9ae9043e963955862e69515018673b7239f2fd625684a59cdd1db81c  curl-7.64.1.tar.xz"
+sha512sums="032c065c1d4bd07ba028625f8fab6a09e7cb8505a5f19339b3abdee5a9cda7d091c11f075fe3fc227d082690a66c558c770a4cd9fb17b52acc13794976a770c5  curl-7.65.0.tar.xz"


### PR DESCRIPTION
https://curl.haxx.se/docs/CVE-2019-5435.html
https://curl.haxx.se/docs/CVE-2019-5436.html