### PR TITLE
testing/weston: enable logind support via elogind

### DIFF
--- a/testing/weston/APKBUILD
+++ b/testing/weston/APKBUILD
@@ -2,19 +2,19 @@
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=weston
 pkgver=6.0.0
-pkgrel=0
+pkgrel=1
 _libname=lib$pkgname
 _libdir=$_libname-${pkgver%%.*}
 pkgdesc="The reference Wayland server"
 url="https://wayland.freedesktop.org/"
 arch="all !s390x !ppc64le"
 license="MIT"
-depends=""
 makedepends="wayland-protocols libxkbcommon-dev xkeyboard-config
 	libinput-dev libunwind-dev mtdev-dev libxcursor-dev glu-dev
 	pango-dev colord-dev libwebp-dev libva-dev dbus-dev
 	linux-pam-dev wayland-dev libevdev-dev libjpeg-turbo-dev
 	freerdp-dev lcms2-dev gstreamer-dev gst-plugins-base-dev meson
+	elogind-dev
 	"
 _cms="cms-colord cms-static"
 _shell="shell-desktop shell-fullscreen shell-ivi"
@@ -33,16 +33,14 @@ source="https://wayland.freedesktop.org/releases/$pkgname-$pkgver.tar.xz
 	timespec.patch
 	weston-launch-custom-error-function.patch
 	"
-builddir="$srcdir/$pkgname-$pkgver"
 # weston-launch requires suid
 options="!check suid"
 install="$pkgname.pre-install"
 
 build() {
-	cd "$builddir"
 	meson \
 		-Dprefix=/usr \
-		-Dlauncher-logind=false \
+		-Dlauncher-logind=true \
 		-Dsystemd=false \
 		-Dsimple-dmabuf-drm=auto \
 		build


### PR DESCRIPTION
This allows launching Weston by any user when elogind is installed. Old methods of launching Weston still work as before.