### PR TITLE
main/llvm8: use default LLVM_TARGETS_TO_BUILD

### DIFF
--- a/main/llvm8/APKBUILD
+++ b/main/llvm8/APKBUILD
@@ -8,7 +8,7 @@ _pkgname=llvm
 pkgver=8.0.0
 _majorver=${pkgver%${pkgver##[0-9]}}
 pkgname=$_pkgname$_majorver
-pkgrel=0
+pkgrel=1
 pkgdesc="Low Level Virtual Machine compiler system, version $_majorver"
 arch="all"
 url="https://llvm.org/"
@@ -100,7 +100,6 @@ build() {
 		-DLLVM_HOST_TRIPLE="$CHOST" \
 		-DLLVM_INCLUDE_EXAMPLES=OFF \
 		-DLLVM_LINK_LLVM_DYLIB=ON \
-		-DLLVM_TARGETS_TO_BUILD='X86;ARM;AArch64;PowerPC;SystemZ;AMDGPU;NVPTX;Mips;BPF' \
 		-DLLVM_APPEND_VC_REV=OFF \
 		"$builddir"
 


### PR DESCRIPTION
This enables a few additional targets, such as the new WebAssembly target.