### PR TITLE
main/mesa: enable Lima and Panfrost support

### DIFF
--- a/main/mesa/APKBUILD
+++ b/main/mesa/APKBUILD
@@ -84,8 +84,12 @@ x86*)
 	esac
 	;;
 armhf|armv7|aarch64)
-	_gallium_drivers="${_gallium_drivers},vc4"
-	subpackages="$subpackages $pkgname-dri-vc4:_dri"
+	_gallium_drivers="${_gallium_drivers},vc4,kmsro,lima"
+	subpackages="$subpackages
+		$pkgname-dri-vc4:_dri
+		$pkgname-dri-kmsro:_dri
+		$pkgname-dri-lima:_dri
+		"
 	;;
 esac
 
@@ -272,6 +276,11 @@ _dri() {
 	virtio)
 		_mv_dri virtio_gpu_dri
 		;;
+	kmsro)
+		_mv_dri exynos_dri hx8357d_dri ili9225_dri ili9341_dri meson_dri mi0283qt_dri pl111_dri repaper_dri rockchip_dri st7586_dri st7735r_dri sun4i-drm_dri
+		;;
+	lima)
+		_mv_dri lima_dri
 	esac
 }
 

--- a/main/mesa/APKBUILD
+++ b/main/mesa/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mesa
 pkgver=19.1.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Mesa DRI OpenGL library"
 url="https://www.mesa3d.org"
 arch="all"
@@ -84,11 +84,12 @@ x86*)
 	esac
 	;;
 armhf|armv7|aarch64)
-	_gallium_drivers="${_gallium_drivers},vc4,kmsro,lima"
+	_gallium_drivers="${_gallium_drivers},vc4,kmsro,lima,panfrost"
 	subpackages="$subpackages
 		$pkgname-dri-vc4:_dri
 		$pkgname-dri-kmsro:_dri
 		$pkgname-dri-lima:_dri
+		$pkgname-dri-panfrost:_dri
 		"
 	;;
 esac
@@ -281,6 +282,10 @@ _dri() {
 		;;
 	lima)
 		_mv_dri lima_dri
+		;;
+	panfrost)
+		_mv_dri panfrost_dri
+		;;
 	esac
 }
 


### PR DESCRIPTION
Depends on Mesa 19.1.1 (next stable release) which isn't out yet, shouldn't be merged till then.

Note that devices using the Lima or Panfrost driver also need to install `mesa-dri-kmsro`, as the former is just the renderer and the latter the display driver.