### PR TITLE
Upgrade Erlang to R22

### DIFF
--- a/community/cloudi/APKBUILD
+++ b/community/cloudi/APKBUILD
@@ -29,7 +29,7 @@
 
 pkgname=cloudi
 pkgver=1.7.5
-pkgrel=3
+pkgrel=4
 pkgdesc="Cloud computing framework for efficient, scalable, and stable soft-realtime event processing."
 url="https://cloudi.org/"
 license="MIT"

--- a/community/elixir/APKBUILD
+++ b/community/elixir/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Marlus Saraiva <marlus.saraiva@gmail.com>
 pkgname=elixir
-pkgver=1.8.1
+pkgver=1.8.2
 pkgrel=0
 pkgdesc="Elixir is a dynamic, functional language designed for building scalable and maintainable applications"
 url="http://elixir-lang.org"
@@ -33,4 +33,4 @@ package() {
 	make DESTDIR="$pkgdir" PREFIX=/usr install
 }
 
-sha512sums="114970707505cbf89f8fa55d5c54989dded7feb39cb3674e88f64e19f1a0680086ae49c856fb76fb7eaf0142fa0a0b81b1d5b9570825e05f083a9c580b0ca017  elixir-1.8.1.tar.gz"
+sha512sums="0b30fec1cdc85884c1076e10c6e594b1855a325ae8c070bb3bd9af11998b21b273d7185b59954183b1fd525a2852a61be9c2eec54d9adb8ec1fdeb0200714857  elixir-1.8.2.tar.gz"

--- a/community/elixir/APKBUILD
+++ b/community/elixir/APKBUILD
@@ -10,7 +10,8 @@ depends="erlang erlang-inets erlang-ssl
 	erlang-public-key erlang-asn1 erlang-sasl erlang-erl-interface erlang-dev erlang-dialyzer erlang-erts erlang-hipe"
 makedepends="erlang-crypto erlang-syntax-tools erlang-parsetools erlang-eunit erlang-tools"
 subpackages="$pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/elixir-lang/elixir/archive/v$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/elixir-lang/elixir/archive/v$pkgver.tar.gz
+	fix-flaky-mix-test-leak.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 case "$CARCH" in
@@ -33,4 +34,5 @@ package() {
 	make DESTDIR="$pkgdir" PREFIX=/usr install
 }
 
-sha512sums="0b30fec1cdc85884c1076e10c6e594b1855a325ae8c070bb3bd9af11998b21b273d7185b59954183b1fd525a2852a61be9c2eec54d9adb8ec1fdeb0200714857  elixir-1.8.2.tar.gz"
+sha512sums="0b30fec1cdc85884c1076e10c6e594b1855a325ae8c070bb3bd9af11998b21b273d7185b59954183b1fd525a2852a61be9c2eec54d9adb8ec1fdeb0200714857  elixir-1.8.2.tar.gz
+b3936c0cc88eaf3b754d751f859353fb54cfb970f13b647b90938fd449e588cca5610c14e99171d702d4755b894dd1701fffd246d8c28a03cf9128fe270aa72e  fix-flaky-mix-test-leak.patch"

