### PR TITLE
testing/plasma: new aports

### DIFF
--- a/testing/breeze/APKBUILD
+++ b/testing/breeze/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=breeze
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="Artwork, styles and assets for the Breeze visual style for the Plasma Desktop"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="LGPL-2.1"
+depends_dev="kdecoration-dev kpackage-dev ki18n-dev kguiaddons-dev kconfigwidgets-dev kwindowsystem-dev"
+makedepends="$depends_dev extra-cmake-modules"
+source="$pkgname-$pkgver.tar.xz::https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="8b95456c22335d227dffd6600c83703cb4bc71c80a9fb6737e9a3798a1cd29f0d914ab8fd95e1510b1bef2aecc74c47bb86e0d7afd1e209bb914a1e51e05ea79  breeze-5.16.1.tar.xz"

--- a/testing/kactivitymanagerd/APKBUILD
+++ b/testing/kactivitymanagerd/APKBUILD
@@ -1,0 +1,39 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kactivitymanagerd
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="System service to manage user's activities and track the usage patterns"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="GPL-2.0-only OR GPL-3.0-only"
+depends_dev="qt5-qtbase-dev kdbusaddons-dev ki18n-dev kconfig-dev kcoreaddons-dev kwindowsystem-dev kglobalaccel-dev kxmlgui-dev kio-dev"
+makedepends="$depends_dev extra-cmake-modules boost-dev"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-lang"
+
+prepare() {
+	default_prepare
+
+	mkdir "$builddir"/build
+}
+
+build() {
+	cd "$builddir"/build
+	cmake "$builddir" \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	cd "$builddir"/build
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	cd "$builddir"/build
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="01502251c9796769af95cad953c5c748c58f1890fbbd274638966f7a632ad6ee95e83adaa01be13e0c3d4db44cdc90b913b3a36cad2e5e798b624cf18ce09736  kactivitymanagerd-5.16.1.tar.xz"

--- a/testing/kde-cli-tools/APKBUILD
+++ b/testing/kde-cli-tools/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kde-cli-tools
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="Tools based on KDE Frameworks 5 to better interact with the system"
+arch="all"
+url="https://cgit.kde.org/kde-cli-tools"
+license="(GPL-2.0-only OR GPL-3.0-only) AND GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-only"
+depends_dev="qt5-qtbase-dev qt5-qtsvg-dev qt5-qtx11extras-dev kconfig-dev kiconthemes-dev kinit-dev ki18n-dev kcmutils-dev kio-dev kservice-dev kwindowsystem-dev kactivities-dev kdeclarative-dev kdesu-dev plasma-workspace-dev"
+makedepends="$depends_dev extra-cmake-modules kdoctools-dev"
+checkdepends="xvfb-run"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-doc $pkgname-lang"
+options="!check" # Broken
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE xvfb-run ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="7c96a75afc482e028d890ebddf1588c05e4d0ba57ca5ca4b424a2414fee2bb26bc2818c21b2cc1d91a0178046eb7fadbc3c48bf59ce167e9ed9887081a1baaf6  kde-cli-tools-5.16.1.tar.xz"

--- a/testing/kdecoration/APKBUILD
+++ b/testing/kdecoration/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kdecoration
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="Plugin based library to create window decorations"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+depends_dev="qt5-qtbase-dev ki18n-dev"
+makedepends="$depends_dev extra-cmake-modules"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-lang"
+options="!check" # Fails due to requiring running X11
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="510c6c81186199c0abcf24514454d45f7a01048dacdf7f48b9e52533a0d7a76f983d4dd6c8593ae74c8f4b6819b35cadc11a0682844aab9233cc60821f74491a  kdecoration-5.16.1.tar.xz"

--- a/testing/kscreen/APKBUILD
+++ b/testing/kscreen/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kscreen
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="KDE's screen management software"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="GPL-2.0-or-later AND LGPL-2.1-or-later"
+depends="hicolor-icon-theme"
+depends_dev="qt5-qtbase-dev kdbusaddons-dev kconfig-dev kconfigwidgets-dev ki18n-dev kxmlgui-dev kglobalaccel-dev kwidgetsaddons-dev kdeclarative-dev kiconthemes-dev plasma-framework-dev libkscreen-dev"
+makedepends="$depends_dev extra-cmake-modules"
+checkdepends="xvfb-run"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE xvfb-run ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="f65a0fb8f34a125e1dec87f236766b033aaa972b5df052ab487029a31a61233db57e48d639911b44d5e2575626da1fe856cfd21cf3424014574fcc74995f3728  kscreen-5.16.1.tar.xz"

--- a/testing/kscreenlocker/APKBUILD
+++ b/testing/kscreenlocker/APKBUILD
@@ -1,0 +1,41 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kscreenlocker
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="Library and components for secure lock screen architecture"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="GPL-2.0-or-later AND (GPL-2.0-only OR GPL-3.0-only)"
+depends="linux-pam elogind"
+depends_dev="qt5-qtbase-dev qt5-qtx11extras-dev kcrash-dev kdeclarative-dev kglobalaccel-dev ki18n-dev kidletime-dev kcmutils-dev knotifications-dev solid-dev ktextwidgets-dev kwindowsystem-dev kxmlgui-dev xcb-util-keysyms-dev kwayland-dev linux-pam-dev libseccomp-dev elogind-dev"
+makedepends="$depends_dev extra-cmake-modules"
+checkdepends="xvfb-run"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz
+	kde.pam
+	kde-np.pam"
+subpackages="$pkgname-dev $pkgname-lang"
+options="!check" # Requires running loginctl
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE xvfb-run ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+
+	install -D -m644 "$srcdir"/kde.pam "$pkgdir"/etc/pam.d/kde
+	install -m644 "$srcdir"/kde-np.pam "$pkgdir"/etc/pam.d/kde-np
+}
+
+sha512sums="5aa7d4ef2cfcc5d95f7d83023df1275ebe2d52465182f8c5743af2067e98edb662d384081b24d8e2905157d8aebcda4a907bda95f1668306319f443a100f1d15  kscreenlocker-5.16.1.tar.xz
+56e87d02d75c4a8cc4ed183faed416fb4972e7f223b8759959c0f5da32e11e657907a1df279d62a44a6a174f5aca8b2ac66a5f3325c5deb92011bcf71eed74c3  kde.pam
+565265485dd7466b77966d75a56766216b8bcc187c95a997e531e9481cf50ddbe576071eb0e334421202bcab19aa6de6b93e042447ca4797a24bf97e1d053ffd  kde-np.pam"

