### PR TITLE
testing/kde-frameworks-tier2: new aports

### DIFF
--- a/testing/kactivities/APKBUILD
+++ b/testing/kactivities/APKBUILD
@@ -1,0 +1,41 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kactivities
+pkgver=5.58.0
+pkgrel=0
+arch="all"
+pkgdesc="Core components for the KDE's Activities"
+url="https://community.kde.org/Frameworks"
+license="GPL-2.0-or-later AND LGPL-2.1-or-later AND (LGPL-2.1-only OR LGPL-3.0-only)"
+depends="qt5-qtbase-sqlite"
+depends_dev="kcoreaddons-dev kconfig-dev kwindowsystem-dev qt5-qtdeclarative-dev"
+makedepends="$depends_dev extra-cmake-modules boost doxygen qt5-qttools-dev boost-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-libs $pkgname-doc"
+
+prepare() {
+	default_prepare
+
+	mkdir "$builddir"/build
+}
+
+build() {
+	cd "$builddir"/build
+	cmake "$builddir" \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"/build
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"/build
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="f51836925f0afd8031b667eea8dae910ad7072c550047b7b012207579d834219260860cd824c0c212e7a3167a1ec256d18cbeeabb78d265aabf6184b870b461f  kactivities-5.58.0.tar.xz"

--- a/testing/kauth/APKBUILD
+++ b/testing/kauth/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kauth
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Abstraction to system policy and authentication features"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev kcoreaddons-dev polkit-qt-1-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	# KAuthHelperTest hangs
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest -E '(KAuthHelperTest)'
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="7d337b4b6507dd1b35df118a5a1f9167efcec67386f85d0ed3c7f22dbb6c56fddf7ba4979c7f1c70c11b525f99a2e3e95e3a1d4f9971d8c02ce40e9664ee0cef  kauth-5.58.0.tar.xz"

--- a/testing/kcompletion/APKBUILD
+++ b/testing/kcompletion/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kcompletion
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Text completion helpers and widgets"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="kwidgetsaddons-dev kconfig-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	# kcompletioncoretest, klineedit_unittest and kcombobox_unittest require X11 to be running
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest -E '(kcompletioncore|klineedit_unit|kcombobox_unit)test'
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="c5da666c8f480d96989ab2566b27c533eed4ebe7df8c2eff9226caf5ffc243e6f3f8f058dcd9d2e53ebfada4fe0e5887bb7d459271e7b6599b168a3ae96505e4  kcompletion-5.58.0.tar.xz"

--- a/testing/kcrash/APKBUILD
+++ b/testing/kcrash/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kcrash
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Support for application crash analysis and bug report from apps"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="kcoreaddons-dev kwindowsystem-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	# kcrashtest requires X11 to be running
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest -E '(kcrashtest)'
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="589622d8aa5235d2311d6ed05c97ba9f9ab64adf36b38f2db51efe8d30062a7e416e1111dbb1986eb757b3e52e588c0bf0b81bf3b6a159ee714e88400dc96d1a  kcrash-5.58.0.tar.xz"

--- a/testing/kdoctools/APKBUILD
+++ b/testing/kdoctools/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kdoctools
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Documentation generation from docbook"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+depends="docbook-xml docbook-xsl"
+depends_dev="qt5-qtbase-dev ki18n-dev karchive-dev libxslt-dev libxml2-dev libxml2-utils"
+makedepends="$depends_dev extra-cmake-modules doxygen graphviz perl-uri qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="ab758d22eb424d5488d034a249d9f828412f78c8dde01b32f3e67feb7b84cec1aa5282135455ad0168d01f0fc54b590103d4d5f85f9f44c3d3a4742fbb160a7e  kdoctools-5.58.0.tar.xz"

--- a/testing/kfilemetadata/APKBUILD
+++ b/testing/kfilemetadata/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kfilemetadata
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="A library for extracting file metadata"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later AND (LGPL-2.1-only OR LGPL-3.0-only)"
+depends_dev="qt5-qtbase-dev karchive-dev kcoreaddons-dev ki18n-dev exiv2-dev taglib-dev ffmpeg-dev attr-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	# extractorcoveragetest, propertyinfotest_localized, extractorcollectiontest fail on armhf
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest -E '(extractorcoveragetest|propertyinfotest_localized|extractorcollectiontest)'
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="1a8967b10882910645254fec74a0b61fa9a7458a5cfeb105d3161deda07591871b505c4b415f2ae8612235a3fc611084da5ea534224405bdb19b0cd04a674c11  kfilemetadata-5.58.0.tar.xz"

--- a/testing/kimageformats/APKBUILD
+++ b/testing/kimageformats/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kimageformats
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Image format plugins for Qt5"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev karchive-dev"
+makedepends="$depends_dev extra-cmake-modules openexr-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	# kimageformats-pic requires X11 to be running
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest -E 'kimageformats-pic'
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="5676c3f9bff8a295dee67a26ff8241b6f0fe608b1ba289a5a90184f01f9a2439ede313e73761e0a0861bf9b06e1baabab6c4d64bd247f23abd980a98603942c4  kimageformats-5.58.0.tar.xz"

--- a/testing/kjobwidgets/APKBUILD
+++ b/testing/kjobwidgets/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kjobwidgets
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Widgets for tracking KJob instances"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only AND (LGPL-2.1-only OR LGPL-3.0-only)"
+depends_dev="qt5-qtx11extras-dev kcoreaddons-dev kwidgetsaddons-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="e753041daf75c00a9d7980b3fdc68faf818c804b339580cb186685e89506b50e148bfe213ebced6e888004761d78ca168d8c0555df22cb491d6b3550f7f81a96  kjobwidgets-5.58.0.tar.xz"

--- a/testing/knotifications/APKBUILD
+++ b/testing/knotifications/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=knotifications
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Abstraction for system notifications"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+depends_dev="qt5-qtbase-dev qt5-qtspeech-dev qt5-qtx11extras-dev kwindowsystem-dev kconfig-dev kcodecs-dev kcoreaddons-dev phonon-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running dbus-daemon
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="40614ca155fe9839e511a3416ee85b233e0b8ce9a3f3ee182f959332d61dcd323267f19dbb71f73fed334f5de22a8efa5bfaea5ca115c21f33efcdd08567ae2d  knotifications-5.58.0.tar.xz"

--- a/testing/kpackage/APKBUILD
+++ b/testing/kpackage/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kpackage
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Framework that lets applications manage user installable packages of non-binary assets"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev karchive-dev ki18n-dev kcoreaddons-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev kdoctools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring installed Plasma, which causes a circular dependency
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="1e62422675ef980c5098a24deac23fb25d4d7dca86accb78c82ab2039e3f03ba2eb93aead26149bb887ae65d3463824a4d1b91c4b73758d6a797cae3a502fc1f  kpackage-5.58.0.tar.xz"

--- a/testing/kpty/APKBUILD
+++ b/testing/kpty/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kpty
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Pty abstraction"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev kcoreaddons-dev ki18n-dev libutempter-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # The one test it has fails: "Can't open a pseudo teletype"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="426d3941dbe9ea5ea23c6a8601976460ca7c847363edf2650e2c921b0916ca08bdf882aa328e7a5d7d89adf6d25f1620c74df7a09139e4b595d772cb73daf084  kpty-5.58.0.tar.xz"

--- a/testing/kunitconversion/APKBUILD
+++ b/testing/kunitconversion/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kunitconversion
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Support for unit conversion"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev ki18n-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="978f8151e89f1bfa00476fdc6b5f19d2ffaf5601f363c89bcf669a68c8b857ef1e290bc9f4abae8199aa68e691dfa96ebc081f75122417e107f120f674ca5042  kunitconversion-5.58.0.tar.xz"

--- a/testing/polkit-qt-1/APKBUILD
+++ b/testing/polkit-qt-1/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=polkit-qt-1
+pkgver=0.112.0
+pkgrel=0
+pkgdesc="Qt wrapper around polkit-1 client libraries"
+arch="all"
+url="https://www.kde.org"
+license="LGPL-2.1-only"
+depends_dev="polkit-dev"
+makedepends="$depends_dev cmake qt5-qtbase-dev"
+source="https://download.kde.org/stable/apps/KDE4.x/admin/$pkgname-$pkgver.tar.bz2"
+subpackages="$pkgname-dev"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="4cb17389b54a09c53052f6d72aa5cbfe09ccb19f7fd4edf8b43ccd4751f5e88609c5f89777f4af92167d32eb2ce1e78537cea7bcfb60a90072d1fe02d6a59b50  polkit-qt-1-0.112.0.tar.bz2"

--- a/testing/syndication/APKBUILD
+++ b/testing/syndication/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=syndication
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="An RSS/Atom parser library"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.0-or-later AND BSD-Clause-3"
+depends_dev="qt5-qtbase-dev kcodecs-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen graphviz qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="fbd3283e37f906b7bde76332721004ad679e99b4d8b3700ee0e98986f14a45dfd32048673d4e5270c351868c6e0f212b17bc4e4bc47f003cee4eb4dd16f9abd6  syndication-5.58.0.tar.xz"


### PR DESCRIPTION
Depends on #7992.

This PR introduces [KDE Framework tier 2](https://api.kde.org/frameworks/index.html#sg-tier_2).

Note that KDE Frameworks has no stable or unstable releases, but new releases are done every month.

The goal is to eventually fully package Plasma Desktop.