### PR TITLE
testing/watchexec: new aport

### DIFF
--- a/testing/watchexec/APKBUILD
+++ b/testing/watchexec/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Chloe Kudryavtsev <toast@toastin.space>
+# Maintainer: Chloe Kudryavtsev <toast@toastin.space>
+pkgname=watchexec
+pkgver=1.10.2
+pkgrel=0
+pkgdesc='Executes commands in response to file modifications'
+url='https://github.com/watchexec/watchexec'
+arch='x86_64' # limited by rust/cargo
+license='Apache-2.0'
+makedepends='cargo'
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/watchexec/watchexec/archive/$pkgver.tar.gz"
+
+export CARGO_HOME="$srcdir"/cargo
+
+build() {
+	cargo build \
+		--release \
+		--verbose
+}
+
+check() {
+	cargo test --all \
+		--release \
+		--verbose
+}
+
+package() {
+	install -Dm755 target/release/"$pkgname" "$pkgdir"/usr/bin/"$pkgname"
+	install -Dm644 doc/"$pkgname".1 "$pkgdir"/usr/share/man/man1/"$pkgname".1
+}
+sha512sums="6fb3cbf818de8cb3548d7b56958aa9f5a8ba7e6b95ed1afdaf789ac87abd7415cc2ccc1afdbd5898d836b7291d179308c7dde62333ddbf54ca35dd327b9befb3  watchexec-1.10.2.tar.gz"


### PR DESCRIPTION
An inotify-related tool to run commands in response to filesystem changes.