### PR TITLE
testing/qtchooser: new aport

### DIFF
--- a/community/qt5-qtbase/APKBUILD
+++ b/community/qt5-qtbase/APKBUILD
@@ -7,11 +7,11 @@ _ver=${_ver/_/-}
 _ver=${_ver/beta0/beta}
 _ver=${_ver/rc0/rc}
 _V=${_ver/rc/RC}
-pkgrel=0
+pkgrel=1
 pkgdesc="Qt5 - QtBase components"
-url="http://qt-project.org/"
+url="https://qt.io/developers/"
 arch="all"
-license="LGPL-2.0 with exceptions or GPL-3.0 with exceptions"
+license="LGPL-2.1-only AND LGPL-3.0-only AND GPL-3.0-only AND Qt-GPL-exception-1.0"
 _sub="$pkgname-sqlite $pkgname-odbc $pkgname-postgresql $pkgname-mysql
 	$pkgname-tds $pkgname-x11"
 depends_dev="mesa-dev libice-dev libsm-dev libx11-dev libxext-dev
@@ -49,6 +49,7 @@ makedepends="$depends_dev
 	xcb-util-renderutil-dev
 	"
 subpackages="$pkgname-dev $pkgname-doc $_sub"
+provides="qtbase"
 
 case $pkgver in
 *_beta*|*_rc*) _rel=development_releases;;

--- a/testing/qtchooser/APKBUILD
+++ b/testing/qtchooser/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=qtchooser
+pkgver=66
+pkgrel=0
+pkgdesc="Wrap the other Qt tools by searching for different instances of Qt on the system"
+arch="all"
+url="https://code.qt.io/cgit/qtsdk/qtchooser.git/"
+license="GPL-3.0-only OR LGPL-2.1-only"
+source="https://download.qt.io/official_releases/qtchooser/$pkgname-$pkgver.tar.xz
+	qt5.conf
+	"
+subpackages="$pkgname-doc"
+
+build() {
+	bindir=/usr/lib/qtchooser/ make
+}
+
+package() {
+	install_if="qtbase"
+	INSTALL_ROOT="$pkgdir" make install
+
+	install -d "$pkgdir"/etc/xdg/qtchooser
+	install -m644 "$srcdir"/qt5.conf \
+		"$pkgdir"/etc/xdg/qtchooser/
+
+	# Set the default Qt
+	ln -s /etc/xdg/qtchooser/qt5.conf \
+		"$pkgdir"/etc/xdg/qtchooser/default.conf
+}
+sha512sums="0c7d3588ddd7b21e6e9d799204924e06e0b0950c898dfd23088f1e7657b7f821a35579aa062658499809f9d9757e82c3c592591aa2e5ec453463929bf2b33bac  qtchooser-66.tar.xz
+aa1c18df9d5279ff00d06a0b3f19223e36e64f6275cf3ebc5a4be1e41bb139787325b88f89e0133e9960a7b2582716962dd5d195202ff68715883ce41babda73  qt5.conf"

--- a/testing/qtchooser/qt5.conf
+++ b/testing/qtchooser/qt5.conf
@@ -1,0 +1,2 @@
+/usr/lib/qt5/bin
+/usr/lib


### PR DESCRIPTION
QtChooser is normally meant to allow the user to switch between several installations of Qt easily (including Qt4), by symlinking all Qt binaries from the actually installed location (`/usr/lib/qt5/bin` for the distro packages) to `/usr/bin`. Currently all Qt binaries are available with a `-qt5` suffix, but some software (most notably KDE Plasma) expects it without the suffix. Rather than patching all the individual applications, this is the proper solution.

Note that this can work with Qt4 quite easily, but my understanding is that we should try to get rid of Qt4 instead and not make any effort in improving it.