--- a/testing/kscreenlocker/kde-np.pam
+++ b/testing/kscreenlocker/kde-np.pam
@@ -1,0 +1,10 @@
+#%PAM-1.0
+
+auth       required     pam_nologin.so
+auth	   required     pam_permit.so
+
+account    include      base-account
+
+password   include      base-password
+
+session    include      base-session-noninteractive

--- a/testing/kscreenlocker/kde.pam
+++ b/testing/kscreenlocker/kde.pam
@@ -1,0 +1,11 @@
+#%PAM-1.0
+
+auth       required     pam_nologin.so
+
+auth       include      base-auth
+
+account    include      base-account
+
+password   include      base-password
+
+session    include      base-session-noninteractive

--- a/testing/ksysguard/APKBUILD
+++ b/testing/ksysguard/APKBUILD
@@ -1,0 +1,29 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=ksysguard
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="Track and control the processes running in your system"
+arch="all"
+url="https://userbase.kde.org/KSysGuard"
+license="GPL-2.0-only"
+makedepends="extra-cmake-modules kconfig-dev kcoreaddons-dev kdbusaddons-dev kdoctools-dev ki18n-dev kiconthemes-dev kinit-dev kitemviews-dev kio-dev knewstuff-dev knotifications-dev kwindowsystem-dev libksysguard-dev"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="eced94d925ae2ceea44e751cf74d4cd7d26fde553dc04e000a214a8c63c0e09be39261304ef0d5ba1bf2ef4fcc78ed4ab08ef386294063e425bc6873f697a4d6  ksysguard-5.16.1.tar.xz"

--- a/testing/kwayland-integration/APKBUILD
+++ b/testing/kwayland-integration/APKBUILD
@@ -1,0 +1,27 @@
+# Contributor: Bhushan Shah <bshah@kde.org>
+# Maintainer: Bhushan Shah <bshah@kde.org>
+pkgname=kwayland-integration
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="KWayland integration"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+arch="all"
+license="LGPL-2.1-only OR LGPL-3.0-only"
+depends="kwayland kglobalaccel kidletime"
+makedepends="cmake extra-cmake-modules qt5-qtbase-dev kwayland-dev kwindowsystem-dev kidletime-dev"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+options="!check" # Broken
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="cde816e04944cd262ab6b154672b54c0d736b366b47666930d3c83c9a6ef47067dbf0407cbc84a3a51cc9a2fe31f338bfe1f2d231e94ecbacd2f2403b9a5dea9  kwayland-integration-5.16.1.tar.xz"

