### PR TITLE
testing/xmrig-proxy: upgrade to 2.14.4

### DIFF
--- a/testing/xmrig-proxy/APKBUILD
+++ b/testing/xmrig-proxy/APKBUILD
@@ -2,36 +2,28 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 
 pkgname=xmrig-proxy
-pkgver=2.14.1
+pkgver=2.14.4
 pkgrel=0
 pkgdesc="XMRig Proxy is a high performance Monero (XMR) Stratum protocol proxy"
 url="https://github.com/xmrig/xmrig-proxy"
 arch="all"
-license="GPL-3.0"
-#depends="libuv libmicrohttpd openssl libuuid"
+license="GPL-3.0-or-later"
+options="!check" # No test suite from upstream
 makedepends="cmake libuv-dev libmicrohttpd-dev openssl-dev util-linux-dev"
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/xmrig/xmrig-proxy/archive/v$pkgver.tar.gz"
-builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
-	cd "$builddir"
 	mkdir build
 	cd build
 	cmake ..
 	make
 }
 
-check() {
-	cd "$builddir"/build
-	./xmrig-proxy --version
-}
-
 package() {
 	install -Dm 755 build/xmrig-proxy $pkgdir/usr/bin/xmrig-proxy
 
-	install -Dm 644 -t "$pkgdir"/usr/share/licenses/$pkgname/ LICENSE
 	install -Dm 644 -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
 }
 
-sha512sums="07556f98af2a424848e766ffc55b9fc83786b6bdb5a61f190d6739475ecf5ffdcc3251adc561c7b2bdebfbff0007421e175049ceaa8bd3d9db48297086ea8508  xmrig-proxy-2.14.1.tar.gz"
+sha512sums="d3bd8545cc4fc1a4a5a509197deb2eb6b0b4580d47ad3843b2a5d51fea4b7ea691532125e2edf5641b448c1b8a649cd64cd9574dfa71af43c7109d8b2e800ec6  xmrig-proxy-2.14.4.tar.gz"


### PR DESCRIPTION
- https://github.com/xmrig/xmrig-proxy/releases 2.14.4
- License clarification
- builddir has default value and was removed
- No upstream testsuite, check() removed
- License file removed