### PR TITLE
testing/deluge: upgrade to 2.0.2

### DIFF
--- a/testing/deluge/APKBUILD
+++ b/testing/deluge/APKBUILD
@@ -1,36 +1,45 @@
 # Contributor: August Klein <amatcoder@gmail.com>
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=deluge
-pkgver=1.3.15
-pkgrel=4
+pkgver=2.0.2
+pkgrel=0
 pkgdesc="A lightweight, Free Software, cross-platform BitTorrent client"
 url="https://deluge-torrent.org"
 arch="noarch"
-license="GPL-3.0"
-depends="py2-libtorrent-rasterbar librsvg py-cffi py-chardet py-cryptography
-	py-enum34 py-gtk py-mako py-openssl py-setuptools py-six py-twisted py-xdg
-	xdg-utils py-constantly py-incremental py-attrs py-service_identity
-	py-automat"
-makedepends="intltool librsvg-dev py-gtk-dev py-mako py-setuptools"
-subpackages="$pkgname-lang $pkgname-doc"
-source="http://download.deluge-torrent.org/source/deluge-$pkgver.tar.xz"
-builddir="$srcdir/$pkgname-$pkgver"
+license="GPL-3.0-or-later"
+depends="
+	py3-setuptools
+	py3-twisted
+	py3-rencode
+	py3-openssl
+	py3-xdg
+	py3-pillow
+	py3-mako
+	py3-chardet
+	py3-six
+	py3-setproctitle
+	py3-zope-interface
+	py3-asn1
+	py3-markupsafe
+	py3-service_identity
+	py3-hamcrest
+	py3-hyperlink
+	py3-automat
+	py3-libtorrent-rasterbar
+	py3-gobject3
+	"
+subpackages="$pkgname-doc"
+source="http://download.deluge-torrent.org/source/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+
+
+replaces="$pkgname-lang" # Overwrite removed subpackage
 
 build() {
-	cd "$builddir"
-	python2 setup.py build
+	python3 setup.py build
 }
 
 package() {
-	cd "$builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir"
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
 }
 
-lang() {
-	mkdir -p "$subpkgdir"/usr/lib/python2.7/site-packages/deluge/i18n
-
-	mv "$pkgdir"/usr/lib/python2.7/site-packages/deluge/i18n/* \
-		"$subpkgdir"/usr/lib/python2.7/site-packages/deluge/i18n/
-}
-
-sha512sums="0aa958184bdc24ea1cbd560ab1e496c6b44094cdafdd22fc4170b851d3255dc6756f8942522a35f90a9be4087e61d7e2656c87593aaa856dec54e39990ef9df0  deluge-1.3.15.tar.xz"
+sha512sums="8c7e0da53c61cd6848dc060b62abc68e53d490741a6e7317e98757e54d60a363527a084611e0b9460970bec7487d1a880dcdc8994882815b8812497cede99632  deluge-2.0.2.tar.xz"


### PR DESCRIPTION
Needs

- [x] #8566 (For GTK3-ui, webui works)
- [x] #8569 (Dependency)
- [x] #8570 (Dependency)
- [ ] #8571 (Dependency, optional)