### PR TITLE
community/gnome-keyring: enable PAM integration

### DIFF
--- a/community/gnome-keyring/APKBUILD
+++ b/community/gnome-keyring/APKBUILD
@@ -1,22 +1,21 @@
-# Contributor: 
-# Maintainer: 
+# Contributor: Rasmus Thomsen <oss@cogitri.dev>
+# Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=gnome-keyring
 pkgver=3.28.2
-pkgrel=0
+pkgrel=1
 pkgdesc="GNOME keyring"
-url="http://www.gnome.org"
+url="https://wiki.gnome.org//Projects/GnomeKeyring"
 arch="all"
-license="GPL"
-options="!check"
-makedepends="gtk+3.0-dev gcr-dev libcap-ng-dev
-	intltool gobject-introspection-dev gtk-doc libxslt"
+license="GPL-2.0-only LGPL-2.0-only"
+makedepends="gtk+3.0-dev gcr-dev libcap-ng-dev linux-pam-dev
+	intltool gobject-introspection-dev gtk-doc libxslt
+	openssh-client libgcrypt-dev"
+checkdepends="python dbus-x11 xvfb-run"
+options="!check" # Gets stuck on CI
 subpackages="$pkgname-lang $pkgname-doc"
 source="https://download.gnome.org/sources/${pkgname}/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz
 	fix-includes.patch"
-builddir="${srcdir}/${pkgname}-${pkgver}"
-
 build() {
-	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -25,8 +24,11 @@ build() {
 	make
 }
 
+check() {
+	xvfb-run make check
+}
+
 package() {
-	cd "$builddir"
 	export GCONF_DISABLE_MAKEFILE_SCHEMA_INSTALL=1
 	make DESTDIR="$pkgdir" install
 }


### PR DESCRIPTION
This is required for stuff like automatically unlocking the keyring on unlock.

* modernize APKBUILD
* Fix homepage
* adopt maintainership
* Fix tests