### PR TITLE
testing/kde-frameworks-tier3: new aports

### DIFF
--- a/testing/baloo/APKBUILD
+++ b/testing/baloo/APKBUILD
@@ -1,0 +1,27 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=baloo
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="A framework for searching and managing metadata"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later AND (LGPL-2.1-only OR LGPL-3.0-only)"
+depends_dev="qt5-qtdeclarative-dev lmdb-dev kcoreaddons-dev kconfig-dev kdbusaddons-dev ki18n-dev kidletime-dev solid-dev kfilemetadata-dev kcrash-dev kio-dev kservice-dev kbookmarks-dev kcompletion-dev kjobwidgets-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qtbase-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-lang"
+options="!check" # Tons of broken tests
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="af7c8f822e71d1928e18875fe026ab6feea80e6cefb6f9ec98f1444c46827cefa8b9ec4e913e079944e96b3de6eed4d0895df2c293933270c5bb464277866396  baloo-5.58.0.tar.xz"

--- a/testing/kactivities-stats/APKBUILD
+++ b/testing/kactivities-stats/APKBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+pkgname=kactivities-stats
+pkgver=5.58.0
+pkgrel=0
+arch="all"
+pkgdesc="A library for accessing the usage data collected by the activities system"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+depends_dev="boost-dev kconfig-dev kactivities-dev graphviz-dev qt5-qttools-dev qt5-qtdeclarative-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qtbase-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+prepare() {
+	default_prepare
+
+	mkdir "$builddir"/build
+}
+
+build() {
+	cd "$builddir"/build
+	cmake "$builddir" \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"/build
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"/build
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="d819cc9cf3232b47e9eaec6884a4a98f69bf6ffec02db8d2f07d90b7d5b3357c6e87b65eda0f842c80b566e0321b62dc27ed2baefc50c1de15cf9fe98001cd17  kactivities-stats-5.58.0.tar.xz"

--- a/testing/kbookmarks/APKBUILD
+++ b/testing/kbookmarks/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kbookmarks
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Support for bookmarks and the XBEL format"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev kconfig-dev kcoreaddons-dev kcodecs-dev kconfigwidgets-dev kwidgetsaddons-dev kxmlgui-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="c0953fd9f0da27ae20ef8f2501a8ad3f5ab2f68d1d1279013b16927803e2325905b57eb6c0a91ad69ba041a2834157f3c8dbd8ece605e40b82f9949157f27e58  kbookmarks-5.58.0.tar.xz"

--- a/testing/kcmutils/APKBUILD
+++ b/testing/kcmutils/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kcmutils
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Utilities for interacting with KCModules"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only AND LGPL-2.1-or-later"
+depends_dev="kitemviews-dev kconfigwidgets-dev kcoreaddons-dev ki18n-dev kiconthemes-dev kservice-dev kxmlgui-dev kdeclarative-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="261b75340fddecc4845622111b9cb00a2f85386e3912c794e4fbb8381e1b67062d1f6b069ad08874e6d37571fc62265f3a1598f2e4ed0a8552582d6e28afac0a  kcmutils-5.58.0.tar.xz"

--- a/testing/kconfigwidgets/APKBUILD
+++ b/testing/kconfigwidgets/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kconfigwidgets
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Widgets for KConfig"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only AND LGPL-2.1-or-later"
+depends_dev="kauth-dev kcoreaddons-dev kcodecs-dev kconfig-dev kguiaddons-dev ki18n-dev kwidgetsaddons-dev"
+makedepends="$depends_dev extra-cmake-modules kdoctools-dev doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="5ab2ff176df4eaffd15861bca535637bdb9e7ae1e30873aedbf39da7fdbc669672ec9f012b9e6fc3ccdfc8a9cb505b6b9dd4b799736ff0ff03c9c6071e2d58e2  kconfigwidgets-5.58.0.tar.xz"

--- a/testing/kdeclarative/APKBUILD
+++ b/testing/kdeclarative/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kdeclarative
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Provides integration of QML and KDE Frameworks"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtdeclarative-dev kconfig-dev ki18n-dev kiconthemes-dev kio-dev kwidgetsaddons-dev kwindowsystem-dev kglobalaccel-dev kguiaddons-dev kpackage-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="fffcb319a15cf89cc7179f0c543376eec83c0de8a49f533ab3c0488e13788b246b051a36249e0212517260fe24db647190e055a72cfa472dc168f0ae776cda41  kdeclarative-5.58.0.tar.xz"

--- a/testing/kded/APKBUILD
+++ b/testing/kded/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kded
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Extensible deamon for providing system level services"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only AND LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev kconfig-dev kcoreaddons-dev kcrash-dev kdbusaddons-dev kinit-dev kservice-dev"
+makedepends="$depends_dev extra-cmake-modules kdoctools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="67638ec4bf65ab74ac4cefb0591bfcbb80bdc37b5bc4ceb4099a9304f00a9f744710fc525c7649ee53c1bc6e590f583cbbded506ee96c0f96547217b21b81766  kded-5.58.0.tar.xz"

--- a/testing/kdesignerplugin/APKBUILD
+++ b/testing/kdesignerplugin/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kdesignerplugin
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Integration of Frameworks widgets in Qt Designer/Creator"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only"
+depends_dev="kcoreaddons-dev kconfig-dev kcompletion-dev kconfigwidgets-dev kiconthemes-dev kio-dev kitemviews-dev kplotting-dev ktextwidgets-dev kwidgetsaddons-dev kxmlgui-dev sonnet-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev kdoctools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="65ff89ffb3797d31e4fde69330cb7966b8e01893895cbe7df6de699912deb5863d45833a0bdddcdeb5b038894115ad79817392ee5ed4ca8254fba369c9aeb133  kdesignerplugin-5.58.0.tar.xz"

--- a/testing/kdesu/APKBUILD
+++ b/testing/kdesu/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kdesu
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Integration with su for elevated privileges"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only"
+depends_dev="kcoreaddons-dev ki18n-dev kservice-dev kpty-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-lang"
+# Since the goal of this library is to elevate privileges, suid being needed should be obvious
+options="suid !check" # Tests require X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="e2318670aa7465ac4268239f882b57af35f6943696498a4da33c51e4a89c3be646d617fe50e3aa132a200373f567b26a2247aba5638ad28b1ad0429c21eaed88  kdesu-5.58.0.tar.xz"

--- a/testing/kdewebkit/APKBUILD
+++ b/testing/kdewebkit/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kdewebkit
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Integration of the HTML rendering engine WebKit"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev qt5-qtwebkit-dev kconfig-dev kcoreaddons-dev kio-dev kjobwidgets-dev kparts-dev kservice-dev kwallet-dev"
+makedepends="$depends_dev extra-cmake-modules"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="00cad08646d47ecb7230b2edeea0901555963ba5969af27a7652151c36509d2d2c501cffc65309c0005d9d97efc261b3190590638a379207541eef41cf160067  kdewebkit-5.58.0.tar.xz"

--- a/testing/kemoticons/APKBUILD
+++ b/testing/kemoticons/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kemoticons
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Support for emoticons and emoticons themes"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1+ AND (LGPL-2.1-only OR LGPL-3.0-only)"
+depends_dev="karchive-dev kconfig-dev kservice-dev kcoreaddons-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="2fb641e05cffa31e7d2d9d2a0110ade0f1fdee7fc3f23924505c874d76db24999b041b7df4cb62ecb455081457e013a7ee906479acd35dfe283843c1d269ecc2  kemoticons-5.58.0.tar.xz"

--- a/testing/kglobalaccel/APKBUILD
+++ b/testing/kglobalaccel/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kglobalaccel
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Add support for global workspace shortcuts"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtx11extras-dev kconfig-dev kcoreaddons-dev kcrash-dev kdbusaddons-dev kwindowsystem-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev xcb-util-keysyms-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="4dfed2f280aefecaf9f8eecda5b3663c831fd85781ec8b64c2cd208d3e7af170b52603f8746193f48a92dbf86f6e9fd3fde90fb592557867cd78473dbe810990  kglobalaccel-5.58.0.tar.xz"

--- a/testing/kiconthemes/APKBUILD
+++ b/testing/kiconthemes/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kiconthemes
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Support for icon themes"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only"
+depends_dev="qt5-qtsvg-dev karchive-dev ki18n-dev kcoreaddons-dev kconfigwidgets-dev kwidgetsaddons-dev kitemviews-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="4ccaa35b81daef5e63ba43ce8baa5097282aa790cb8596ced8f8c23570813433ac497090fee257f764363150a487a433af68cf6e065d90c2163acfbea1e36bab  kiconthemes-5.58.0.tar.xz"

--- a/testing/kinit/APKBUILD
+++ b/testing/kinit/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kinit
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Process launcher to speed up launching KDE applications"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+depends_dev="qt5-qtbase-dev libcap-dev kservice-dev kio-dev ki18n-dev kwindowsystem-dev kcrash-dev kconfig-dev"
+makedepends="$depends_dev extra-cmake-modules kdoctools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="71c3fa045c727fbc548f8714e70866f857ce9b90decd234833d4f1655c660b97cc787b2ead28ace3d16e770a109fb357f1520ea22e83f4d0a651ca1357ea9082  kinit-5.58.0.tar.xz"

--- a/testing/kio/APKBUILD
+++ b/testing/kio/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kio
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Resource and network access abstraction"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only AND LGPL-2.1-or-later AND (LGPL-2.1-only OR LGPL-3.0-only)"
+depends_dev="qt5-qtscript-dev karchive-dev kconfig-dev kcoreaddons-dev kcrash-dev kdbusaddons-dev ki18n-dev kservice-dev solid-dev kbookmarks-dev kcompletion-dev kconfigwidgets-dev kiconthemes-dev kitemviews-dev kjobwidgets-dev kwidgetsaddons-dev kwindowsystem-dev kwallet-dev knotifications-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev libxslt-dev libxml2-dev kdoctools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="3d2d881f802516d890ffd3b5013972a6cd507228006d1e86d0c130209e776083a95b69bfb578509440a6ee387bea2d888029441b0ce9e6d93196536ef40f0c12  kio-5.58.0.tar.xz"

--- a/testing/knewstuff/APKBUILD
+++ b/testing/knewstuff/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=knewstuff
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Framework for downloading and sharing additional application data"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends="kirigami2"
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev karchive-dev kcompletion-dev kconfig-dev kcoreaddons-dev ki18n-dev kiconthemes-dev kio-dev kitemviews-dev kservice-dev ktextwidgets-dev kwidgetsaddons-dev kxmlgui-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
+}
+sha512sums="2cb66fd3ed5f35eca3373b3e6ad39813fd17607f8b128c028067f39c39c354e9eb7cae4173a92107b021e83dceab46625b71305bc2bff37590bb43baacc33caa  knewstuff-5.58.0.tar.xz"

