### PR TITLE
community/py3-python-gssapi: new aport

### DIFF
--- a/community/py3-python-gssapi/APKBUILD
+++ b/community/py3-python-gssapi/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Dmitry Romanenko <dmitry@romanenko.in>
+# Maintainer: Dmitry Romanenko <dmitry@romanenko.in>
+pkgname=py3-python-gssapi
+_pkgname=gssapi
+pkgver=1.5.1
+pkgrel=0
+pkgdesc="A Python interface to RFC 2743/2744 (plus common extensions)"
+url="https://github.com/pythongssapi/python-gssapi"
+arch="all"
+license="ISC"
+depends="python3"
+#checkdepends="py-nose py-shouldbe py-k5test" # Tests are missing alpine packages
+makedepends="python3-dev krb5-dev py-setuptools"
+subpackages=""
+source="https://files.pythonhosted.org/packages/source/g/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+build() {
+	python3 setup.py build
+}
+
+#check() {
+#	python3 setup.py test
+#}
+
+package() {
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+sha512sums="d0c27360e1f54a322f311f102ad498a3794e5f22aa9e07f917fa074d02f1643932ba34d630761c62500e5f780a5c6b207ee4662507ca88f99fcfd4563d7241b0  gssapi-1.5.1.tar.gz"


### PR DESCRIPTION
This package offers quite comprehensive interface for RFC 2743/2744. It means most of functional wrappers around C-binding of Kerberos. Tests are disabled because dependent test packages are missing from Alpine + they're not even confirmed working for latest versions of pythons 2.7/3.6+ (check forbiddenfruit). They might be added later in the future if I get them to compile and run tests.