### PR TITLE
 main/daq: split static and sfbpf libs

### DIFF
--- a/main/daq/APKBUILD
+++ b/main/daq/APKBUILD
@@ -1,21 +1,17 @@
-# Contributor: Natanael Copa <ncopa@alpinelinux.org>
+# Contributor: Karim Kanso <kaz.kanso@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=daq
 pkgver=2.0.6
-pkgrel=2
+pkgrel=3
 pkgdesc="Data Acquisition library - packet I/O library"
 url="https://www.snort.org/"
 arch="all"
-license="GPL-2.0"
-depends=
+license="GPL-2.0-only"
 makedepends="libpcap-dev flex bison"
-install=""
-subpackages="$pkgname-dev"
+subpackages="$pkgname-static $pkgname-sfbpf $pkgname-dev"
 source="https://www.snort.org/downloads/snort/daq-$pkgver.tar.gz
 	fix-includes.patch
 	"
-
-builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
@@ -40,6 +36,12 @@ check() {
 package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install
+}
+
+sfbpf() {
+	pkgdesc="snort's berkley packet filter shared lib"
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/libsfbpf.so* "$subpkgdir"/usr/lib/
 }
 
 sha512sums="61dd5408c587e57999445b9549ac539ffc5bb16ddc179601de1065fc5e251c1893536d8aa2251096e34b54093529d3578e7b5d97e3514cb2bbf4de113639b08c  daq-2.0.6.tar.gz

--- a/main/snort/APKBUILD
+++ b/main/snort/APKBUILD
@@ -4,12 +4,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=snort
 pkgver=2.9.13
-pkgrel=1
+pkgrel=2
 pkgdesc="An open source network intrusion prevention and detection system"
 url="https://www.snort.org/"
 arch="all"
 license="GPL-2.0-only"
-makedepends="pcre-dev libpcap-dev libnet-dev libdnet-dev daq-dev
+makedepends="pcre-dev libpcap-dev libnet-dev libdnet-dev daq-dev daq-static
 	bison flex zlib-dev libtirpc-dev xz-dev"
 install="$pkgname.pre-install"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-openrc"
@@ -20,7 +20,6 @@ source="https://www.snort.org/downloads/snort/snort-$pkgver.tar.gz
 pkgusers="snort"
 pkggroups="snort"
 
-builddir="$srcdir/$pkgname-$pkgver"
 prepare() {
 	default_prepare
 	cd "$builddir"


### PR DESCRIPTION
`snort` is the only consumer of this package. By default it uses a mix of static and dynamic libraries provided by this package. This PR reduces the install size of `daq` by ensuring that unused dynamic libs are not installed for run time.

Requires a tweak to `snort`'s make dependencies to ensure it continues to compile as before. I included in this PR instead of its own to ensure that nothing is broken.