### PR TITLE
testing/lxd: defined __NR_mknod if missing for aarch64

### DIFF
--- a/testing/lxd/APKBUILD
+++ b/testing/lxd/APKBUILD
@@ -50,6 +50,7 @@ source="https://linuxcontainers.org/downloads/$pkgname/$pkgname-$pkgver.tar.gz
 	$pkgname.confd
 	$pkgname.initd
 	lxd-dont-go-get.patch
+	__NR_mknod.patch
 	"
 
 # avoid conflict with system libsqlite3.so.0 by adding a soname prefix.
@@ -157,4 +158,5 @@ libs() {
 sha512sums="3d2d4e61298fc9fde49defad776a398fcccf7639485e810173c9c7f7d939c354a9ad8112a4a631b0850f6eb54435012d289236ff61839416caf95434eb23c8ff  lxd-3.14.tar.gz
 bc32c71f2ce10f508433e1e4651c08c18e8a17e9419a7ce391c0f127fc7cf378c665178926b35eae8813e290d9c5eab3ceb605679fd32efdf2cf98a57cee4127  lxd.confd
 94de0c0d5ab63463a929a4151359950b1117d0ada5ccf0944311cc70c6b6d4c437ccb4158734ab35db67bfb4abc437074c3f3515be4531f63adc74da21fefb5b  lxd.initd
-a77a74950110c94727956457843cd3f64c0db901fb05b95ab0edaa966f7fe76a993d86c8a51d14724a11846a69261199594f683dfefa1db633f4ca35c7f23607  lxd-dont-go-get.patch"
+a77a74950110c94727956457843cd3f64c0db901fb05b95ab0edaa966f7fe76a993d86c8a51d14724a11846a69261199594f683dfefa1db633f4ca35c7f23607  lxd-dont-go-get.patch
+a5ee2e8747cdfcb2222b594a579b686f10ce59a383299eab8048033d29ea112a0cf94aeea57ec442da06b73011fe5a51478c07e94dfc39fac45ebc8f5ed74a30  __NR_mknod.patch"

--- a/testing/lxd/__NR_mknod.patch
+++ b/testing/lxd/__NR_mknod.patch
@@ -1,0 +1,64 @@
+From a181ed43172755cf9fcd3e1068f914c373e7091b Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian.brauner@ubuntu.com>
+Date: Fri, 14 Jun 2019 01:05:52 +0200
+Subject: [PATCH] seccomp: define __NR_mknod if missing
+
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+---
+ lxd/seccomp.go | 42 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 42 insertions(+)
+
+diff --git a/lxd/seccomp.go b/lxd/seccomp.go
+index 0afad7cacc..071859d6a2 100644
+--- a/lxd/seccomp.go
++++ b/lxd/seccomp.go
+@@ -109,6 +109,48 @@ static int device_allowed(dev_t dev, mode_t mode)
+ 	return -EPERM;
+ }
+ 
++#ifndef __NR_mknod
++	#ifdef __x86_64__
++		#define __NR_mknod 133
++	#elif defined __arm__
++		#define __NR_mknod 14
++	#elif defined __aarch64__
++		#define __NR_mknod 14
++	#elif defined __s390__
++		#define __NR_mknod 14
++	#elif defined __s390x__
++		#define __NR_mknod 14
++	#elif __mips__ && _MIPSEB && _MIPS_SIM ==_ABIO32
++		#define __NR_mknod 14
++	#elif __mips__ && _MIPSEL && _MIPS_SIM==_ABIO32
++		#define __NR_mknod 14
++	#elif __mips__ && _MIPSEB && _MIPS_SIM==_ABI64
++		#define __NR_mknod 131
++	#elif __mips__ && _MIPSEL && _MIPS_SIM==_ABI64
++		#define __NR_mknod 131
++	#elif __mips__ && _MIPSEB && _MIPS_SIM==_ABIN32
++		#define __NR_mknod 131
++	#elif __mips__ && _MIPSEL && _MIPS_SIM==_ABIN32
++		#define __NR_mknod 131
++	#elif defined __i386__
++		#define __NR_mknod 14
++	#elif defined __alpha__
++		#define __NR_mknod 14
++	#elif defined __ia64__
++		#define __NR_mknod 13
++	#elif defined __m68k__
++		#define __NR_mknod 14
++	#elif defined __sparc__
++		#define __NR_mknod 14
++	#elif defined __powerpc__
++		#define __NR_mknod 14
++	#elif defined __sh__
++		#define __NR_mknod 14
++	#else
++		#warning "__NR_mknod unknown for your architecture"
++	#endif
++#endif
++
+ static int seccomp_notify_mknod_set_response(int fd_mem, struct seccomp_notify_proxy_msg *msg,
+ 					     char *buf, size_t size,
+ 					     mode_t *mode, dev_t *dev,
+


### PR DESCRIPTION
@fcolista