### PR TITLE
U boot pine64

### DIFF
--- a/main/u-boot/APKBUILD
+++ b/main/u-boot/APKBUILD
@@ -1,5 +1,5 @@
 # Contributor: He Yangxuan <yangxuan8282@gmail.com>
-# Contributor: 
+# Contributor:
 # Contributor: Timo Teras <timo.teras@iki.fi>
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=u-boot
@@ -10,10 +10,10 @@ url="http://www.denx.de/wiki/U-Boot/"
 arch="armhf armv7 aarch64"
 license="GPL-2.0-or-later OFL-1.1 BSD-2-Clause BSD-3-Clause eCos-2.0 IBM-pibs
 	ISC LGPL-2.0-only LGPL-2.1-only X11"
-depends=""
-depends_dev=""
 makedepends="$depends_dev bc dtc python2-dev swig bison flex openssl-dev"
-install=""
+if [ "$CARCH" = "aarch64" ]; then
+	makedepends="$makedepends arm-trusted-firmware-sun50i"
+fi
 source="ftp://ftp.denx.de/pub/u-boot/u-boot-${pkgver//_/-}.tar.bz2
 	README.txt
 	update-u-boot
@@ -37,6 +37,7 @@ aarch64) board_configs="
 	odroid:odroid-c2
 	libretech:libretech-cc
 	qemu:qemu_arm64
+	pine64:pine64-lts
 	";;
 esac
 
@@ -57,6 +58,13 @@ build() {
 		local configs="${board_config#*:}"
 		for board in ${configs//,/ }; do
 			msg "Building u-boot for $board"
+
+			case "$board" in
+				"pine64-lts")
+					export BL31="/usr/share/arm-trusted-firmware-sun50i/bl31.bin"
+					;;
+			esac
+
 			export BUILD_DIR="$builddir"/build/$board
 			mkdir -p "$BUILD_DIR"
 			make O="$BUILD_DIR" ${board}_config || return 1


### PR DESCRIPTION
`pine64-lts` includes Pine64 A64-LTS, Pine64 Don't be evil (PinePhone devkit) and eventually the actual Pine64 PinePhone. These are Allwinner devices, which require `arm-trusted-firmware` to be built into the image. This firmware is free software (BSD-3 licensed).

I've tested this on my Pine64 Don't be evil device where it boots successfully using this setup.

This is a redo of #7899, which for some reason can't be reopened.