--- a/testing/kwin/APKBUILD
+++ b/testing/kwin/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=kwin
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="An easy to use, but flexible, composited Window Manager"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="GPL-2.0-or-later AND (GPL-2.0-only OR GPL-3.0-only) AND LGPL-2.1-only"
+depends="qt5-qtwayland qt5-qtmultimedia kirigami2 xorg-server-xwayland"
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev qt5-qtscript-dev qt5-qtsensors-dev qt5-qtx11extras-dev kconfig-dev kconfigwidgets-dev kcoreaddons-dev kcrash-dev kglobalaccel-dev ki18n-dev kinit-dev knotifications-dev kpackage-dev plasma-framework-dev kwidgetsaddons-dev kwindowsystem-dev kiconthemes-dev kidletime-dev kwayland-dev kcompletion-dev kdeclarative-dev kcmutils-dev kio-dev ktextwidgets-dev knewstuff-dev kservice-dev kxmlgui-dev kactivities-dev kdecoration-dev kscreenlocker-dev breeze-dev libepoxy-dev mesa-dev wayland-dev xcb-util-cursor-dev xcb-util-image-dev xcb-util-wm-dev libinput-dev eudev-dev libdrm-dev mesa-gbm fontconfig-dev libxkbcommon-dev libxi-dev"
+makedepends="$depends_dev extra-cmake-modules qt5-qttools-dev kdoctools-dev"
+checkdepends="xvfb-run"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # Broken
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE xvfb-run ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="0f739ac0b60d6869b7a24b948c72a6371b11a6d40c8f3013228ef300f3963e374e69409f8e2699aa0cb3c07b1d2204f8d9dc2a56e09ca459b6024befd7c77aef  kwin-5.16.1.tar.xz"

--- a/testing/libkscreen/APKBUILD
+++ b/testing/libkscreen/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=libkscreen
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="KDE screen management software"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="LGPL-2.1-or-later AND GPL-2.0-or-later AND (GPL-2.0-only OR GPL-3.0-only)"
+depends_dev="qt5-qtbase-dev qt5-qtx11extras-dev kwayland-dev"
+makedepends="$depends_dev extra-cmake-modules doxygen graphviz qt5-qttools-dev"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc"
+options="!check" # Fails due to requiring dbus-x11 and it running
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_QCH=ON
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="6e9077a1bae1d202bf8c6110e03654d4c5a0e37af7dac4139df5efe9090a85c0b2f39a2c2636d699ff16a35985b674615bd0991343aff28e27d80d3c89a6616f  libkscreen-5.16.1.tar.xz"

--- a/testing/libksysguard/APKBUILD
+++ b/testing/libksysguard/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=libksysguard
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="KDE system monitor library"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="LGPL-2.1-or-later AND (GPL-2.0-only OR GPL-3.0-only)"
+depends_dev="qt5-qtwebengine-dev kcoreaddons-dev kconfig-dev ki18n-dev kwindowsystem-dev kcompletion-dev kauth-dev kwidgetsaddons-dev kiconthemes-dev kconfigwidgets-dev kservice-dev kglobalaccel-dev kio-dev plasma-framework-dev zlib-dev"
+makedepends="$depends_dev extra-cmake-modules"
+checkdepends="xvfb-run"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	# processtest requires working OpenGL
+	CTEST_OUTPUT_ON_FAILURE=TRUE xvfb-run ctest -E "processtest"
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="72e03801a3d14e83511369777f3ec9bb9bb1c0ef4e1a9d9a7e9ada3eed1d3a7686bd1106a9903aa54b627953d7a02791b7e0552f460dc14f377bf113e665e399  libksysguard-5.16.1.tar.xz"

