### PR TITLE
testing/gdm: with deps fixed re-enable for ppc64le

### DIFF
--- a/testing/gdm/APKBUILD
+++ b/testing/gdm/APKBUILD
@@ -5,7 +5,7 @@ pkgver=3.32.0
 pkgrel=1
 pkgdesc="GNOME display manager"
 url="https://wiki.gnome.org/Projects/GDM"
-arch="all !aarch64 !armhf !armv7 !s390x !ppc64le" # ppc64le limited by mutter
+arch="all !aarch64 !armhf !armv7 !s390x"
 license="GPL-2.0-or-later"
 depends="dconf linux-pam gnome-settings-daemon gnome-shell xorg-server
 	xorg-server-xwayland xrdb gsettings-desktop-schemas gnome-session"


### PR DESCRIPTION
with mutter, gnome-shell, and gnome-shell deps fixed, re-enable ppc64le and bump pkgrel to force rebuild.