--- a/testing/knotifyconfig/APKBUILD
+++ b/testing/knotifyconfig/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=knotifyconfig
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Configuration system for KNotify"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.0-only"
+depends_dev="kcompletion-dev kconfig-dev ki18n-dev kio-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="881f54d22dfd7920eced65d869303f1bec593a995a966d1a641ebae22bcbff5800f4d992c8190049ef6ff821a279f272ab7342f59a4d9aaddb66fb8535090c1b  knotifyconfig-5.58.0.tar.xz"

--- a/testing/kparts/APKBUILD
+++ b/testing/kparts/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kparts
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Document centric plugin system"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only AND LGPL-2.1+ AND (LGPL-2.1-only OR LGPL-3.0-only)"
+depends_dev="qt5-qtbase-dev kconfig-dev kcoreaddons-dev ki18n-dev kiconthemes-dev kio-dev kjobwidgets-dev kservice-dev ktextwidgets-dev kwidgetsaddons-dev kxmlgui-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="3b932af859a6e34538949ce7bb7c17bbf2d8e7ee7cc0c144180c5f36a3dad28b9b26b9ebf7ae08f6e586d24e066da17f3edd6fee096577151b386f327faeb70b  kparts-5.58.0.tar.xz"

--- a/testing/kpeople/APKBUILD
+++ b/testing/kpeople/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kpeople
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="A library that provides access to all contacts and the people who hold them"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtdeclarative-dev kcoreaddons-dev kwidgetsaddons-dev ki18n-dev kitemviews-dev kservice-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	# personsmodeltest fails
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest -E '(personsmodeltest)'
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="b10a232852c190ab21fb85a4b3eb894a46c83f01fba1fbf6235484a20f8dd4d9d93ba19c758e6b11f179993460b9aa86ad1a36f91899ae4c6ccaafe5d0392459  kpeople-5.58.0.tar.xz"

