### PR TITLE
testing/xmrig: upgrade to 2.14.4

### DIFF
--- a/testing/xmrig/APKBUILD
+++ b/testing/xmrig/APKBUILD
@@ -2,16 +2,16 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 
 pkgname=xmrig
-pkgver=2.14.1
+pkgver=2.14.4
 pkgrel=0
 pkgdesc="XMRig is a high performance Monero (XMR) miner"
 url="https://github.com/xmrig/xmrig"
 arch="all !s390x !ppc64le"
-license="GPL-3.0"
+license="GPL-3.0-or-later"
+options="!check" # No test suite from upstream
 makedepends="cmake libmicrohttpd-dev libuv-dev openssl-dev"
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/xmrig/xmrig/archive/v$pkgver.tar.gz"
-builddir="$srcdir/$pkgname-$pkgver"
 
 case "$CARCH" in
 	aarch64*) CMAKE_CROSSOPTS="-DARM_TARGET=8"; makedepends="$makedepends linux-headers" ;;
@@ -20,24 +20,16 @@ case "$CARCH" in
 esac
 
 build() {
-	cd "$builddir"
 	mkdir build
 	cd build
 	cmake .. ${CMAKE_CROSSOPTS}
 	make
 }
 
-check() {
-	cd "$builddir"
-	# xmrig -V returns 2
-	build/xmrig -V || test $? = 2
-}
-
 package() {
 	install -Dm 755 build/xmrig $pkgdir/usr/bin/xmrig
 
-	install -Dm 644 -t "$pkgdir"/usr/share/licenses/$pkgname/ LICENSE
 	install -Dm 644 -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
 }
 
-sha512sums="a9e11964e1fc7f040d835734cd418319e289f4def0004311ac1b0a7edaad74ea30698ffcea4ca80bc39b8b2620ee0ebdfeef3d13a8b0c93be9ebb2be5fdd10c7  xmrig-2.14.1.tar.gz"
+sha512sums="eaa43f9916e90f4d211ab037402cc898192a38c907a47920636defa387cc2b0535362423f929404555fa7f765fdf9f5ace0e506ded4d92653dcddd98055ad5c3  xmrig-2.14.4.tar.gz"


### PR DESCRIPTION
- https://github.com/xmrig/xmrig/releases 2.14.4
- License clarification
- No upstream testsuite, removing check()
- License file removed
- builddir has default value and was removed