### PR TITLE
main/valgrind: suppressions file for musl

### DIFF
--- a/main/valgrind/APKBUILD
+++ b/main/valgrind/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=valgrind
 pkgver=3.14.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A tool to help find memory-management problems in programs"
 url="http://valgrind.org/"
 arch="all"
@@ -16,6 +16,9 @@ makedepends="sed paxmark perl bash autoconf automake libtool"
 options="!strip !check"
 subpackages="$pkgname-dev $pkgname-doc"
 source="ftp://sourceware.org/pub/$pkgname/$pkgname-$pkgver.tar.bz2
+	musl.supp
+
+	activate-musl-supp.patch
 	uclibc.patch
 	arm.patch"
 #	musl-fixes.patch
@@ -24,6 +27,7 @@ builddir="$srcdir"/$pkgname-$pkgver
 prepare() {
 	default_prepare
 	cd "$builddir"
+	cp "$srcdir"/musl.supp .
 	aclocal && autoconf && automake --add-missing
 	echo '#include <linux/a.out.h>' > include/a.out.h
 }
@@ -70,5 +74,7 @@ package() {
 }
 
 sha512sums="68e548c42df31dc2b883a403e0faff7480c49b3054841870f5d2f742141ba199eca5d83c96bbf283115f0633f2bdb0860161d422f98e3ec720ec65760d250f97  valgrind-3.14.0.tar.bz2
+05ecb7bf5a1f5b5ec0eedea7c4f9f4ad1745ceeccf01b84057852effcd81f2ace95fd3fd8f93640756ffbcec3ed4859824f8d921dc92e7dc46526aa9bd9c3d56  musl.supp
+09a992c39e755d92894f79cd95ed2a6e84daa3ac1af1fe8907ebb2c90dca27d224aae882389c2c246aff8a6bb7d8b9c57a6ca62bd7b36f6fb43e182471186821  activate-musl-supp.patch
 d59a10db9037e120df2ee94a103402ca95a79abee9d8be63e4e1bca29c82dca775cc402a79b854ec11a2160a4d2da202c237369418e221d1925267ea2613fd5d  uclibc.patch
 9ee297d1b2b86891584443ad0caadc4977e1447979611ccf1cc55dbee61911b0b063bc4ad936d86c451cedae410cb3219b5a088b2ad0aa17df182d564fe36cfe  arm.patch"

--- a/main/valgrind/activate-musl-supp.patch
+++ b/main/valgrind/activate-musl-supp.patch
@@ -1,0 +1,12 @@
+diff -upr valgrind-3.14.0.orig/configure.ac valgrind-3.14.0/configure.ac
+--- valgrind-3.14.0.orig/configure.ac	2019-06-13 21:56:14.023469250 +0200
++++ valgrind-3.14.0/configure.ac	2019-06-13 21:56:35.130452552 +0200
+@@ -1103,7 +1103,7 @@ case "${GLIBC_VERSION}" in
+      musl)
+ 	AC_MSG_RESULT(Musl)
+ 	AC_DEFINE([MUSL_LIBC], 1, [Define to 1 if you're using Musl libc])
+-	# no DEFAULT_SUPP file yet for musl libc.
++	DEFAULT_SUPP="musl.supp ${DEFAULT_SUPP}"
+ 	;;
+      2.0|2.1|*)
+ 	AC_MSG_RESULT([unsupported version ${GLIBC_VERSION}])

--- a/main/valgrind/musl.supp
+++ b/main/valgrind/musl.supp
@@ -1,0 +1,25 @@
+# Suppressions for musl libc
+# See: https://www.openwall.com/lists/musl/2017/06/15/4
+
+{
+   musl-dynlink-false-positive1
+   Memcheck:Leak
+   fun:calloc
+   fun:load_direct_deps
+   fun:load_deps
+   fun:load_deps
+   fun:__dls3
+   fun:__dls2b
+   fun:__dls2
+}
+
+{
+   musl-dynlink-false-positive2
+   Memcheck:Leak
+   fun:calloc
+   fun:load_library
+   fun:load_preload
+   fun:__dls3
+   fun:__dls2b
+   fun:__dls2
+}


### PR DESCRIPTION
Consider the following C program:

```C
#include <stdio.h>
#include <string.h>
#include <stdlib.h>

int
main(void)
{
	char *str;

	str = strdup("foo");
	printf("%s\n", str);
	free(str);
	return 0;
}
```

It doesn't have any obvious memory leaks, however: compiling it and running it with valgrind will yield the following error message:

```
$ cc -o test test.c
$ valgrind --leak-check=full --show-leak-kinds=all ./test
==29077== HEAP SUMMARY:
==29077==     in use at exit: 476 bytes in 4 blocks
==29077==   total heap usage: 6 allocs, 2 frees, 520 bytes allocated
==29077== 
==29077== 48 bytes in 3 blocks are still reachable in loss record 1 of 2
==29077==    at 0x489D6F0: calloc (vg_replace_malloc.c:752)
==29077==    by 0x40587F2: load_direct_deps (dynlink.c:1170)
==29077==    by 0x40587F2: load_deps (dynlink.c:1197)
==29077==    by 0x40587F2: load_deps (dynlink.c:1193)
==29077==    by 0x40591BF: __dls3 (dynlink.c:1832)
==29077==    by 0x4058BA6: __dls2b (dynlink.c:1660)
==29077==    by 0x4058B4B: __dls2 (dynlink.c:1638)
==29077==    by 0x405674F: ??? (in /lib/ld-musl-x86_64.so.1)
==29077== 
==29077== 428 bytes in 1 blocks are still reachable in loss record 2 of 2
==29077==    at 0x489D6F0: calloc (vg_replace_malloc.c:752)
==29077==    by 0x40585BA: load_library (dynlink.c:1110)
==29077==    by 0x40591FD: load_preload (dynlink.c:1260)
==29077==    by 0x40591FD: __dls3 (dynlink.c:1831)
==29077==    by 0x4058BA6: __dls2b (dynlink.c:1660)
==29077==    by 0x4058B4B: __dls2 (dynlink.c:1638)
==29077==    by 0x405674F: ??? (in /lib/ld-musl-x86_64.so.1)
==29077== 
==29077== LEAK SUMMARY:
==29077==    definitely lost: 0 bytes in 0 blocks
==29077==    indirectly lost: 0 bytes in 0 blocks
==29077==      possibly lost: 0 bytes in 0 blocks
==29077==    still reachable: 476 bytes in 4 blocks
==29077==         suppressed: 0 bytes in 0 blocks
==29077== 
==29077== For counts of detected and suppressed errors, rerun with: -v
==29077== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

After googling around a bit I figured out that this is not an error in musl but a [lack of a suppression file for musl in valgrind][rich suppression].

This PR adds such a suppression file. Not merging this myself as I am not a valgrind expert but it fixes a false-positive valgrind error I encountered in my setup.

[rich suppression]: https://www.openwall.com/lists/musl/2017/06/15/4