### PR TITLE
main/acl: fix compile break due to obsolete use of attr/xattr.h

### DIFF
--- a/main/acl/0001-fix-compilation-with-latest-xattr.patch
+++ b/main/acl/0001-fix-compilation-with-latest-xattr.patch
@@ -1,0 +1,252 @@
+From 79f563779b9b9ba89cc2352d70e3cdf27acff513 Mon Sep 17 00:00:00 2001
+From: Brice De Bruyne <bricedb@gmail.com>
+Date: Mon, 27 Apr 2015 14:57:56 +0200
+Subject: [PATCH] fix compilation with latest xattr git
+
+The attr package has <attr/xattr.h> removed, but acl has not been adapted yet.
+
+I took the liberty to cook up this patch that includes <sys/xattr.h> instead of
+<attr/xattr.h> in affected c files and I added errno.h plus a define of ENOATTR
+to c files where needed.
+
+I also removed the AC_PACKAGE_NEED_ATTR_XATTR_H definition from
+package_attrdev.m4, and changed configure to skip this test.
+
+Further changes by Andreas: Move the ENOATTR check into libacl.h.
+---
+ libacl/__acl_extended_file.c        |  3 +--
+ libacl/acl_delete_def_file.c        |  4 ++--
+ libacl/acl_extended_fd.c            |  3 +--
+ libacl/acl_extended_file.c          |  2 +-
+ libacl/acl_extended_file_nofollow.c |  2 +-
+ libacl/acl_get_fd.c                 |  3 +--
+ libacl/acl_get_file.c               |  3 +--
+ libacl/acl_set_fd.c                 |  2 +-
+ libacl/acl_set_file.c               |  2 +-
+ libacl/libacl.h                     |  5 +++++
+ m4/package_attrdev.m4               | 11 -----------
+ 12 files changed, 15 insertions(+), 26 deletions(-)
+
+diff --git a/libacl/__acl_extended_file.c b/libacl/__acl_extended_file.c
+index 3e45abd..c81dc8f 100644
+--- a/libacl/__acl_extended_file.c
++++ b/libacl/__acl_extended_file.c
+@@ -20,14 +20,13 @@
+ */
+ 
+ #include <unistd.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #include "libacl.h"
+ 
+ #include "byteorder.h"
+ #include "acl_ea.h"
+ #include "__acl_extended_file.h"
+ 
+-
+ int
+ __acl_extended_file(const char *path_p,
+ 		    ssize_t (*fun)(const char *, const char *,
+diff --git a/libacl/acl_delete_def_file.c b/libacl/acl_delete_def_file.c
+index fae4460..845940c 100644
+--- a/libacl/acl_delete_def_file.c
++++ b/libacl/acl_delete_def_file.c
+@@ -20,11 +20,11 @@
+ */
+ 
+ #include <sys/types.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #include "byteorder.h"
+ #include "acl_ea.h"
+ #include "config.h"
+-
++#include "libacl.h"
+ 
+ /* 23.4.8 */
+ int
+diff --git a/libacl/acl_extended_fd.c b/libacl/acl_extended_fd.c
+index f19ad7b..bbf9055 100644
+--- a/libacl/acl_extended_fd.c
++++ b/libacl/acl_extended_fd.c
+@@ -20,13 +20,12 @@
+ */
+ 
+ #include <unistd.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #include "libacl.h"
+ 
+ #include "byteorder.h"
+ #include "acl_ea.h"
+ 
+-
+ int
+ acl_extended_fd(int fd)
+ {
+diff --git a/libacl/acl_extended_file.c b/libacl/acl_extended_file.c
+index f417784..87f8e6e 100644
+--- a/libacl/acl_extended_file.c
++++ b/libacl/acl_extended_file.c
+@@ -20,7 +20,7 @@
+ */
+ 
+ #include <unistd.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #include "libacl.h"
+ 
+ #include "__acl_extended_file.h"
+diff --git a/libacl/acl_extended_file_nofollow.c b/libacl/acl_extended_file_nofollow.c
+index c253e4d..a15b076 100644
+--- a/libacl/acl_extended_file_nofollow.c
++++ b/libacl/acl_extended_file_nofollow.c
+@@ -20,7 +20,7 @@
+ */
+ 
+ #include <unistd.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #include "libacl.h"
+ 
+ #include "__acl_extended_file.h"
+diff --git a/libacl/acl_get_fd.c b/libacl/acl_get_fd.c
+index f2525ef..15e3880 100644
+--- a/libacl/acl_get_fd.c
++++ b/libacl/acl_get_fd.c
+@@ -23,7 +23,7 @@
+ #include <sys/stat.h>
+ #include <unistd.h>
+ #include <stdio.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #include <acl/libacl.h>
+ #include "libacl.h"
+ #include "__acl_from_xattr.h"
+@@ -31,7 +31,6 @@
+ #include "byteorder.h"
+ #include "acl_ea.h"
+ 
+-
+ /* 23.4.15 */
+ acl_t
+ acl_get_fd(int fd)
+diff --git a/libacl/acl_get_file.c b/libacl/acl_get_file.c
+index 110ef2e..d3131bc 100644
+--- a/libacl/acl_get_file.c
++++ b/libacl/acl_get_file.c
+@@ -23,7 +23,7 @@
+ #include <sys/stat.h>
+ #include <unistd.h>
+ #include <stdio.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #include <acl/libacl.h>
+ #include "libacl.h"
+ #include "__acl_from_xattr.h"
+@@ -31,7 +31,6 @@
+ #include "byteorder.h"
+ #include "acl_ea.h"
+ 
+-
+ /* 23.4.16 */
+ acl_t
+ acl_get_file(const char *path_p, acl_type_t type)
+diff --git a/libacl/acl_set_fd.c b/libacl/acl_set_fd.c
+index e6413ad..38dcd4a 100644
+--- a/libacl/acl_set_fd.c
++++ b/libacl/acl_set_fd.c
+@@ -20,7 +20,7 @@
+ */
+ 
+ #include <unistd.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #include "libacl.h"
+ #include "__acl_to_xattr.h"
+ 
+diff --git a/libacl/acl_set_file.c b/libacl/acl_set_file.c
+index a7e368f..c234b4a 100644
+--- a/libacl/acl_set_file.c
++++ b/libacl/acl_set_file.c
+@@ -22,7 +22,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <unistd.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #include "libacl.h"
+ #include "__acl_to_xattr.h"
+ 
+diff --git a/libacl/libacl.h b/libacl/libacl.h
+index e79575d..08ba905 100644
+--- a/libacl/libacl.h
++++ b/libacl/libacl.h
+@@ -17,8 +17,13 @@
+ 
+ #include <errno.h>
+ #include <sys/acl.h>
++#include <errno.h>
+ #include "libobj.h"
+ 
++#ifndef ENOATTR
++# define ENOATTR ENODATA
++#endif
++
+ typedef unsigned int permset_t;
+ 
+ #define ACL_PERM_NONE		(0x0000)
+diff --git a/m4/package_attrdev.m4 b/m4/package_attrdev.m4
+index 92c9135..1891bb2 100644
+--- a/m4/package_attrdev.m4
++++ b/m4/package_attrdev.m4
+@@ -12,17 +12,6 @@ dnl GNU General Public License for more details.
+ dnl
+ dnl You should have received a copy of the GNU General Public License
+ dnl along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-AC_DEFUN([AC_PACKAGE_NEED_ATTR_XATTR_H],
+-  [ AC_CHECK_HEADERS([attr/xattr.h])
+-    if test "$ac_cv_header_attr_xattr_h" != "yes"; then
+-        echo
+-        echo 'FATAL ERROR: attr/xattr.h does not exist.'
+-        echo 'Install the extended attributes (attr) development package.'
+-        echo 'Alternatively, run "make install-dev" from the attr source.'
+-        exit 1
+-    fi
+-  ])
+-
+ AC_DEFUN([AC_PACKAGE_NEED_ATTR_ERROR_H],
+   [ AC_CHECK_HEADERS([attr/error_context.h])
+     if test "$ac_cv_header_attr_error_context_h" != "yes"; then
+-- 
+2.21.0
+
+
+diff --git a/configure b/configure
+@@ -12416,26 +12416,6 @@
+     fi
+ 
+ 
+- for ac_header in attr/xattr.h
+-do :
+-  ac_fn_c_check_header_mongrel "$LINENO" "attr/xattr.h" "ac_cv_header_attr_xattr_h" "$ac_includes_default"
+-if test "x$ac_cv_header_attr_xattr_h" = xyes; then :
+-  cat >>confdefs.h <<_ACEOF
+-#define HAVE_ATTR_XATTR_H 1
+-_ACEOF
+-
+-fi
+-
+-done
+-
+-    if test "$ac_cv_header_attr_xattr_h" != "yes"; then
+-        echo
+-        echo 'FATAL ERROR: attr/xattr.h does not exist.'
+-        echo 'Install the extended attributes (attr) development package.'
+-        echo 'Alternatively, run "make install-dev" from the attr source.'
+-        exit 1
+-    fi
+-
+  for ac_header in attr/error_context.h
+ do :
+   ac_fn_c_check_header_mongrel "$LINENO" "attr/error_context.h" "ac_cv_header_attr_error_context_h" "$ac_includes_default"

--- a/main/acl/APKBUILD
+++ b/main/acl/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=acl
 pkgver=2.2.52
-pkgrel=5
+pkgrel=6
 pkgdesc="Access control list utilities"
 url="https://savannah.nongnu.org/projects/acl"
 arch="all"
@@ -14,6 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc libacl"
 # depends on order of nftw, and requires test machine to have ACLs enabled on FS
 options="!check"
 source="http://download.savannah.nongnu.org/releases/acl/acl-$pkgver.src.tar.gz
+	0001-fix-compilation-with-latest-xattr.patch
 	busybox-gzip.patch"
 
 prepare() {
@@ -57,4 +58,5 @@ libacl() {
 }
 
 sha512sums="59973199d371cd0b2368e95bc829a1b47f04e808a174fefba4c6854e766158bd19a71d9dbcc8d6fdc1573a1f971cdda39c453f7fa243bce02c1ab97c6e7c72e7  acl-2.2.52.src.tar.gz
+55f866dec1d23ece5ffc6d276756853aa0c3ea119e9860ed01b406e5d4f761b7ad1064e6cd15c9b66d2226de3a898b0e2016e32a65f7d97bcb28bf998edc32f4  0001-fix-compilation-with-latest-xattr.patch
 00a929f0079714b38956f0680d33a2b288ecfc97784192f91d8ce738f7e590201b2ca7e905dff7b853d724f6c4803710f6b37fc721eab88d29abbfca47691291  busybox-gzip.patch"


### PR DESCRIPTION
Compile fails with error:
```
checking for attr/xattr.h... no

FATAL ERROR: attr/xattr.h does not exist.
Install the extended attributes (attr) development package.
Alternatively, run "make install-dev" from the attr source.
>>> ERROR: acl: build failed
```
attr/xattr.h was previously provided by attr-dev until version 2.4.48 when it was removed. The acl source was subsequently modified to use version sys/xattr.h provided by musl-dev-1.1.22-r0.

The provided PR is based on commit made to acl source,  http://git.savannah.nongnu.org/cgit/acl.git/commit/?id=79f563779b9b9ba89cc2352d70e3cdf27acff513