### PR TITLE
community/virtualbox-guest-additions: Fix mount -t vboxsf

### DIFF
--- a/community/virtualbox-guest-additions/APKBUILD
+++ b/community/virtualbox-guest-additions/APKBUILD
@@ -3,7 +3,7 @@
 
 pkgname=virtualbox-guest-additions
 pkgver=6.0.8
-pkgrel=0
+pkgrel=1
 pkgdesc="VirtualBox Addtions userland components"
 arch='x86 x86_64'
 url='https://virtualbox.org/'
@@ -50,7 +50,8 @@ build() {
 package() {
 	install -v -Dm755 "$builddir"/out/linux.*/release/bin/additions/VBoxService "$pkgdir/usr/sbin/VBoxService"
 	install -v -Dm755 "$builddir"/out/linux.*/release/bin/additions/VBoxControl "$pkgdir/usr/bin/VBoxControl"
-	install -v -Dm755 "$builddir"/out/linux.*/release/bin/additions/mount.vboxsf "$pkgdir/usr/sbin/mount.vboxsf"
+	# mount.vboxsf needs to be in /sbin for "mount -t vboxsf..." to work.
+	install -v -Dm755 "$builddir"/out/linux.*/release/bin/additions/mount.vboxsf "$pkgdir/sbin/mount.vboxsf"
 	install -v -Dm755 "$srcdir"/$pkgname.initd "$pkgdir"/etc/init.d/$pkgname
 }
 


### PR DESCRIPTION
* Fixing the issue when trying to manually mount a virtualbox shared
  folder and getting message:
  [43349.351484] vboxsf: No mount data. Is mount.vboxsf installed
  (typically in /sbin)?