### PR TITLE
 main/snort: package fixes and enable functions

### DIFF
--- a/main/daq/APKBUILD
+++ b/main/daq/APKBUILD
@@ -2,12 +2,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=daq
 pkgver=2.0.6
-pkgrel=3
+pkgrel=4
 pkgdesc="Data Acquisition library - packet I/O library"
 url="https://www.snort.org/"
 arch="all"
 license="GPL-2.0-only"
-makedepends="libpcap-dev flex bison"
+makedepends="libpcap-dev flex bison linux-headers libnetfilter_queue-dev
+	libnfnetlink-dev libdnet-dev"
 subpackages="$pkgname-static $pkgname-sfbpf $pkgname-dev"
 source="https://www.snort.org/downloads/snort/daq-$pkgver.tar.gz
 	fix-includes.patch

--- a/main/snort/APKBUILD
+++ b/main/snort/APKBUILD
@@ -4,13 +4,14 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=snort
 pkgver=2.9.13
-pkgrel=2
+pkgrel=3
 pkgdesc="An open source network intrusion prevention and detection system"
 url="https://www.snort.org/"
 arch="all"
 license="GPL-2.0-only"
 makedepends="pcre-dev libpcap-dev libnet-dev libdnet-dev daq-dev daq-static
-	bison flex zlib-dev libtirpc-dev xz-dev"
+	bison flex zlib-dev libtirpc-dev xz-dev
+	libnfnetlink-dev libnetfilter_queue-dev"
 install="$pkgname.pre-install"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-openrc"
 source="https://www.snort.org/downloads/snort/snort-$pkgver.tar.gz
