### PR TITLE
testing/prometheus-node-exporter: upgrade to 0.18.1

### DIFF
--- a/testing/prometheus-node-exporter/APKBUILD
+++ b/testing/prometheus-node-exporter/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Tiago Ilieve <tiago.myhro@gmail.com>
 pkgname=prometheus-node-exporter
 _pkgname=node_exporter
-pkgver=0.18.0
+pkgver=0.18.1
 pkgrel=0
 pkgdesc="Prometheus exporter for machine metrics"
 url="https://github.com/prometheus/node_exporter"
@@ -38,7 +38,7 @@ package() {
 	install -Dm755 ./node_exporter "$pkgdir"/usr/bin/node_exporter
 }
 
-sha512sums="9c6f9f82b0d3f5147cef8cc933ab9d7854065782f83b9821d4ae394a5101c45de6c8e8fcdc53d076af0c8683c47030557ec8e2bd27386a81a815d714e0f88987  node_exporter-0.18.0.tar.gz
+sha512sums="cf2b854fbec1ba39b18432cdc11ab507ebc5b2828e6b34b4f49af9b949fcd365cb3e5eb1e265d0825783810c6b1572a8b3512ec27a46e5c83f89a505590159c0  node_exporter-0.18.1.tar.gz
 36952039e5db39aa06a2ca16fa5d318f22eb967e3e9b1363508b2f3d3d0b14e5df111c77ce951bea2f65dd2be0a0a1582be245acfe4641623381a940204e53d9  disable-go-race-detector.patch
 592d3f17a3cf487d97a14c803dded07d2dfb112b159ab1a3575310fc0176fc3255ddad6657f16a8d6d3c161bfb03c203a6271ec6e6395b75716a14b0de8baced  node-exporter.confd
 df006b184c3b2d5e773044838db7143dc3a64e621f4da6b106f41915a07d5cef32933ab9bb44464f10c132f86997ae7753ae19627afd4ba6cfb125161786dfe0  node-exporter.initd"


### PR DESCRIPTION
Released on 2019-06-04: https://github.com/prometheus/node_exporter/releases/tag/v0.18.1