### PR TITLE
community/gnome-themes-extra: remove noarch

### DIFF
--- a/community/gnome-themes-extra/APKBUILD
+++ b/community/gnome-themes-extra/APKBUILD
@@ -2,15 +2,15 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=gnome-themes-extra
 pkgver=3.28
-pkgrel=0
+pkgrel=1
 pkgdesc="Misc themes and theme-y tidbits"
 url="https://gitlab.gnome.org/GNOME/gnome-themes-extra"
-arch="noarch"
+arch="all"
 license="LGPL-2.1-only"
 depends="ttf-cantarell librsvg adwaita-gtk2-theme"
 makedepends="intltool gtk+3.0-dev gtk+2.0-dev librsvg-dev"
 options="!check" # no tests
-subpackages="$pkgname-lang adwaita-gtk2-theme:_gtk2:all"
+subpackages="$pkgname-lang adwaita-gtk2-theme:_gtk2"
 source="https://download.gnome.org/sources/gnome-themes-extra/${pkgver}/gnome-themes-extra-${pkgver}.tar.xz"
 replaces="gnome-themes-standard" # upstream rename
 provides="gnome-themes-standard=$pkgver-r$pkgrel"


### PR DESCRIPTION
Turns out we can't have a noarch package with arch specific subpackages