### PR TITLE
community/isync: upgrade to 1.3.1

### DIFF
--- a/community/isync/APKBUILD
+++ b/community/isync/APKBUILD
@@ -1,20 +1,17 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=isync
-pkgver=1.3.0
-pkgrel=5
+pkgver=1.3.1
+pkgrel=0
 pkgdesc="IMAP and MailDir mailbox synchronizer"
 url="http://isync.sourceforge.net"
 arch="all"
-license="GPL-2.0"
-depends=""
-makedepends="$depends_dev openssl-dev cyrus-sasl-dev zlib-dev db-dev perl-dev"
+license="GPL-3.0-or-later"
+makedepends="openssl-dev cyrus-sasl-dev zlib-dev db-dev perl-dev"
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::http://downloads.sourceforge.net/sourceforge/isync/$pkgname-$pkgver.tar.gz"
-builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
-	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -25,13 +22,11 @@ build() {
 }
 
 check() {
-	cd "$builddir"
 	make check
 }
 
 package() {
-	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="b5186f2afe97cab58ce55d3ec19ae7371676ae614448614a9e3e02d09662c34b74e559f0926661fa0300ab22dab9e2e9089b78ee38b94141ff3f8b4d75578ffa  isync-1.3.0.tar.gz"
+sha512sums="59d702d41d4a4e72f03cb282b414d0bb859593171763e845bc24d116a74f807a79e5be61f1dd1f59a9ece492322bceac156b08958a246cbfbe7f230fab4cdda2  isync-1.3.1.tar.gz"


### PR DESCRIPTION
Source: `README`:

> This is a long overdue maintenance release:
> 
> * SSL now uses SNI, which for example GMail requires
> * fixed fallbacks for missing UIDPLUS extension (with e.g. DavMail)
> * fixed UIDVALIDITY recovery with really long Message-id headers
> * fixed GSSAPI authentication with Kerberos
> * fixed support for IMAP servers which do not sort search results (e.g., poczta.o2.pl)
> * fixed CopyArrivalDate on platforms without glibc
> * fixed useless SASL warnings with certain plugins
> * the perl 5.14 requirement is now made explicit
> * improved OpenBSD support
> * fixed a bunch of compiler warnings