### PR TITLE
community/appstream-glib: add missing dep on gsettings-desktop-schemas

### DIFF
--- a/community/appstream-glib/APKBUILD
+++ b/community/appstream-glib/APKBUILD
@@ -2,11 +2,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=appstream-glib
 pkgver=0.7.5
-pkgrel=0
+pkgrel=1
 pkgdesc="Library for AppStream metadata"
 url="https://people.freedesktop.org/~hughsient/appstream-glib/"
 arch="all"
 license="LGPL-2.0-or-later"
+depends="gsettings-desktop-schemas"
 makedepends="
 	meson
 	glib-dev
@@ -22,7 +23,6 @@ makedepends="
 	libgcab-dev
 	gobject-introspection-dev
 	"
-checkdepends="gsettings-desktop-schemas"
 subpackages="
 	$pkgname-dev
 	$pkgname-doc


### PR DESCRIPTION
Otherwise we'd get errors like:

(appstream-util:5474): GLib-GIO-ERROR **: 09:53:31.453: Settings schema 'org.gnome.system.proxy' is not installed