--- a/community/elixir/fix-flaky-mix-test-leak.patch
+++ b/community/elixir/fix-flaky-mix-test-leak.patch
@@ -1,0 +1,217 @@
+From 2548965a1ee3cb92a10fbd77fb0e951e455f3249 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Valim?= <jose.valim@plataformatec.com.br>
+Date: Thu, 13 Jun 2019 13:49:47 +0200
+Subject: [PATCH] Ensure started/loaded apps do not leak between Mix tests,
+ closes #9137
+
+---
+ lib/mix/test/mix/tasks/app.start_test.exs     | 10 ---------
+ lib/mix/test/mix/tasks/profile.cprof_test.exs |  2 --
+ lib/mix/test/mix/tasks/profile.eprof_test.exs |  2 --
+ lib/mix/test/mix/tasks/profile.fprof_test.exs |  2 --
+ lib/mix/test/mix/tasks/run_test.exs           |  2 --
+ lib/mix/test/mix/umbrella_test.exs            |  2 --
+ lib/mix/test/test_helper.exs                  | 21 +++++++------------
+ 7 files changed, 8 insertions(+), 33 deletions(-)
+
+diff --git a/lib/mix/test/mix/tasks/app.start_test.exs b/lib/mix/test/mix/tasks/app.start_test.exs
+index a7565733f4..7ae3b89e2a 100644
+--- a/lib/mix/test/mix/tasks/app.start_test.exs
++++ b/lib/mix/test/mix/tasks/app.start_test.exs
+@@ -19,7 +19,6 @@ defmodule Mix.Tasks.App.StartTest do
+     end
+   end
+ 
+-  @tag apps: [:app_start_sample]
+   test "compiles and starts the project" do
+     Mix.Project.push(AppStartSample)
+ 
+@@ -50,7 +49,6 @@ defmodule Mix.Tasks.App.StartTest do
+     end)
+   end
+ 
+-  @tag apps: [:app_start_sample, :app_loaded_sample]
+   test "start checks for invalid configuration", context do
+     Mix.Project.push(AppStartSample)
+ 
+@@ -77,7 +75,6 @@ defmodule Mix.Tasks.App.StartTest do
+     end)
+   end
+ 
+-  @tag apps: [:error]
+   test "validates Elixir version requirement", context do
+     Mix.ProjectStack.post_config(elixir: "~> ~> 0.8.1")
+     Mix.Project.push(WrongElixirProject)
+@@ -89,7 +86,6 @@ defmodule Mix.Tasks.App.StartTest do
+     end)
+   end
+ 
+-  @tag apps: [:error]
+   test "validates the Elixir version with requirement", context do
+     Mix.Project.push(WrongElixirProject)
+ 
+@@ -100,7 +96,6 @@ defmodule Mix.Tasks.App.StartTest do
+     end)
+   end
+ 
+-  @tag apps: [:error]
+   test "does not validate the Elixir version with requirement when disabled", context do
+     Mix.Project.push(WrongElixirProject)
+ 
+@@ -136,7 +131,6 @@ defmodule Mix.Tasks.App.StartTest do
+     def start(_type, return), do: return
+   end
+ 
+-  @tag apps: [:return_sample]
+   test "start points to report on error", context do
+     Mix.Project.push(ReturnSample)
+ 
+@@ -155,7 +149,6 @@ defmodule Mix.Tasks.App.StartTest do
+     end)
+   end
+ 
+-  @tag apps: [:return_sample]
+   test "start points to report on exception error", context do
+     Mix.Project.push(ReturnSample)
+ 
+@@ -177,7 +170,6 @@ defmodule Mix.Tasks.App.StartTest do
+     end)
+   end
+ 
+-  @tag apps: [:return_sample]
+   test "start points to report on bad return", context do
+     Mix.Project.push(ReturnSample)
+ 
+@@ -212,7 +204,6 @@ defmodule Mix.Tasks.App.StartTest do
+     def start(_type, reason), do: exit(reason)
+   end
+ 
+-  @tag apps: [:exit_sample]
+   test "start points to report on exit", context do
+     Mix.Project.push(ExitSample)
+ 
+@@ -230,7 +221,6 @@ defmodule Mix.Tasks.App.StartTest do
+     end)
+   end
+ 
+-  @tag apps: [:exit_sample]
+   test "start points to report on normal exit", context do
+     Mix.Project.push(ExitSample)
+ 
+diff --git a/lib/mix/test/mix/tasks/profile.cprof_test.exs b/lib/mix/test/mix/tasks/profile.cprof_test.exs
+index 30e432f63e..084b3a8d0e 100644
+--- a/lib/mix/test/mix/tasks/profile.cprof_test.exs
++++ b/lib/mix/test/mix/tasks/profile.cprof_test.exs
+@@ -4,10 +4,8 @@ defmodule Mix.Tasks.Profile.CprofTest do
+   use MixTest.Case
+ 
+   import ExUnit.CaptureIO
+-
+   alias Mix.Tasks.Profile.Cprof
+ 
+-  @moduletag apps: [:sample]
+   @expr "Enum.each(1..5, &String.Chars.Integer.to_string/1)"
+ 
+   test "profiles evaluated expression", context do
+diff --git a/lib/mix/test/mix/tasks/profile.eprof_test.exs b/lib/mix/test/mix/tasks/profile.eprof_test.exs
+index adc86b5a62..19e46856e3 100644
+--- a/lib/mix/test/mix/tasks/profile.eprof_test.exs
++++ b/lib/mix/test/mix/tasks/profile.eprof_test.exs
+@@ -4,10 +4,8 @@ defmodule Mix.Tasks.Profile.EprofTest do
+   use MixTest.Case
+ 
+   import ExUnit.CaptureIO
+-
+   alias Mix.Tasks.Profile.Eprof
+ 
+-  @moduletag apps: [:sample]
+   @expr "Enum.each(1..5, &String.Chars.Integer.to_string/1)"
+ 
+   test "profiles evaluated expression", context do
+diff --git a/lib/mix/test/mix/tasks/profile.fprof_test.exs b/lib/mix/test/mix/tasks/profile.fprof_test.exs
+index 8f84077e7b..d40717a256 100644
+--- a/lib/mix/test/mix/tasks/profile.fprof_test.exs
++++ b/lib/mix/test/mix/tasks/profile.fprof_test.exs
+@@ -4,9 +4,7 @@ defmodule Mix.Tasks.Profile.FprofTest do
+   use MixTest.Case
+ 
+   import ExUnit.CaptureIO
+-
+   alias Mix.Tasks.Profile.Fprof
+-  @moduletag apps: [:sample]
+ 
+   test "profiles evaluated expression", context do
+     in_tmp(context.test, fn ->
+diff --git a/lib/mix/test/mix/tasks/run_test.exs b/lib/mix/test/mix/tasks/run_test.exs
+index 6748130000..7d2ffe9888 100644
+--- a/lib/mix/test/mix/tasks/run_test.exs
++++ b/lib/mix/test/mix/tasks/run_test.exs
+@@ -5,8 +5,6 @@ defmodule Mix.Tasks.RunTest do
+ 
+   import ExUnit.CaptureIO
+ 
+-  @moduletag apps: [:sample]
+-
+   setup do
+     Mix.Project.push(MixTest.Case.Sample)
+   end
+diff --git a/lib/mix/test/mix/umbrella_test.exs b/lib/mix/test/mix/umbrella_test.exs
+index 914da5aa6d..d6f8f1a4f5 100644
+--- a/lib/mix/test/mix/umbrella_test.exs
++++ b/lib/mix/test/mix/umbrella_test.exs
+@@ -3,8 +3,6 @@ Code.require_file("../test_helper.exs", __DIR__)
+ defmodule Mix.UmbrellaTest do
+   use MixTest.Case
+ 
+-  @moduletag apps: [:foo, :bar]
+-
+   test "apps_paths" do
+     in_fixture("umbrella_dep/deps/umbrella", fn ->
+       assert Mix.Project.apps_paths() == nil
+diff --git a/lib/mix/test/test_helper.exs b/lib/mix/test/test_helper.exs
+index 0204c7fecc..bce247b2f5 100644
+--- a/lib/mix/test/test_helper.exs
++++ b/lib/mix/test/test_helper.exs
+@@ -2,6 +2,9 @@ Mix.start()
+ Mix.shell(Mix.Shell.Process)
+ Application.put_env(:mix, :colors, enabled: false)
+ 
++Logger.remove_backend(:console)
++Application.put_env(:logger, :backends, [])
++
+ exclude = if match?({:win32, _}, :os.type()), do: [unix: true], else: [windows: true]
+ ExUnit.start(trace: "--trace" in System.argv(), exclude: exclude)
+ 
+@@ -32,12 +35,9 @@ defmodule MixTest.Case do
+     end
+   end
+ 
+-  setup config do
+-    if apps = config[:apps] do
+-      Logger.remove_backend(:console)
+-      Application.put_env(:logger, :backends, [])
+-    end
++  @apps Enum.map(Application.loaded_applications(), &elem(&1, 0))
+ 
++  setup do
+     on_exit(fn ->
+       Application.start(:logger)
+       Mix.env(:dev)
+@@ -48,14 +48,9 @@ defmodule MixTest.Case do
+       Mix.ProjectStack.clear_stack()
+       delete_tmp_paths()
+ 
+-      if apps do
+-        for app <- apps do
+-          Application.stop(app)
+-          Application.unload(app)
+-        end
+-
+-        Logger.add_backend(:console, flush: true)
+-        Application.put_env(:logger, :backends, [:console])
++      for {app, _, _} <- Application.loaded_applications(), app not in @apps do
++        Application.stop(app)
++        Application.unload(app)
+       end
+     end)
+ 

--- a/community/erlang/0005-Do-not-install-nteventlog-and-related-doc-files-on-n.patch
+++ b/community/erlang/0005-Do-not-install-nteventlog-and-related-doc-files-on-n.patch
@@ -5,45 +5,47 @@ Subject: [PATCH] Do not install nteventlog and related doc-files on non-win32
 
 Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>
 
+diff --git a/lib/os_mon/doc/src/Makefile b/lib/os_mon/doc/src/Makefile
+index 8e9a4c333c..2c9d395cdc 100644
 --- a/lib/os_mon/doc/src/Makefile
 +++ b/lib/os_mon/doc/src/Makefile
-@@ -36,12 +36,17 @@
+@@ -36,11 +36,16 @@ RELSYSDIR = $(RELEASE_PATH)/lib/$(APPLICATION)-$(VSN)
  # Target Specs
  # ----------------------------------------------------
  XML_APPLICATION_FILES = ref_man.xml
 +ifeq ($(findstring win32,$(TARGET)),win32)
-+NTEVENTLOG_DOCFILE=nteventlog.xml
++	NTEVENTLOG_DOCFILE=nteventlog.xml
 +else
-+NTEVENTLOG_DOCFILE=
++	NTEVENTLOG_DOCFILE=
 +endif
  XML_REF3_FILES = cpu_sup.xml \
  	disksup.xml \
  	memsup.xml \
- 	os_mon_mib.xml \
  	os_sup.xml \
 -	nteventlog.xml
 +	$(NTEVENTLOG_DOCFILE)
  
- XML_REF6_FILES = os_mon_app.xml 
+ XML_REF6_FILES = os_mon_app.xml
  
+diff --git a/lib/os_mon/src/Makefile b/lib/os_mon/src/Makefile
+index 923a31f290..3d0edf1ef9 100644
 --- a/lib/os_mon/src/Makefile
 +++ b/lib/os_mon/src/Makefile
-@@ -34,8 +34,13 @@
+@@ -34,7 +34,12 @@ RELSYSDIR = $(RELEASE_PATH)/lib/os_mon-$(VSN)
  # ----------------------------------------------------
  # Target Specs
  # ----------------------------------------------------
+-MODULES= disksup memsup cpu_sup os_mon os_sup os_mon_sysinfo nteventlog
 +ifeq ($(findstring win32,$(TARGET)),win32)
-+NTEVENTLOG=nteventlog
++	NTEVENTLOG=nteventlog
 +else
-+NTEVENTLOG=
++	NTEVENTLOG=
 +endif
- MODULES= disksup memsup cpu_sup os_mon os_mon_mib os_sup os_mon_sysinfo \
--	nteventlog
-+	 $(NTEVENTLOG)
++MODULES= disksup memsup cpu_sup os_mon os_sup os_mon_sysinfo $(NTEVENTLOG)
  
  INCLUDE=../include
  CSRC=../c_src
-@@ -79,7 +84,11 @@
+@@ -78,7 +83,11 @@ docs:
  # ----------------------------------------------------
  
  $(APP_TARGET): $(APP_SRC) ../vsn.mk

--- a/community/erlang/0010-fix-nteventlog-remove.patch
+++ b/community/erlang/0010-fix-nteventlog-remove.patch
@@ -1,9 +1,11 @@
+diff --git a/lib/os_mon/src/os_mon.app.src b/lib/os_mon/src/os_mon.app.src
+index 6c9b0d7576..4f21264c2e 100644
 --- a/lib/os_mon/src/os_mon.app.src
 +++ b/lib/os_mon/src/os_mon.app.src
 @@ -22,7 +22,7 @@
     [{description, "CPO  CXC 138 46"},
      {vsn, "%VSN%"},
-     {modules, [os_mon, os_mon_mib, os_sup,
+     {modules, [os_mon, os_sup,
 -               disksup, memsup, cpu_sup, os_mon_sysinfo, nteventlog]},
 +               disksup, memsup, cpu_sup, os_mon_sysinfo]},
      {registered, [os_mon_sup, os_mon_sysinfo, disksup, memsup, cpu_sup, 

--- a/community/erlang/APKBUILD
+++ b/community/erlang/APKBUILD
@@ -1,76 +1,68 @@
 # Contributor: Michael Mason <ms13sp@gmail.com>
 # Contributor: Gabriele Santomaggio <g.santomaggio@gmail.com>
 # Contributor: Marlus Saraiva <marlus.saraiva@gmail.com>
-# Maintainer: 
+# Maintainer: Daniel Isaksen <d@duniel.no>
 pkgname=erlang
-pkgver=21.2.6
+pkgver=22.0.2
 _srcver=$pkgver
-pkgrel=2
+pkgrel=0
 pkgdesc="General-purpose programming language and runtime environment"
 url="http://www.erlang.org/"
 license="Apache-2.0"
 arch="all"
 depends="$pkgname-kernel $pkgname-stdlib $pkgname-compiler"
-makedepends="perl-dev zlib-dev ncurses-dev openssl-dev openjdk8 unixodbc-dev
-	autoconf wxgtk-dev glu-dev"
+makedepends="perl-dev perl zlib-dev ncurses-dev openssl-dev openjdk8
+	unixodbc-dev autoconf wxgtk-dev glu-dev"
 subpackages="$pkgname-dev
-             $pkgname-asn1:asn
-	     $pkgname-common-test:common_test
-	     $pkgname-compiler:compiler
-	     $pkgname-crypto:crypto
-	     $pkgname-debugger:debugger
-	     $pkgname-dialyzer:dialyzer
-	     $pkgname-diameter:diameter
-	     $pkgname-edoc:edoc
-	     $pkgname-eldap:eldap
-	     $pkgname-erl-docgen:erl_docgen
-	     $pkgname-erl-interface:erl_interface
-	     $pkgname-erts:erts
-	     $pkgname-et:et
-	     $pkgname-eunit:eunit
-	     $pkgname-hipe:hipe
-	     $pkgname-inets:inets
-	     $pkgname-jinterface:jinterface
-	     $pkgname-kernel:kernel
-	     $pkgname-megaco:megaco
-	     $pkgname-mnesia:mnesia
-	     $pkgname-observer:observer
-	     $pkgname-odbc:odbc
-	     $pkgname-os-mon:os_mon
-	     $pkgname-otp-mibs:otp_mibs
-	     $pkgname-parsetools:parsetools
-	     $pkgname-public-key:public_key
-	     $pkgname-reltool:reltool
-	     $pkgname-runtime-tools:runtime_tools
-	     $pkgname-sasl:sasl
-	     $pkgname-snmp:snmp
-	     $pkgname-ssh:ssh
-	     $pkgname-ssl:ssl
-	     $pkgname-stdlib:stdlib
-	     $pkgname-syntax-tools:syntax_tools
-	     $pkgname-tools:tools
-	     $pkgname-xmerl:xmerl
-	     $pkgname-wx:wx"
-options="!check"
+	$pkgname-asn1:asn
+	$pkgname-common-test:common_test
+	$pkgname-compiler:compiler
+	$pkgname-crypto:crypto
+	$pkgname-debugger:debugger
+	$pkgname-dialyzer:dialyzer
+	$pkgname-diameter:diameter
+	$pkgname-edoc:edoc
+	$pkgname-eldap:eldap
+	$pkgname-erl-docgen:erl_docgen
+	$pkgname-erl-interface:erl_interface
+	$pkgname-erts:erts
+	$pkgname-et:et
+	$pkgname-eunit:eunit
+	$pkgname-hipe:hipe
+	$pkgname-inets:inets
+	$pkgname-jinterface:jinterface
+	$pkgname-kernel:kernel
+	$pkgname-megaco:megaco
+	$pkgname-mnesia:mnesia
+	$pkgname-observer:observer
+	$pkgname-odbc:odbc
+	$pkgname-os-mon:os_mon
+	$pkgname-parsetools:parsetools
+	$pkgname-public-key:public_key
+	$pkgname-reltool:reltool
+	$pkgname-runtime-tools:runtime_tools
+	$pkgname-sasl:sasl
+	$pkgname-snmp:snmp
+	$pkgname-ssh:ssh
+	$pkgname-ssl:ssl
+	$pkgname-stdlib:stdlib
+	$pkgname-syntax-tools:syntax_tools
+	$pkgname-tftp:tftp
+	$pkgname-tools:tools
+	$pkgname-wx:wx
+	$pkgname-xmerl:xmerl"
+#options="!check"
 source="https://github.com/erlang/otp/archive/OTP-$_srcver.tar.gz
-        0005-Do-not-install-nteventlog-and-related-doc-files-on-n.patch
-        0010-fix-nteventlog-remove.patch
-	safe-signal-handling.patch
-	"
+	0005-Do-not-install-nteventlog-and-related-doc-files-on-n.patch
+	0010-fix-nteventlog-remove.patch
+	safe-signal-handling.patch"
 
 builddir="$srcdir/otp-OTP-$_srcver"
 
-prepare() {
-	default_prepare || return 1
-
-	cd "$builddir"
-	#rm lib/os_mon/ebin/*
-}
-
 build() {
-	cd "$builddir"
 	export CPPFLAGS="-D_BSD_SOURCE $CPPFLAGS"
 	export PATH="/usr/lib/jvm/java-1.8-openjdk/bin:$PATH"
+
 	./otp_build autoconf
 	./configure --prefix=/usr \
 		--sysconfdir=/etc \
@@ -80,25 +72,27 @@ build() {
 		--build="$CBUILD" \
 		--enable-threads \
 		--enable-shared-zlib \
-		--enable-ssl=dynamic-ssl-lib \
-		|| return 1
-	make -j1 || return 1
-}
+		--enable-ssl=dynamic-ssl-lib
+			make
+		}
+
+	check() {
+		ERL_TOP="$builddir" make release_tests
+	}
 
 package() {
-	cd "$builddir"
-	make -j1 DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
 
 _mv_erlang_lib() {
 	local lib=$1
 	case "$depends" in
-	*$subpkgname*)	depends="";;
-	*)		depends="$pkgname=$pkgver-r$pkgrel";;
+		*$subpkgname*)  depends="";;
+		*)      depends="$pkgname=$pkgver-r$pkgrel";;
 	esac
 
 	mkdir -p "$subpkgdir"/usr/lib/erlang/lib
-        rm -f "$pkgdir"/usr/lib/erlang/lib/$lib-*/src/*.erl
+	rm -f "$pkgdir"/usr/lib/erlang/lib/$lib-*/src/*.erl
 	mv "$pkgdir"/usr/lib/erlang/lib/$lib-* "$subpkgdir"/usr/lib/erlang/lib/
 }
 
@@ -127,7 +121,6 @@ observer() { _mv_erlang_lib observer; }
 odbc() { _mv_erlang_lib odbc; }
 orber() { _mv_erlang_lib orber; }
 os_mon() { _mv_erlang_lib os_mon; }
-otp_mibs() { _mv_erlang_lib otp_mibs; }
 parsetools() { _mv_erlang_lib parsetools; }
 public_key() { _mv_erlang_lib public_key; depends="$depends erlang-asn1"; }
 reltool() { _mv_erlang_lib reltool; }
@@ -138,9 +131,10 @@ ssh() { _mv_erlang_lib ssh; depends="$depends erlang-public-key erlang-inets"; }
 ssl() { _mv_erlang_lib ssl; depends="$depends erlang-public-key erlang-inets"; }
 stdlib() { _mv_erlang_lib stdlib; }
 syntax_tools() { _mv_erlang_lib syntax_tools; }
+tftp() { _mv_erlang_lib tftp; }
 tools() { _mv_erlang_lib tools; }
-xmerl() { _mv_erlang_lib xmerl; }
 wx() { _mv_erlang_lib wx; }
+xmerl() { _mv_erlang_lib xmerl; }
 
 dev() {
 	set -x
@@ -148,37 +142,37 @@ dev() {
 	depends="$pkgname=$pkgver-r$pkgrel $depends_dev"
 	pkgdesc="$pkgdesc (development files)"
 
-	cd "$pkgdir" || return 0
+	cd "$pkgdir"
 	local libdirs=usr/
 	[ -d lib/ ] && libdirs="lib/ $libdirs"
 	for i in usr/include usr/lib/pkgconfig usr/share/aclocal\
-			usr/share/gettext usr/bin/*-config	\
-			usr/share/vala/vapi usr/share/gir-[0-9]*\
-			usr/share/qt*/mkspecs			\
-			usr/lib/qt*/mkspecs			\
-			usr/lib/cmake				\
-			$(find . -name include -type d) 	\
-			$(find $libdirs -name '*.[acho]' \
-				-o -name '*.prl' 2>/dev/null); do
-		if [ -e "$pkgdir/$i" ] || [ -L "$pkgdir/$i" ]; then
-			d="$subpkgdir/${i%/*}"	# dirname $i
-			mkdir -p "$d"
-			mv "$pkgdir/$i" "$d"
-			rmdir "$pkgdir/${i%/*}" 2>/dev/null || true
-		fi
-	done
-	# move *.so links needed when linking the apps to -dev packages
-	for i in lib/*.so usr/lib/*.so; do
-		if [ -L "$i" ]; then
-			mkdir -p "$subpkgdir"/"${i%/*}"
-			mv "$i" "$subpkgdir/$i" || return 1
-		fi
-	done
-	return 0
-}
+		usr/share/gettext usr/bin/*-config		\
+		usr/share/vala/vapi usr/share/gir-[0-9]*	\
+		usr/share/qt*/mkspecs				\
+		usr/lib/qt*/mkspecs				\
+		usr/lib/cmake					\
+		$(find . -name include -type d)			\
+		$(find $libdirs -name '*.[acho]'		\
+		-o -name '*.prl' 2>/dev/null); do
+			if [ -e "$pkgdir/$i" ] || [ -L "$pkgdir/$i" ]; then
+				d="$subpkgdir/${i%/*}"  # dirname $i
+				mkdir -p "$d"
+				mv "$pkgdir/$i" "$d"
+				rmdir "$pkgdir/${i%/*}" 2>/dev/null || true
+			fi
+		done
+
+		# move *.so links needed when linking the apps to -dev packages
+		for i in lib/*.so usr/lib/*.so; do
+			if [ -L "$i" ]; then
+				mkdir -p "$subpkgdir"/"${i%/*}"
+				mv "$i" "$subpkgdir/$i"
+			fi
+		done
+	}
 
 
-sha512sums="0d43a5eb6e9d01e2997b7c82a15b2bd7483a0623f86f8aaff3ec59b5da6aa2cd8135d48cf66233e28c780473f83b90ad56c076374273cefa79b79622e57027f9  OTP-21.2.6.tar.gz
-5d377faccd73382bc86c5aa3182767bc5d1639220c78c2f624135f597f3c823a6871ff13f6f8a109baa8a9ae5d215233b40193e5cfe07af275aa53f327e956de  0005-Do-not-install-nteventlog-and-related-doc-files-on-n.patch
-bb4346dabe17115bc310837c5f0aeb367a745d8ba2159495084e599d0419fc57648d144c811306914ac48d0e087d6150a356f38640ba070642b4578acc5fe573  0010-fix-nteventlog-remove.patch
+sha512sums="6dbc3705a8b9ba5c8b6694e256c226c882521d87c3af4deb9212c33fff83b510191ea547888d15ced17dd66857fb1d7ba72d9fbd54a5c63091aa86680b960436  OTP-22.0.2.tar.gz
+6a711e25b55816527c0a793e45dafb9a95b0a20fa537f8e03fb918e0137f1b1f60e414861a7005b8230a72e3e2f5e0caedb054a6c492b6f6f859ddbad47d2175  0005-Do-not-install-nteventlog-and-related-doc-files-on-n.patch
+dbbc05908cd4b1a3842ff32afcef8a0621b1ec532e83d70fed4ee9263b3f82afc0d173c7a7c776196c8f54c2ab2bca3c9ce35da676dedd5802dbc23111525577  0010-fix-nteventlog-remove.patch
 dc2fe08e40c73b48b356382c43c982f9f0091e601bbdf6e032358bd5c74c3573b423ef4df454b87c8534105fdbc19ce2245609cc7d5679109c15abaf56d3ef69  safe-signal-handling.patch"

--- a/testing/ejabberd/APKBUILD
+++ b/testing/ejabberd/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: John Regan <john@jrjrtech.com>
 pkgname=ejabberd
 pkgver=17.09
-pkgrel=4
+pkgrel=5
 pkgdesc="An erlang jabber server"
 url="https://www.ejabberd.im/"
 arch="all"

--- a/testing/rabbitmq-server/APKBUILD
+++ b/testing/rabbitmq-server/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Nathan Johnson <nathan@nathanjohnson.info>
 # Maintainer: Nathan Johnson <nathan@nathanjohnson.info>
 pkgname=rabbitmq-server
-pkgver=3.7.11
+pkgver=3.7.15
 pkgrel=0
 pkgdesc="RabbitMQ is an open source multi-protocol messaging broker."
 url="https://www.rabbitmq.com/"
@@ -14,7 +14,7 @@ depends="erlang erlang-tools erlang-runtime-tools erlang-stdlib
 depends_dev=""
 makedepends="$depends_dev erlang-dev python2 py2-simplejson xmlto libxslt
 	rsync zip gawk grep erlang-compiler erlang-erl-docgen
-	erlang-edoc socat elixir"
+	erlang-edoc socat erlang-eunit elixir"
 install="$pkgname.pre-install $pkgname.post-deinstall"
 pkgusers="rabbitmq"
 pkggroups="rabbitmq"
@@ -79,4 +79,4 @@ package() {
 
 sha512sums="a8bb02a7cae1f8720e5c7aaabfe6a2c0e731cffbe0d8f99bdcb6597daa654dc49e6d41943974601435700cf469eaa8286dc91a3255a6b9023754c3861fbb5cd9  rabbitmq-server.initd
 b8655cb048ab3b32001d4e6920bb5366696f3a5da75c053605e9b270e771c548e36858dca8338813d34376534515bba00af5e6dd7b4b1754a0e64a8fb756e3f3  rabbitmq-server.logrotate
-a54034ebc919be0c6f58832ea5d47f8e3964e30ca9185c59bf882c3dc17d1df5b6e1ab0460f75e8cf0cc325504cc3a674f7cb44a5d7613e16a5ad8b721a286a4  rabbitmq-server-3.7.11.tar.xz"
+6fe527ac9ce417ddd7cc5caeccb6bc706f7b882d7c4aea693f8c97b1b6b4ab42eed241751179e4283df3121a617792fe89950a3699d28632bb3811d8f02119df  rabbitmq-server-3.7.15.tar.xz"

--- a/testing/rebar3/APKBUILD
+++ b/testing/rebar3/APKBUILD
@@ -1,25 +1,27 @@
-# Maintainer: 
+# Maintainer: Daniel Isaksen <d@duniel.no>
 pkgname=rebar3
-pkgver=3.5.0
-pkgrel=0
+pkgver=3.11.1
+pkgrel=1
 pkgdesc="erlang build tool that makes it easy to compile and test erlang applications and releases"
 url="http://www.rebar3.org/"
 arch="noarch !armv7"
 license="Apache-2.0"
 depends="erlang erlang-compiler"
-makedepends="erlang-dev erlang-ssl erlang-eunit erlang-sasl erlang-dialyzer"
+makedepends="erlang-dev erlang-ssl erlang-eunit erlang-sasl erlang-dialyzer erlang-hipe"
+checkdepends="erlang-common-test erlang-tools erlang-snmp erlang-edoc erlang-erts"
 install=""
 subpackages=""
-_bbmustache_ver="1.3.0"
-_certifi_ver="2.0.0"
+_bbmustache_ver="1.6.1"
+_certifi_ver="2.5.1"
 _cf_ver="0.2.2"
-_cth_readable_ver="1.3.2"
-_erlware_commons_ver="1.0.4"
+_cth_readable_ver="1.4.4"
+_erlware_commons_ver="1.3.1"
 _eunit_formatters_ver="0.5.0"
 _getopt_ver="1.0.1"
-_providers_ver="1.7.0"
-_relx_ver="3.24.3"
-_ssl_verify_fun_ver="1.1.3"
+_providers_ver="1.8.1"
+_relx_ver="3.32.1"
+_ssl_verify_fun_ver="1.1.5"
+_meck_ver="0.8.13"
 source="rebar3-$pkgver.tar.gz::https://github.com/erlang/rebar3/archive/$pkgver.tar.gz
 	https://repo.hex.pm/tarballs/bbmustache-$_bbmustache_ver.tar
 	https://repo.hex.pm/tarballs/certifi-$_certifi_ver.tar
@@ -31,6 +33,7 @@ source="rebar3-$pkgver.tar.gz::https://github.com/erlang/rebar3/archive/$pkgver.
 	https://repo.hex.pm/tarballs/providers-$_providers_ver.tar
 	https://repo.hex.pm/tarballs/relx-$_relx_ver.tar
 	https://repo.hex.pm/tarballs/ssl_verify_fun-$_ssl_verify_fun_ver.tar
+	https://repo.hex.pm/tarballs/meck-$_meck_ver.tar
 	"
 builddir="$srcdir/rebar3-$pkgver"
 
@@ -38,7 +41,7 @@ builddir="$srcdir/rebar3-$pkgver"
 # XXX: rebar3 bootstrap tries to download a package index (but all of the dependencies are predownloaded),
 #      which means we need networking enabled
 
-options="net !check"
+#options="net !check"
 
 _prepare_subpkg() {
 	msg "unpacking $1 $2 to _build/default/lib"
@@ -55,8 +58,6 @@ _prepare_subpkg() {
 prepare() {
 	default_prepare
 
-	cd "$builddir"
-
 	_prepare_subpkg bbmustache		$_bbmustache_ver
 	_prepare_subpkg certifi			$_certifi_ver
 	_prepare_subpkg cf			$_cf_ver
@@ -67,13 +68,12 @@ prepare() {
 	_prepare_subpkg providers		$_providers_ver
 	_prepare_subpkg relx			$_relx_ver
 	_prepare_subpkg ssl_verify_fun		$_ssl_verify_fun_ver
+	_prepare_subpkg meck			$_meck_ver
 
 	ln -sf default "$builddir"/_build/bootstrap
 }
 
 build() {
-	cd "$builddir"
-
 	# DEBUG=1 gives us verbose build output
 	# we use /tmp/rebar-build as home dir because rebar3 bootstrap downloads a package index and it cannot be disabled
 
@@ -81,6 +81,13 @@ build() {
 	HOME=/tmp/rebar-build ./bootstrap
 
 	# clean up
+	#rm -rf /tmp/rebar-build
+}
+
+check() {
+	HOME=/tmp/rebar-build ./rebar3 ct
+
+	# cleanup
 	rm -rf /tmp/rebar-build
 }
 
@@ -89,14 +96,15 @@ package() {
 	install -D -m0755 rebar3 "$pkgdir"/usr/bin/rebar3
 }
 
-sha512sums="c29471e241e144abf466382e18b022e6d06d10ee965de984d69f0fd7ba9f64745806e28c87c980ea3a8e01ff61562c434c6ced4aeaee2a2aedf4d24bde66801f  rebar3-3.5.0.tar.gz
-de5ac693a1a1655838a657020e35a7e77c80fc39a0478f14381a830a1421b64af6d755ca12577cb4ff9ed70685631a471b7a16f9302eae81266ac7197c76bbc3  bbmustache-$_bbmustache_ver.tar
-7e8fa461054c784d50d028e130641cfed1897206eca46f4b3067482607611aeeb90652f0075a1551a8672e635976088be6a2836f744ec1303775a0170fb1a2af  certifi-2.0.0.tar
+sha512sums="749368c8c19641d0c1083f1750438cfc5f1c75e284bd74b4f8ae368103e79a376f4bd91e85db35e1619116cd2f3b1a8dc2d3d89db19da8f4440e0b58d3c0a37c  rebar3-3.11.1.tar.gz
+7da99c76c5bb5b7cdc213784184c06d8be093a53c2d1da45d82677a3b18672c9368c4dac39797dee50c83cae7be4d06979d5ad2bee6b9d9d7f83fb56ebb8b032  bbmustache-1.6.1.tar
+478126f314065d6d91f6854b9565461ca0c3d31265b952bbe6eb3643e861ee1faeba388c2d356d3595381aa3a5d5871c7c98cb85d8e6ab614917eb5c8be9082a  certifi-2.5.1.tar
 0afbe335c6170f1f4efa6fb22111d8698abc288b1cc125fb69653958df1dbdb1a936f927309b460dc6cfa1fc2b15c82838b8935d5fa8e28dab1c050295608698  cf-0.2.2.tar
-f18eabca5ed9739116c9195d38515ba1362d2f1ff0f93342b1bee6526044e059232118ad50118a68bfd3ffd6c020153cd6bec626036d0082e973737d552a9ab7  cth_readable-1.3.2.tar
-350e09d1dc1e7e22be5f331f95c3e4375c03739edb3126c3994cdbd2aeee4bbab12c856197a10e5a97a21e633e86a8774087e215f60ec87412e745aced7093cc  erlware_commons-1.0.4.tar
+2036b947d33037afd2d043447bd533e207490c290ef1bd0115660c76824dbd95ce03c56bb4b89377a82bab25dab1bb19e28fc42d3f56064ea261a57b7f9f183e  cth_readable-1.4.4.tar
+1f9e7617b88ec7cae6e83da1a60a2d22ce3325b6425cd284c3ec3dd0de49a26220b868ea60a937758dd65d7ea137819e314504a98ced99fc2617056ada4d2fa0  erlware_commons-1.3.1.tar
 e8692ff35f979dfaf99ccac58014429d300a71ff76f2ce945814a0d4d9431821f04f988dc0271271858a37e6903a73b4dd9ae3abf215333f3135fa883ec07022  eunit_formatters-0.5.0.tar
 859642dc26c42414474fa8af8a32fed827b0773ac6d6eb51ec19c291672408e71619ad2bb0c7f08d84ff591b33a655a7e0b6241b94372e9cc816a648ee6cdaf6  getopt-1.0.1.tar
-c942b6468df7a5562205d8c65415bbecdc8bc87416deb081ed524541db3e3706110ef49dc55c91e9914e2baaeb1323ac8e2f44d0013856501fd4eeb774d3722b  providers-1.7.0.tar
-c05d2c143e66ef17e5ccd6d69216551616b0a25c11140235b7e6e8905c27cd2a1808f454533499710a1ecd3048280cc77e35a2ce4e547e4e127a3dfce7b96934  relx-3.24.3.tar
-8d907b8746cb61806892965af3e12e95a4f2e552212993fe62f121ded5c8502907d8daf1228ae747ea81c3fa4bbd364747316a75790f4644146f3e77c2896c95  ssl_verify_fun-1.1.3.tar"
+b1db18264c98717849ed521f8eb1ef0f112ea5e602bcd529fd97996120640c7567097174180673ba166d4c408496ce63c351ce70a3f385ed1ae7d1e444e2587a  providers-1.8.1.tar
+2bcc9a8a12cc1fbca3c195cc61d60acda98b49df72a068dcc8bed3fa645ad76f3d008f31f914bdb5ec48fc372b6196abeadf8dddf188b5c91a314f1852aa9d27  relx-3.32.1.tar
+9beef3fb7b1aa2e40202d321442159a502a6efdcac3d15397c0dfffef633a1f5af8baa006eb4437d14620ffc2e23018111f1626d2f34a63e804cd8e11fe17f71  ssl_verify_fun-1.1.5.tar
+adcfd3fdf69d4926dc1d9c2f0b477c8977bddba8b8ffdbfedcf1b5dc3c1af47b39b1c6263c922a43efede90f145f009d71b27178597320522960c5ebbd84a15a  meck-0.8.13.tar"

--- a/testing/tsung/APKBUILD
+++ b/testing/tsung/APKBUILD
@@ -3,7 +3,7 @@
 
 pkgname=tsung
 pkgver=1.7.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Tsung is a high-performance benchmark framework for various protocols including HTTP,XMPP,LDAP,etc."
 url="https://www.process-one.net/en/tsung/"
 options="!check" # Tests fail on CI


### PR DESCRIPTION
This PR upgrades erlang and friends to run on OTP R22 (latest is 22.0.2 at the time of writing).