### PR TITLE
main/java-common: Fix sorting function for newer java version (10+)

### DIFF
--- a/main/java-common/APKBUILD
+++ b/main/java-common/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Timo Teras <timo.teras@iki.fi>
 # Maintainer: Timo Teras <timo.teras@iki.fi>
 pkgname=java-common
-pkgver=0.1
+pkgver=0.2
 pkgrel=0
 pkgdesc="Java common (updates java links)"
 url="https://git.alpinelinux.org/aports.git"

--- a/main/java-common/java-common.trigger
+++ b/main/java-common/java-common.trigger
@@ -6,7 +6,7 @@ if [ -x /usr/lib/jvm/forced-jvm ]; then
 fi
 
 cd /usr/lib/jvm
-LATEST=`ls -d java-* | sort -r | head -1`
+LATEST=`ls -d java-* | sort -Vr | head -1`
 if [ "$LATEST" ]; then
 	ln -sfn $LATEST default-jvm
 fi


### PR DESCRIPTION
This fixes the java-common trigger to detect the right order of installed java version.
Without the ```-V``` switch, 9 was larger than 10 and 11.