### PR TITLE
testing/gnome-session: with deps fixed re-enable for ppc64le

### DIFF
--- a/testing/gnome-session/APKBUILD
+++ b/testing/gnome-session/APKBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=gnome-session
 pkgver=3.32.0
-pkgrel=0
+pkgrel=1
 pkgdesc="GNOME session manager"
 url="https://www.gnome.org/"
-arch="all !aarch64 !armhf !armv7 !s390x !ppc64le" # ppc64le limited by mutter
+arch="all !aarch64 !armhf !armv7 !s390x"
 license="GPL-2.0-or-later"
 depends="gnome-shell polkit alsa-plugins-pulse dconf pulseaudio-alsa"
 makedepends="gnome-settings-daemon-dev libsm-dev


### PR DESCRIPTION
with mutter and gnome-shell deps fixed, re-enable ppc64le and bump pkgrel to force rebuild.