### PR TITLE
testing/mutter: fix cogl path build order and re-enable ppc64le

### DIFF
--- a/testing/mutter/APKBUILD
+++ b/testing/mutter/APKBUILD
@@ -2,10 +2,10 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=mutter
 pkgver=3.32.2
-pkgrel=0
+pkgrel=1
 pkgdesc="clutter-based window manager and compositor"
 url="https://wiki.gnome.org/Projects/Mutter/"
-arch="all !s390x !ppc64le" # limited by gnome-settings-daemon
+arch="all !s390x" # limited by gnome-settings-daemon
 license="GPL-2.0-or-later"
 depends="xkeyboard-config zenity gsettings-desktop-schemas xorg-server-xwayland"
 makedepends="gnome-desktop-dev libcanberra-dev upower-dev json-glib-dev
@@ -17,6 +17,7 @@ makedepends="gnome-desktop-dev libcanberra-dev upower-dev json-glib-dev
 options="!check" # Can't be run with release builds
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 source="https://download.gnome.org/sources/$pkgname/${pkgver%.*}/$pkgname-$pkgver.tar.xz
+	fix-cogl-path-build-ordering.patch
 	fixudev-req.patch"
 
 build() {
@@ -41,4 +42,5 @@ package() {
 }
 
 sha512sums="e4494d028ae71441fbdc584bd8acd9c2559d52ac72402bad9a7cb43f4f519487d11df6453172fd27a9df7f2cade020d6317931613bd0be343c66170e6cda0269  mutter-3.32.2.tar.xz
+7959d301a89ba067b7b34a474abcc0f22a2355571b5a10508efd852b3f1a1bd6f17f0e16345552ebc3654d07bb7167588afee1d73ad66bc0237ee308757ac3b8  fix-cogl-path-build-ordering.patch
 6f21171bbd0ad0fc67cbaf5fb1478b22b482a9ae33b9328cc51a5dd31bcf7d95cd41e6cbbac21d3d8801cc064a62a64ae38ed7d0501ab605b861058c32f3bc30  fixudev-req.patch"

--- a/testing/mutter/fix-cogl-path-build-ordering.patch
+++ b/testing/mutter/fix-cogl-path-build-ordering.patch
@@ -1,0 +1,20 @@
+--- a/clutter/clutter/meson.build
++++ b/clutter/clutter/meson.build
+@@ -487,7 +487,7 @@
+   soversion: 0,
+   c_args: clutter_c_args,
+   include_directories: clutter_includes,
+-  dependencies: [clutter_deps],
++  dependencies: [clutter_deps,libmutter_cogl_path_dep],
+   gnu_symbol_visibility: 'hidden',
+   link_with: [
+     libmutter_cogl,
+@@ -499,7 +499,7 @@
+   install: true,
+ )
+ libmutter_clutter_dep = declare_dependency(
+-  sources: [clutter_enum_types[1]],
++  sources: [clutter_enum_types[1],libmutter_cogl_path_enum_types[1]],
+   link_with: libmutter_clutter,
+ )
+ 


### PR DESCRIPTION
on ppc64le mutter build fails with errors of type:
```
In file included from ../cogl/cogl/cogl.h:153,
                 from ../clutter/clutter/clutter-types.h:32,
                 from ../clutter/clutter/clutter-test-utils.h:29,
                 from ../clutter/clutter/clutter-test-utils.c:3:
../cogl/cogl-path/cogl-path.h:55:10: fatal error: cogl-path/cogl-path-enum-types.h: No such file or directory
 #include <cogl-path/cogl-path-enum-types.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
The error occurs because of subcomponent build ordering issues where the cogl-path component must be built before the clutter components so that the generated cogl-path-enum-types.h file is available. This PR  modifies the clutter meson.build to enforce this order.