### PR TITLE
main/hiredis: bump to build on armv7

### DIFF
--- a/main/hiredis/APKBUILD
+++ b/main/hiredis/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=hiredis
 pkgver=0.14.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Minimalistic C client library for Redis"
 url="https://github.com/redis/hiredis"
 arch="all"


### PR DESCRIPTION
hiredis has not been built on armv7, while there should be nothing
preventing it from being built. greenbone-security-assistant
depends on hiredis and is now failing to build on armv7.

Bump pkgrel to force a rebuild.