### PR TITLE
testing/kde-frameworks: update to 5.59.0

### DIFF
--- a/community/attica/APKBUILD
+++ b/community/attica/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor:
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=attica
-pkgver=5.58.0
-pkgrel=1
+pkgver=5.59.0
+pkgrel=0
 pkgdesc="Freedesktop OCS binding for Qt"
 url="http://www.kde.org/"
 arch="all"
@@ -38,4 +38,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="e33104beb353982e587384b1ddc831f640177d2b0e24ec2c7f378ef8e9b7e2a998e3425ebdb3c17cab56fe3873b296c86302e7a9a00641e06e8a2896163e7703  attica-5.58.0.tar.xz"
+sha512sums="094d29045ec19c94300cd4dce9da12520e0d6685aa9dde4a468dc439fdf2c8617d369a396609a77ecb6fd0ca48a6e5da211ad7668dcd16f998307be87c25cefc  attica-5.59.0.tar.xz"

--- a/community/extra-cmake-modules/APKBUILD
+++ b/community/extra-cmake-modules/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: Ivan Tham <pickfire@riseup.net>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=extra-cmake-modules
-pkgver=5.58.0
-pkgrel=1
+pkgver=5.59.0
+pkgrel=0
 pkgdesc="Extra CMake modules"
 url="https://projects.kde.org/projects/kdesupport/extra-cmake-modules"
 arch="noarch"
