### PR TITLE
main/syslog-ng: Provided support for aarch64

### DIFF
--- a/main/syslog-ng/APKBUILD
+++ b/main/syslog-ng/APKBUILD
@@ -7,7 +7,7 @@ pkgver=3.19.1
 pkgrel=1
 pkgdesc="Next generation logging daemon"
 url="http://www.balabit.com"
-arch="all !aarch64"
+arch="all"
 license="GPL-2.0-or-later"
 makedepends="
 	curl-dev


### PR DESCRIPTION
Architecture specific condition has been added for aarch64.