### PR TITLE
main/memcached: upgrade to 1.5.16

### DIFF
--- a/main/memcached/APKBUILD
+++ b/main/memcached/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jeff Bilyk <jbilyk@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=memcached
-pkgver=1.5.14
+pkgver=1.5.16
 pkgrel=0
 pkgdesc="Distributed memory object caching system"
 url="http://memcached.org/"
@@ -14,7 +14,6 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-openrc"
 source="https://www.memcached.org/files/${pkgname}-${pkgver}.tar.gz
 	$pkgname.confd
 	$pkgname.initd"
-builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	# extstore is broken on s390x
@@ -50,6 +49,6 @@ package() {
 		"$pkgdir/etc/conf.d/$pkgname"
 }
 
-sha512sums="d06083d971d0a40195b4dfb252a3bf7c3a0d20b2dcad56726ff9e0b87ba84024309300516dad40181f1b7af4d9c4f35924383977c5e1ff9b5f13d2ef05f684ed  memcached-1.5.14.tar.gz
+sha512sums="999872c4c68e0210feab76f74c9487fbfb652cf3e6b7fa347f882767aad41ea6d8ba3ee056494409c054d673fc209032d8a890605810b2c6c9048d26d50751a0  memcached-1.5.16.tar.gz
 31bd788433b8021ed332f86d291e7f03222ae234520e52ba673b581d5da2adf5656e8f73e8b985df73258dea9b2a1b8ef36195163fe47a92fda59825deedfed4  memcached.confd
 11566ce544c3feedbbcca7f87cf21c9d7f7e47c8a0ebdbc0e833ac18a858211c5b00d4128457f957401f6f20453f0cbe902570488133a503c79ee01c102a7c18  memcached.initd"


### PR DESCRIPTION
Fixes critical potential segfault/memory corruption bug in 1.5.15 when storing items with client flags of "0". Bug only exists in 1.5.15, and the fix is the only change in this release.