### PR TITLE
main/at-spi2-core: pass dbus_daemon option to meson

### DIFF
--- a/main/at-spi2-core/APKBUILD
+++ b/main/at-spi2-core/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=at-spi2-core
 pkgver=2.32.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Protocol definitions and daemon for D-Bus at-spi"
 url="https://www.freedesktop.org/wiki/Accessibility/AT-SPI2/"
 arch="all"
 options="!check"  # Requires running dbus daemon.
 license="LGPL-2.0-or-later"
-makedepends="libxtst-dev dbus-dev glib-dev gobject-introspection-dev meson"
-subpackages="$pkgname-dbg $pkgname-dev $pkgname-lang"
+makedepends="libxtst-dev dbus-dev glib-dev gobject-introspection-dev gtk-doc meson"
+subpackages="$pkgname-dbg $pkgname-dev $pkgname-lang $pkgname-doc"
 source="https://download.gnome.org/sources/at-spi2-core/${pkgver%.*}/at-spi2-core-$pkgver.tar.xz"
 
 build() {
@@ -17,6 +17,10 @@ build() {
 	meson \
 		--buildtype=release \
 		--prefix=/usr \
+		-Dx11=yes \
+		-Dintrospection=yes \
+		-Ddocs=true \
+		-Ddbus_daemon=/usr/bin/dbus-daemon \
 		. build
 	ninja -C build
 }


### PR DESCRIPTION
This fixes launching at-spi2-core via its executable (as opposed to starting it
via D-Bus). Also add a -doc subpackage while we're at it.