### PR TITLE
testing/py3-pytest-timeout: new aport

### DIFF
--- a/testing/py3-pytest-timeout/APKBUILD
+++ b/testing/py3-pytest-timeout/APKBUILD
@@ -1,0 +1,42 @@
+# Contributor: Oleg Titov <oleg.titov@gmail.com>
+# Maintainer: Oleg Titov <oleg.titov@gmail.com>
+pkgname=py3-pytest-timeout
+pkgver=1.3.3
+pkgrel=0
+pkgdesc="py.test plugin to abort hanging tests"
+url="https://bitbucket.org/pytest-dev/pytest-timeout"
+arch="noarch"
+license="MIT"
+depends="py3-pytest"
+makedepends="py3-setuptools"
+checkdepends="py3-pexpect py3-tox"
+subpackages="$pkgname-doc"
+source="https://files.pythonhosted.org/packages/13/48/7a166eaa29c1dca6cc253e3ba5773ff2e4aa4f567c1ea3905808e95ac5c1/pytest-timeout-$pkgver.tar.gz"
+builddir="$srcdir/pytest-timeout-$pkgver"
+
+build() {
+	python3 setup.py build
+}
+
+check() {
+	tox -e py37 -- \
+		--deselect="test_pytest_timeout.py::test_fix_setup[function-meth0]" \
+		--deselect="test_pytest_timeout.py::test_fix_setup[class-meth0]" \
+		--deselect="test_pytest_timeout.py::test_fix_setup[module-meth0]" \
+		--deselect="test_pytest_timeout.py::test_fix_setup[session-meth0]" \
+		--deselect="test_pytest_timeout.py::test_fix_finalizer[function-meth0]" \
+		--deselect="test_pytest_timeout.py::test_fix_finalizer[class-meth0]" \
+		--deselect="test_pytest_timeout.py::test_fix_finalizer[module-meth0]" \
+		--deselect="test_pytest_timeout.py::test_fix_finalizer[session-meth0]"
+}
+
+package() {
+	python3 setup.py install \
+		--prefix=/usr \
+		--root="$pkgdir" \
+		--single-version-externally-managed
+
+	install -Dm644 README "$pkgdir/usr/share/doc/$pkgname/README"
+}
+
+sha512sums="633f5aee550d568e403b958f4490ecb828eb322811c9f18cfefb26613be4fc36da14232ecbef8666fcf2dc693a93674c00a853ab546ea8328a07ea34da79fb84  pytest-timeout-1.3.3.tar.gz"


### PR DESCRIPTION
https://pypi.org/project/pytest-timeout/
py.test plugin to abort hanging tests