### PR TITLE
testing/crypto++: upgrade to 8.2.0

### DIFF
--- a/testing/amule/APKBUILD
+++ b/testing/amule/APKBUILD
@@ -1,25 +1,20 @@
 # Contributor: August Klein <amatcoder@gmail.com>
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=amule
-_pkgname=aMule-SVN-r
-pkgver=10990
-pkgrel=1
+_commit=21c3aa111bc8ff04c876494054580a7ccaa6a3a4
+pkgver=11015
+pkgrel=0
 pkgdesc="An eMule-like client for the eD2k and Kademlia networks"
 url="http://www.amule.org"
 arch="all"
-license="GPL-2.0"
-makedepends="bison crypto++-dev gd-dev geoip-dev libsm-dev libupnp-dev wxgtk2.8-dev"
+license="GPL-2.0-or-later"
+makedepends="bison crypto++-dev gd-dev geoip-dev libsm-dev libupnp-dev wxgtk-dev"
 subpackages="$pkgname-lang $pkgname-doc"
-source="http://amule.sourceforge.net/tarballs/${_pkgname}${pkgver}.tar.bz2"
-builddir=$srcdir/${_pkgname}${pkgver}
+source="$pkgname-$pkgver.tar.gz::https://repo.or.cz/amule.git/snapshot/$_commit.tar.gz"
 
-prepare() {
-	cd "$builddir"
-	update_config_sub
-}
+builddir="$srcdir/$pkgname-${_commit:0:7}"
 
 build() {
-	cd "$builddir"
 	./configure \
 		CPPFLAGS="$CPPFLAGS -Wno-unused-local-typedefs" \
 		CFLAGS="$CFLAGS -fPIC" \
@@ -28,7 +23,6 @@ build() {
 		--host=$CHOST \
 		--prefix=/usr \
 		--mandir=/usr/share/man \
-		--with-wxversion=2.8 \
 		--enable-amule-daemon \
 		--enable-amulecmd \
 		--enable-amule-gui \
@@ -43,9 +37,8 @@ build() {
 }
 
 package() {
-	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 	rm -f "$pkgdir"/usr/lib/charset.alias
 }
 
-sha512sums="1883426e3d0e2a58227a5a95efcb3193d207e6b6c2d6c9c256aa430debc601ade3551f86c7519e9942d440cc1e87672b4d1e7f2dc69a8bb50bef89ddcb3170f5  aMule-SVN-r10990.tar.bz2"
+sha512sums="7c39aaff50c419197996123a77a9795dfeff302e22d7d3c11bee50d319c7839fb6e22393a13e789ca084ee9fd1748f842348bc7c71085dc318a8e8593f673a3b  amule-11015.tar.gz"

--- a/testing/crypto++/APKBUILD
+++ b/testing/crypto++/APKBUILD
@@ -2,35 +2,28 @@
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=crypto++
 _pkgname=cryptopp
-pkgver=5.6.5
+pkgver=8.2.0
 _pkgver=${pkgver//./}
-pkgrel=1
+pkgrel=0
 pkgdesc="A free C++ class library of cryptographic schemes"
 url="https://www.cryptopp.com/"
 arch="all"
 license="BSL-1.0"
-depends=""
 depends_dev="$pkgname"
-makedepends=""
-subpackages="$pkgname-dev"
+subpackages="$pkgname-static $pkgname-dev"
 source="https://www.cryptopp.com/${_pkgname}${_pkgver}.zip"
-
 builddir="$srcdir"
 
 build() {
-	cd "$builddir"
-	sed -i -e 's/^CXXFLAGS/#CXXFLAGS/' GNUmakefile || return 1
-	export CXXFLAGS="${CXXFLAGS} -DNDEBUG -fPIC"
-	make -f GNUmakefile || return 1
-	make libcryptopp.so || return 1
+	make CXXFLAGS="${CXXFLAGS} -DNDEBUG -fPIC" -f GNUmakefile dynamic libcryptopp.pc
+}
+
+check() {
+	make -f GNUmakefile check
 }
 
 package() {
-	cd "$builddir"
-	install -Dm644 libcryptopp.so "$pkgdir"/usr/lib/libcryptopp.so || return 1
-	install -Dm644 License.txt "$pkgdir"/usr/share/licenses/$pkgname/LICENSE || return 1
-	mkdir -p "$pkgdir"/usr/include/cryptopp/ || return 1
-	install -m644 *.h "$pkgdir"/usr/include/cryptopp/ || return 1
+	make DESTDIR="$pkgdir" PREFIX="/usr" install-lib
 }
 
-sha512sums="f13718d02ca69b0129aaf9e767c9d2e0333aa7538355f9c63d9eaf1ff369062084a18dc01489439ebf37797b3ea81b01beb072057d47ec962bfb824ddc72abc7  cryptopp565.zip"
+sha512sums="753513a4ec8dd0fff2f551853ce6bd265d82219c28b033565b565b5e567fbee17adb419f4cde58a97e62b7d6533f4099aa4996cd0ba4775c6a2e7ae63a879da5  cryptopp820.zip"


### PR DESCRIPTION
This package has been out of date for quite a long time and didn't correctly package the shared libraries.

Upgraded to latest version released in April, added check and now uses provided install make targets to correctly install all soversioned libs.