### PR TITLE
testing/py3-avro: Adding check()

### DIFF
--- a/testing/py3-avro/APKBUILD
+++ b/testing/py3-avro/APKBUILD
@@ -1,24 +1,28 @@
 # Maintainer: Gennady Feldman <gena01@gmail.com>
 # Contributor: Gennady Feldman <gena01@gmail.com>
 pkgname=py3-avro
-_pkgname=avro-python3
+_pkgname=avro
 pkgver=1.9.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Avro is a serialization and RPC framework."
 url="https://avro.apache.org/"
 arch="noarch"
 license="Apache-2.0"
 depends="py3-six"
-makedepends="py3-setuptools python3-dev"
-source="$pkgname-$pkgver.tar.gz::http://apache.mirrors.tds.net/avro/stable/py3/$_pkgname-$pkgver.tar.gz"
-builddir="$srcdir/$_pkgname-$pkgver"
+makedepends="py3-setuptools"
+source="$pkgname-$pkgver.tar.gz::http://github.com/apache/$_pkgname/archive/release-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-release-$pkgver/lang/py3"
 
 build() {
 	python3 setup.py build
+}
+
+check() {
+	python3 setup.py test
 }
 
 package() {
 	python3 setup.py install --prefix=/usr --root="$pkgdir"
 }
 
-sha512sums="46719cdcc672d842eb696a69a5aff67afe507b66ca145b6fd8f4fc0300ec3b9b165e06a168224607d96841d339c8222e211bf794dd05ce90f406dbccbad04046  py3-avro-1.9.0.tar.gz"
+sha512sums="a26b926d48bb8f669a9be5bd526417b0620f2173403eea46e88b68ba66e5cf7483fd3799ef150ccb13a23a231decb3497151fb1aebaa4d673d0705e548f8b9db  py3-avro-1.9.0.tar.gz"


### PR DESCRIPTION
* Fixing type of package we download (and download URL).
* Download the full avro package (w/ tests)
* Add check() to run python3 setup.py test
NOTE: Tests use python 3 unittest (not pytest)