### PR TITLE
testing/bat: new aport

### DIFF
--- a/testing/bat/APKBUILD
+++ b/testing/bat/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Chloe Kudryavtsev <toast@toastin.space>
+# Maintainer: Chloe Kudryavtsev <toast@toastin.space>
+pkgname=bat
+pkgver=0.11.0
+pkgrel=0
+pkgdesc="A cat(1) clone with wings"
+url="https://github.com/sharkdp/bat"
+arch="x86_64" # limited by rust/cargo
+license="Apache-2.0"
+makedepends="cargo"
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/sharkdp/bat/archive/v$pkgver.tar.gz"
+
+export CARGO_HOME="$srcdir"/cargo
+export RUSTFLAGS="-C target-feature=-crt-static"
+
+build() {
+	cargo build \
+		--release \
+		--verbose
+}
+
+check() {
+	cargo test --all \
+		--release \
+		--verbose
+}
+
+package() {
+	install -Dm755 target/release/"$pkgname" "$pkgdir"/usr/bin/"$pkgname"
+	install -Dm644 doc/"$pkgname".1 "$pkgdir"/usr/share/man/man1/"$pkgname".1
+}
+sha512sums="29b4ba1a5b42cef43835faec48aca25450ae8ebcc4e3d20933df552462ebd28bb06e1d0245161bf815fce2fcebab547907ac223457320c67eaf8bc053e9d7adf  bat-0.11.0.tar.gz"


### PR DESCRIPTION
bat is a cat(1) clone that acts like standard cat when the output is not
a tty.
If the output *is* a tty, it provides syntax highlighting and integrated
paging on top of the typical cat(1) features.