### PR TITLE
testing/gjs: re-enable aarch64, armhf and armv7

### DIFF
--- a/testing/gjs/APKBUILD
+++ b/testing/gjs/APKBUILD
@@ -5,7 +5,7 @@ pkgver=1.56.2
 pkgrel=0
 pkgdesc="GNOME javascript library"
 url="https://wiki.gnome.org/Projects/Gjs"
-arch="all !aarch64 !armhf !armv7 !s390x"
+arch="all !s390x"
 license="MIT LGPL-2.0-or-later"
 makedepends="$depends_dev dbus gobject-introspection-dev mozjs60-dev mozjs60
 	gtk+3.0-dev cairo-dev"


### PR DESCRIPTION
Tested and they build fine on all these arches.

New arches don't require a pkgrel bump right?