### PR TITLE
testing/py3-forbiddenfruit: new aport

### DIFF
--- a/testing/py3-forbiddenfruit/APKBUILD
+++ b/testing/py3-forbiddenfruit/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Dmitry Romanenko <dmitry@romanenko.in>
+# Maintainer: Dmitry Romanenko <dmitry@romanenko.in>
+pkgname=py3-forbiddenfruit
+_pkgname=forbiddenfruit
+pkgver=0.1.3
+pkgrel=0
+pkgdesc="Patch built-in python objects"
+url="https://github.com/clarete/forbiddenfruit"
+arch="all"
+license="GPL-3.0-or-later OR MIT"
+depends="python3"
+checkdepends="py3-nose py3-coverage"
+makedepends="python3-dev"
+source="https://files.pythonhosted.org/packages/source/f/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+build() {
+	python3 setup.py build
+}
+
+check() {
+	find ./build -name '*.so' -exec cp {} tests/unit \;
+	nosetests --stop --with-coverage --cover-package=$_pkgname --cover-branches --verbosity=2 -s tests/unit
+}
+
+package() {
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+sha512sums="abd3e95a03f60bbe2c522cc77487fcbafce1325e1537bcfdaaa347db0eb283adf3c97c08b5cb05e37a3ee10f5bff160bc8c96e61f1b5aa64a55f58dd1563d25b  forbiddenfruit-0.1.3.tar.gz"


### PR DESCRIPTION
This is one of dependencies for [should_be](https://github.com/DirectXMan12/should_be/blob/master/setup.py) which is often used for tests.