### PR TITLE
testing/howard-bc: update to 2.0.0

### DIFF
--- a/testing/howard-bc/APKBUILD
+++ b/testing/howard-bc/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Gavin D. Howard <yzena.tech@gmail.com>
 pkgname=howard-bc
 _pkgname=bc
-pkgver=1.2.8
+pkgver=2.0.0
 pkgrel=0
 pkgdesc="POSIX bc with GNU extensions"
 url="https://github.com/gavinhoward/bc"
@@ -25,4 +25,4 @@ package() {
 	make install
 }
 
-sha512sums="34941e73edf35a24f96469453643277b4fb8bfbdabda945ef20fddbb1d42be572659225859939f994d29fc17aab9da7d04ffc1f3217b1875eed3d6070a22bb3f  howard-bc-1.2.8.tar.xz"
+sha512sums="183cec17ed5020e673abb886eb1f391f8a97ac37a67ca63bb00d8b4c8e52ba0e502f7f813d5b4abf650b0fd0dc74a7e8a7a752faf8a47bd7a8014fd4703bca05  howard-bc-2.0.0.tar.xz"


### PR DESCRIPTION
This version got some extreme performance improvements and fixed a few subtle bugs. See the [release notes][1] for more information.

[1]: https://github.com/gavinhoward/bc/releases/tag/2.0.0