### PR TITLE
testing/gnome-shell: with mutter dep fixed re-enable ppc64le

### DIFF
--- a/testing/gnome-shell/APKBUILD
+++ b/testing/gnome-shell/APKBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=gnome-shell
 pkgver=3.32.2
-pkgrel=1
+pkgrel=2
 pkgdesc="GNOME shell"
 url="https://wiki.gnome.org/Projects/GnomeShell"
-arch="all !aarch64 !armhf !armv7 !s390x !ppc64le" # ppc64le limited by mutter
+arch="all !aarch64 !armhf !armv7 !s390x"
 license="GPL-2.0-or-later"
 depends="accountsservice
 	caribou


### PR DESCRIPTION
With mutter dependency fixed for ppc64le, re-enable ppc64le and bump pkgrel to force rebuild.