### PR TITLE
testing/log4cplus: Enable implicit initialization to preserve backwards compatibility

### DIFF
--- a/testing/log4cplus/APKBUILD
+++ b/testing/log4cplus/APKBUILD
@@ -13,17 +13,12 @@ url="https://sourceforge.net/p/log4cplus/wiki/Home/"
 # 5 Aborted (core dumped)
 arch="all !armhf !armv7" # test 50 dumps core
 license="Apache-2.0"
-depends=""
-depends_dev=""
 checkdepends="findutils"
-makedepends="$depends_dev"
-install=""
 subpackages="$pkgname-dev"
 source="https://downloads.sourceforge.net/$pkgname/$pkgname-$_ver.tar.xz"
 builddir="$srcdir/$pkgname-$_ver"
 
 build() {
-	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \

--- a/testing/log4cplus/APKBUILD
+++ b/testing/log4cplus/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:
 pkgname=log4cplus
 pkgver=2.0.4
-pkgrel=0
+pkgrel=1
 _ver=${pkgver%%_rc*}
 _rc=${pkgver##*_rc}
 [ "$_rc" = "$pkgver" ] || _ver="${_ver}-rc$_rc"
@@ -31,7 +31,6 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--localstatedir=/var \
-		--disable-implicit-initialization \
 		--with-working-c-locale
 	make
 }


### PR DESCRIPTION
Such as https://gitlab.isc.org/isc-projects/kea/issues/625