### PR TITLE
testing/minio: allow infinite respawning

### DIFF
--- a/testing/minio/APKBUILD
+++ b/testing/minio/APKBUILD
@@ -5,7 +5,7 @@ _pkgver='RELEASE.2019-06-04T01-15-58Z'
 pkgver=${_pkgver#*.}
 pkgver=${pkgver%T*}
 pkgver=0.${pkgver//-}
-pkgrel=0
+pkgrel=1
 pkgdesc="An open source object storage server compatible with Amazon S3"
 pkgusers="minio"
 pkggroups="minio"
@@ -56,6 +56,6 @@ cleanup_srcdir() {
 	default_cleanup_srcdir
 }
 
-sha512sums="ee2881200295cb638a55eb58b27c10752f1c0eec8fd1b60c1d4457b494c1b5b4b43de9953de4f92d54cdf41d3ec86158e8ae9ad2dffbc590dfda30332b02e2a9  minio.initd
+sha512sums="1e48f298a28e400d378a08816b617a134357f52dd66bbf9ec5bc8467cf7202a917d9a162a95f40617feb191b13834fd92ab920b04b436d2df55a2cd4adc4b062  minio.initd
 ed9790fbadfb38e4d660eb1befd87e803d70dec04d936e8cd26def4a9c21240bb7cae8750ae3395aa4761e6738b9e346c86ba57761cfde30efe46d2cb459a7e4  minio.confd
 1c0bf8d10f1f2a0fc3cca9fe25081ee042ba69cb0a3ea12ad3f3029a5dbc1795d98553ee1fb19da8e7c9fe324f47bbd694d2926fb96612f28a0701da074e2c76  RELEASE.2019-06-04T01-15-58Z.tar.gz"

--- a/testing/minio/minio.initd
+++ b/testing/minio/minio.initd
@@ -1,5 +1,7 @@
 #!/sbin/openrc-run
 supervisor=supervise-daemon
+respawn_delay=5
+respawn_max=0
 healthcheck_timer=30
 
 name='Minio Block Storage Server'


### PR DESCRIPTION
Minio will crash on startup if networking is not available.
A short period of the network dropping should not prevent the service
from coming up once networking is back.
As such, allow infinite respawns.
To avoid CPU thrashing, enforce a 5-second delay between respawns.