### PR TITLE
testing/nautilus: upgrade to 3.32.1, fixes CVE-2019-11461

### DIFF
--- a/testing/nautilus/APKBUILD
+++ b/testing/nautilus/APKBUILD
@@ -1,6 +1,12 @@
+# Contributor: Rasmus Thomsen <oss@cogitri.dev>
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
+#
+# secfixes:
+#   3.32.1:
+#    - CVE-2019-11461
+
 pkgname=nautilus
-pkgver=3.32.0
+pkgver=3.32.1
 pkgrel=0
 pkgdesc="GNOME file manager"
 url="https://wiki.gnome.org/Apps/Nautilus"
@@ -11,7 +17,7 @@ depends_dev="gnome-desktop-dev gnome-autoar-dev"
 makedepends="$depends_dev itstool libxml2-dev libxml2-utils docbook-xsl
 	docbook-xml libxslt intltool libexif-dev jpeg-dev tiff-dev librsvg-dev
 	libseccomp-dev tracker-dev gst-plugins-base-dev meson gexiv2-dev"
-checkdepends="tracker-miners"
+checkdepends="desktop-file-utils appstream-glib"
 subpackages="$pkgname-dev $pkgname-lang"
 source="https://download.gnome.org/sources/nautilus/${pkgver%.*}/nautilus-$pkgver.tar.xz"
 
@@ -33,4 +39,4 @@ package() {
 	DESTDIR="$pkgdir" ninja -C output install
 }
 
-sha512sums="a964fa03fc186016f9f37efd5958d6abc1ecd23ea821d97f2a00af0b2a98e715e7284abfb457ca73cfa434094b9298a4f1ceed5dc0729bcd11ba446c7e955bdb  nautilus-3.32.0.tar.xz"
+sha512sums="5430aa8666728d3189e704e9aeb5db7a993ed29a6c148067dcb5a1f1fef5b18853642cd672092f8a90a90c6e0158bfeec4e1db18443eb09b4c0ccb967e83ffb6  nautilus-3.32.1.tar.xz"


### PR DESCRIPTION
* Add desktop-file-utils and appstream-glib to checkdepends to run additional tests