### PR TITLE
community/phpmyadmin: security upgrade to 4.9.0.1

### DIFF
--- a/community/phpmyadmin/APKBUILD
+++ b/community/phpmyadmin/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Matt Smith <mcs@darkregion.net>
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
 pkgname=phpmyadmin
-pkgver=4.8.5
+pkgver=4.9.0.1
 pkgrel=0
 pkgdesc="A Web-based PHP tool for administering MySQL"
 url="https://www.phpmyadmin.net/"
@@ -20,6 +20,9 @@ source="https://files.phpmyadmin.net/phpMyAdmin/$pkgver/$_fullpkgname.tar.xz
 options="!check"  # tests require running MySQL
 
 # secfixes:
+#   4.9.0.1-r0:
+#     - CVE-2019-11768
+#     - CVE-2019-12616
 #   4.8.5-r0:
 #     - CVE-2019-6798
 #     - CVE-2019-6799
@@ -96,5 +99,5 @@ doc() {
 	done
 }
 
-sha512sums="590efd46f4ae5a9cafd3b33f3565d74e4bfd535e3de8763e72da7bccea06fabb2f9fb90af3fe144846573507c5eefc20ee412bf6b51adfb494402302dc81aa2f  phpMyAdmin-4.8.5-all-languages.tar.xz
+sha512sums="92fc032ba44e84f6c6a62bb658c2c7ea984bfd8c963b18bf19c26c3991cfe635771376ad8aebf90140bb1bd723b62a5adaca35d88f7bb68169fd0d07c3995356  phpMyAdmin-4.9.0.1-all-languages.tar.xz
 ba5776800f5c7b6cbb4ae594ec77c4d3e0d0bd319d109c676bd6c969054967baef99cab1a30c2efa26487b2ec03ef9b81d035a4323003565cffb19b08fdce9f5  phpmyadmin.apache2.conf"


### PR DESCRIPTION
https://www.phpmyadmin.net/news/2019/6/4/security-fix-phpmyadmin-490-released/

CVE-2019-12616 CVE-2019-11768