### PR TITLE
main/multipath-tools: bump pkgrel

### DIFF
--- a/main/multipath-tools/APKBUILD
+++ b/main/multipath-tools/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=multipath-tools
 pkgver=0.8.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Device Mapper Multipathing Driver"
 url="http://christophe.varoqui.free.fr"
 arch="all"


### PR DESCRIPTION
Rebuild to fix missing liburcu.so.6 dependency (userspace-rcu).