### PR TITLE
testing/singularity: enable arm architectures

### DIFF
--- a/testing/singularity/APKBUILD
+++ b/testing/singularity/APKBUILD
@@ -2,16 +2,17 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=singularity
 pkgver=3.2.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Application containers focused on reproducibility for scientific computing and HPC world."
 url="https://www.sylabs.io/singularity/"
-arch="all !aarch64 !armhf !armv7"
+arch="all"
 license="BSD-3-Clause BSD-3-Clause-LBNL"
 options="suid !check" # no test suite from upstream
 depends="squashfs-tools"
 makedepends="
 	go
 	linux-headers
+	binutils-gold
 	openssl-dev
 	libuuid
 	util-linux-dev


### PR DESCRIPTION
- Add binutils-gold to makedepends