### PR TITLE
main/syslinux: upgrade to 6.04-pre3

### DIFF
--- a/main/syslinux/APKBUILD
+++ b/main/syslinux/APKBUILD
@@ -1,12 +1,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=syslinux
-pkgver=6.04_pre1
-pkgrel=3
+pkgver=6.04_pre3
+pkgrel=0
 _ver=${pkgver/_/-}
 pkgdesc="Boot loader for the Linux operating system"
 url="http://syslinux.org"
 arch="x86 x86_64"
-license="GPL"
+license="GPL-2.0-or-later"
 makedepends="linux-headers nasm perl util-linux-dev gnu-efi-dev"
 depends="mtools blkid mkinitfs"
 triggers="syslinux.trigger=/boot"
@@ -14,7 +14,7 @@ install="syslinux.post-upgrade"
 options="textrels"
 ldpath="/usr/share/syslinux"
 
-source="https://www.kernel.org/pub/linux/utils/boot/syslinux/Testing/${pkgver%_pre*}/syslinux-$_ver.tar.xz
+source="https://www.zytor.com/pub/syslinux/Testing/${pkgver%_pre*}/syslinux-${_ver}.tar.xz
 	update-extlinux.conf
 	update-extlinux
 	0018-prevent-pow-optimization.patch
@@ -28,26 +28,15 @@ x86_64)	_loaderarch=efi64;;
 esac
 
 builddir="$srcdir"/$pkgname-$_ver
-prepare() {
-	cd "$builddir"
-	for i in $source; do
-		i=${i%%::*}
-		case "$i" in
-		*.patch) msg $i; patch -p1 -i "$srcdir"/$i || return 1;;
-		esac
-	done
-}
 
 build() {
-	cd "$builddir"
 	unset LDFLAGS
-	make $_loaderarch installer || return 1
+	make $_loaderarch installer
 }
 
 package() {
-	cd "$builddir"
 	make -j1 INSTALLROOT="$pkgdir" MANDIR=/usr/share/man \
-		bios $_loaderarch install || return 1
+		bios $_loaderarch install
 
 	mkdir -p "$pkgdir"/etc/update-extlinux.d
 	cp "$srcdir"/update-extlinux.conf "$pkgdir"/etc/
@@ -56,7 +45,7 @@ package() {
 	chmod 755 "$pkgdir"/sbin/update-extlinux
 }
 
-sha512sums="7927dd39be8e2dcf4138a6fea33def67d19d938379d694f15b48fdd2f5924c028b7a9e7bd71d0c7c6630c203e9e2a54296628e530632ad5e6f55b1ebefe8fc98  syslinux-6.04-pre1.tar.xz
+sha512sums="42283f72390ea4e95125cc11417bc0c2384851b208e8e4c5efc78f0666684ac2fd30266e1f21a01a5c4482b4ebbfbb2422cfddd2b6e4caa32cb4d2079264cd02  syslinux-6.04-pre3.tar.xz
 c3ff809f9cd60aa8a837d9508e6fcd08204b03cd8a9df86ab42fc6a8fe68784416b359b46378fb0a8f4163bbcbe444957e0e5751c30ff4631d4677eaa94874f4  update-extlinux.conf
 bfeb911507c079c8b01027a7823e562d81100b1fcd0786c707ad33c5ce18fa0eb6d6db34bc7b6cbbc419248188970cebe8286345f4aa3662d16644c51f50b98c  update-extlinux
 92fa48133ef702092d7acafae0e0e20f9355cd2b5fe199b96fcccba5a1e688c360de4d069391815255f5493228ad03998d20b99748323396d20d12a1f27c60cd  0018-prevent-pow-optimization.patch"


### PR DESCRIPTION
The change to zytor.com is because kernel.org didn't get the new release tarball.
But they are all official repositories. Confirmation from syslinux website: https://wiki.syslinux.org/wiki/index.php?title=Development#Browse_the_SYSLINUX_source_code

"These repositories are official, but they are sometimes not fully synchronized during development periods between stable releases."

I'd also like to thank the Alpine developers for keeping syslinux around and rocking for x86_64 and x86.
I understand some architectures are doomed to use other (bigger, more complex) bootloaders, but it's great we can keep using syslinux where possible.

Regards,
Liq

