### PR TITLE
testing/gnome-shell: use xvfb-run to run testsuite

### DIFF
--- a/testing/gnome-shell/APKBUILD
+++ b/testing/gnome-shell/APKBUILD
@@ -45,9 +45,14 @@ makedepends="gnome-desktop-dev
 	py3-setuptools
 	gnome-bluetooth-dev
 	gstreamer-dev"
+checkdepends="
+	xvfb-run
+	mesa-dri-swrast
+	gdm
+	"
 subpackages="$pkgname-lang $pkgname-doc"
 source="https://download.gnome.org/sources/gnome-shell/${pkgver%.*}/gnome-shell-$pkgver.tar.xz"
-options="!check" # Requires running X11 server
+options="!check" # Tests have circular dependency 'gnome-shell <-> gdm'
 
 build() {
 	meson \
@@ -62,7 +67,7 @@ build() {
 }
 
 check() {
-	ninja -C output test
+	xvfb-run ninja -C output test
 }
 
 package() {


### PR DESCRIPTION
Sadly the tests require on gdm which depends on gnome-shell so we can't
enable them, but still, individual maintainers when updating gnome-shell
can make use of an already compiled gdm to run the testsuite.

@Cogitri