### PR TITLE
testing/py-zipp: new aport

### DIFF
--- a/testing/py-zipp/APKBUILD
+++ b/testing/py-zipp/APKBUILD
@@ -1,0 +1,49 @@
+# Contributor: prspkt <prspkt@protonmail.com>
+# Maintainer: prspkt <prspkt@protonmail.com>
+pkgname=py-zipp
+_pkgname=zipp
+pkgver=0.5.1
+pkgrel=0
+pkgdesc="Pathlib-compatible object wrapper for zip files"
+url="https://github.com/jaraco/zipp"
+arch="noarch"
+license="MIT"
+makedepends="py2-setuptools py3-setuptools"
+checkdepends="py2-contextlib2 py2-pathlib2 py2-unittest2"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir"/$_pkgname-$pkgver
+
+build() {
+	python2 setup.py build
+	python3 setup.py build
+}
+
+check() {
+	python2 setup.py test
+	python3 setup.py test
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	_py python2
+}
+
+_py3() {
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="d4486ae98159677cd481cddb3bd00d5d2237dc94f0f3129b03994800b0e136c12b05e02d2ca7d628043dabce323f34dd919b9ba731549656802527abdcfea120  zipp-0.5.1.tar.gz"


### PR DESCRIPTION
new depends for:
- [pytest-4.6.3](https://github.com/pytest-dev/pytest/blob/4.6.3/setup.py#L6) (packaging, pluggy>=0.12, importlib-metadata>=0.12)
- [pluggy-0.12.0](https://github.com/pytest-dev/pluggy/blob/0.12.0/setup.py#L40) (importlib-metadata>=0.12)