@@ -61,12 +62,13 @@ package() {
         install -D -m 755 ../snort.initd "$pkgdir"/etc/init.d/snort
         install -D -m 644 ../snort.confd "$pkgdir"/etc/conf.d/snort
         install -D -m 644 etc/snort.conf "$pkgdir"/etc/snort/snort.conf
+        install -D -m 644 etc/gen-msg.map "$pkgdir"/etc/snort/gen-msg.map
         install -D -m 644 rpm/snort.logrotate "$pkgdir"/etc/logrotate.d/snort
 	mkdir -p "$pkgdir"/usr/lib/snort_dynamicrules
 	mkdir -p "$pkgdir"/var/lib/snort/rules
 	mkdir -m 770 -p "$pkgdir"/var/log/snort && chown snort.snort "$pkgdir"/var/log/snort
 	for file in classification.config reference.config threshold.conf \
-		unicode.map
+		unicode.map sid-msg.map
 	do
 		ln -s /var/lib/snort/etc/$file "$pkgdir"/etc/snort/$file
 	done
@@ -76,4 +78,4 @@ package() {
 
 sha512sums="3bc90d3753b01f779e587d8f6a514a18ea446732b0a41809df028b60eacc93fca2c158030c0743a9662958220a98757629eb1d11e7d4d709bf3b76b807b935bd  snort-2.9.13.tar.gz
 c71d11f4cde4aba432641d3915faec8070e9fea5b33c71f6b2872b2208871180b3c7dbbadd2ddaebe5f3280adf7c5c9daf1585afd331fe552486a675ff676e52  snort.initd
-abc0846ea6e08029c772f24e213f211a39219701e6e2c8b3aa112632318479db7b21014c5f2c4987cb2981cafce0ea744549c3ce754e9145cba9ec5604ae66f3  snort.confd"
+b21491ba5798a5ce3a03a61ada391a667f1684aaf86e7536abb9dd975f6acefe75688c60b8ce28cbfb0c4e66ec19078e468792289d26f1f2e2d401609fd22771  snort.confd"

--- a/main/snort/snort.confd
+++ b/main/snort/snort.confd
@@ -4,7 +4,7 @@
 IFACE=eth0
 
 # Make sure this matches your IFACE
-PIDFILE=/var/run/snort_$IFACE.pid
+PIDFILE=/var/lib/snort/snort_$IFACE.pid
 
 # You probably don't want to change this, but in case you do
 LOGDIR="/var/log/snort"
@@ -12,5 +12,8 @@ LOGDIR="/var/log/snort"
 # Probably not this either
 CONF=/etc/snort/snort.conf
 
+# Allow log files to be read by members of snort group (default is 077).
+UMASK=037
+
 # This pulls in the options above
-SNORT_OPTS="-D -u snort -i $IFACE -l $LOGDIR -c $CONF"
+SNORT_OPTS="-D -u snort -i $IFACE -l $LOGDIR -c $CONF -m $UMASK"

--- a/testing/barnyard2/10-fix-output-fwsam-and-database_cache.patch
+++ b/testing/barnyard2/10-fix-output-fwsam-and-database_cache.patch
@@ -1,0 +1,21 @@
+--- a/src/output-plugins/spo_alert_fwsam.c
++++ b/src/output-plugins/spo_alert_fwsam.c
+@@ -115,6 +115,7 @@
+ #include <sys/filio.h>
+ #endif
+ 
++#undef SOCKET
+ typedef int SOCKET;
+ 
+ #ifndef INVALID_SOCKET
+--- a/src/output-plugins/spo_database_cache.c
++++ b/src/output-plugins/spo_database_cache.c
+@@ -107,7 +107,7 @@
+ /* Destructor */
+ 
+ /* Return largest string lenght */
+-inline u_int32_t glsl(char *a,char *b)
++static inline u_int32_t glsl(char *a,char *b)
+ {
+     u_int32_t alen = 0;
+     u_int32_t blen = 0;

--- a/testing/barnyard2/20-disable-outputs.patch
+++ b/testing/barnyard2/20-disable-outputs.patch
@@ -1,0 +1,45 @@
+--- a/src/output-plugins/Makefile.am
++++ b/src/output-plugins/Makefile.am
+@@ -10,7 +10,6 @@
+ spo_alert_csv.c spo_alert_csv.h \
+ spo_alert_fast.c spo_alert_fast.h \
+ spo_alert_full.c spo_alert_full.h \
+-spo_alert_fwsam.c spo_alert_fwsam.h \
+ spo_alert_prelude.c spo_alert_prelude.h \
+ spo_alert_syslog.c spo_alert_syslog.h \
+ spo_alert_test.c spo_alert_test.h \
+--- a/src/plugbase.c
++++ b/src/plugbase.c
+@@ -63,7 +63,6 @@
+ #include "output-plugins/spo_alert_csv.h"
+ #include "output-plugins/spo_alert_fast.h"
+ #include "output-plugins/spo_alert_full.h"
+-#include "output-plugins/spo_alert_fwsam.h"
+ #include "output-plugins/spo_alert_syslog.h"
+ #include "output-plugins/spo_alert_test.h"
+ #include "output-plugins/spo_alert_prelude.h"
+@@ -335,7 +334,6 @@
+     DatabaseSetup();
+     AlertFastSetup();
+     AlertFullSetup();
+-    AlertFWsamSetup();
+ #ifndef WIN32
+     /* Win32 doesn't support AF_UNIX sockets */
+     AlertUnixSockSetup();
+--- a/src/output-plugins/spo_alert_arubaaction.c
++++ b/src/output-plugins/spo_alert_arubaaction.c
+@@ -42,6 +42,9 @@
+  */
+ 
+ /* output plugin header file */
++
++#ifdef ARUBA
++
+ #ifdef HAVE_CONFIG_H
+ #include "config.h"
+ #endif
+@@ -649,3 +652,4 @@
+ }
+ 
+ 
++#endif // ARUBA

--- a/testing/barnyard2/30-remove-warnings.patch
+++ b/testing/barnyard2/30-remove-warnings.patch
@@ -1,0 +1,86 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -1109,7 +1109,7 @@
+ fi
+ 
+ if test -n "$GCC"; then
+-    CFLAGS="$CFLAGS -Wall"
++    CFLAGS="$CFLAGS -Wall -Wno-unused-but-set-variable"
+ fi
+ 
+ echo $CFLAGS > cflags.out
+--- a/src/spooler.c
++++ b/src/spooler.c
+@@ -41,7 +41,10 @@
+ #include "unified2.h"
+ #include "util.h"
+ 
+-
++/**
++ * Missing signature for function defined in decider.c
++ */
++int DecodePacket(int linktype, Packet *p, const struct pcap_pkthdr *pkthdr, const uint8_t *pkt);
+ 
+ /*
+ ** PRIVATE FUNCTIONS
+--- a/src/decode.c
++++ b/src/decode.c
+@@ -81,8 +81,10 @@
+     }
+ }
+ 
+-int DecodePacket(int linktype, Packet *p, const struct DAQ_PktHdr_t *pkthdr, const uint8_t *pkt)
++int DecodePacket(int linktype, Packet *p, const struct pcap_pkthdr *_pkthdr, const uint8_t *pkt)
+ {
++    // valid cast as below code only references fields in 'struct pcap_pkthdr'
++    const DAQ_PktHdr_t* pkthdr = (const DAQ_PktHdr_t*)_pkthdr;
+     DEBUG_WRAP(DebugMessage(DEBUG_DECODE,"Decoding linktype %d\n",linktype););
+     switch(linktype)
+     {
+--- a/src/output-plugins/spo_log_tcpdump.c
++++ b/src/output-plugins/spo_log_tcpdump.c
+@@ -358,10 +357,7 @@
+     }
+ }
+ 
+-static INLINE size_t SizeOf (const struct pcap_pkthdr *pkth)
+-{
+-    return PCAP_PKT_HDR_SZ + pkth->caplen;
+-}
++#define SizeOf(pkth) (PCAP_PKT_HDR_SZ + pkth->caplen)
+ 
+ static void LogTcpdumpSingle(Packet *p, void *event, uint32_t event_type, void *arg)
+ {
+@@ -388,7 +384,7 @@
+ //    else if ( data->size + dumpSize > data->limit )
+ //        TcpdumpRollLogFile(data);
+ 
+-    pcap_dump((u_char *)data->dumpd, p->pkth, p->pkt);
++    pcap_dump((u_char *)data->dumpd, (const struct pcap_pkthdr *)p->pkth, p->pkt);
+     data->size += dumpSize;
+ 
+     if (!BcLineBufferedLogging())
+--- a/src/output-plugins/spo_database_cache.c
++++ b/src/output-plugins/spo_database_cache.c
+@@ -5298,7 +5298,7 @@
+ 	{
+ 	    sigSeq = cacheLookup->obj.db_sig_id;
+ 	    databasemaxSeq = 0;
+-	    memset(sigRefArr,'\0',MAX_REF_OBJ);
++	    memset(sigRefArr,'\0',MAX_REF_OBJ * sizeof(u_int32_t));
+ 	}
+ 	
+ 	if(dbSignatureReferenceLookup(&cacheLookup->obj,tempCache,&rNode,1))
+--- a/src/output-plugins/spo_alert_unixsock.c
++++ b/src/output-plugins/spo_alert_unixsock.c
+@@ -251,8 +251,9 @@
+ 		 alertpkt.pkth.caplen > PKT_SNAPLEN ? PKT_SNAPLEN : alertpkt.pkth.caplen);
+     }
+     else
++    {
+         alertpkt.val|=NOPACKET_STRUCT;
+-
++    }
+ 	sn = GetSigByGidSid(ntohl(((Unified2EventCommon *)event)->generator_id),
+ 			    ntohl(((Unified2EventCommon *)event)->signature_id),
+ 			    ntohl(((Unified2EventCommon *)event)->signature_revision));

--- a/testing/barnyard2/APKBUILD
+++ b/testing/barnyard2/APKBUILD
@@ -1,0 +1,69 @@
+# Contributor: Karim Kanso <kaz.kanso@gmail.com>
+# Maintainer: Karim Kanso <kaz.kanso@gmail.com>
+pkgname=barnyard2
+pkgver=2.1.14_git20160413
+_gitrev=f9186f2478bfb096c5a43bdb0c91985c3ef3e20d
+pkgrel=0
+pkgdesc="Parser for Snort unified/unified2 files"
+url="https://github.com/firnsy/barnyard2"
+arch="all"
+license="GPL-2.0-only"
+depends="snort"
+install="$pkgname.pre-install"
+makedepends="libtool autoconf automake make libpcap-dev libdnet-dev daq-dev
+	mariadb-connector-c-dev postgresql-dev"
+subpackages="$pkgname-openrc"
+source="$pkgname-$pkgver.zip::https://github.com/firnsy/barnyard2/archive/$_gitrev.zip
+	10-fix-output-fwsam-and-database_cache.patch
+	20-disable-outputs.patch
+	30-remove-warnings.patch
+	barnyard2.confd
+	barnyard2.initd"
+builddir="$srcdir/"$pkgname-$_gitrev
+pkgusers="barnyard2"
+pkggroups="barnyard2"
+
+prepare() {
+	default_prepare
+	sed -i -e 's|^output alert_fast:|# &|' etc/barnyard2.conf
+	sed -i -E 's|^#(config interface:)|\1|' etc/barnyard2.conf
+	./autogen.sh
+}
+
+build() {
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var \
+		--with-mysql \
+		--with-postgresql \
+		--disable-ipv6 \
+		--disable-prelude \
+		--disable-mysql-ssl-support \
+		--disable-aruba \
+		--without-tcl \
+		--without-oracle
+	make
+}
+
+check() {
+	make check
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+	install -D -m 755 ../barnyard2.initd "$pkgdir"/etc/init.d/barnyard2
+	install -D -m 644 ../barnyard2.confd "$pkgdir"/etc/conf.d/barnyard2
+	mkdir -m 770 -p "$pkgdir"/var/log/barnyard2
+	chown barnyard2:barnyard2 "$pkgdir"/var/log/barnyard2
+}
+
+sha512sums="6b9a4b87287f6386f1df65a9138e243a69ab1b59f2a30c2cbb5d52630a64ed71b56293d26e1672b494cfe4b0b48ab50038b356c8f95ef22a19628847634ffd7d  barnyard2-2.1.14_git20160413.zip
+2a5c8b44ecc4b6377d2d045271f2ca22ed4643eee3777ca7aaf522c72fb928367633256f00a4673201434b57f3c02ae6f8e8320a40ec3e2720a6925dc2b30162  10-fix-output-fwsam-and-database_cache.patch
+b1348f9c8132899faef8e60fc81efd8f6477a268ed69e2d55b623c13e303ca681fde842f23ed15fd5c61836467e571e8fa8f2a39948653d54955927b3e306783  20-disable-outputs.patch
+7dccc629d7fb6c3f98c7f3cff6acfb27dea88a2f3c756c37cafb3a42a727c61ec8f853c044a8358bb3223eb5078dc508d63d721cdb37c6deb7b87cfb52bb1773  30-remove-warnings.patch
+20b6a0bb7f72f252d8d7547831aae7a79b7dd3dd327fd211c28013e7928f10480bf7d7114adf8baae2cf979fb5b65e5f001f9597a8df53569437e2396de67d05  barnyard2.confd
+60a6cf49a268d41253057af99839e68f3b69a156f56318e687e0cbf96e521f7b99051748163c4f02ca952e481b66b01acbb06d1af243d646125e9d0a6b32da3b  barnyard2.initd"

--- a/testing/barnyard2/barnyard2.confd
+++ b/testing/barnyard2/barnyard2.confd
@@ -1,0 +1,36 @@
+# Config file for /etc/init.d/barnyard2
+
+# This file only contains variables needed by the init.d script.
+# All other configuration options are located in the barnyard2.conf file
+
+# This should be the first part of the unified/unified2 log file name (without the time stamp)
+# Ex. If you log files look like this 'snort.unified2.1239801645' then you would use 'snort.unified2'
+SPOOL_FILE="snort.unified2"
+
+# Location of your unified/unified2 log files
+SPOOL_DIR="/var/log/snort"
+
+# Directory to log to
+LOG_DIR="/var/log/barnyard2"
+
+# This MUST match what you set for "config interface:" in your barnyard2.conf
+# If you do not set this correctly then Barnyard2 will not stop when you do a 
+# "/etc/init.d/barnyard2 stop"
+INTERFACE="eth0"
+
+# You probably don't want to change this, but in case you do
+PID_FILE="barnyard2_${INTERFACE}.pid"
+PID_PATH="/var/run"
+
+# The waldo file is located in the SPOOL_DIR to support multipule instances of barnyard2
+WALDO_FILE="${SPOOL_DIR}/barnyard2.waldo"
+CONF="/etc/barnyard2.conf"
+
+# Location of the archive directory if you choose to use it.
+# The ARCHIVE_DIR is located in the SPOOL_DIR to support multipule instances of barnyard2
+#ARCHIVE_DIR="${SPOOL_DIR}/archive"
+
+# This pulls in the options above
+BARNYARD_OPTS="-u barnyard2 -g barnyard2 -D -c ${CONF} -d ${SPOOL_DIR} -w ${WALDO_FILE} -f ${SPOOL_FILE} -l ${LOG_DIR}"
+# Or with an archive directory
+#BARNYARD_OPTS="-u barnyard2 -g barnyard2 -D -c ${CONF} -d ${SPOOL_DIR} -w ${WALDO_FILE} -f ${SPOOL_FILE} -l ${LOG_DIR} -a ${ARCHIVE_DIR}"

--- a/testing/barnyard2/barnyard2.initd
+++ b/testing/barnyard2/barnyard2.initd
@@ -1,0 +1,29 @@
+#!/sbin/openrc-run
+# Copyright 1999-2004 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+depend() {
+	need net
+}
+
+checkconfig() {
+	if [ ! -e ${CONF} ] ; then
+		eerror "You need a configuration file to run barnyard2"
+		eerror "Download an example from: https://raw.githubusercontent.com/firnsy/barnyard2/master/etc/barnyard2.conf"
+		return 1
+	fi
+}
+
+start() {
+	checkconfig || return 1
+	ebegin "Starting barnyard2"
+	start-stop-daemon --start --quiet --exec /usr/bin/barnyard2 \
+		-- --pid-path ${PID_PATH} --nolock-pidfile ${BARNYARD_OPTS} >/dev/null 2>&1
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping barnyard2"
+	start-stop-daemon --stop --quiet --pidfile ${PID_PATH}/${PID_FILE}
+	eend $?
+}

--- a/testing/barnyard2/barnyard2.pre-install
+++ b/testing/barnyard2/barnyard2.pre-install
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+addgroup -S barnyard2 2>/dev/null
+adduser -S -D -h /var/log/barnyard2 -s /sbin/nologin -G barnyard2 -g barnyard2 barnyard2 2>/dev/null
+adduser barnyard2 snort 2>/dev/null
+
+exit 0


### PR DESCRIPTION
Collection of patches that either fix issues or enable functionality for *snort*. These have been provided in a single PR to reduce the number of needed review cycles as they all would increment snorts package revision.


* 751cfdd - Fixes issue where openrc looks in wrong location for PID file, hence `rc-service snort stop` does not have any effect.
* a561b68 and 9a0b993 - Enable additional packet capture modes for *snort*:
    * `AFPACKET` (improved performance over standard `pcap` for promiscuous mode and allows for layer 2 inline operation)
    * `NFQ` (supports layer 3 inline operation)
* 886c7ca and 7c621af - Add the tool `barnyard2` ([https://github.com/firnsy/barnyard2](https://github.com/firnsy/barnyard2)) that is capable of parsing and processing log files generated from *snort*. This requires additional files that are not installed by default within the snort package. The build/openrc scripts are based on Gentoo.