### PR TITLE
main/syslinux: Apply Debian's patch to fix HDT.

### DIFF
--- a/main/syslinux/0018-prevent-pow-optimization.patch
+++ b/main/syslinux/0018-prevent-pow-optimization.patch
@@ -1,0 +1,36 @@
+From: Lukas Schwaighofer <lukas@schwaighofer.name>
+Date: Tue, 26 Feb 2019 23:13:58 +0100
+Subject: Prevent optimizing the pow() function
+
+With the current GCC 8.2.0 from Debian, a section of code calling pow() in
+zzjson_parse.c is turned into a sequence calling exp(). Since no exp()
+implementation is available in syslinux those optimizations need to be
+disabled.
+---
+ com32/gpllib/zzjson/zzjson_parse.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/com32/gpllib/zzjson/zzjson_parse.c b/com32/gpllib/zzjson/zzjson_parse.c
+index ecb6f61..e66a9d8 100644
+--- a/com32/gpllib/zzjson/zzjson_parse.c
++++ b/com32/gpllib/zzjson/zzjson_parse.c
+@@ -138,6 +138,10 @@ static ZZJSON *parse_string2(ZZJSON_CONFIG *config) {
+     return zzjson;
+ }
+ 
++static double __attribute__((optimize("O0"))) pow_noopt(double x, double y) {
++	return pow(x, y);
++}
++
+ static ZZJSON *parse_number(ZZJSON_CONFIG *config) {
+     ZZJSON *zzjson;
+     unsigned long long ival = 0, expo = 0;
+@@ -213,7 +217,7 @@ skipexpo:
+     if (dbl) {
+         dval = sign * (long long) ival;
+         dval += sign * frac;
+-        dval *= pow(10.0, (double) signexpo * expo);
++        dval *= pow_noopt(10.0, (double) signexpo * expo);
+     }
+ 
+     zzjson = config->calloc(1, sizeof(ZZJSON));

--- a/main/syslinux/APKBUILD
+++ b/main/syslinux/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=syslinux
 pkgver=6.04_pre1
-pkgrel=2
+pkgrel=3
 _ver=${pkgver/_/-}
 pkgdesc="Boot loader for the Linux operating system"
 url="http://syslinux.org"
@@ -17,6 +17,7 @@ ldpath="/usr/share/syslinux"
 source="https://www.kernel.org/pub/linux/utils/boot/syslinux/Testing/${pkgver%_pre*}/syslinux-$_ver.tar.xz
 	update-extlinux.conf
 	update-extlinux
+	0018-prevent-pow-optimization.patch
 	"
 subpackages="$pkgname-doc $pkgname-dev"
 
@@ -57,4 +58,5 @@ package() {
 
 sha512sums="7927dd39be8e2dcf4138a6fea33def67d19d938379d694f15b48fdd2f5924c028b7a9e7bd71d0c7c6630c203e9e2a54296628e530632ad5e6f55b1ebefe8fc98  syslinux-6.04-pre1.tar.xz
 c3ff809f9cd60aa8a837d9508e6fcd08204b03cd8a9df86ab42fc6a8fe68784416b359b46378fb0a8f4163bbcbe444957e0e5751c30ff4631d4677eaa94874f4  update-extlinux.conf
-bfeb911507c079c8b01027a7823e562d81100b1fcd0786c707ad33c5ce18fa0eb6d6db34bc7b6cbbc419248188970cebe8286345f4aa3662d16644c51f50b98c  update-extlinux"
+bfeb911507c079c8b01027a7823e562d81100b1fcd0786c707ad33c5ce18fa0eb6d6db34bc7b6cbbc419248188970cebe8286345f4aa3662d16644c51f50b98c  update-extlinux
+92fa48133ef702092d7acafae0e0e20f9355cd2b5fe199b96fcccba5a1e688c360de4d069391815255f5493228ad03998d20b99748323396d20d12a1f27c60cd  0018-prevent-pow-optimization.patch"


### PR DESCRIPTION
With the current GCC 8.2.0 from Debian, a section of code calling pow() in
zzjson_parse.c is turned into a sequence calling exp(). Since no exp()
implementation is available in syslinux those optimizations need to be
disabled.

Closes #10546