### PR TITLE
main/vim: upgrade to 8.1.1365

### DIFF
--- a/main/vim/APKBUILD
+++ b/main/vim/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=vim
-pkgver=8.1.1364
+pkgver=8.1.1365
 pkgrel=0
 pkgdesc="Improved vi-style text editor"
 url="https://www.vim.org/"
@@ -24,6 +24,8 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$
 #     - CVE-2017-5953
 #   8.0.0056-r0:
 #     - CVE-2016-1248
+#   8.1.1365:
+#     - TBD
 
 prepare() {
 	cd "$builddir"
@@ -98,5 +100,5 @@ vimdiff() {
 	mv "$pkgdir"/usr/bin/vimdiff "$subpkgdir"/usr/bin
 }
 
-sha512sums="f5a92f44c9ad605ac18cd3e5afd9cfd6cebb4e7af797b2e669c74c572be2cf83109656b87aac6bbbb183179484a68e8bf0536f613306cc2376624129b8aceeb1  vim-8.1.1364.tar.gz
+sha512sums="907627c9c0f429ec195ffe7417e14811de2c20aabb99d00deb81d41c82fdc855879cad336cf1e4ead6b0a725dfec992c40f449327032d7efa71c87a58e6a1027  vim-8.1.1365.tar.gz
 d9586b777881973cb5e48e18750336a522ed72c3127b2d6b6991e2b943468ca5b694476e7fa39ab469178c1375fc8f52627484e0fe377aea5811a513e35a7b02  vimrc"


### PR DESCRIPTION
Arbitrari code execution has been found in vim modelines:

https://github.com/numirias/security/blob/master/doc/2019-06-04_ace-vim-neovim.md

No CVE assigned yet.