### PR TITLE
testing/gnome-control-center: upgrade to 3.32.2

### DIFF
--- a/testing/gnome-control-center/APKBUILD
+++ b/testing/gnome-control-center/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Rasmus Thomsen <oss@cogitri.dev>
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=gnome-control-center
-pkgver=3.32.1
-pkgrel=1
+pkgver=3.32.2
+pkgrel=0
 pkgdesc="GNOME control center"
 url="https://gitlab.gnome.org/GNOME/gnome-control-center"
 # limited by gnome-online-accounts
@@ -39,7 +39,6 @@ makedepends="
 	libgudev-dev
 	polkit-dev
 	libhandy-dev
-	py3-setuptools
 	cheese-dev
 	ibus-dev"
 options="!check" # needs unpackaged py-dbusmock
@@ -67,4 +66,4 @@ package() {
 	DESTDIR="$pkgdir" ninja -C output install
 }
 
-sha512sums="ef479c95b5d9eb287e252740821e561fb426905d31d975ac0ecae9bb4f03c1e409a43f3ccced484d697b486be64381bc50c51e10012f091f628035f6c31e8d65  gnome-control-center-3.32.1.tar.xz"
+sha512sums="6f69f72e15d901935bd2fba90e0a598e6c6463d4b0f914d2a9c330c77378a461c8da86f198408045c07de370d3c1558046323a4c23a97ceed96602597e167c78  gnome-control-center-3.32.2.tar.xz"


### PR DESCRIPTION
* remove py3-setuptools dep now that meson correctly depends on it.