--- a/testing/milou/APKBUILD
+++ b/testing/milou/APKBUILD
@@ -1,0 +1,30 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=milou
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="A dedicated search application built on top of Baloo"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="GPL-2.0-or-later AND (GPL-2.0-only OR GPL-3.0-only) AND (LGPL-2.1-only OR LGPL-3.0-only)"
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev kcoreaddons-dev ki18n-dev kdeclarative-dev kservice-dev plasma-framework-dev krunner-dev"
+makedepends="$depends_dev extra-cmake-modules"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="96f08f57c4d84645104c176f425cdb93d252c66c9c2e39a9fc2dfb8a15e98bf9d8128e7fb8fca9f97c8febf7eb9bde7210801dacadbf1d715df844f879209b2b  milou-5.16.1.tar.xz"

--- a/testing/plasma-desktop/APKBUILD
+++ b/testing/plasma-desktop/APKBUILD
@@ -1,0 +1,44 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=plasma-desktop
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="KDE Plasma Desktop"
+arch="all"
+url='https://www.kde.org/workspaces/plasmadesktop/'
+license="GPL-2.0-only AND LGPL-2.1-only"
+depends="kirigami2 plasma-workspace"
+depends_dev="qt5-qtbase-dev qt5-qtdeclarative-dev qt5-qtx11extras-dev qt5-qtsvg-dev kauth-dev plasma-framework-dev ki18n-dev kcmutils-dev knewstuff-dev kdelibs4support-dev knotifications-dev knotifyconfig-dev attica-dev kwallet-dev krunner-dev kglobalaccel-dev kdeclarative-dev kpeople-dev kdbusaddons-dev kactivities-dev kactivities-stats-dev kconfig-dev plasma-workspace-dev kwin-dev kitemmodels-dev kemoticons-dev baloo-dev fontconfig-dev eudev-dev xf86-input-libinput-dev xf86-input-evdev-dev libxkbfile-dev libxcursor-dev libxi-dev"
+makedepends="$depends_dev extra-cmake-modules kdoctools-dev"
+checkdepends="xvfb-run iso-codes"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-lang knetattach"
+options="!check" # Requires running dbus
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE xvfb-run ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+
+	rm "$pkgdir"/usr/bin/knetattach
+	rm "$pkgdir"/usr/share/applications/org.kde.knetattach.desktop
+}
+
+knetattach() {
+	pkgdesc="Wizard which makes it easier to integrate network resources with the Plasma Desktop"
+	depends="kdelibs4support"
+
+	cd "$builddir"/knetattach
+	DESTDIR="$subpkgdir" make install
+}
+sha512sums="543e0c28c73a776e93089610603bd8a37e2b0295e9abf9476f62f841cc98c48edb94e34d92dabd596c88c75e7629b3d09b4ba1fe818a5a99fdd949c3b022f56d  plasma-desktop-5.16.1.tar.xz"

--- a/testing/plasma-integration/APKBUILD
+++ b/testing/plasma-integration/APKBUILD
@@ -1,0 +1,34 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=plasma-integration
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="Qt Platform Theme integration plugins for the Plasma workspaces"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="(LGPL-2.1-only OR LGPL-3.0-only) AND LGPL-2.1-only AND ((LGPL-2.1-only WITH Nokia-Qt-exception-1.1) OR (GPL-3.0-only WITH Nokia-Qt-exception-1.1))"
+depends="font-noto"
+makedepends="extra-cmake-modules qt5-qtbase-dev qt5-qtx11extras-dev qt5-qtquickcontrols2-dev kconfig-dev kconfigwidgets-dev ki18n-dev kiconthemes-dev kio-dev knotifications-dev kwayland-dev kwidgetsaddons-dev kwindowsystem-dev kconfigwidgets-dev breeze-dev libxcursor-dev"
+checkdepends="xvfb-run"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-lang"
+options="!check" # Broken
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DCMAKE_DISABLE_FIND_PACKAGE_FontNotoSans=true \
+		-DCMAKE_DISABLE_FIND_PACKAGE_FontHack=true
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE xvfb-run ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="427697f72e56f2727cafc2e70a50c0d2b9497aaea6b2f5806707242499534f15fb0c1ffae6def513ad2671673099824e242043d222dba84a17287f21bebeb437  plasma-integration-5.16.1.tar.xz"

