### PR TITLE
main/mesa: upgrade to 19.1.0

### DIFF
--- a/main/mesa/APKBUILD
+++ b/main/mesa/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mesa
-pkgver=19.0.6
+pkgver=19.1.0
 pkgrel=0
 pkgdesc="Mesa DRI OpenGL library"
 url="https://www.mesa3d.org"
@@ -287,7 +287,7 @@ _vulkan() {
 		_mv_vulkan intel ;;
 	esac
 }
-sha512sums="320fd6b12ccd5e4a40dfc93546354848a38da09d90e4d5a1dae5d100b8106942acfc25ac3f705a2d3ab3b355162c74c7dfadbdb99a46cf2e5e0761f8542bfeb1  mesa-19.0.6.tar.xz
+sha512sums="25b186ae8037dedea5691e0b77b22f2065f3c877838378651726dfa1b34ef49dcc56f1dbd124e99285e5f14489db936a886a6740495b5b279e8363424bfb3433  mesa-19.1.0.tar.xz
 cdf22d2da3328e116c379264886bd01fd3ad5cc45fe03dc6fd97bdc4794502598ee195c0b9d975fa264d6ac31c6fa108c0535c91800ecf4fcabfd308e53074cc  adjust-cache-deflate-buffer.patch
 cf849044d6cc7d2af4ff015208fb09d70bf9660538699797da21bda2ecb7c1892d312af83d05116afd826708d9caafb1d05a13f09139c558aea6fee931e3eee7  musl-fix-includes.patch
 1d89e305659bb0ca95b0b593dbc1a17ed28f4a18fabe468c20527302fc90c1ce11ca40a79c8786f1eca68ef643027af706b8689068e31c7f27ceb2303d51633e  add-glx-use-tls.patch"


### PR DESCRIPTION
19.1.0 is a development release, but is required for Lima (and thus Pine64-LTS) support (#8764).