### PR TITLE
testing/postgis: upgrade to 2.5.2

### DIFF
--- a/testing/postgis/APKBUILD
+++ b/testing/postgis/APKBUILD
@@ -6,7 +6,8 @@ pkgrel=0
 pkgdesc="PostGIS is a spatial database extender for PostgreSQL object-relational database."
 url="https://postgis.net/"
 # geos test fails on other archs
-arch="x86 x86_64" # fails on x86*
+# we lack a proj4 6 package for x86
+arch="x86_64" # fails on x86*
 license="GPL-2.0-or-later"
 depends="postgresql perl"
 makedepends="postgresql-dev geos-dev gdal-dev libxml2-dev proj4-dev perl-dev

--- a/testing/postgis/APKBUILD
+++ b/testing/postgis/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Bjoern Schilberg <bjoern@intevation.de>
 # Maintainer: Bjoern Schilberg <bjoern@intevation.de>
 pkgname=postgis
-pkgver=2.5.1
-pkgrel=1
+pkgver=2.5.2
+pkgrel=0
 pkgdesc="PostGIS is a spatial database extender for PostgreSQL object-relational database."
 url="https://postgis.net/"
 # geos test fails on other archs
@@ -35,4 +35,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="c6c9c8c5befd945614e92d1062df1d753ca8b7fd69b70226065c2dac77a59783b14ece4da994187079b683ee090ba5a79389ba679f22fce8c20a5afc2c8dfca0  postgis-2.5.1.tar.gz"
+sha512sums="b10781f0b74bad8162c33eb111a6090fba184b45fe5874d22cd3a5b0acfb057f3407c073bc44c9d4cd20ed8c2cb1fbb34480b0cf331340bc8b52580d4eccb819  postgis-2.5.2.tar.gz"


### PR DESCRIPTION
PostGIS has to be bumped to 2.5.2 to support Proj 6.