--- a/testing/plasma-workspace/APKBUILD
+++ b/testing/plasma-workspace/APKBUILD
@@ -1,0 +1,36 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=plasma-workspace
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="KDE Plasma Workspace"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="(GPL-2.0-only OR GPL-3.0-only) AND LGPL-2.1-or-later AND GPL-2.0-or-later AND MIT AND LGPL-2.1-only AND LGPL-2.0-or-later AND (LGPL-2.1-only OR LGPL-3.0-only) AND LGPL-2.0-only"
+depends="qt5-qtquickcontrols kirigami2 kinit qt5-qttools kwin kactivitymanagerd milou"
+depends_dev="plasma-framework-dev krunner-dev kjsembed-dev knotifyconfig-dev kdesu-dev knewstuff-dev kwallet-dev kidletime-dev kdeclarative-dev ki18n-dev kcmutils-dev ktextwidgets-dev kdelibs4support-dev kcrash-dev kglobalaccel-dev kdbusaddons-dev kwayland-dev kcoreaddons-dev kded-dev libksysguard-dev kpackage-dev kscreenlocker-dev phonon-dev zlib-dev kitemmodels-dev networkmanager-qt-dev baloo-dev ktexteditor-dev kwin-dev kholidays-dev prison-dev gpsd-dev iso-codes-dev"
+makedepends="$depends_dev extra-cmake-modules kdoctools-dev libxtst-dev"
+checkdepends="xvfb-run"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-libs $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	# nightcolortest requires running dbus
+	# testdesktop is broken
+	CTEST_OUTPUT_ON_FAILURE=TRUE xvfb-run ctest -E "(nightcolortest|testdesktop)"
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+
+	install -Dm644 plasmawayland.desktop "$pkgdir"/usr/share/wayland-sessions/plasmawayland.desktop
+}
+sha512sums="7c33e539f5a2504e603767ed1792b099784aefe0aa1c818f771257e5983883df56dc1a304b079081f5d3d98cc863dae3799d7553ecbc48b79721d16fdbe2eef9  plasma-workspace-5.16.1.tar.xz"

--- a/testing/polkit-kde-agent-1/APKBUILD
+++ b/testing/polkit-kde-agent-1/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=polkit-kde-agent-1
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="Daemon providing a polkit authentication UI for KDE"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="GPL-2.0-or-later"
+depends_dev="qt5-qtbase-dev ki18n-dev kwindowsystem-dev kdbusaddons-dev kwidgetsaddons-dev kcoreaddons-dev kcrash-dev kiconthemes-dev polkit-qt-1-dev"
+makedepends="$depends_dev extra-cmake-modules"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="221a76ee1a397b296dc4575bd21183a13f78ed9ce7290496d18e25135d612406f9608cc8e044f575d9d0a1fed8b6f69e70f68aee071433401bb9b651615ae02c  polkit-kde-agent-1-5.16.1.tar.xz"

--- a/testing/powerdevil/APKBUILD
+++ b/testing/powerdevil/APKBUILD
@@ -1,0 +1,31 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=powerdevil
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="Manages the power consumption settings of a Plasma Shell"
+arch="all"
+url="https://www.kde.org/workspaces/plasmadesktop/"
+license="GPL-2.0-or-later AND LGPL-2.0-or-later AND (LGPL-2.1-only OR LGPL-3.0-only)"
+depends_dev="qt5-qtbase-dev qt5-qtx11extras-dev kactivities-dev kauth-dev kidletime-dev kconfig-dev kdbusaddons-dev solid-dev ki18n-dev kglobalaccel-dev kio-dev knotifyconfig-dev kwayland-dev kcrash-dev knotifications-dev libkscreen-dev plasma-workspace-dev bluez-qt-dev networkmanager-qt-dev eudev-dev"
+makedepends="$depends_dev extra-cmake-modules kdoctools-dev"
+source="https://download.kde.org/stable/plasma/$pkgver/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-dev $pkgname-libs $pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+
+sha512sums="4b7f7c728978289ac25fe9e54643b7bd486a67920d4d2aff0ee6767ecb3b989d6cafbc4a3b5c08cd2ba3e9b03d601d6b736fff0c73552fb8a2c4edc951ffabf9  powerdevil-5.16.1.tar.xz"


### PR DESCRIPTION
You get a minimal Plasma desktop now by installing `plasma-desktop`, which can be launched either through a display manager like LightDM or SDDM (the latter being recommended and officially supported by KDE) or manually by putting `/usr/bin/startkde` in `~/.xinitrc` and running `xinit`.

Install Breeze for the default theme and background. Once I packaged some KDE Applications, I'll make a meta package with a minimal desktop but usable out of the box (e.g. Breeze, a file manager, terminal, etc, pre-installed).

Depends on #8467