### PR TITLE
main/linux-vanilla: add patch to export now GPL-only fpu functions

### DIFF
--- a/main/linux-vanilla/APKBUILD
+++ b/main/linux-vanilla/APKBUILD
@@ -7,7 +7,7 @@ case $pkgver in
 	*.*.*)	_kernver=${pkgver%.*};;
 	*.*) _kernver=$pkgver;;
 esac
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux vanilla kernel"
 url="http://kernel.org"
 depends="mkinitfs"
@@ -15,8 +15,8 @@ _depends_dev="perl gmp-dev elfutils-dev bash flex bison"
 makedepends="$_depends_dev sed installkernel bc linux-headers linux-firmware openssl-dev"
 options="!strip"
 _config=${config:-config-vanilla.${CARCH}}
-install=
 source="https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/linux-$_kernver.tar.xz
+	export_kernel_fpu_functions.patch
 	config-vanilla.aarch64
 	config-vanilla.armhf
 	config-vanilla.armv7
@@ -101,8 +101,7 @@ oldconfig() {
 		local _config=config-$i.${CARCH}
 		local _builddir="$srcdir"/build-$i.$CARCH
 		mkdir -p "$_builddir"
-		echo "-$pkgrel-$i" > "$_builddir"/localversion-alpine \
-			|| return 1
+		echo "-$pkgrel-$i" > "$_builddir"/localversion-alpine
 
 		cp "$srcdir"/$_config "$_builddir"/.config
 		make -C "$srcdir"/linux-$_kernver \
@@ -148,8 +147,7 @@ _package() {
 	make -j1 modules_install $_install \
 		ARCH="$_carch" \
 		INSTALL_MOD_PATH="$_outdir" \
-		INSTALL_PATH="$_outdir"/boot \
-		|| return 1
+		INSTALL_PATH="$_outdir"/boot
 
 	rm -f "$_outdir"/lib/modules/${_abi_release}/build \
 		"$_outdir"/lib/modules/${_abi_release}/source
@@ -189,8 +187,7 @@ _dev() {
 	# external modules, and create the scripts
 	mkdir -p "$dir"
 	cp "$srcdir"/config-$_flavor.${CARCH} "$dir"/.config
-	echo "-$pkgrel-$_flavor" > "$dir"/localversion-alpine \
-		|| return 1
+	echo "-$pkgrel-$_flavor" > "$dir"/localversion-alpine
 	make -j1 -C "$srcdir"/linux-$_kernver O="$dir" ARCH="$_carch" HOSTCC="$HOSTCC" \
 		silentoldconfig prepare modules_prepare scripts
 
@@ -207,9 +204,9 @@ _dev() {
 		-o -path './scripts/*' -prune -o -type f \
 		\( -name 'Makefile*' -o -name 'Kconfig*' -o -name 'Kbuild*' -o \
 		   -name '*.sh' -o -name '*.pl' -o -name '*.lds' \) \
-		-print | cpio -pdm "$dir" || return 1
+		-print | cpio -pdm "$dir"
 
-	cp -a scripts include "$dir" || return 1
+	cp -a scripts include "$dir"
 	find $(find arch -name include -type d -print) -type f \
 		| cpio -pdm "$dir"
 
@@ -222,6 +219,7 @@ _dev() {
 }
 
 sha512sums="ab67cc746b375a8b135e8b23e35e1d6787930d19b3c26b2679787d62951cbdbc3bb66f8ededeb9b890e5008b2459397f9018f1a6772fdef67780b06a4cb9f6f4  linux-4.19.tar.xz
+a281e45b6145bc4d1341e82aee32d006abf6ec375b444ce6fcae9cc54e811a67de80f4b4c6aa73c969634f7cf1699aadc6fb217e2a27557ca3a324585f792039  export_kernel_fpu_functions.patch
 110cf0fa432b2ac4dd721b5efe3084ac2624db12241f4a947b13b88e77281a92179f628c21ea94c5e3012c7290ca3229cfb5bf54c92ed6fe8e3aa3c39bc5b233  config-vanilla.aarch64
 82391b4be50d36b80a1aab24b1d3783de7ec2badefd281f05684a6e8243c6e48848c6db30ca05c0fc820cb3570430d8e5f31e4dac9a3ba08c35a8f15a67fe462  config-vanilla.armhf
 82391b4be50d36b80a1aab24b1d3783de7ec2badefd281f05684a6e8243c6e48848c6db30ca05c0fc820cb3570430d8e5f31e4dac9a3ba08c35a8f15a67fe462  config-vanilla.armv7

--- a/main/linux-vanilla/export_kernel_fpu_functions.patch
+++ b/main/linux-vanilla/export_kernel_fpu_functions.patch
@@ -1,0 +1,62 @@
+See https://raw.githubusercontent.com/NixOS/nixpkgs/7b77c27caa8617c82df5c5af6b9ce6ae010d7f9a/pkgs/os-specific/linux/kernel/export_kernel_fpu_functions.patch
+
+From 245e0f743d814c9ff2d1c748175e321301eb16cf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Thu, 2 May 2019 05:28:08 +0100
+Subject: [PATCH] x86/fpu: Export __kernel_fpu_{begin,end}()
+
+This partially undo commit:
+
+12209993  x86/fpu: Don't export __kernel_fpu_{begin,end}()
+
+We need this symbol in zfs for AES-NI/AVX support.
+---
+ arch/x86/include/asm/fpu/api.h | 2 ++
+ arch/x86/kernel/fpu/core.c     | 6 ++++--
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/fpu/api.h b/arch/x86/include/asm/fpu/api.h
+index b56d504af6545..7d53388d266ea 100644
+--- a/arch/x86/include/asm/fpu/api.h
++++ b/arch/x86/include/asm/fpu/api.h
+@@ -18,6 +18,8 @@
+  * If you intend to use the FPU in softirq you need to check first with
+  * irq_fpu_usable() if it is possible.
+  */
++extern void __kernel_fpu_begin(void);
++extern void __kernel_fpu_end(void);
+ extern void kernel_fpu_begin(void);
+ extern void kernel_fpu_end(void);
+ extern bool irq_fpu_usable(void);
+diff --git a/arch/x86/kernel/fpu/core.c b/arch/x86/kernel/fpu/core.c
+index 2e5003fef51a9..2ea85b32421a0 100644
+--- a/arch/x86/kernel/fpu/core.c
++++ b/arch/x86/kernel/fpu/core.c
+@@ -93,7 +93,7 @@ bool irq_fpu_usable(void)
+ }
+ EXPORT_SYMBOL(irq_fpu_usable);
+ 
+-static void __kernel_fpu_begin(void)
++void __kernel_fpu_begin(void)
+ {
+ 	struct fpu *fpu = &current->thread.fpu;
+ 
+@@ -111,8 +111,9 @@ static void __kernel_fpu_begin(void)
+ 		__cpu_invalidate_fpregs_state();
+ 	}
+ }
++EXPORT_SYMBOL(__kernel_fpu_begin);
+ 
+-static void __kernel_fpu_end(void)
++void __kernel_fpu_end(void)
+ {
+ 	struct fpu *fpu = &current->thread.fpu;
+ 
+@@ -121,6 +122,7 @@ static void __kernel_fpu_end(void)
+ 
+ 	kernel_fpu_enable();
+ }
++EXPORT_SYMBOL(__kernel_fpu_end);
+ 
+ void kernel_fpu_begin(void)
+ {

--- a/main/zfs-vanilla/APKBUILD
+++ b/main/zfs-vanilla/APKBUILD
@@ -9,7 +9,7 @@ _rel=0
 _flavor=${FLAVOR:-vanilla}
 _kpkg=linux-$_flavor
 _kver=4.19.50
-_krel=0
+_krel=1
 
 _kpkgver="$_kver-r$_krel"
 _kabi="$_kver-$_krel-$_flavor"

--- a/main/zfs/APKBUILD
+++ b/main/zfs/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=zfs
 pkgver=0.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc="ZFS for Linux"
 url="http://zfsonlinux.org"
 arch="all !armhf !armv7"
@@ -38,8 +38,8 @@ build() {
 }
 
 package() {
-        cd "$builddir"
-        make DESTDIR="$pkgdir" install
+	cd "$builddir"
+	make DESTDIR="$pkgdir" install
 	rm -rf "$pkgdir"/usr/share/initramfs-tools
 	mv "$pkgdir"/usr/share/pkgconfig "$pkgdir"/usr/lib/
 }


### PR DESCRIPTION
This significantly speeds up ZFS' due to allowing it to use SIMD. Other distros
such as NixOS use the same patch.

Also do some minor cleanups while we're at it.