--- a/testing/krunner/APKBUILD
+++ b/testing/krunner/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=krunner
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Framework for providing different actions given a string query"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only AND LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev kconfig-dev kcoreaddons-dev ki18n-dev kio-dev kservice-dev plasma-framework-dev threadweaver-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="43e6d0a06a9cc639fde105013fb82e9264a1c0444b2a88d761f92b23f38317d532be113fce5f4896e0cdf6b30f9b4db164e47335c944f0d4a8112c079230fcaf  krunner-5.58.0.tar.xz"

--- a/testing/kservice/APKBUILD
+++ b/testing/kservice/APKBUILD
@@ -1,0 +1,42 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kservice
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Advanced plugin and service introspection"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only AND LGPL-2.1-or-later"
+depends_dev="kconfig-dev kcoreaddons-dev kcrash-dev kdbusaddons-dev ki18n-dev"
+makedepends="$depends_dev extra-cmake-modules kdoctools-dev doxygen qt5-qttools-dev flex-dev bison"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+prepare() {
+	default_prepare
+
+	mkdir "$builddir"/build
+}
+
+build() {
+	cd "$builddir"/build
+	cmake "$builddir" \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	cd "$builddir"/build
+	# ksycoca_xdgdirstest and kmimeassociationstest are broken
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest -E '(ksycoca_xdgdirs|kmimeassociations)test'
+}
+
+package() {
+	cd "$builddir"/build
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="4170b2dbe4021947862ec946e1282cada74ba12f5bfa1251087363e7693d334cd0775fb7b76900f661c65c525ce5480d69d551203c58c938e73e2622942a494e  kservice-5.58.0.tar.xz"

--- a/testing/ktexteditor/APKBUILD
+++ b/testing/ktexteditor/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=ktexteditor
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Advanced embeddable text editor"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only AND LGPL-2.1+ AND (LGPL-2.1-only OR LGPL-3.0-only)"
+depends_dev="karchive-dev kconfig-dev kguiaddons-dev ki18n-dev kio-dev kparts-dev sonnet-dev kiconthemes-dev syntax-highlighting-dev kauth-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="fb6b11e257089b7d13d39e05dcddec5797e462d537a263adae680534b22f9f86bf17e844e6d769c3c4f801916e7a38c59cc996785a07c0c3996093eff2aa14d7  ktexteditor-5.58.0.tar.xz"

--- a/testing/ktextwidgets/APKBUILD
+++ b/testing/ktextwidgets/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=ktextwidgets
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Advanced text editing widgets"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtspeech-dev kcompletion-dev kconfig-dev kconfigwidgets-dev ki18n-dev kiconthemes-dev kservice-dev kwidgetsaddons-dev kwindowsystem-dev sonnet-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="d3c33fb32fcf7611e06fcfa25c3450ed10076e96c19a4aaa327b0fc005003ee8cd910c9b0519eaefd3ef730da95d40effafe8b008bb9d767b55344ec4805a3cc  ktextwidgets-5.58.0.tar.xz"

--- a/testing/kwallet/APKBUILD
+++ b/testing/kwallet/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kwallet
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Secure and unified container for user passwords"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="libgcrypt-dev kcoreaddons-dev kconfig-dev kwindowsystem-dev ki18n-dev kconfigwidgets-dev kdbusaddons-dev kiconthemes-dev knotifications-dev kservice-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen graphviz kdoctools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="7145510aa75c179a7c283f26c6d479d753a435a14e423881793ef061b3dc6144c4126365719118b3fdd5d36560a706b36cb003d829d3c469f6f0844351ddc4f4  kwallet-5.58.0.tar.xz"

--- a/testing/kxmlgui/APKBUILD
+++ b/testing/kxmlgui/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kxmlgui
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="User configurable main windows"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-only AND LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev kcoreaddons-dev kitemviews-dev kconfig-dev kconfigwidgets-dev ki18n-dev kiconthemes-dev ktextwidgets-dev kwidgetsaddons-dev kwindowsystem-dev attica-dev kglobalaccel-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="22d718f49b5d9b4caca4fc38be4fac42c21d2ff481d0fa0d821df0223b255a79ac27dfd83773a8c0d24b9db79bbc0d486ada7c73d44ce1aeae35792ab4551be6  kxmlgui-5.58.0.tar.xz"

--- a/testing/kxmlrpcclient/APKBUILD
+++ b/testing/kxmlrpcclient/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kxmlrpcclient
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="XML-RPC client library for KDE"
+arch="all"
+url="https://projects.kde.org/projects/kde/pim/kxmlrpcclient"
+license="BSD-2-Clause"
+depends_dev="ki18n-dev kio-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/${pkgname}-${pkgver}.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="7046113f391169bef272fa98900d564d65b53f8fd8e5ac95babe21979139cb7f91e902d00801fb928e6a4a5c3a8f5b09689f3c49038194bb5e24650f8b6cebe2  kxmlrpcclient-5.58.0.tar.xz"

--- a/testing/plasma-framework/APKBUILD
+++ b/testing/plasma-framework/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=plasma-framework
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Plasma library and runtime components based upon KF5 and Qt5"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later AND GPL-2.0-or-later"
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev qt5-qtquickcontrols2-dev kactivities-dev karchive-dev kconfig-dev kconfigwidgets-dev kcoreaddons-dev kdbusaddons-dev kdeclarative-dev kglobalaccel-dev kguiaddons-dev ki18n-dev kiconthemes-dev kio-dev kservice-dev kwindowsystem-dev kxmlgui-dev knotifications-dev kpackage-dev kirigami2-dev kwayland-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev doxygen kdoctools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="4ceb9b2261012179cd0d9e0f1eec7b9d22b0f8a0582b4ccd7846a26619c429d3105962dec95af7daee0087e3011cc956d336a4aeed44671d6a6cbae3d663bc0d  plasma-framework-5.58.0.tar.xz"

--- a/testing/purpose/APKBUILD
+++ b/testing/purpose/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=purpose
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Framework for providing abstractions to get the developer's purposes fulfilled"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1"
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev kcoreaddons-dev ki18n-dev kconfig-dev kio-dev"
+makedepends="$depends_dev extra-cmake-modules"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-lang"
+options="!check" # Requires running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_TESTING=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="41a7c99b012c892680d786ce8f0aa982b79e814763847f86884e4c5a5f36bd925dd8f916b92f5786deafb6f22a5aa5af5bc39c1b73efdc9c58a6b9aab16ae026  purpose-5.58.0.tar.xz"


### PR DESCRIPTION
This PR introduces [KDE Framework tier 3](https://api.kde.org/frameworks/index.html#sg-tier_3).

Note that KDE Frameworks has no stable or unstable releases, but new releases are done every month.

The goal is to eventually fully package Plasma Desktop.