### PR TITLE
testing/frameworkintegration: new aport

### DIFF
--- a/testing/frameworkintegration/APKBUILD
+++ b/testing/frameworkintegration/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=frameworkintegration
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Framework providing components to allow applications to integrate with a KDE Workspace"
+arch="all"
+url="https://www.kde.org"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev kconfig-dev kconfigwidgets-dev kiconthemes-dev knotifications-dev knewstuff-dev kwidgetsaddons-dev kpackage-dev ki18n-dev"
+makedepends="$depends_dev extra-cmake-modules"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev"
+options="!check" # Requires X11 running
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="80f2d8c3dcaa57632bab12ca581ae57665b6bbea9f68aa439cf91f8bb7e987954a0b6787bc7f73e6e5cc8f605b28162a654bce6fa2aa3f699fc909fd5f0f5794  frameworkintegration-5.58.0.tar.xz"


### PR DESCRIPTION
This PR introduces frameworkintegration, which is the only package in KDE Framework tier 4.

Note that KDE Frameworks has no stable or unstable releases, but new releases are done every month.

The goal is to eventually fully package Plasma Desktop.

This PR depends on #8328.