### PR TITLE
main/imagemagick: security upgrade to 7.0.8-53

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -2,6 +2,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
+_pkgname=ImageMagick
 pkgver=7.0.8.49
 pkgrel=2
 _pkgver=${pkgver%.*}-${pkgver##*.}
@@ -17,9 +18,9 @@ makedepends="zlib-dev libpng-dev libjpeg-turbo-dev freetype-dev fontconfig-dev
 	libheif-dev"
 checkdepends="freetype fontconfig ghostscript ghostscript-fonts lcms2 graphviz"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-c++:_cxx $pkgname-libs $pkgname-perlmagick:_perlmagick $pkgname-perlmagick-doc:_perlmagick_doc"
-source="https://www.imagemagick.org/download/releases/ImageMagick-$_pkgver.tar.xz
+source="$_pkgname-$_pkgver.tar.gz::https://github.com/ImageMagick/ImageMagick/archive/$_pkgver.tar.gz
 	disable-avaraging-tests.patch"
-builddir="$srcdir/ImageMagick-${_pkgver}"
+builddir="$srcdir/$_pkgname-$_pkgver"
 
 # secfixes:
 #   7.0.8.44-r0:
@@ -104,5 +105,5 @@ _perlmagick_doc() {
 	make -j1 DESTDIR="$subpkgdir" doc_vendor_install
 }
 
-sha512sums="8dd4a45f4d95d949bcd797f44d1602a3767386ee7d73888fb8a1ee6d4d8be7c4881a88262e7261a253da6f4b3c8ac9442d5eacb44e267e2d25e11bda10b12526  ImageMagick-7.0.8-49.tar.xz
+sha512sums="5deed9084cd28239733b54cd86a8ea81fac67847cef8b155bd41208f1a8fa4928551edcea2024b20d3f326be3f6204163ec0168e09ee5df907730d6212e0ca48  ImageMagick-7.0.8-49.tar.gz
 58afb2da075a6208b6a990ff297b3a827d260687c3355198a8b4d987e1596c0b0cd78aff6f0be0e1896e537fbe44a3d467473183f5f149664ea6e6fb3d3291a9  disable-avaraging-tests.patch"

--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -3,8 +3,8 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
 _pkgname=ImageMagick
-pkgver=7.0.8.49
-pkgrel=2
+pkgver=7.0.8.53
+pkgrel=0
 _pkgver=${pkgver%.*}-${pkgver##*.}
 _abiver=7
 pkgdesc="Collection of tools and libraries for many image formats"
@@ -105,5 +105,5 @@ _perlmagick_doc() {
 	make -j1 DESTDIR="$subpkgdir" doc_vendor_install
 }
 
-sha512sums="5deed9084cd28239733b54cd86a8ea81fac67847cef8b155bd41208f1a8fa4928551edcea2024b20d3f326be3f6204163ec0168e09ee5df907730d6212e0ca48  ImageMagick-7.0.8-49.tar.gz
+sha512sums="f96de743266cefdb48e14e8c18cd36d629641894b056637e2d17bbf8cd0626c81b3c762db0893c919a3caaa60c6b34ab777f40d19c8f75b7604eb2975fdd56be  ImageMagick-7.0.8-53.tar.gz
 58afb2da075a6208b6a990ff297b3a827d260687c3355198a8b4d987e1596c0b0cd78aff6f0be0e1896e537fbe44a3d467473183f5f149664ea6e6fb3d3291a9  disable-avaraging-tests.patch"


### PR DESCRIPTION
Remaining change from #7990:
Source url changed, because older releases are no longer available on imagemagick.org

cc @tcely