### PR TITLE
community/rust: quote "$@"

### DIFF
--- a/community/rust/APKBUILD
+++ b/community/rust/APKBUILD
@@ -254,8 +254,7 @@ _cargo_doc() {
 _mv() {
 	local dest; for dest; do true; done  # get last argument
 	mkdir -p "$dest"
-	# shellcheck disable=SC2068
-	mv $@
+	mv "$@"
 }
 
 sha512sums="65ae2615f4639ccea146fc431aca62e6f0793aa5e584e786e706eefb30588056080300fd5752ce9226067dc213f1a468f96c21b2334f22c5751fa90ddbd3a2b4  rustc-1.33.0-src.tar.gz


### PR DESCRIPTION
Expansion of $@ inside double-quotes is special.

It is not appropriate here to re-split the results of the expansion.