### PR TITLE
community/exim: update secfixes comment

### DIFF
--- a/community/exim/APKBUILD
+++ b/community/exim/APKBUILD
@@ -30,6 +30,8 @@ source="https://ftp.exim.org/pub/exim/exim4/$pkgname-$pkgver.tar.xz
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   4.92-r0:
+#     - CVE-2019-10149
 #   4.91-r0:
 #     - CVE-2018-6789
 #   4.89-r5:


### PR DESCRIPTION
https://www.exim.org/static/doc/security/CVE-2019-10149.txt

Please backport 4.92 to stable branches.