### PR TITLE
testing/shunit2: new aport

### DIFF
--- a/testing/shunit2/APKBUILD
+++ b/testing/shunit2/APKBUILD
@@ -1,0 +1,27 @@
+# Contributor: Olliver Schinagl <oliver@schinagl.nl>
+# Maintainer: Olliver Schinagl <oliver@schinagl.nl>
+pkgname="shunit2"
+pkgver="2.1.7"
+pkgrel=0
+pkgdesc="A xUnit based unit test framework for Bourne based shell scripts."
+url="https://github.com/kward/shunit2/"
+arch="noarch"
+license="Apache-2.0"
+makedepends="bash dash loksh zsh"
+subpackages="${pkgname}-doc"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/kward/shunit2/archive/v${pkgver}.tar.gz"
+
+check() {
+	_tmpdir="${TMPDIR:-/tmp/}"
+	TMPDIR="$(mktemp -d -p "${_tmpdir}" shunit2.XXXXXXXX)" ./gen_test_report.sh
+	rm -rf "${_tmpdir}/shunit2.*"
+}
+
+package() {
+	install -D -m 644 -t "${pkgdir}/usr/bin/" \
+		"shunit2"
+	install -D -m 644 -t "${pkgdir}/usr/share/doc/${pkgname}/" \
+		"README.md"
+}
+
+sha512sums="35453cf2c469eb1bab2fff0624b8037a09d405c377fec0938875a6339749d5934fe246eec5691a121290ae9e4ee5cbf7768b740c5f0010a5345c4e111c50fbbd  shunit2-2.1.7.tar.gz"


### PR DESCRIPTION
shUnit2 is a xUnit based unit test framework for Bourne based shell scripts.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>