### PR TITLE
community/yelp-tools: fix install-sh

### DIFF
--- a/community/yelp-tools/APKBUILD
+++ b/community/yelp-tools/APKBUILD
@@ -7,10 +7,11 @@ pkgdesc="Collection of utilities to help create documentation"
 url="https://wiki.gnome.org/Apps/Yelp/Tools"
 arch="noarch"
 license="GPL-2.0-or-later"
-makedepends="gawk yelp-xsl itstool libxml2-utils libxslt"
+makedepends="autoconf-archive automake gawk yelp-xsl itstool libxml2-utils libxslt"
 source="https://download.gnome.org/sources/yelp-tools/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
 
 build() {
+	autoreconf --force --install --verbose
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \


### PR DESCRIPTION
The `install-sh` in the tarball is using `#!/usr/bin/sh` instead of `#!/bin/sh`.