### PR TITLE
testing/ostinato: update to latest Git and move to Qt5

### DIFF
--- a/testing/ostinato/APKBUILD
+++ b/testing/ostinato/APKBUILD
@@ -1,31 +1,31 @@
 # Maintainer: Corentin Henry <corentinhenry@gmail.com>
 # Contributor: Corentin Henry <corentinhenry@gmail.com>
 pkgname=ostinato
-pkgver=0.9
-pkgrel=1
+pkgver=0.9_git20190528
+pkgrel=0
+_commit="edc7ed677c1d5c308e66441f464dfd69aa922643"
 pkgdesc="Packet/Traffic Generator and Analyzer"
 url="https://www.ostinato.org"
 arch="all"
 license="GPL-3.0-or-later"
 options="!check" # make test does nothing
-makedepends="qt-dev protobuf-dev libpcap-dev paxmark"
+makedepends="qt5-qtbase-dev protobuf-dev libpcap-dev qt5-qtscript-dev libnl3-dev"
 subpackages="$pkgname-drone $pkgname-gui"
-source="$pkgname-$pkgver.tar.gz::https://github.com/pstavirs/$pkgname/archive/v$pkgver.tar.gz"
-builddir="$srcdir/$pkgname-$pkgver"
+source="$pkgname-$_commit.tar.gz::https://github.com/pstavirs/$pkgname/archive/$_commit.tar.gz
+	bug-265.patch
+	ModelTest.patch
+	"
+	# pstavirs/ostinato#265
+	# ModelTest::ModelTest is included and needed during linking even in release mode
+builddir="$srcdir/$pkgname-$_commit"
 
 build() {
-	cd "$builddir"
-
-	qmake PREFIX=/usr
-	make
+	qmake-qt5 PREFIX=/usr
+	make CXXFLAGS="$CXXFLAGS" # qmake generates broken CFLAGS, demand it use ours
 }
 
 package() {
-	cd "$builddir"
-
 	make INSTALL_ROOT="$pkgdir" install
-	paxmark -m "$pkgdir"/usr/bin/drone
-	paxmark -m "$pkgdir"/usr/bin/ostinato
 }
 
 drone() {
@@ -42,4 +42,6 @@ gui() {
 	mv "$pkgdir"/usr/bin/ostinato "$subpkgdir"/usr/bin/ostinato
 }
 
-sha512sums="a50f6e20d8a2a4d76ca43a89feaa774778981377ce1f4c731ad8b1a97aa658013082fb85cc3f4dfdd888d708c45c8093e55facaa7f02cecbd2ce5228f57e2e14  ostinato-0.9.tar.gz"
+sha512sums="b71bb38d9bd429198a0cce7f4abbe599f68ceb6a13d377aef437d12a972818f53ed67090191405f8b95538c9f2101fc20548f32258a1da1aca10a812fbd05a3c  ostinato-edc7ed677c1d5c308e66441f464dfd69aa922643.tar.gz
+25ebe30724a22cbecada8e26b07dccbd4cbcf572e10988af11baa6dc9e4aeb31e6d332cb766f726626ef8ecc889ecaae083a540cdd41cc05edb4c354554cdced  bug-265.patch
+e0a3d2781c62b1898a80af8522b36d6b1a7aeae9831c33c42e4e76fe002ee7ebff50d432508a18046d7b5988f09d9a9f90a0433cfae1d2c1cbeaf664671abf6c  ModelTest.patch"

--- a/testing/ostinato/ModelTest.patch
+++ b/testing/ostinato/ModelTest.patch
@@ -1,0 +1,18 @@
+Undefined reference to ModelTest::ModelTest under defaults.
+Clearly, we're not in a debug mode, but the sources think we are.
+
+Patch is not upstream, made by SpaceToast on #alpine-devel
+diff -ur a/client/ostinato.pro b/client/ostinato.pro
+--- a/client/ostinato.pro	2019-05-28 09:32:50.000000000 -0400
++++ b/client/ostinato.pro	2019-06-04 19:14:23.477762179 -0400
+@@ -123,6 +123,6 @@
+ 
+ INCLUDEPATH += "../extra/modeltest"
+ greaterThan(QT_MINOR_VERSION, 6) {
+-CONFIG(debug, debug|release): LIBS += -L"../extra/modeltest/$(OBJECTS_DIR)/" -lmodeltest
+-CONFIG(debug, debug|release): QT += testlib
++LIBS += -L"../extra/modeltest/$(OBJECTS_DIR)/" -lmodeltest
++QT += testlib
+ }
+
+

--- a/testing/ostinato/bug-265.patch
+++ b/testing/ostinato/bug-265.patch
@@ -1,0 +1,97 @@
+https://github.com/pstavirs/ostinato/issues/265#issuecomment-429008063
+diff --git a/common/mld.cpp b/common/mld.cpp
+index 52b48a5..fbb22f5 100644
+--- a/common/mld.cpp
++++ b/common/mld.cpp
+@@ -225,9 +225,9 @@ QVariant MldProtocol::fieldData(int index, FieldAttrib attrib,
+                 fv.resize(16);
+                 for (int i = 0; i < data.sources_size(); i++)
+                 {
+-                    qToBigEndian(data.sources(i).v6_hi(), 
++                    qToBigEndian(quint64(data.sources(i).v6_hi()), 
+                             (uchar*)fv.data());
+-                    qToBigEndian(data.sources(i).v6_lo(),
++                    qToBigEndian(quint64(data.sources(i).v6_lo()),
+                             (uchar*)fv.data()+8);
+ 
+                     list << QHostAddress((quint8*)fv.constData()).toString();
+@@ -240,9 +240,9 @@ QVariant MldProtocol::fieldData(int index, FieldAttrib attrib,
+                 fv.resize(16 * data.sources_size());
+                 for (int i = 0; i < data.sources_size(); i++)
+                 {
+-                    qToBigEndian(data.sources(i).v6_hi(), 
++                    qToBigEndian(quint64(data.sources(i).v6_hi()), 
+                             (uchar*)(fv.data() + i*16));
+-                    qToBigEndian(data.sources(i).v6_lo(),
++                    qToBigEndian(quint64(data.sources(i).v6_lo()),
+                             (uchar*)(fv.data() + i*16 + 8));
+                 }
+                 return fv;
+@@ -254,9 +254,9 @@ QVariant MldProtocol::fieldData(int index, FieldAttrib attrib,
+                 fv.resize(16);
+                 for (int i = 0; i < data.sources_size(); i++)
+                 {
+-                    qToBigEndian(data.sources(i).v6_hi(), 
++                    qToBigEndian(quint64(data.sources(i).v6_hi()),
+                             (uchar*)fv.data());
+-                    qToBigEndian(data.sources(i).v6_lo(),
++                    qToBigEndian(quint64(data.sources(i).v6_lo()),
+                             (uchar*)fv.data()+8);
+ 
+                     list << QHostAddress((quint8*)fv.constData()).toString();
+@@ -295,9 +295,9 @@ QVariant MldProtocol::fieldData(int index, FieldAttrib attrib,
+                     QStringList sl;
+                     for (int j = 0; j < rec.sources_size(); j++)
+                     {
+-                        qToBigEndian(rec.sources(j).v6_hi(), 
++                        qToBigEndian(quint64(rec.sources(j).v6_hi()), 
+                                 (uchar*)(ip.data()));
+-                        qToBigEndian(rec.sources(j).v6_lo(),
++                        qToBigEndian(quint64(rec.sources(j).v6_lo()),
+                                 (uchar*)(ip.data() + 8));
+                         sl.append(QHostAddress(
+                                 (quint8*)ip.constData()).toString());
+@@ -322,15 +322,15 @@ QVariant MldProtocol::fieldData(int index, FieldAttrib attrib,
+                     QByteArray rv = list.at(i).toByteArray();
+ 
+                     rv.insert(4, QByteArray(16+16*rec.sources_size(), char(0)));
+-                    qToBigEndian(rec.group_address().v6_hi(), 
++                    qToBigEndian(quint64(rec.group_address().v6_hi()),
+                             (uchar*)(rv.data()+4));
+-                    qToBigEndian(rec.group_address().v6_lo(), 
++                    qToBigEndian(quint64(rec.group_address().v6_lo()),
+                             (uchar*)(rv.data()+4+8));
+                     for (int j = 0; j < rec.sources_size(); j++)
+                     {
+-                        qToBigEndian(rec.sources(j).v6_hi(),
++                        qToBigEndian(quint64(rec.sources(j).v6_hi()),
+                                 (uchar*)(rv.data()+20+16*j));
+-                        qToBigEndian(rec.sources(j).v6_lo(),
++                        qToBigEndian(quint64(rec.sources(j).v6_lo()),
+                                 (uchar*)(rv.data()+20+16*j+8));
+                     }
+ 
+@@ -352,9 +352,9 @@ QVariant MldProtocol::fieldData(int index, FieldAttrib attrib,
+                     QString recStr = list.at(i);
+                     QString str;
+ 
+-                    qToBigEndian(rec.group_address().v6_hi(), 
++                    qToBigEndian(quint64(rec.group_address().v6_hi()),
+                             (uchar*)(ip.data()));
+-                    qToBigEndian(rec.group_address().v6_lo(),
++                    qToBigEndian(quint64(rec.group_address().v6_lo()),
+                             (uchar*)(ip.data() + 8));
+                     str.append(QString("Group: %1").arg(
+                         QHostAddress((quint8*)ip.constData()).toString()));
+@@ -363,9 +363,9 @@ QVariant MldProtocol::fieldData(int index, FieldAttrib attrib,
+                     QStringList sl;
+                     for (int j = 0; j < rec.sources_size(); j++)
+                     {
+-                        qToBigEndian(rec.sources(j).v6_hi(), 
++                        qToBigEndian(quint64(rec.sources(j).v6_hi()),
+                                 (uchar*)(ip.data()));
+-                        qToBigEndian(rec.sources(j).v6_lo(),
++                        qToBigEndian(quint64(rec.sources(j).v6_lo()),
+                                 (uchar*)(ip.data() + 8));
+                         sl.append(QHostAddress(
+                                 (quint8*)ip.constData()).toString());


### PR DESCRIPTION
This should be the last of the Qt4 dependent packages :tada:

Thanks to SpaceToast on IRC on helping it get to compile.

The update to a Git version is required for Qt5 support, as no new release with support for it has been made yet.

CC @little-dude 