### PR TITLE
zimtools upgrade

### DIFF
--- a/testing/libzim/APKBUILD
+++ b/testing/libzim/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=libzim
-pkgver=4.0.7
+pkgver=5.0.0
 pkgrel=2
 pkgdesc="Reference implementation of the ZIM file format"
 url="https://openzim.org/"
@@ -40,8 +40,7 @@ check() {
 package() {
 	DESTDIR="$pkgdir" ninja -C output install
 
-	install -Dm 644 -t "$pkgdir/usr/share/licenses/$pkgname/" COPYING
 	install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
 }
 
-sha512sums="5fbb7b112acccefab1fc325258a6353285a7f5e1e002d90ca851e3caf7805f503c6a87e31b7d1131ea3e1564bc02c4a81e196a0f0ab7fd8f708ba650b50f1447  libzim-4.0.7.tar.gz"
+sha512sums="b1d5bee583364dcd7967e3b826afb08bea25a11512b7a522cb74cde25ae304d4b7f65354ec2160599d145c5b67ba26109e281482021ba1d8d88a1041c0c785d9  libzim-5.0.0.tar.gz"

--- a/testing/zim-tools/APKBUILD
+++ b/testing/zim-tools/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=zim-tools
-pkgver=1.0.1
+pkgver=1.0.2
 pkgrel=0
 pkgdesc="Various ZIM command line tools"
 url="https://github.com/openzim/zim-tools"
@@ -28,8 +28,7 @@ build() {
 package() {
 	DESTDIR="$pkgdir" ninja -C build install
 
-	install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 	install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md" 
 }
 
-sha512sums="0a4194d25740da3bf6b455e29a8d1c498ac29c7a90060790c4221c6024de90f87c6de11fbf6bee5c14e7d1b80340241d185bd231adac3a761c77568c038dfc2f  zim-tools-1.0.1.tar.gz"
+sha512sums="5bf12fed0d0768e769b2ede4fa46b6ad50c93889e68c04ba51c49bdced3daba8798fe0730a6d432b9e29fae587958e1fcc3b5126e9ddfdc50303df887ce34ba8  zim-tools-1.0.2.tar.gz"

--- a/testing/zimwriterfs/APKBUILD
+++ b/testing/zimwriterfs/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=zimwriterfs
-pkgver=1.3.1
+pkgver=1.3.3
 pkgrel=0
 pkgdesc="Console tool to create ZIM files"
 url="https://openzim.org/"
@@ -30,8 +30,7 @@ check() {
 package() {
 	DESTDIR="$pkgdir" ninja -C build install
 
-	install -Dm 644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
 	install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname" README.md
 }
 
-sha512sums="477793dc82de17352f9466a2e65f0bf7dc280653c2189841188a93db5eada12d39f5a68f6290f79e08366f8ac00daaf7f6b8ddcbbc98ae3de4f0e3a91f515610  zimwriterfs-1.3.1.tar.gz"
+sha512sums="db13eaf5e278c9ca1f7f31eb87f1cbb79d8f7d36824b9221699a5dd2cb97dec690189c76b967a97c32e2097240b34c133b7217f05c544361086291037c2c9dd0  zimwriterfs-1.3.3.tar.gz"


### PR DESCRIPTION
Upgrades for 3 packages, `zim-tools` and `zimwriterfs` depend on new `libzim`.

testing/libzim: upgrade to 5.0.0
- License remove

testing/zimwriterfs: upgrade to 1.3.3
- License remove

testing/zim-tools: upgrade to 1.0.2
- License remove