### PR TITLE
community/flatpak: add flatpak user

### DIFF
--- a/community/flatpak/APKBUILD
+++ b/community/flatpak/APKBUILD
@@ -1,8 +1,9 @@
+# Contributor: Rasmus Thomsen <oss@cogitri.dev>
 # Contributor: André Klitzing <aklitzing@gmail.com>
 # Maintainer: André Klitzing <aklitzing@gmail.com>
 pkgname=flatpak
 pkgver=1.4.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Application deployment framework for desktop apps"
 url="https://flatpak.org"
 arch="all !aarch64"
@@ -13,6 +14,7 @@ makedepends="glib-dev libarchive-dev libsoup-dev libcap-dev polkit-dev
 	libgcab-dev appstream-glib-dev dconf-dev
 	libseccomp-dev libxslt-dev gpgme-dev bison"
 subpackages="$pkgname-dev $pkgname-lang"
+install="flatpak.pre-install flatpak.pre-upgrade"
 source="https://github.com/flatpak/$pkgname/releases/download/$pkgver/$pkgname-$pkgver.tar.xz
 		musl-fixes.patch"
 options="suid !check" # Tests fail with no error message
@@ -33,7 +35,8 @@ build() {
 		--disable-static \
 		--disable-documentation \
 		--with-priv-mode=setuid \
-		--with-system-bubblewrap
+		--with-system-bubblewrap \
+		--with-system-helper-user=flatpak
 
 	make
 }

--- a/community/flatpak/flatpak.pre-install
+++ b/community/flatpak/flatpak.pre-install
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+addgroup -S flatpak 2>/dev/null
+adduser -S -D -h /var/lib/flatpak -s /sbin/nologin -G flatpak -g flatpak flatpak 2>/dev/null
+
+exit 0

--- a/community/flatpak/flatpak.pre-upgrade
+++ b/community/flatpak/flatpak.pre-upgrade
@@ -1,0 +1,1 @@
+flatpak.pre-install


### PR DESCRIPTION
It's required for its new update/installation mechanism, see the flatpak
release notes.