### PR TITLE
testing/kde-porting-aids

### DIFF
--- a/testing/kdelibs4support/APKBUILD
+++ b/testing/kdelibs4support/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kdelibs4support
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Porting aid from KDELibs4"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1+ AND MIT AND LGPL-2.1-only AND LGPL-2.0-only AND (LGPL-2.1-only OR LGPL-3.0-only) AND (LGPL-2.0-only OR LGPL-3.0-only)"
+depends_dev="qt5-qtbase-dev qt5-qttools-dev kcompletion-dev kconfig-dev kconfigwidgets-dev kcrash-dev kdesignerplugin kdesignerplugin-dev kglobalaccel-dev kemoticons-dev kguiaddons-dev ki18n-dev kiconthemes-dev kio-dev knotifications-dev kparts-dev kservice-dev ktextwidgets-dev kunitconversion-dev kwidgetsaddons-dev kwindowsystem-dev kxmlgui-dev kdbusaddons-dev kded kded-dev perl-uri"
+makedepends="$depends_dev extra-cmake-modules kdoctools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/portingAids/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="suid !check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="c5b24bca72814e2ef32212f6834cdafa9a52329330ce782cde567a46144d6eac89141718053a3d905d344c14b7b51a5b49737f85761f3324c12e43f81ecac0c9  kdelibs4support-5.58.0.tar.xz"

--- a/testing/khtml/APKBUILD
+++ b/testing/khtml/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=khtml
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="The KDE HTML library, ancestor of WebKit"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later AND LGPL-2.1-only"
+depends_dev="qt5-qtbase-dev perl-dev giflib-dev libjpeg-turbo-dev karchive-dev kcodecs-dev kglobalaccel-dev ki18n-dev kiconthemes-dev kio-dev kjs-dev knotifications-dev kparts-dev sonnet-dev ktextwidgets-dev kwallet-dev kwidgetsaddons-dev kwindowsystem-dev kxmlgui-dev"
+makedepends="$depends_dev extra-cmake-modules gperf"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/portingAids/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="f4bc0f9a5a6288e76efe79596957aefeff5757cb447c9752bd20fd6dc48a199311fdcce78c22696d66c5dc2ca509d4c3cde56c0335be1c8e19bf104544546824  khtml-5.58.0.tar.xz"

--- a/testing/kjs/APKBUILD
+++ b/testing/kjs/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kjs
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Support for JS scripting in applications"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later AND BSD-3-Clause AND MIT"
+depends_dev="qt5-qtbase-dev perl-dev pcre-dev"
+makedepends="$depends_dev extra-cmake-modules kdoctools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/portingAids/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="6faa3bb2e0dbc8a1126010249b2b8e7668e158ff1ecaad7ee2f1b6869f32dff56dd09d5d1c26cbea157f41e4af47b7e95ac00053e61e3a86d29702eb09a5c29f  kjs-5.58.0.tar.xz"

--- a/testing/kjsembed/APKBUILD
+++ b/testing/kjsembed/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kjsembed
+pkgver=5.58.0
+pkgrel=1
+pkgdesc="JavaScript bindings for QObject"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtsvg-dev kjs-dev ki18n-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev kdoctools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/portingAids/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="a6fe93c0ecfee82394878fc4c388ba749f50e0e935c131e422dd80a1b81246f3b1eea74ab21df5016284b02a19fb27c06354a1f10582809a59f9cb40421845ec  kjsembed-5.58.0.tar.xz"

--- a/testing/kmediaplayer/APKBUILD
+++ b/testing/kmediaplayer/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kmediaplayer
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Media player framework for KDE 5"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="X11 AND LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev kparts-dev kxmlgui-dev"
+makedepends="$depends_dev extra-cmake-modules"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/portingAids/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	# viewtest requires X11 to be running
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest -E "viewtest"
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="08c48d48ed149b52ed2b9838a78d9b08011c859d63f1b18ad8238042c3e710d9b40a7c719e36d5a70161a3c27827ea0394f61c9556f72a25bc6acaee31791e74  kmediaplayer-5.58.0.tar.xz"

--- a/testing/kross/APKBUILD
+++ b/testing/kross/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kross
+pkgver=5.58.0
+pkgrel=0
+pkgdesc="Framework for scripting KDE applications"
+arch="all"
+url="https://community.kde.org/Frameworks"
+license="LGPL-2.1-or-later"
+depends_dev="qt5-qtbase-dev qt5-qttools-dev kcompletion-dev kcoreaddons-dev ki18n-dev kiconthemes-dev kio-dev kparts-dev kwidgetsaddons-dev kxmlgui-dev"
+makedepends="$depends_dev extra-cmake-modules kdoctools-dev"
+source="https://download.kde.org/stable/frameworks/${pkgver%.*}/portingAids/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="cdcdf4c649ee46ae3540af83717a161a46f40e5304780124b68f7b4c2e45c8c3b75ea067b13a562defdc88ffc266006871d1413b9c59ff9255a8cd74affb9f14  kross-5.58.0.tar.xz"


### PR DESCRIPTION
This PR introduces [KDE Framework Porting Aids](https://api.kde.org/frameworks/index.html#sg-porting_aids).

Note that KDE Frameworks has no stable or unstable releases, but new releases are done every month.

The goal is to eventually fully package Plasma Desktop.

This PR depends on #8328.