### PR TITLE
testing/py3-columnize: modernize, enable tests.

### DIFF
--- a/testing/py3-columnize/APKBUILD
+++ b/testing/py3-columnize/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=py3-columnize
 _pkgname=columnize
 pkgver=0.3.9
-pkgrel=2
+pkgrel=3
 pkgdesc="Python module to align in columns a simple list"
 url="https://github.com/rocky/pycolumnize"
 arch="noarch"
@@ -11,18 +11,21 @@ license="MIT"
 replaces="py-columnize" # for backwards compatibility
 provides="py-columnize=$pkgver-r$pkgrel" # for backwards compatibility
 depends="python3"
-makedepends="python3-dev py3-setuptools"
-source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
-builddir="$srcdir"/$_pkgname-$pkgver
+makedepends="py3-setuptools"
+checkdepends="py3-pytest py3-mock py3-pytest-mock"
+source="$pkgname-$pkgver.tar.gz::https://github.com/rocky/pycolumnize/archive/release-${pkgver}.tar.gz"
+builddir="$srcdir"/py$_pkgname-release-$pkgver
 
 build() {
-	cd "$builddir"
 	python3 setup.py build
 }
 
+check() {
+	python3 setup.py test
+}
+
 package() {
-	cd "$builddir"
 	python3 setup.py install --prefix=/usr --root="$pkgdir"
 }
 
-sha512sums="2bb9a25200a1574cc6471ce06dfb2b4b62c5a23fa0e4fabad515dd2939b3f67ca61132121e4326dd820691691dce67d664302d99248ea2d5c5f25357203d9d08  columnize-0.3.9.tar.gz"
+sha512sums="4bf85218ace4e8729626c3953132ef7eef9f6b111446e685119f329d6367c265331d345c6928c98c76b78dbed646e9feddba0679f8af95172cc8657287fbb8b4  py3-columnize-0.3.9.tar.gz"


### PR DESCRIPTION
- Switch to GitHub tarball since that one provides the tests required
- Bump pkgrel even though it isn't strictly necessary