### PR TITLE
testing/go-ipfs: enable arm architectures

### DIFF
--- a/testing/go-ipfs/APKBUILD
+++ b/testing/go-ipfs/APKBUILD
@@ -2,15 +2,15 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=go-ipfs
 pkgver=0.4.21
-pkgrel=0
+pkgrel=1
 pkgdesc="Inter Platnetary File System (IPFS), a peer-to-peer hypermedia distribution protocol"
 url="https://ipfs.io/"
-arch="x86_64 x86"
+arch="x86_64 x86 aarch64 armhf armv7"
 license="MIT Apache-2.0"
 pkgusers="ipfs"
 pkggroups="ipfs"
 options="!check" # No test suite from upstream
-makedepends="make go bash git gx gx-go"
+makedepends="make go bash binutils-gold git gx gx-go"
 install="$pkgname.pre-install $pkgname.post-install"
 subpackages="$pkgname-doc $pkgname-openrc $pkgname-bash-completion:bashcomp:noarch"
 source="$pkgname-$pkgver.tar.gz::https://github.com/ipfs/go-ipfs/archive/v$pkgver.tar.gz


### PR DESCRIPTION
- Add binutils-gold to makedepends