### PR TITLE
[3.9] main/ferm: add missing install_if to openrc

### DIFF
--- a/main/ferm/APKBUILD
+++ b/main/ferm/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Michael Mason <ms13sp@gmail.com>
 pkgname=ferm
 pkgver=2.4.1
-pkgrel=2
+pkgrel=3
 pkgdesc="firewall configuration tool"
 url="http://ferm.foo-projects.org/"
 arch="noarch"
@@ -44,6 +44,7 @@ package() {
 openrc() {
 	mkdir -p "$subpkgdir"
 	mv "$pkgdir/etc" "$subpkgdir/"
+	install_if="openrc ferm=$pkgver-r$pkgrel"
 }
 sha512sums="beea4b8dd04e00662ef380442f8249c2d2dadf6d35b90e415038df807c8d08295d2575efbf3265f48f5e92afa174135a9c662f74d52545dd3e1c55a1436aa5bb  ferm-2.4.1.tar.xz
 26e4673f7c8d0f77eb1d8fdc2051f1a3729e482b075346c65e39305e29014391c390c682cd597cf3dc67fa0f9fe69818e928c41cb362814a69fc67e8bbdf7ad5  ferm.confd


### PR DESCRIPTION
(cherry picked from commit ec5cf1352d742fc0c40566a088435f47a92357bc)