### PR TITLE
testing/libbpf: use new version scheme

### DIFF
--- a/testing/libbpf/APKBUILD
+++ b/testing/libbpf/APKBUILD
@@ -1,7 +1,6 @@
 # Maintainer: Adam Jensen <acjensen@gmail.com>
 pkgname=libbpf
-pkgver=5.0.8
-_versionref="816253000e918f22e3b395d1bf743503d3508b41"
+pkgver=0.0.3
 pkgrel=0
 pkgdesc="A library for interacting with the Linux kernel's Berkeley Packet Filter (BPF) facility from user space"
 url="https://github.com/libbpf/libbpf"
@@ -11,23 +10,22 @@ license="GPL-2.0-only"
 options="!check"
 depends="elfutils"
 makedepends="build-base linux-headers elfutils-dev"
-subpackages="$pkgname-static $pkgname-dev"
-source="$pkgname-$pkgver.tar.gz::https://codeload.github.com/libbpf/$pkgname/tar.gz/$_versionref
+subpackages="$pkgname-dev"
+source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$pkgver.tar.gz
 	10-include-stddef.patch
 	20-trailing-ldflags.patch"
-builddir="$srcdir/libbpf-$_versionref"
 
 build() {
-	cd "$builddir/src"
+	cd src
 	make NO_PKG_CONFIG=1
 }
 
 package() {
-	cd "$builddir/src"
+	cd src
 	make install DESTDIR="$pkgdir"
 	cp -R "$builddir/include/uapi" "$pkgdir/usr/include/uapi"
 }
 
-sha512sums="cc14587830c7a24fb5c8c994febe4633733f0a364a0ee4c4c1d282f3b18892e90b950fae202860e76d564934cfacd023b5c68f59118a91779c29cfc23fd4e5c1  libbpf-5.0.8.tar.gz
+sha512sums="ee489d968cd9a20a1f091dcd2696d3807ab0db2a001613684402de2c696391eea033f3bd961eaf1d0df95c1e15f4f0ccfb7003ff98c3f08f24a7e9a8db22cdad  libbpf-0.0.3.tar.gz
 946e445ffa4c5df42ebac77b7a1c6478b37dc7b55e0883aee195c6a8c4f8718b4dbf98b7c6d3016e1619e59440d8e4a76dad1e843114dfe2f9a2610e5cbb7943  10-include-stddef.patch
 1ec15c45fc085b44aa1f6d5626f0ba9e57280304d1f6e1c4e7fe8e2b81fc927f5500fd48f8e70d2affb91dd67a74a80c85698d39bb85febde5abd479df5cdccc  20-trailing-ldflags.patch"


### PR DESCRIPTION
libbpf now has tagged releases and a version that's independent from the Linux kernel, so I'm updating this package to use them.