### PR TITLE
testing/minio: upgrade to 0.20190615

### DIFF
--- a/testing/minio/APKBUILD
+++ b/testing/minio/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
 # Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=minio
-_pkgver='RELEASE.2019-06-13T01-41-13Z'
+_pkgver='RELEASE.2019-06-15T23-07-18Z'
 pkgver=${_pkgver#*.}
 pkgver=${pkgver%T*}
 pkgver=0.${pkgver//-}
@@ -58,4 +58,4 @@ cleanup_srcdir() {
 
 sha512sums="1e48f298a28e400d378a08816b617a134357f52dd66bbf9ec5bc8467cf7202a917d9a162a95f40617feb191b13834fd92ab920b04b436d2df55a2cd4adc4b062  minio.initd
 ed9790fbadfb38e4d660eb1befd87e803d70dec04d936e8cd26def4a9c21240bb7cae8750ae3395aa4761e6738b9e346c86ba57761cfde30efe46d2cb459a7e4  minio.confd
-bba69ccfc6018affa26884f0d6f864ee069b3dddbf8cf92d1e4080e78493a4e2528feb5580e4c9de156432b59741a7936d1f6e2d456c913a5377238ab7c63a91  RELEASE.2019-06-13T01-41-13Z.tar.gz"
+88b4ec5232e44f7f574a8576b74d878eaac2024679491c7fe44865f12b5b1b5a005f629bda6ebc1750c0700676ad077583628f5a5e83d511c93da4dacf31fa91  RELEASE.2019-06-15T23-07-18Z.tar.gz"


### PR DESCRIPTION
This is an urgent security update.