### PR TITLE
[WIP] testing/qutebrowser: upgrade to 1.6.2

### DIFF
--- a/testing/qutebrowser/APKBUILD
+++ b/testing/qutebrowser/APKBUILD
@@ -1,41 +1,29 @@
 # Maintainer: Drew DeVault <sir@cmpwn.com>
 pkgname=qutebrowser
-pkgver=1.5.2
-pkgrel=1
+pkgver=1.6.2
+pkgrel=0
 pkgdesc="A keyboard-driven, vim-like browser based on PyQT5"
 url="https://qutebrowser.org/"
 arch="noarch !s390x !ppc64le !x86" # limited by qt5-qtwebengine
 license="GPL-3.0-only"
 depends="
 	py3-attrs py3-jinja2 py3-pygments py3-pypeg2 py3-qt5 py3-yaml qt5-qtbase
-	qt5-qtwebengine qt5-qtbase-sqlite
+	qt5-qtwebengine qt5-qtbase-sqlite py3-qtwebengine py3-setuptools
 "
-makedepends="asciidoc py3-pytest py3-hypothesis py3-setuptools"
+makedepends="asciidoc"
+checkdepends="py3-pytest py3-hypothesis"
+subpackages="$pkgname-doc"
 source="
 	https://github.com/qutebrowser/qutebrowser/releases/download/v$pkgver/qutebrowser-$pkgver.tar.gz
 "
-builddir="$srcdir/$pkgname-$pkgver"
-options="!check"
 
 build() {
-	cd "$builddir"
 	a2x -f manpage doc/qutebrowser.1.asciidoc
 	python3 setup.py build
 }
 
 package() {
-	cd "$builddir"
-	python3 setup.py install --root="$pkgdir/" --optimize=1
-	install -Dm644 misc/qutebrowser.desktop \
-		"$pkgdir"/usr/share/applications/qutebrowser.desktop
-	for i in 16 24 32 48 64 128 256 512; do
-		install -Dm644 "icons/qutebrowser-${i}x$i.png" \
-			"$pkgdir/usr/share/icons/hicolor/${i}x$i/apps/qutebrowser.png"
-	done
-	install -Dm644 icons/qutebrowser.svg \
-		"$pkgdir/usr/share/icons/hicolor/scalable/apps/qutebrowser.svg"
-	mkdir -p "$pkgdir/usr/share/qutebrowser/userscripts"
-	install -Dm755 -t "$pkgdir/usr/share/qutebrowser/userscripts/" misc/userscripts/*
+	make -f misc/Makefile DESTDIR="$pkgdir" PREFIX=/usr install
 }
 
-sha512sums="29c48d86b95bf2b40459ef06dab37fff7e30409f78d8c50c494ebafc9698a0c0123a63d160679b3a4778ecb15e5c339dc67357a60f493499ad4b6443f7dacc7a  qutebrowser-1.5.2.tar.gz"
+sha512sums="708fe9c5db54fdab0697e03ce26d901ee18da2a04d3934c0705f9cdff543e859892de2ac9aa9e3b0b12c4a3d6be7a492d34a868058e4a6b21f06d4343caff89a  qutebrowser-1.6.2.tar.gz"


### PR DESCRIPTION
Requires Qt5WebEngine to be fixed with musl like chromium/firefox so in the meantime you need to run with --qt-arg disable-seccomp-filter

Fails to load a page in quickstart, if someone can test would be grateful