### PR TITLE
community/py-opencl: fix compiler choice and re-enable ppc64le

### DIFF
--- a/community/py-opencl/APKBUILD
+++ b/community/py-opencl/APKBUILD
@@ -3,10 +3,10 @@
 pkgname=py-opencl
 _pkgreal=${pkgname/-/}
 pkgver=2018.2.5
-pkgrel=0
+pkgrel=1
 pkgdesc="Python wrapper for OpenCL"
 url="https://pypi.python.org/pypi/pyopencl"
-arch="all !ppc64le"
+arch="all"
 license="MIT"
 depends="py-mako"
 makedepends="python2-dev python3-dev py-setuptools py-numpy>=1.14.3-r1 ctags
@@ -14,7 +14,8 @@ makedepends="python2-dev python3-dev py-setuptools py-numpy>=1.14.3-r1 ctags
 	py-pybind11 py-numpy-dev"
 checkdepends="py-six py-decorator pytest py-py"
 subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
-source="https://files.pythonhosted.org/packages/source/${_pkgreal:0:1}/$_pkgreal/$_pkgreal-$pkgver.tar.gz"
+source="https://files.pythonhosted.org/packages/source/${_pkgreal:0:1}/$_pkgreal/$_pkgreal-$pkgver.tar.gz
+	fix-compiler-choice.patch"
 builddir="$srcdir/$_pkgreal-$pkgver"
 options="!check" # tests require python-theano which isn't packed yet
 
@@ -52,4 +53,5 @@ check() {
 	python2 setup.py test
 }
 
-sha512sums="91f9e9b15ef0dbf22440b6abf762c729e8de587966c9d9a5da8c7ac02230ef700e31056248f1d93ec7e7af6e79918d68e18139e413f3cef287ecf683ee81ac05  pyopencl-2018.2.5.tar.gz"
+sha512sums="91f9e9b15ef0dbf22440b6abf762c729e8de587966c9d9a5da8c7ac02230ef700e31056248f1d93ec7e7af6e79918d68e18139e413f3cef287ecf683ee81ac05  pyopencl-2018.2.5.tar.gz
+b6d1295f2b413d3b27a13632df1bc7b9390423622c5748bd0d929555797ee63fd9f217b132a005a3b082d9e96952115c7846eeb675e23f69d6aeea8aa57af5e1  fix-compiler-choice.patch"

--- a/community/py-opencl/fix-compiler-choice.patch
+++ b/community/py-opencl/fix-compiler-choice.patch
@@ -1,0 +1,25 @@
+From 2dd4a31f03c2fbf7504dca64a9f66c63fc37f018 Mon Sep 17 00:00:00 2001
+From: Andreas Kloeckner <inform@tiker.net>
+Date: Fri, 3 May 2019 17:58:49 -0500
+Subject: [PATCH] Try -std=gnu++14 before c++14
+ (https://github.com/inducer/pyopencl/issues/280)
+
+---
+ aksetup_helper.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/aksetup_helper.py b/aksetup_helper.py
+index e86f4cd..f90d085 100644
+--- a/aksetup_helper.py
++++ b/aksetup_helper.py
+@@ -917,7 +917,9 @@ def cpp_flag(compiler):
+ 
+     The c++14 is prefered over c++11 (when it is available).
+     """
+-    if has_flag(compiler, '-std=c++14'):
++    if has_flag(compiler, '-std=gnu++14'):
++        return '-std=gnu++14'
++    elif has_flag(compiler, '-std=c++14'):
+         return '-std=c++14'
+     elif has_flag(compiler, '-std=c++11'):
+         return '-std=c++11'


### PR DESCRIPTION
As specified in https://github.com/inducer/pyopencl/issues/280 commit https://github.com/inducer/aksetup/commit/2dd4a31f03c2fbf7504dca64a9f66c63fc37f018 needs to be added to allow build setup to choose the correct compiler to use.