### PR TITLE
community/cfengine: upgrade to 3.13.0

### DIFF
--- a/community/cfengine/APKBUILD
+++ b/community/cfengine/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cfengine
-pkgver=3.12.2
+pkgver=3.13.0
 pkgrel=0
 pkgdesc="A systems administration tool for networks"
 url="https://www.cfengine.com/"
@@ -16,6 +16,10 @@ source="https://cfengine-package-repos.s3.amazonaws.com/tarballs/$pkgname-$pkgve
 builddir="$srcdir"/cfengine-${pkgver%_p*}
 builddirmasterfiles="$srcdir"/cfengine-masterfiles-${pkgver%_p*}
 options="!check" # testsuite shows some unknown errors
+
+# secfixes:
+#   3.12.2-r0:
+#     - CVE-2019-9929
 
 prepare() {
 	default_prepare
@@ -64,5 +68,5 @@ masterfiles() {
 	make install DESTDIR="$subpkgdir"
 }
 
-sha512sums="fd2947c6b61dd6cc0f171ef5b74cb5908dc8494b3ed9580dea879e872580231faaf8b88c882fd7935b7315ee91a7222f949db8a37747a65c715f295756981942  cfengine-3.12.2.tar.gz
-a8a861d6191055e208147765a1348a7f05a4acbc7c6305e4a8be4f68aa7318f918b28a164f856465f5d8e53b739e4a31ea8064723db0844f4a68b5eb8743d52b  cfengine-masterfiles-3.12.2.tar.gz"
+sha512sums="002bee68ec696417d803135723c1a4f743d42e0431f3b0d746b94ac8a18c6cc208ef21ed04b287736ff80017c0bdecbb16367a035d03fc612c18909d51987f27  cfengine-3.13.0.tar.gz
+c065574f27a04e968aa2774452b63f09b53cf96d3a11dc022e0572ecb4a3be5d270eec6c474c3f7fab879f9949d61e57b412806ae0de48fbc296c4743291c884  cfengine-masterfiles-3.13.0.tar.gz"


### PR DESCRIPTION
https://cfengine.com/company/blog-detail/cve-2019-9929-internal-authentication-secrets-leaked-in-logs/