@@ -17,12 +17,13 @@ source="http://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.
 build() {
 	cmake \
 		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DBUILD_TESTING=OFF
+		-DBUILD_TESTING=ON
 	make
 }
 
 check() {
-	make test
+	# Broken tests
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest -E "(KDEFetchTranslations|KDEInstallDirsTest.relative_or_absolute_usr|KDEInstallDirsTest.relative_or_absolute_qt)"
 }
 
 package() {
@@ -32,5 +33,4 @@ package() {
 		"$pkgdir"/usr/share/licenses/$pkgname/COPYING
 }
 
-sha512sums="edff7bcef7effad524743cf234ff6bb41ab59b7d8e4629ee11be9faea97985f32fff0d96cfaf25277acce9806abea3abe475c9dfe2f8c2dc1b61b7f52d2396bb  extra-cmake-modules-5.58.0.tar.xz
-94f66c2977928d83499e69b326227c548401d0cba73dd70241f4745ba488571712081263da306fcd54b2abe935a6e9fb65ea3460994862e134fb37b51b2d5524  disable-KDEFetchTranslations.patch"
+sha512sums="fcd57e78e0810408c6f7ef1f9d5d790a156ac473c0ff0fbfe4d7959367a825a210504dc1cf34024fdf677fdfe7144e18c594b8969c5333cacd2940cd7930deb8  extra-cmake-modules-5.59.0.tar.xz"

--- a/testing/baloo/APKBUILD
+++ b/testing/baloo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=baloo
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="A framework for searching and managing metadata"
 arch="all"
@@ -15,7 +15,7 @@ options="!check" # Tons of broken tests
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -24,4 +24,4 @@ build() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="af7c8f822e71d1928e18875fe026ab6feea80e6cefb6f9ec98f1444c46827cefa8b9ec4e913e079944e96b3de6eed4d0895df2c293933270c5bb464277866396  baloo-5.58.0.tar.xz"
+sha512sums="44b3bb8a118427ecff46f8edc59ad6afb5873280693152f48ff9af03d30ff921e63757d0e1fd2396f0d5930d79ac262400794bf9182fcdb188a4b8f3245fc316  baloo-5.59.0.tar.xz"

--- a/testing/bluez-qt/APKBUILD
+++ b/testing/bluez-qt/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=bluez-qt
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 arch="all"
 pkgdesc="Qt wrapper for Bluez 5 DBus API"
@@ -15,7 +15,7 @@ options="!check" # Multiple tests either hang or fail completely
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -25,4 +25,4 @@ build() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="c6447bc8464876f91d8a9e2a0bd545791fa627ae94c47990ae58df7ac29ea9bf932482ca0ff94e84946950ddd95c9784d53ac6fd25e98901267d5267251d0d6f  bluez-qt-5.58.0.tar.xz"
+sha512sums="9e9602ddb500aafec4c66c6e68f6a14bc4f2219cf707cb86d7b944b9f82b5e76ce2fc0f2640fc3462a1d106fef2ce5af6862784666d09b8de64d7ae59f4b873b  bluez-qt-5.59.0.tar.xz"

--- a/testing/breeze-icons/APKBUILD
+++ b/testing/breeze-icons/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=breeze-icons
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Breeze icon themes"
 arch="noarch"
@@ -12,7 +12,7 @@ source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DBINARY_ICONS_RESOURCE=ON
 	make
@@ -25,4 +25,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="3733fe1634dbfce4f5713689c334948f28f133936c7b069088b68b1c468fc0bdf6a95a6743c10ed3a0d13afd6814756e9ff32f1da34a33bebd579044507a92d5  breeze-icons-5.58.0.tar.xz"
+sha512sums="cf7e310765b06fbd61ff0aaf0ee3132e093557540a17e25b22eaaa7351da98a4b2056a2f4cce4bdbd534b2223904bed93f5ab33f35653fe42ab657ada9c90566  breeze-icons-5.59.0.tar.xz"

--- a/testing/frameworkintegration/APKBUILD
+++ b/testing/frameworkintegration/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=frameworkintegration
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Framework providing components to allow applications to integrate with a KDE Workspace"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -29,4 +29,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="80f2d8c3dcaa57632bab12ca581ae57665b6bbea9f68aa439cf91f8bb7e987954a0b6787bc7f73e6e5cc8f605b28162a654bce6fa2aa3f699fc909fd5f0f5794  frameworkintegration-5.58.0.tar.xz"
+sha512sums="31aead885ab8834f85c32aa824078e0a4047a4c57f6106345f568b47f2a67af2193166e4cb429310580601589ad046a2a5fcee170cab00ce93abc9f56675fc8c  frameworkintegration-5.59.0.tar.xz"

--- a/testing/kactivities-stats/APKBUILD
+++ b/testing/kactivities-stats/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 pkgname=kactivities-stats
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 arch="all"
 pkgdesc="A library for accessing the usage data collected by the activities system"
@@ -21,7 +21,7 @@ prepare() {
 build() {
 	cd "$builddir"/build
 	cmake "$builddir" \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -37,4 +37,4 @@ package() {
 	cd "$builddir"/build
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="d819cc9cf3232b47e9eaec6884a4a98f69bf6ffec02db8d2f07d90b7d5b3357c6e87b65eda0f842c80b566e0321b62dc27ed2baefc50c1de15cf9fe98001cd17  kactivities-stats-5.58.0.tar.xz"
+sha512sums="fe7fcc7171a1c2082908950dcc98b123f31675183f7fa54572bf0e15e6f7ba40fcc364732059f31567ba10764cac1c4d4b238adb83cc52f0342f7dda917b12dd  kactivities-stats-5.59.0.tar.xz"

--- a/testing/kactivities/APKBUILD
+++ b/testing/kactivities/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kactivities
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 arch="all"
 pkgdesc="Core components for the KDE's Activities"
@@ -22,7 +22,7 @@ prepare() {
 build() {
 	cd "$builddir"/build
 	cmake "$builddir" \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -38,4 +38,4 @@ package() {
 	cd "$builddir"/build
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="f51836925f0afd8031b667eea8dae910ad7072c550047b7b012207579d834219260860cd824c0c212e7a3167a1ec256d18cbeeabb78d265aabf6184b870b461f  kactivities-5.58.0.tar.xz"
+sha512sums="2f507a4d0c3cce5d9e932a963803494eef465a7cb7ccb9f73a7073ca5225868b042e5b0da04c49fe8bb3a3b82bb6b39cbbeaf73b7d7a56ad65ea510023b787dc  kactivities-5.59.0.tar.xz"

--- a/testing/kapidox/APKBUILD
+++ b/testing/kapidox/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kapidox
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 arch="noarch"
 pkgdesc="Scripts and data for building API documentation (dox) in a standard format and style"
@@ -14,7 +14,7 @@ subpackages="$pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="3ad73329f72fe78abb48a72a4caf06e09ef4237e2dd44732ec30b12af433f62bdc08501a4b00c37f390c71e79b90d1ca90de0d0d04854b30b647cde7e48f050d  kapidox-5.58.0.tar.xz"
+sha512sums="0394c2038a16023d1e21641fa56791b0ea26b989729f15b4e802ee9f9e6282e2252cce858ff722b00d7efaf1b14934bbadd7d492dcaa76a5bcd651b6ca825ec8  kapidox-5.59.0.tar.xz"

--- a/testing/karchive/APKBUILD
+++ b/testing/karchive/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=karchive
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Qt 5 addon providing access to numerous types of archives"
 arch="all"
@@ -13,7 +13,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -27,4 +27,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="fd3e4f013a18a2e2876a010ba673c207a8cc05f3e41723daf46181f915259a06ba63e02d0d47cbf9da0445da94ce02cc62cee4fb90d0da2323c3e51a4d3e4d35  karchive-5.58.0.tar.xz"
+sha512sums="1d198e284b79e89c6c2c80304b8ba070f18ddd50da8b0a1e4eef3a4f32582c2b06d0c7fa18de98d618eceb0074f56f9b079e8248bf54c958f6de66382f67ca9b  karchive-5.59.0.tar.xz"

--- a/testing/kauth/APKBUILD
+++ b/testing/kauth/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kauth
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Abstraction to system policy and authentication features"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="7d337b4b6507dd1b35df118a5a1f9167efcec67386f85d0ed3c7f22dbb6c56fddf7ba4979c7f1c70c11b525f99a2e3e95e3a1d4f9971d8c02ce40e9664ee0cef  kauth-5.58.0.tar.xz"
+sha512sums="c0f871da993cf7a44ef7bc5a06a393c4f5479dd26378de98812bfc9a14c6b017b04890735da8cf72ebbc4e3ab212e0a131a19ff5b8be28c64e4e8467b10de026  kauth-5.59.0.tar.xz"

--- a/testing/kbookmarks/APKBUILD
+++ b/testing/kbookmarks/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kbookmarks
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Support for bookmarks and the XBEL format"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="c0953fd9f0da27ae20ef8f2501a8ad3f5ab2f68d1d1279013b16927803e2325905b57eb6c0a91ad69ba041a2834157f3c8dbd8ece605e40b82f9949157f27e58  kbookmarks-5.58.0.tar.xz"
+sha512sums="c0d5699cf2427b6a2ff72fc9e4f02704ef414f82bb84a1852501eb33ef2d130b5f1f861171198054fcdf8957b104c9e1818546dad577afb0ef4de6f29fe42c4d  kbookmarks-5.59.0.tar.xz"

--- a/testing/kcmutils/APKBUILD
+++ b/testing/kcmutils/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kcmutils
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Utilities for interacting with KCModules"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="261b75340fddecc4845622111b9cb00a2f85386e3912c794e4fbb8381e1b67062d1f6b069ad08874e6d37571fc62265f3a1598f2e4ed0a8552582d6e28afac0a  kcmutils-5.58.0.tar.xz"
+sha512sums="c90e6e7b082bc8a5db6991041a5ccd330d4dd5e158566bb7f473af6260108a7be20211cd1150d5f7d052b448a1d059d2ff87724548faa9af4426a75995abec1f  kcmutils-5.59.0.tar.xz"

--- a/testing/kcodecs/APKBUILD
+++ b/testing/kcodecs/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kcodecs
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Provide a collection of methods to manipulate strings using various encodings"
 arch="all"
@@ -13,7 +13,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -27,4 +27,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="4e4f8083066972a9fc9565673b571d98316bb818646110768d5a68fe47e2db88dd453c22edbb307a65bfdb8a90eac5136507424a2fee5b85bdd77240d33b94f0  kcodecs-5.58.0.tar.xz"
+sha512sums="ca32984c2a5d1770dd9577357c4f211b4ceba30a76019354a4234f97ebc55462703403dea449351dfc2b33fb7c5a2e844a72b8c88493bd6bdd481b3ae31bc6fe  kcodecs-5.59.0.tar.xz"

--- a/testing/kcompletion/APKBUILD
+++ b/testing/kcompletion/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kcompletion
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Text completion helpers and widgets"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="c5da666c8f480d96989ab2566b27c533eed4ebe7df8c2eff9226caf5ffc243e6f3f8f058dcd9d2e53ebfada4fe0e5887bb7d459271e7b6599b168a3ae96505e4  kcompletion-5.58.0.tar.xz"
+sha512sums="013623947b7c83ddaf66c90f568823a72ffa9827c7d0a03850428a486fbf519c74c9dda738c22992d56a2f6b008c7e2633ee3cc805b48a1bdc1612cf514b9d47  kcompletion-5.59.0.tar.xz"

--- a/testing/kconfig/APKBUILD
+++ b/testing/kconfig/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kconfig
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Configuration system"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="bdcd7b28734406ea5bc8e323659cae99754ca0da799a97d20a0e56ae74386cbec9bdaa447ab1b445bf137dfe928bece0c28a7630a1856eee9d822e6b01783c19  kconfig-5.58.0.tar.xz"
+sha512sums="c8f21979e3508b9bf1b695a22e4843ff0d311db957817fcc3bbc5c65e397c7e2a0ed8fb2f1194fea79e90a5369f52d758bb684354b9d9e1856dd9552e5f837e7  kconfig-5.59.0.tar.xz"

--- a/testing/kconfigwidgets/APKBUILD
+++ b/testing/kconfigwidgets/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kconfigwidgets
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Widgets for KConfig"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="5ab2ff176df4eaffd15861bca535637bdb9e7ae1e30873aedbf39da7fdbc669672ec9f012b9e6fc3ccdfc8a9cb505b6b9dd4b799736ff0ff03c9c6071e2d58e2  kconfigwidgets-5.58.0.tar.xz"
+sha512sums="06762e15adf8c6dd94c1bf7ac52622fde40cbafe5e16327db04dc642385b93db752be868c822ce5cf5eaddf489a2f522291724392e9b0689b440f4d5934bf030  kconfigwidgets-5.59.0.tar.xz"

--- a/testing/kcoreaddons/APKBUILD
+++ b/testing/kcoreaddons/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kcoreaddons
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Addons to QtCore"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -34,4 +34,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="704985ec358804089267dc43efff0947dd56b74e627db900e38af5ca6c03be4c5f271a5e4ca8817f4ca67642b13c22bfdce57d77ea64266766e2d84a53d0238e  kcoreaddons-5.58.0.tar.xz"
+sha512sums="a142612e48b8920cd6beb572320d77a30622d34209b7655ee9db4b5272fb3c0f7eede651e6056bed77fb526391f98e6bfdc3954becf6461a2fd410854763dcbc  kcoreaddons-5.59.0.tar.xz"

--- a/testing/kcrash/APKBUILD
+++ b/testing/kcrash/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kcrash
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Support for application crash analysis and bug report from apps"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="589622d8aa5235d2311d6ed05c97ba9f9ab64adf36b38f2db51efe8d30062a7e416e1111dbb1986eb757b3e52e588c0bf0b81bf3b6a159ee714e88400dc96d1a  kcrash-5.58.0.tar.xz"
+sha512sums="25795a6dcff72e6f956c65fe2df2079b71cab9993b1c15c7f4f2a5d850e14377ecbdd6b3c8c943402b47621c85f99f8b72322a3dad9d1482f50e55aec62130e4  kcrash-5.59.0.tar.xz"

--- a/testing/kdbusaddons/APKBUILD
+++ b/testing/kdbusaddons/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kdbusaddons
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Addons to QtDBus"
 arch="all"
@@ -14,7 +14,7 @@ options="!check" # Requires running dbus-daemon
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="ddba1e9d535be578f68deea2e38919db691cdb25719b18197d13fd98a0d81ad537550b4b0f0243971741c30dc0fb1b9a242b56310fa52c756c1911b76b880002  kdbusaddons-5.58.0.tar.xz"
+sha512sums="f3235593673627267b14102f042e3ba39449305320ca4f17a6c8369906d69796c68827086b3caa214e33ebb6b2b071e370311c8d2d3b3d2436cb528bd56298a6  kdbusaddons-5.59.0.tar.xz"

--- a/testing/kdeclarative/APKBUILD
+++ b/testing/kdeclarative/APKBUILD
@@ -1,15 +1,13 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kdeclarative
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Provides integration of QML and KDE Frameworks"
 arch="all"
 url="https://community.kde.org/Frameworks"
 license="LGPL-2.1-or-later"
-depends_dev="qt5-qtdeclarative-dev kconfig-dev ki18n-dev kiconthemes-dev
-	kio-dev kwidgetsaddons-dev kwindowsystem-dev kglobalaccel-dev
-	kguiaddons-dev kpackage-dev"
+depends_dev="qt5-qtdeclarative-dev kconfig-dev ki18n-dev kiconthemes-dev kio-dev kwidgetsaddons-dev kwindowsystem-dev kglobalaccel-dev kguiaddons-dev kpackage-dev libepoxy-dev"
 makedepends="$depends_dev extra-cmake-modules doxygen qt5-qttools-dev"
 checkdepends="xvfb-run"
 source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
@@ -17,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -31,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="fffcb319a15cf89cc7179f0c543376eec83c0de8a49f533ab3c0488e13788b246b051a36249e0212517260fe24db647190e055a72cfa472dc168f0ae776cda41  kdeclarative-5.58.0.tar.xz"
+sha512sums="dd17d5a73c3751d9f8267f569ef3941dc9752855128d308f6425585ec777f2d9e65d6acc50e474378fdc2639c47a411c8197743da166d3a9018d9384981b53d2  kdeclarative-5.59.0.tar.xz"

--- a/testing/kded/APKBUILD
+++ b/testing/kded/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kded
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Extensible deamon for providing system level services"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="67638ec4bf65ab74ac4cefb0591bfcbb80bdc37b5bc4ceb4099a9304f00a9f744710fc525c7649ee53c1bc6e590f583cbbded506ee96c0f96547217b21b81766  kded-5.58.0.tar.xz"
+sha512sums="9672bd8ac2d694c150b43987cf256e4783d16710450bcee6a9c398bdcf4da198dc30365109ddcb5dbbaa0c812503999337035089f6667939e359dafddeee71b6  kded-5.59.0.tar.xz"

--- a/testing/kdelibs4support/APKBUILD
+++ b/testing/kdelibs4support/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kdelibs4support
-pkgver=5.58.0
-pkgrel=1
+pkgver=5.59.0
+pkgrel=0
 pkgdesc="Porting aid from KDELibs4"
 arch="all"
 url="https://community.kde.org/Frameworks"
@@ -16,7 +16,7 @@ options="suid !check" # Fails due to requiring running dbus
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -30,4 +30,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="c5b24bca72814e2ef32212f6834cdafa9a52329330ce782cde567a46144d6eac89141718053a3d905d344c14b7b51a5b49737f85761f3324c12e43f81ecac0c9  kdelibs4support-5.58.0.tar.xz"
+sha512sums="13e693a7d8807d77a01af8b69485558bdaa1d7d0692b4c3fc70e8eb528ef9f5588354f2d5d4314026ea59df7f9942883cfce6dcfeb9a8af76edb31edb1e81c2b  kdelibs4support-5.59.0.tar.xz"

--- a/testing/kdesignerplugin/APKBUILD
+++ b/testing/kdesignerplugin/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kdesignerplugin
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Integration of Frameworks widgets in Qt Designer/Creator"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -29,4 +29,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="65ff89ffb3797d31e4fde69330cb7966b8e01893895cbe7df6de699912deb5863d45833a0bdddcdeb5b038894115ad79817392ee5ed4ca8254fba369c9aeb133  kdesignerplugin-5.58.0.tar.xz"
+sha512sums="d860210f43e499d957184b43f6d3ba8f3f2c8d5af4349f2133551990e2062206304499f43053e6669ba68b6ff3cf2aeabb794672a55cbacae61a76ab22b02eb6  kdesignerplugin-5.59.0.tar.xz"

--- a/testing/kdesu/APKBUILD
+++ b/testing/kdesu/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kdesu
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Integration with su for elevated privileges"
 arch="all"
@@ -17,7 +17,7 @@ options="suid"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -30,4 +30,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="e2318670aa7465ac4268239f882b57af35f6943696498a4da33c51e4a89c3be646d617fe50e3aa132a200373f567b26a2247aba5638ad28b1ad0429c21eaed88  kdesu-5.58.0.tar.xz"
+sha512sums="48310a62eff32735afcca4b5afa2ca61bfe89c019ed52fefb09a2c3eecfa57a85cbd0039014f95929b6b74b52b150085e13ec37fc2221bab5386483d1f63ce73  kdesu-5.59.0.tar.xz"

--- a/testing/kdewebkit/APKBUILD
+++ b/testing/kdewebkit/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kdewebkit
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Integration of the HTML rendering engine WebKit"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -29,4 +29,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="00cad08646d47ecb7230b2edeea0901555963ba5969af27a7652151c36509d2d2c501cffc65309c0005d9d97efc261b3190590638a379207541eef41cf160067  kdewebkit-5.58.0.tar.xz"
+sha512sums="15714cc1100a8c47e693853bf3a84b924fcde645a14ee80d53b868f83e050080678ff83b25fbcc74a57abb8c6a6ffeb6443185aa55432486f177076e243c26ef  kdewebkit-5.59.0.tar.xz"

--- a/testing/kdnssd/APKBUILD
+++ b/testing/kdnssd/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kdnssd
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 arch="all"
 pkgdesc="Network service discovery using Zeroconf"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="af54e5c275f58b51a538dd5a0e50c53b78a9d421c142a3f812e63c4064b5ad5907bc668512b982a02accbe4fdeff3646eb85405e559514eea8c98368316a22b8  kdnssd-5.58.0.tar.xz"
+sha512sums="558f3f80472f896bd3fe4479812f101a78ce7b88cf80b50d6ca4415ec2dcc467cc4129163060f312b6b8da8a61bd3d3bffd0006eea61784f13bf1da9cce549db  kdnssd-5.59.0.tar.xz"

--- a/testing/kdoctools/APKBUILD
+++ b/testing/kdoctools/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kdoctools
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Documentation generation from docbook"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -31,4 +31,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="ab758d22eb424d5488d034a249d9f828412f78c8dde01b32f3e67feb7b84cec1aa5282135455ad0168d01f0fc54b590103d4d5f85f9f44c3d3a4742fbb160a7e  kdoctools-5.58.0.tar.xz"
+sha512sums="f66db9c71e5181f03956257615a1260330d16133f2393c9dc3e2e157c64464abde9706cb2bcccc3ea7fd29bffaabe408ea02a6ed0e6cf2c1d248bd5379e1b738  kdoctools-5.59.0.tar.xz"

--- a/testing/kemoticons/APKBUILD
+++ b/testing/kemoticons/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kemoticons
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Support for emoticons and emoticons themes"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="2fb641e05cffa31e7d2d9d2a0110ade0f1fdee7fc3f23924505c874d76db24999b041b7df4cb62ecb455081457e013a7ee906479acd35dfe283843c1d269ecc2  kemoticons-5.58.0.tar.xz"
+sha512sums="71d2096b3b764c069d5bfe3a63e9658236ef5e273710bd09af9f6b745d379d9b906d521c7ba34b6718b6853f979b341758d58efd52a11676111c687a571953ff  kemoticons-5.59.0.tar.xz"

--- a/testing/kfilemetadata/APKBUILD
+++ b/testing/kfilemetadata/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kfilemetadata
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="A library for extracting file metadata"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -31,4 +31,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="1a8967b10882910645254fec74a0b61fa9a7458a5cfeb105d3161deda07591871b505c4b415f2ae8612235a3fc611084da5ea534224405bdb19b0cd04a674c11  kfilemetadata-5.58.0.tar.xz"
+sha512sums="ef427635762f63b79aede696dd61855add888e97bf0eeeaaf24fbfb6338ad4b9caf45c7903d2a7682a7494b6a48e608f74626d486d480c166057632b3b70552c  kfilemetadata-5.59.0.tar.xz"

--- a/testing/kglobalaccel/APKBUILD
+++ b/testing/kglobalaccel/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kglobalaccel
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Add support for global workspace shortcuts"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="4dfed2f280aefecaf9f8eecda5b3663c831fd85781ec8b64c2cd208d3e7af170b52603f8746193f48a92dbf86f6e9fd3fde90fb592557867cd78473dbe810990  kglobalaccel-5.58.0.tar.xz"
+sha512sums="5e8128044a40c9dfbdc9baa01c5e51b790790c8780d4cd2a7bf1820c0e51b661591b600b3c3fd5cba17bbf05152c38d3c2f22a0a77b3e5c028ba43e43265d0f8  kglobalaccel-5.59.0.tar.xz"

--- a/testing/kguiaddons/APKBUILD
+++ b/testing/kguiaddons/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kguiaddons
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Addons to QtGui"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -30,4 +30,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="a675fe76ef2d46c59d8d9ec5e949dbfca8d24cdb5ef4e5c3774dee45c82cafa0ff8e94c9508ac6cb875fc2188d564754081c5a1fe7b0cd096a128499a544c106  kguiaddons-5.58.0.tar.xz"
+sha512sums="f23c7eab76b5e5813722e54f6148487583dc0b031730b6c590a36cd4f319fde02601216c4e81e08d3799c0f3c727113b0ecb74e880edc6b7e3178a9cba55ab15  kguiaddons-5.59.0.tar.xz"

--- a/testing/kholidays/APKBUILD
+++ b/testing/kholidays/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kholidays
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Support for icon themes"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -30,4 +30,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="ef5a62331ee788d08913d4ebc68d6d420670d3bbb0823447e4ebfd1d0a7dec8cf44a5bda7453147160885a98900a081d60c5f175d4c6872688d394f8ea08180b  kholidays-5.58.0.tar.xz"
+sha512sums="8a8e4a5e0d97879129ed67efe08bc7afb4a706d525113c4fd36e1750a6bdfa69c720491ccd48d1376c928444f4fc6578ce1b359dfc6d0b995ba5f625e27eb226  kholidays-5.59.0.tar.xz"

--- a/testing/khtml/APKBUILD
+++ b/testing/khtml/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=khtml
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="The KDE HTML library, ancestor of WebKit"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="f4bc0f9a5a6288e76efe79596957aefeff5757cb447c9752bd20fd6dc48a199311fdcce78c22696d66c5dc2ca509d4c3cde56c0335be1c8e19bf104544546824  khtml-5.58.0.tar.xz"
+sha512sums="26f822972b5de644745ab67988bcb5763b7f5d0546dfcb40d2be2751ea4ab167373ebf76b72538d546a4dcd0adf2b8b383d69405a7e7d9122d27f419c4371e09  khtml-5.59.0.tar.xz"

--- a/testing/ki18n/APKBUILD
+++ b/testing/ki18n/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=ki18n
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Advanced internationalization framework"
 arch="all"
@@ -15,7 +15,7 @@ options="!check"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -31,4 +31,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="dae7dbfeb887db2f799619222702e2767a7a4f83e21a718af7f9376e735928846f4d792f9fa30dcf4d9010efdd5ffd926a89fb0fa9dd068e2573d2d47159a971  ki18n-5.58.0.tar.xz"
+sha512sums="1cef4e76fbfb39a06dd635f5be03f8b5918ee9f7fccd55fc0e6a75761b96557be2762cc6e0170f2af46df1bde40822060a4f209928958c4a208fd687823dc510  ki18n-5.59.0.tar.xz"

--- a/testing/kiconthemes/APKBUILD
+++ b/testing/kiconthemes/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kiconthemes
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Support for icon themes"
 arch="all"
@@ -16,7 +16,7 @@ options="!check" # 1 Test fail
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -31,4 +31,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="4ccaa35b81daef5e63ba43ce8baa5097282aa790cb8596ced8f8c23570813433ac497090fee257f764363150a487a433af68cf6e065d90c2163acfbea1e36bab  kiconthemes-5.58.0.tar.xz"
+sha512sums="4fef2f0d6b6054d21ea6273864da75a8f33db386e91d1c8167081b22d0efe6d85796ccfb51328f336b5c261f2ed99a58649aea757899c7d13a0629361e5a69a9  kiconthemes-5.59.0.tar.xz"

--- a/testing/kidletime/APKBUILD
+++ b/testing/kidletime/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kidletime
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Monitoring user activity"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="73c81679d969a03e8e8aefb53896a463493cc6f252e2bd6d86219458761ef75df8b6795254544e4db33229a8775e6f6758183719ba21ec9eb21e5ac72b105886  kidletime-5.58.0.tar.xz"
+sha512sums="d515ec0a2a66abeb8b8a9886686c3762760bf5c7b0dfe71b80897aa6bb37fc1441efe8e041393593ded88c54f70977dc15d448f537fc83eb8f3f2547752ee611  kidletime-5.59.0.tar.xz"

--- a/testing/kimageformats/APKBUILD
+++ b/testing/kimageformats/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kimageformats
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Image format plugins for Qt5"
 arch="all"
@@ -13,7 +13,7 @@ source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -26,4 +26,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="5676c3f9bff8a295dee67a26ff8241b6f0fe608b1ba289a5a90184f01f9a2439ede313e73761e0a0861bf9b06e1baabab6c4d64bd247f23abd980a98603942c4  kimageformats-5.58.0.tar.xz"
+sha512sums="54cd403726b675957d22546da397beb4539772c71a2efac9485ca6a1b73b1f234fea1a151cc9cde2acffd9874e40f89a23196a9f85e410f413f2b84ec206a1be  kimageformats-5.59.0.tar.xz"

--- a/testing/kinit/APKBUILD
+++ b/testing/kinit/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kinit
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Process launcher to speed up launching KDE applications"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="71c3fa045c727fbc548f8714e70866f857ce9b90decd234833d4f1655c660b97cc787b2ead28ace3d16e770a109fb357f1520ea22e83f4d0a651ca1357ea9082  kinit-5.58.0.tar.xz"
+sha512sums="1f1275f9f0393e49b87714a8e396debbed04153f9d3a9e8604f8ab45001d6818036a3db24284fc6c80c130dfe0f75e1afcdf488c2f9f309a157d64e3606f25c3  kinit-5.59.0.tar.xz"

--- a/testing/kio/APKBUILD
+++ b/testing/kio/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kio
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Resource and network access abstraction"
 arch="all"
@@ -20,7 +20,7 @@ options="!check" # Fails due to requiring physical devices not normally availabl
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -34,4 +34,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="3d2d881f802516d890ffd3b5013972a6cd507228006d1e86d0c130209e776083a95b69bfb578509440a6ee387bea2d888029441b0ce9e6d93196536ef40f0c12  kio-5.58.0.tar.xz"
+sha512sums="db41cb54017952d17f897e1844abf08cde2d54c3c351ff951092e29a12d1c474710152ba0d9f1e8ddfebfb2779ae8ee0e21f9ad22784aa34eedb97ae1f8b10d1  kio-5.59.0.tar.xz"

--- a/testing/kirigami2/APKBUILD
+++ b/testing/kirigami2/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kirigami2
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="A QtQuick based components set"
 arch="all"
@@ -21,7 +21,7 @@ prepare() {
 
 build() {
 	cmake .. \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DKDE_INSTALL_LIBDIR=lib \
 		-DBUILD_EXAMPLES=ON
@@ -35,4 +35,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="db7da93a1af3ba5216fd903667d75fc89e45197f7bdee713cfdf04b6bd1269d67c756369503561ff0c4766f088bd261b87a6fa7e5000d7533f9ccd088d710da3  kirigami2-5.58.0.tar.xz"
+sha512sums="3ed574974c82fca18279307a23caf89935d199338688d34a760f8ce09341a44996f7ae7536cbf95a45f8920a54ed2693583df3ae1d6563b8d5712bce158e58a5  kirigami2-5.59.0.tar.xz"

--- a/testing/kitemmodels/APKBUILD
+++ b/testing/kitemmodels/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kitemmodels
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Models for Qt Model/View system"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="10f6af35a689a22106bc3df2eb7c069251c8ed61fc665cef224d861d8551805d0fdcf0c22a2b0d44fd5d2e4f7a94283d06a92dbb6b648bfa5a71bb63b873a87b  kitemmodels-5.58.0.tar.xz"
+sha512sums="93e39705463d566b85513c9d3d9840866fe943636d833d18a5a149d7f293f15b4fca6b3f1281af989af4ddf3049491a72fffba55f8033d6ca85e64150b33e844  kitemmodels-5.59.0.tar.xz"

--- a/testing/kitemviews/APKBUILD
+++ b/testing/kitemviews/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kitemviews
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Widget addons for Qt Model/View"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="fe08b97c3b698ee4cad96cfff6907b88f6c77841619abff4caf2f949d4e9379860a0e5c0be6ace4b573b0efd9dfab2dda10ee4856b5ea99e8a8be836444f048f  kitemviews-5.58.0.tar.xz"
+sha512sums="2992290c4b0981a00e1d14aedf724315cc0a421f6bf1107cc622124d13d33f4a4c38429efbf1afd526ebf1ff294d4f617b0fe1cb0bbe036c16ae477dc959a1f9  kitemviews-5.59.0.tar.xz"

--- a/testing/kjobwidgets/APKBUILD
+++ b/testing/kjobwidgets/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kjobwidgets
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Widgets for tracking KJob instances"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="e753041daf75c00a9d7980b3fdc68faf818c804b339580cb186685e89506b50e148bfe213ebced6e888004761d78ca168d8c0555df22cb491d6b3550f7f81a96  kjobwidgets-5.58.0.tar.xz"
+sha512sums="59be5926c3cb30bb0cc8d1caaefb048549fecc8ee44eacbe6a44a63943ce954f4e44329fb6061f6833620291213d043fd08ca2749ac9e46d25ac602f481eacb7  kjobwidgets-5.59.0.tar.xz"

--- a/testing/kjs/APKBUILD
+++ b/testing/kjs/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kjs
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Support for JS scripting in applications"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -27,4 +27,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="6faa3bb2e0dbc8a1126010249b2b8e7668e158ff1ecaad7ee2f1b6869f32dff56dd09d5d1c26cbea157f41e4af47b7e95ac00053e61e3a86d29702eb09a5c29f  kjs-5.58.0.tar.xz"
+sha512sums="3552269d3e4299bb92d68ee961275712a629ebece0abd847f8d69afc18559bf167b882534c0c40ca6b2a42d964af11dff991fa7c636045c99790c0bab5398072  kjs-5.59.0.tar.xz"

--- a/testing/kjsembed/APKBUILD
+++ b/testing/kjsembed/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kjsembed
-pkgver=5.58.0
-pkgrel=1
+pkgver=5.59.0
+pkgrel=0
 pkgdesc="JavaScript bindings for QObject"
 arch="all"
 url="https://community.kde.org/Frameworks"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -27,4 +27,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="a6fe93c0ecfee82394878fc4c388ba749f50e0e935c131e422dd80a1b81246f3b1eea74ab21df5016284b02a19fb27c06354a1f10582809a59f9cb40421845ec  kjsembed-5.58.0.tar.xz"
+sha512sums="2510b0ca4c2e04ddc5b3d408a252539bd031b3729051ea53d7cb05e588ea5c445337cb6f7e755ccca70808fad1c4eae31b9bca4786efc9aa47584c11398d6d60  kjsembed-5.59.0.tar.xz"

--- a/testing/kmediaplayer/APKBUILD
+++ b/testing/kmediaplayer/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kmediaplayer
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Media player framework for KDE 5"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="08c48d48ed149b52ed2b9838a78d9b08011c859d63f1b18ad8238042c3e710d9b40a7c719e36d5a70161a3c27827ea0394f61c9556f72a25bc6acaee31791e74  kmediaplayer-5.58.0.tar.xz"
+sha512sums="4253e7fcb477ac6657844c90854584aa2b8a029ddde87ef6a588a3850cc7573db28a9b01174d4872a451c5bbf0388c42dc579a46726f9054e74d0da358b651c7  kmediaplayer-5.59.0.tar.xz"

--- a/testing/knewstuff/APKBUILD
+++ b/testing/knewstuff/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=knewstuff
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Framework for downloading and sharing additional application data"
 arch="all"
@@ -18,7 +18,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -32,4 +32,4 @@ check() {
 package() {
 	make DESTDIR="$pkgdir" install
 }
-sha512sums="2cb66fd3ed5f35eca3373b3e6ad39813fd17607f8b128c028067f39c39c354e9eb7cae4173a92107b021e83dceab46625b71305bc2bff37590bb43baacc33caa  knewstuff-5.58.0.tar.xz"
+sha512sums="1c6f3d637467374097010c7adfa1bb661cb29127a51f559cd16fcc317946ef0394d37e85a31c59fc1c848be80013cd5573544ff61a250ba72985a5faa6584495  knewstuff-5.59.0.tar.xz"

--- a/testing/knotifications/APKBUILD
+++ b/testing/knotifications/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=knotifications
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Abstraction for system notifications"
 arch="all"
@@ -15,7 +15,7 @@ options="!check" # Fails due to requiring running dbus-daemon
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="40614ca155fe9839e511a3416ee85b233e0b8ce9a3f3ee182f959332d61dcd323267f19dbb71f73fed334f5de22a8efa5bfaea5ca115c21f33efcdd08567ae2d  knotifications-5.58.0.tar.xz"
+sha512sums="d84ea9047a3b41ff8bbaa7eb838e5ce5f7ca694bfee4c67505bcf08b06a5e00b387047c7229b32ea52acf503e67aae4ec20496ce3f04bcbc423063acfb21dd3a  knotifications-5.59.0.tar.xz"

--- a/testing/knotifyconfig/APKBUILD
+++ b/testing/knotifyconfig/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=knotifyconfig
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Configuration system for KNotify"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="881f54d22dfd7920eced65d869303f1bec593a995a966d1a641ebae22bcbff5800f4d992c8190049ef6ff821a279f272ab7342f59a4d9aaddb66fb8535090c1b  knotifyconfig-5.58.0.tar.xz"
+sha512sums="714e4b3434c087e27fe7ea8d7513869901ac13be9f6aa6511bdae8a03b3386903e08e0110f298e907bc8bd60e842ba7e8ecde8a57841b1f85d598ce3801ccdef  knotifyconfig-5.59.0.tar.xz"

--- a/testing/kpackage/APKBUILD
+++ b/testing/kpackage/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kpackage
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Framework that lets applications manage user installable packages of non-binary assets"
 arch="all"
@@ -15,7 +15,7 @@ options="!check" # Fails due to requiring installed Plasma, which causes a circu
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -30,4 +30,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="1e62422675ef980c5098a24deac23fb25d4d7dca86accb78c82ab2039e3f03ba2eb93aead26149bb887ae65d3463824a4d1b91c4b73758d6a797cae3a502fc1f  kpackage-5.58.0.tar.xz"
+sha512sums="dc17ad256910b1ddfa297aa2dd073d6bb6278ddbc0c28a4714348cc39fe9d7139543ae8aa61c84697c8efd578bdcfb74fd2d21f7aab0e6899214639f0edb784b  kpackage-5.59.0.tar.xz"

--- a/testing/kparts/APKBUILD
+++ b/testing/kparts/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kparts
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Document centric plugin system"
 arch="all"
@@ -16,7 +16,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -30,4 +30,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="3b932af859a6e34538949ce7bb7c17bbf2d8e7ee7cc0c144180c5f36a3dad28b9b26b9ebf7ae08f6e586d24e066da17f3edd6fee096577151b386f327faeb70b  kparts-5.58.0.tar.xz"
+sha512sums="c0c9104f44d5264d553f6d07ac8daec42da1b032404ee0902fb971cedf66cd9b40916e47f67a64b0f2c858ffb282bb5ea8b315ed48551e469d4b89c9b5ed429d  kparts-5.59.0.tar.xz"

--- a/testing/kpeople/APKBUILD
+++ b/testing/kpeople/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kpeople
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="A library that provides access to all contacts and the people who hold them"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 build() {
 	cmake \
 		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
 	make
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="b10a232852c190ab21fb85a4b3eb894a46c83f01fba1fbf6235484a20f8dd4d9d93ba19c758e6b11f179993460b9aa86ad1a36f91899ae4c6ccaafe5d0392459  kpeople-5.58.0.tar.xz"
+sha512sums="3e2f70a4b74edd7d746eb062effead5d86360ced7f920e4511018e86e11e905b8803772f980a57e98d537b16295a5dc0a4f3699f96db317fd4af225ff14e1ae7  kpeople-5.59.0.tar.xz"

--- a/testing/kplotting/APKBUILD
+++ b/testing/kplotting/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kplotting
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Lightweight plotting framework"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -30,4 +30,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="5c447f24d7dae28b75da8c2102d03f47757094dc41c79d21c474e0a19fb0c3ff96eda308b761bf8ca2f9a242cc611aaf496c3b67ee1ee587d64447413717f215  kplotting-5.58.0.tar.xz"
+sha512sums="d31dc517f584f129f72dae63e570a3cc077df08e6a0159d719b3bd11769c9a4d22ec5d641b147524db454eeb41c7221fc900ac1852b1fa439cc489f68de6b994  kplotting-5.59.0.tar.xz"

--- a/testing/kpty/APKBUILD
+++ b/testing/kpty/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kpty
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Pty abstraction"
 arch="all"
@@ -15,7 +15,7 @@ options="!check" # The one test it has fails: "Can't open a pseudo teletype"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="426d3941dbe9ea5ea23c6a8601976460ca7c847363edf2650e2c921b0916ca08bdf882aa328e7a5d7d89adf6d25f1620c74df7a09139e4b595d772cb73daf084  kpty-5.58.0.tar.xz"
+sha512sums="9c3418266032f324b9ea29fd46ca20f8614ba7c89d5ba495ac5c2b91d1077ca9bda28e18f3fc290f1022f55d6a62b33acc5ee8d2178b6c779c160d6f77d80c0e  kpty-5.59.0.tar.xz"

--- a/testing/kross/APKBUILD
+++ b/testing/kross/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kross
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Framework for scripting KDE applications"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make
@@ -27,4 +27,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="cdcdf4c649ee46ae3540af83717a161a46f40e5304780124b68f7b4c2e45c8c3b75ea067b13a562defdc88ffc266006871d1413b9c59ff9255a8cd74affb9f14  kross-5.58.0.tar.xz"
+sha512sums="61224da3ca4a0bceb1c5c14355491bcab618cbb0329e571245ec2b442966d2c62558f8ea94336e830be0263562823f0a2c0eb13ea1d969ce5f8137b17e7fd359  kross-5.59.0.tar.xz"

--- a/testing/krunner/APKBUILD
+++ b/testing/krunner/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=krunner
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Framework for providing different actions given a string query"
 arch="all"
@@ -17,7 +17,7 @@ options="!check" # Requires running dbus instance
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -31,4 +31,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="43e6d0a06a9cc639fde105013fb82e9264a1c0444b2a88d761f92b23f38317d532be113fce5f4896e0cdf6b30f9b4db164e47335c944f0d4a8112c079230fcaf  krunner-5.58.0.tar.xz"
+sha512sums="c50da3338f5b5f33b5255b56d3d0162154fd162a70ec1f709eef45658ee862e7f602f3be3caf9afe99193e4914ccab3eb675dc5d77c12d2a293c099075b52f19  krunner-5.59.0.tar.xz"

--- a/testing/kservice/APKBUILD
+++ b/testing/kservice/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kservice
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Advanced plugin and service introspection"
 arch="all"
@@ -21,7 +21,7 @@ prepare() {
 build() {
 	cd "$builddir"/build
 	cmake "$builddir" \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -39,4 +39,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="4170b2dbe4021947862ec946e1282cada74ba12f5bfa1251087363e7693d334cd0775fb7b76900f661c65c525ce5480d69d551203c58c938e73e2622942a494e  kservice-5.58.0.tar.xz"
+sha512sums="2ffd06c12791de89058e8180013f44e3bf9aeae05d2dffba1468be8f2614724d5ea6a8ec26aefb93134298029e465cff6981a4c6dcc69888c6c13e51d2e016ff  kservice-5.59.0.tar.xz"

--- a/testing/ktexteditor/APKBUILD
+++ b/testing/ktexteditor/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=ktexteditor
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Advanced embeddable text editor"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="fb6b11e257089b7d13d39e05dcddec5797e462d537a263adae680534b22f9f86bf17e844e6d769c3c4f801916e7a38c59cc996785a07c0c3996093eff2aa14d7  ktexteditor-5.58.0.tar.xz"
+sha512sums="d073bf4ff7dca238597089d3f44a4e37f1e6318a45a43d15365017a4c2e2343a6cba6abcc11590945002111730f6877cbb29d77875425cf112771a4b863ff0e0  ktexteditor-5.59.0.tar.xz"

--- a/testing/ktextwidgets/APKBUILD
+++ b/testing/ktextwidgets/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=ktextwidgets
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Advanced text editing widgets"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="d3c33fb32fcf7611e06fcfa25c3450ed10076e96c19a4aaa327b0fc005003ee8cd910c9b0519eaefd3ef730da95d40effafe8b008bb9d767b55344ec4805a3cc  ktextwidgets-5.58.0.tar.xz"
+sha512sums="ad009344bd3dd2fb10d19e8846cf837bc5f849ad565d82997762ca47698e827e84fe1288f9c6ec08e528bfd65b44af48c254867eda15d8cc10443032adea8f72  ktextwidgets-5.59.0.tar.xz"

--- a/testing/kunitconversion/APKBUILD
+++ b/testing/kunitconversion/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kunitconversion
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Support for unit conversion"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="978f8151e89f1bfa00476fdc6b5f19d2ffaf5601f363c89bcf669a68c8b857ef1e290bc9f4abae8199aa68e691dfa96ebc081f75122417e107f120f674ca5042  kunitconversion-5.58.0.tar.xz"
+sha512sums="1d0ffc2015c982f7f8aa6f4d0cf2772f90ce249a09f2fd43c8d560241ceb3d2aafe8e1f06b36c18f003649cf458905879e602c8c6ddec8078695dbd61e1f95e9  kunitconversion-5.59.0.tar.xz"

--- a/testing/kwallet/APKBUILD
+++ b/testing/kwallet/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kwallet
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Secure and unified container for user passwords"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -32,4 +32,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="7145510aa75c179a7c283f26c6d479d753a435a14e423881793ef061b3dc6144c4126365719118b3fdd5d36560a706b36cb003d829d3c469f6f0844351ddc4f4  kwallet-5.58.0.tar.xz"
+sha512sums="5f7094c914ad37c634758826d878f5cc204e853722d2555e20ff4f8fb5471311d1ad43d3aad5ca05df0e7b60b6febc243f4205d9c68919d62cbe2f0e9d4f2d04  kwallet-5.59.0.tar.xz"

--- a/testing/kwayland/APKBUILD
+++ b/testing/kwayland/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kwayland
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Qt-style Client and Server library wrapper for the Wayland libraries"
 arch="all"
@@ -15,7 +15,7 @@ options="!check" # Fails due to requiring running Wayland compositor
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -30,4 +30,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="5512621e69f354efccc52af1f571c6660ff72581ad00bc4766c4cc42d731baf1358107325af6a3b5685372c84f5c9f4b583d1bcf44ef81dbc252e15d6cede53a  kwayland-5.58.0.tar.xz"
+sha512sums="6b4077ec8badaf133111904f5397e9b781c7d2cbb3febd3f652887adca416442d9fc5c12effbc0998cee0b597e6b165ef477a246a2508c42f32b37b69672e180  kwayland-5.59.0.tar.xz"

--- a/testing/kwidgetsaddons/APKBUILD
+++ b/testing/kwidgetsaddons/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kwidgetsaddons
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Addons to QtWidgets"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -30,4 +30,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="987512048c1ec90bed7252783fc82165a4e30dedfd2d2e3b3407febb624aef30a3969b5a0e78586b1ec0c811a1671620a2dc0f311f48946143c7c2d74322dcd1  kwidgetsaddons-5.58.0.tar.xz"
+sha512sums="f00e4ecd7c17f044b682217f6b681bda754f2eceff3c553d54349809f19a20d6e4a874e742fb2620dd2f69384853259e1d402a4ddcf206160ca0f879d84856c4  kwidgetsaddons-5.59.0.tar.xz"

--- a/testing/kwindowsystem/APKBUILD
+++ b/testing/kwindowsystem/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kwindowsystem
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Access to the windowing system"
 arch="all"
@@ -16,7 +16,7 @@ options="!check" # Test 6 hangs
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -31,4 +31,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="7d54ee2629940d6dd80fefb673e7e0955cad5b76b17fa74f300bab8b13d97dc755b0562efa013ba05bf070339bb50f3a85b017797dd207d4c34bcb3315b656fd  kwindowsystem-5.58.0.tar.xz"
+sha512sums="be0b71c05586c4a65332510f7ae3db4bed1d8a7cec72068932ed58e6f707c477e4f04a6df11d7268d0bc2a29b295a40ed9da4e9d31ab2a6a8a7881eb4ddf095b  kwindowsystem-5.59.0.tar.xz"

--- a/testing/kxmlgui/APKBUILD
+++ b/testing/kxmlgui/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kxmlgui
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="User configurable main windows"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -30,4 +30,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="22d718f49b5d9b4caca4fc38be4fac42c21d2ff481d0fa0d821df0223b255a79ac27dfd83773a8c0d24b9db79bbc0d486ada7c73d44ce1aeae35792ab4551be6  kxmlgui-5.58.0.tar.xz"
+sha512sums="68ea9308379a931703718f0c29556ea0ad32288151ebae53df711aea55c5ddf505d309d23d8a47c595d77f86d20bb968a8fc77894d5785204a6657937cf302b5  kxmlgui-5.59.0.tar.xz"

--- a/testing/kxmlrpcclient/APKBUILD
+++ b/testing/kxmlrpcclient/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kxmlrpcclient
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="XML-RPC client library for KDE"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="7046113f391169bef272fa98900d564d65b53f8fd8e5ac95babe21979139cb7f91e902d00801fb928e6a4a5c3a8f5b09689f3c49038194bb5e24650f8b6cebe2  kxmlrpcclient-5.58.0.tar.xz"
+sha512sums="521b830a25fe13909a0de187428bc9f10200997dd277bbde27afef347b36ab8a57b348e4ca2b75f444bc6b09db733f82d23fd1c1eade5c703f06caa9610d8a31  kxmlrpcclient-5.59.0.tar.xz"

--- a/testing/modemmanager-qt/APKBUILD
+++ b/testing/modemmanager-qt/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=modemmanager-qt
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Qt wrapper for ModemManager DBus API"
 arch="all"
@@ -15,7 +15,7 @@ source="https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -30,4 +30,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="96aa702c3b07bc48132aa9567a25de73cb820c1b3fa59b4532ec5f3f0a9b1528f6def51ca660d7d2ed9e4eec4c4401af6bbeecd7f2b7ef3f92eb40ba74ccac2e  modemmanager-qt-5.58.0.tar.xz"
+sha512sums="0cfaf5673a739623e525965da941ef58b2ac3960b6e74af580da7adf98af5f24aee7e5b83523b9c23377780b460b161d4a5a284e7bcee48e1f53b52fa3e32822  modemmanager-qt-5.59.0.tar.xz"

--- a/testing/networkmanager-qt/APKBUILD
+++ b/testing/networkmanager-qt/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=networkmanager-qt
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Qt wrapper for NetworkManager API"
 arch="all"
@@ -22,7 +22,7 @@ prepare() {
 
 build() {
 	cmake .. \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -38,4 +38,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="f10a898d7374a236f33766ec7a96ce349e1a11aaea28d9f728e8941f3ff6fc368b6d065a16ef3e18eae392199bbd669c63a1a6e64f9bc534960bb31b08b26856  networkmanager-qt-5.58.0.tar.xz"
+sha512sums="87ded171d82d73b11b73ab5066e882ad87fe2f138d0823e10d7bb441255efffc0fe08dd53b09b831afc1d4dc875cede23e8da93e8cfd496f725f40994cbe7236  networkmanager-qt-5.59.0.tar.xz"

--- a/testing/nheko/APKBUILD
+++ b/testing/nheko/APKBUILD
@@ -25,7 +25,7 @@ build() {
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_SHARED_LIBS=True \
 		-DCMAKE_SKIP_RPATH=True \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_CXX_FLAGS="$CXXFLAGS -stdlib=libstdc++" \
 		-DCMAKE_C_FLAGS="$CFLAGS" \
 		-DCMAKE_CXX_COMPILER=clang++ \

--- a/testing/olm/APKBUILD
+++ b/testing/olm/APKBUILD
@@ -13,7 +13,7 @@ subpackages="$pkgname-dev"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make

--- a/testing/oxygen-icons/APKBUILD
+++ b/testing/oxygen-icons/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=oxygen-icons
 _pkgname=oxygen-icons5
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 arch="noarch"
 pkgdesc="Oxygen icon theme"
@@ -14,7 +14,7 @@ builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="a18c7f4433b89a12d5ee2a3e8666c5486927a93cc2d2fbef9b3107b72dc6fe2af42d9df5f4f16fafbd5b93d9e4ee0525a08883d82b5e4bf1c3f026fdd84a93fa  oxygen-icons5-5.58.0.tar.xz"
+sha512sums="4cd2fd74d517c3c3686a69ea226bc9709a0f2b54693cfd67305336b393be4f30f8f6e18ed1d69e9ddd2833b69cf380320b0511ad1bed46338ccc06a42f661e62  oxygen-icons5-5.59.0.tar.xz"

--- a/testing/plasma-framework/APKBUILD
+++ b/testing/plasma-framework/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=plasma-framework
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Plasma library and runtime components based upon KF5 and Qt5"
 arch="all"
@@ -16,7 +16,7 @@ options="!check" # 8 out of 13 tests fail
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -30,4 +30,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="4ceb9b2261012179cd0d9e0f1eec7b9d22b0f8a0582b4ccd7846a26619c429d3105962dec95af7daee0087e3011cc956d336a4aeed44671d6a6cbae3d663bc0d  plasma-framework-5.58.0.tar.xz"
+sha512sums="31c7668076ed2c83247b358780aedb4497987eb6a30d5394800367d78f3f27966a4c0282517b0012b7d63e47f8d4f6b50ddc4c514bd096b01b130a1282d77296  plasma-framework-5.59.0.tar.xz"

--- a/testing/polkit-qt-1/APKBUILD
+++ b/testing/polkit-qt-1/APKBUILD
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make

--- a/testing/prison/APKBUILD
+++ b/testing/prison/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=prison
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="A barcode API to produce QRCode barcodes and DataMatrix barcodes"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="868ba1784043f1b77592f71810e37623309581f14a4d0348e8b673f466c258993d59dc1cd5920f30439083c48dc2f4e2cdb35c296eb9c7d9f7935a0ba6c9a9ab  prison-5.58.0.tar.xz"
+sha512sums="c8fcee315b39d3d4f755a0760e05d54baf6b1b3f517e4b2782165b15018eaf9dc3166bb81d7674c96dd14a60cc8018aa78749225d6c81f992e778e57e8a76893  prison-5.59.0.tar.xz"

--- a/testing/purpose/APKBUILD
+++ b/testing/purpose/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=purpose
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Framework for providing abstractions to get the developer's purposes fulfilled"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_TESTING=ON
@@ -30,4 +30,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="41a7c99b012c892680d786ce8f0aa982b79e814763847f86884e4c5a5f36bd925dd8f916b92f5786deafb6f22a5aa5af5bc39c1b73efdc9c58a6b9aab16ae026  purpose-5.58.0.tar.xz"
+sha512sums="526e9b761a88e957d4125d55ddfc1edef28ff31457ebcc4099d118d7644368ddc39541d88c9651ac6e69a86d02885cf81b54087ede7c304783a683d3ef66caa9  purpose-5.59.0.tar.xz"

--- a/testing/solid/APKBUILD
+++ b/testing/solid/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=solid
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Hardware integration and detection"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-libs $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="f0b741be7702bae8cd80be83e41a2d328a85c04913e9a5cf745b81e22cacd493bf62931c6e1a0c283e1fb45000bf8e103436dae521a842f439f9cfcfa471781e  solid-5.58.0.tar.xz"
+sha512sums="fc3fa7b13f2899b2d198c38ca7e09e74e8e97eedd673081033950ba07999f0fbe1fc0a6779ae188cd9295571cc627642ea3fb2f3dbd0a26c3670bfda81262e55  solid-5.59.0.tar.xz"

--- a/testing/sonnet/APKBUILD
+++ b/testing/sonnet/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=sonnet
-pkgver=5.58.0
-pkgrel=1
+pkgver=5.59.0
+pkgrel=0
 pkgdesc="Spelling framework for Qt5"
 arch="all"
 url="https://community.kde.org/Frameworks"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="c98d5d8fb19e0995b38ff414c54ea38e4d8303963b36fe140fddb53378c790adfbac3289045b147a6baa283d0a2db8112106808e09c068b180689a8f055719d0  sonnet-5.58.0.tar.xz"
+sha512sums="d95f1adabd43503bfb2fdf513bb2657ca755b9130c3ff90cb14908426241f265303aa6dbb2af03377d44ccb003e597614dd0b653ca6be2ad6d4ced1d6476ac76  sonnet-5.59.0.tar.xz"

--- a/testing/syndication/APKBUILD
+++ b/testing/syndication/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=syndication
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="An RSS/Atom parser library"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="fbd3283e37f906b7bde76332721004ad679e99b4d8b3700ee0e98986f14a45dfd32048673d4e5270c351868c6e0f212b17bc4e4bc47f003cee4eb4dd16f9abd6  syndication-5.58.0.tar.xz"
+sha512sums="a6e91895464b593f89538b0252ad576c0a6526977bfaba92575de385f8364db990071ffd0380e336a208766e1e79977a622ac9f96495195a2252bc299ec50c54  syndication-5.59.0.tar.xz"

--- a/testing/syntax-highlighting/APKBUILD
+++ b/testing/syntax-highlighting/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=syntax-highlighting
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="Syntax highlighting engine for structured text and code"
 arch="all"
@@ -15,7 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 build() {
 	cmake \
 		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
 	make
@@ -28,4 +28,4 @@ check() {
 package() {
 	DESTDIR="$pkgdir" make install
 }
-sha512sums="a4b95a8ca9fcccf3fd5ea8d8a0d4a5b35712e69ce466bf28cf1f87831be6120c0bdb62b30fc14b1094cca7ad393fa8348ea1e0f13abc1a6cc742a521d4d7c350  syntax-highlighting-5.58.0.tar.xz"
+sha512sums="9566700809ba657b71861932ed82c4485f1fef676d6435ae9022f0e9ef745fdeea787c6bc958fe48a34f69294ac386e48424a4c77b329451f18a0bad1a2994c6  syntax-highlighting-5.59.0.tar.xz"

--- a/testing/threadweaver/APKBUILD
+++ b/testing/threadweaver/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Bart Ribbers <bribbers@disroot.org>
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=threadweaver
-pkgver=5.58.0
+pkgver=5.59.0
 pkgrel=0
 pkgdesc="High-level multithreading framework"
 arch="all"
@@ -14,7 +14,7 @@ subpackages="$pkgname-dev $pkgname-doc"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_QCH=ON
@@ -29,4 +29,4 @@ package() {
 	DESTDIR="$pkgdir" make install
 }
 
-sha512sums="75c43383995d053b9f65da1b62a2c52a91449a7eea6713b2363c90b87cfb0ea44d3fa81bb5c6964fd776d5c613ade0dcfb2c4b7a666e55b08fcc27d5c0a9ca54  threadweaver-5.58.0.tar.xz"
+sha512sums="9f83f29e5a6facd27d2d3d41eb39d40f52e679934f527e95aa45d4e59a50fff917130725bca94a3decad4bbcf3ff875d41840750dd05851e8504f4fb62d41ecc  threadweaver-5.59.0.tar.xz"


### PR DESCRIPTION
I very much doubt this will succeed in the CI within the output or 1 hour time limit.

The previous `-DCMAKE_BUILD_TYPE=RelWithDebugInfo` was incorrect and an invalid value, it should be `-DCMAKE_BUILD_TYPE=RelWithDebInfo`.