### PR TITLE
testing/mergerfs: upgrade to 2.27.1

### DIFF
--- a/testing/mergerfs/APKBUILD
+++ b/testing/mergerfs/APKBUILD
@@ -3,7 +3,7 @@
 # NOTE: For now we must use vendored libfuse, see the URL below for details.
 #       https://github.com/trapexit/mergerfs/blob/2.27.0/README.md#why-was-libfuse-embedded-into-mergerfs
 pkgname=mergerfs
-pkgver=2.27.0
+pkgver=2.27.1
 pkgrel=0
 pkgdesc="A FUSE based union filesystem"
 url="https://github.com/trapexit/mergerfs"
@@ -29,4 +29,4 @@ package() {
 	make PREFIX="/usr" DESTDIR="$pkgdir" install
 }
 
-sha512sums="d6de527795fec31bac948e2606140463b9912f53a4f565ae2a1305c67a8ec3ad943a6fe7445d584135e4646e1bd282aa5683dc12d35d89b3e575f4c39a599948  mergerfs-2.27.0.tar.gz"
+sha512sums="76a4161fdf79e3b6f72ebe3314e29c4273363984994b8cb0048809bce4408e2ed717f534c13f2bb199ec6dfa7536d786e8609b2dab0dc862bbc4a490d0c10d52  mergerfs-2.27.1.tar.gz"


### PR DESCRIPTION
fixes an unlink race condition