### PR TITLE
testing/ark: new aport

### DIFF
--- a/testing/ark/APKBUILD
+++ b/testing/ark/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=ark
+pkgver=19.04.2
+pkgrel=0
+pkgdesc="Graphical file compression/decompression utility with support for multiple formats"
+arch="all"
+url="https://kde.org/applications/utilities/org.kde.ark"
+license="GPL-2.0-only"
+depends="lrzip zstd p7zip zip unzip unrar"
+makedepends="extra-cmake-modules qt5-qtbase-dev karchive-dev kconfig-dev kcrash-dev kdbusaddons-dev kdoctools-dev ki18n-dev kiconthemes-dev kitemmodels-dev kio-dev kservice-dev kparts-dev kpty-dev kwidgetsaddons-dev libarchive-dev libzip-dev xz-dev shared-mime-info"
+checkdepends="xvfb-run"
+source="https://download.kde.org/stable/applications/$pkgver/src/$pkgname-$pkgver.tar.xz"
+subpackages="$pkgname-doc $pkgname-lang"
+
+build() {
+	cmake \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib
+	make
+}
+
+check() {
+	# plugins-cliunarchivertest is broken since Qt 5.11
+	CTEST_OUTPUT_ON_FAILURE=TRUE xvfb-run ctest -E "plugins-clirartest"
+}
+
+package() {
+	DESTDIR="$pkgdir" make install
+}
+sha512sums="a6991ce707294436520ba1cac0ed8c6125f88ce7448d7dff5dbfdd1ebf116a302f9d434793db08eb712681b16aee6ee826af027bb608be66ef08de5df8d222da  ark-19.04.2.tar.xz"


### PR DESCRIPTION
I'm not sure what to do with the `$depends` of this package. To do anything, Ark needs at least one of the dependencies. However, every archive format is optional in theory, and people could decide to not want support for a certain format. Especially in the case of `unrar` as that's effectively a proprietary application. Which depends should I keep in? Maybe just `zip` and `unzip`, and keep the rest optional?