### PR TITLE
community/containerd: update to 1.2.7

### DIFF
--- a/community/containerd/APKBUILD
+++ b/community/containerd/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=containerd
 
 # NOTE: containerd's Makefile tries to get REVISION from git, but we're building from a tarball.
-_commit=894b81a4b802e4eb2a91d1ce216b8817763c29fb
-pkgver=1.2.6
+_commit=85f6aa58b8a3170aec9824568f7a31832878b603
+pkgver=1.2.7
 pkgrel=0
 pkgdesc="An open and reliable container runtime"
 url="https://containerd.io"
@@ -46,4 +46,4 @@ package() {
 	install -Dm644 "$builddir"/man/*.5 "$pkgdir"/usr/share/man/man5/
 }
 
-sha512sums="287b064cb3e57369e34f6debb434526d6bd4857e337e489c56e4ca484c66e161bbda911b4fc29cb49808a756f6ec7af5629e46d693644500e3bf2d9e45e87e73  containerd-1.2.6.tar.gz"
+sha512sums="b96ca236d28933c1bf309fc7204af7d2c356e19af394d5c2274a178c8f15298faf6ca9bb8e7d04acb7c3c9c41035446643a8df0103017f7ed0320bfc37cb8ca9  containerd-1.2.7.tar.gz"


### PR DESCRIPTION
See https://github.com/containerd/containerd/releases/tag/v1.2.7

Contains several important bug fixes for goroutine and file descriptor leakage in containerd and containerd shims.