### PR TITLE
community/xe-guest-utilities upgrade to v7.12.0

### DIFF
--- a/community/xe-guest-utilities/APKBUILD
+++ b/community/xe-guest-utilities/APKBUILD
@@ -1,15 +1,13 @@
 # Contributor: Ian Bashford <ianbashford@gmail.com>
 # Maintainer: Ian Bashford <ianbashford@gmail.com>
 pkgname=xe-guest-utilities
-pkgver=7.11.0
+pkgver=7.12.0
 pkgrel=0
 pkgdesc="XenServer guest tools"
 url="https://github.com/xenserver/xe-guest-utilities"
 arch="x86 x86_64"
 license="BSD-2-Clause"
-depends=
 makedepends="go udev"
-install=
 subpackages="${pkgname}-udev:udev:noarch $pkgname-openrc"
 options="!check"
 source="${pkgname}-${pkgver}.tar.gz::https://github.com/xenserver/${pkgname}/archive/v${pkgver}.tar.gz
@@ -39,5 +37,5 @@ udev() {
 	install -m644 -D "${builddir}/build/stage/${udev_dir}/${filename}" "${subpkgdir}/${udev_dir}/${filename}"
 }
 
-sha512sums="a047095d98fbcbe271f2c7354c3585cd180fcb5f33c16b4b43fc600b627f1eb996b28e45ac5d2a4ed4a3b0d420caa26f7957fdcd7b46243266dafda7a2602025  xe-guest-utilities-7.11.0.tar.gz
+sha512sums="397d788244a7ea71887667128f4662131fcae92f9b812779c5201f7ad2ccf72e9436232945c095ca2a7d4da603093b8896e468d8168409385b6054851c84fbd8  xe-guest-utilities-7.12.0.tar.gz
 3e898b473f6e71ecc5b820717df0a460b31756b68f4bb9bf454df39f430e64ca5e33582c03bfea044d93f49937883fe9b6807c31dee72307750de670bfca8bcd  xe-guest-utilities.initd"


### PR DESCRIPTION
security checks added upstream
release uri: https://github.com/xenserver/xe-guest-utilities/releases/tag/v7.12.0