### PR TITLE
main/clang: bump pkgrel, to use new llvm

### DIFF
--- a/main/clang/APKBUILD
+++ b/main/clang/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=clang
 # Note: Update together with llvm.
 pkgver=8.0.0
-pkgrel=0
+pkgrel=1
 _llvmver=${pkgver%%.*}
 pkgdesc="A C language family front-end for LLVM"
 arch="all"


### PR DESCRIPTION
Clang statically links against libraries from LLVM, since LLVM_LINK_LLVM_DYLIB is not used.

LLVM was updated in 84dff3bf837eeb0e47439bbd3dd2b4e6fd53ed56.