### PR TITLE
testing/sd: new aport

### DIFF
--- a/testing/sd/APKBUILD
+++ b/testing/sd/APKBUILD
@@ -1,0 +1,75 @@
+# Contributor: Chloe Kudryavtsev <toast@toastin.space>
+# Maintainer: Chloe Kudryavtsev <toast@toastin.space>
+pkgname=sd
+pkgver=0.6.4
+pkgrel=0
+pkgdesc="An intuitive find & replace CLI"
+url="https://github.com/chmln/sd"
+arch="x86_64" # limited by rust/cargo
+license="MIT"
+options="net"
+makedepends="cargo"
+source="$pkgname-$pkgver.tar.gz::https://github.com/chmln/sd/archive/$pkgver.tar.gz"
+subpackages="$pkgname-doc
+	$pkgname-bash-completion:bashcomp:noarch
+	$pkgname-zsh-completion:zshcomp:noarch
+	$pkgname-fish-completion:fishcomp:noarch"
+
+export CARGO_HOME="$srcdir"/cargo
+
+build() {
+	cargo build \
+		--release \
+		--verbose
+}
+
+check() {
+	cargo test --all \
+		--release \
+		--verbose
+}
+
+package() {
+	install -Dm755 target/release/"$pkgname" "$pkgdir"/usr/bin/"$pkgname"
+
+	# doc
+	find target/release -name "$pkgname.1" \
+		-exec install -Dm644 {} "$pkgdir"/usr/share/man/man1/"$pkgname.1" \;
+
+	# comp
+	find target/release -name "$pkgname.bash" \
+		-exec install -Dm644 {} "$pkgdir"/usr/share/bash-completion/completions/"$pkgname" \;
+	find target/release -name "$pkgname.fish" \
+		-exec install -Dm644 {} "$pkgdir"/usr/share/fish/completions/"$pkgname.fish" \;
+	find target/release -name "_$pkgname" \
+		-exec install -Dm644 {} "$pkgdir"/usr/share/zsh/site-functions/"_$pkgname" \;
+}
+
+bashcomp() {
+	depends=""
+	pkgdesk="Bash completions for $pkgname"
+	install_if="$pkgname=$pkgver-r$pkgrel bash-completion"
+
+	mkdir -p "$subpkgdir"/usr/share
+	mv "$pkgdir"/usr/share/bash-completion "$subpkgdir"/usr/share/
+}
+
+fishcomp() {
+	depends=""
+	pkgdesc="Fish completions for $pkgname"
+	install_if="$pkgname=$pkgver-r$pkgrel fish"
+
+	mkdir -p "$subpkgdir"/usr/share
+	mv "$pkgdir"/usr/share/fish "$subpkgdir"/usr/share/
+}
+
+zshcomp() {
+	depends=""
+	pkgdesc="Zsh completions for $pkgname"
+	install_if="$pkgname=$pkgver-r$pkgrel zsh"
+
+	mkdir -p "$subpkgdir"/usr/share
+	mv "$pkgdir"/usr/share/zsh "$subpkgdir"/usr/share
+}
+
+sha512sums="cf0a2890013cc00c21fc29513931df14cf2523337a490d3cd4534c2d350f7331f332e4fb60559346f47820f5a6df25d31556628d49e8d52cd30fdd43a1d735a6  sd-0.6.4.tar.gz"


### PR DESCRIPTION
Fast and intuitive sed-like.
Useful in most cases, when sed/awk are overkill.