### PR TITLE
testing/py-pandas: Remove double package() call

### DIFF
--- a/testing/py-pandas/APKBUILD
+++ b/testing/py-pandas/APKBUILD
@@ -22,17 +22,6 @@ build() {
 
 package() {
 	mkdir -p "$pkgdir"
-
-	local python; for python in python2 python3; do
-		$python setup.py install --prefix=/usr --root="$pkgdir"
-	done
-
-	install -D -m 644 LICENSE \
-		"$pkgdir"/usr/share/licenses/$pkgname/LICENSE
-}
-
-package() {
-	mkdir -p "$pkgdir"
 }
 
 _py() {


### PR DESCRIPTION
💁 Removes the duplicated function definition in the `APKBUILD` file.