### PR TITLE
testing/go-ipfs: upgrade to 0.4.21

### DIFF
--- a/testing/go-ipfs/APKBUILD
+++ b/testing/go-ipfs/APKBUILD
@@ -1,16 +1,15 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=go-ipfs
-pkgver=0.4.20
+pkgver=0.4.21
 pkgrel=0
 pkgdesc="Inter Platnetary File System (IPFS), a peer-to-peer hypermedia distribution protocol"
 url="https://ipfs.io/"
 arch="x86_64 x86"
-license="MIT"
+license="MIT Apache-2.0"
 pkgusers="ipfs"
 pkggroups="ipfs"
-options="!check" # No test suit
-depends="musl"
+options="!check" # No test suite from upstream
 makedepends="make go bash git gx gx-go"
 install="$pkgname.pre-install $pkgname.post-install"
 subpackages="$pkgname-doc $pkgname-openrc $pkgname-bash-completion:bashcomp:noarch"
@@ -32,22 +31,15 @@ build() {
 	export GOPATH="$srcdir"
 	export GOBIN="$GOPATH/bin"
 
-	make IPFS_GX_USE_GLOBAL=1 build
-}
-
-check() {
-	cd "$builddir"
-	make test_short
+	make build
 }
 
 package() {
-	cd "$builddir"
-
 	install -m755 -D cmd/ipfs/ipfs \
 		"$pkgdir"/usr/bin/ipfs
 
-	install -m644 -D -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
 	install -m644 -D -t "$pkgdir/usr/share/doc/$pkgname" README.md
+
 	install -m755 -D "$srcdir"/ipfs.initd \
 		"$pkgdir"/etc/init.d/ipfs
 	install -m644 -D "$srcdir"/ipfs.confd \
@@ -67,11 +59,11 @@ bashcomp() {
 }
 
 cleanup_srcdir() {
-	go clean -modcache
+	[ -d src ] && chmod -R +w src; go clean -modcache;
 
 	default_cleanup_srcdir
 }
 
-sha512sums="623d085aa65b84f85e96e1d2be3f48113e6484ae4c505a479b0b5f778f11ddec5061145a3e5c9df702ee9cfdadb3cbde1aadc2c7ea9d9d9ad29e226e7120a7dd  go-ipfs-0.4.20.tar.gz
+sha512sums="570ea2c126538b88264242bac961cabfed5bf964e3e4ff294978f96aaf931a3df9d5a82659255cefbeedc00b748b8933a28d9862a233760e35d4ae9993e18dad  go-ipfs-0.4.21.tar.gz
 3e51e9a3dca1b991e8549f8354f7c2cfd1bb9b73d7a59557878d5c9ab4189988676d789172af3ba1fd57193ec48ca9125919507b0de7d0400ce0d6166622e556  ipfs.initd
 c55afeb3efe381d18258ddf00f58325b77156375cf223fb2daa049df056efe22e9139cce0f81dc4c73759dad5097af5f3201414beb5950bd894df9ae8c7c4ed1  ipfs.confd"


### PR DESCRIPTION
- https://github.com/ipfs/go-ipfs/releases 0.4.21
- License clarification
- License file remove
- Modernization