### PR TITLE
testing/hdf5: upgrade to 1.10.5

### DIFF
--- a/testing/hdf5/APKBUILD
+++ b/testing/hdf5/APKBUILD
@@ -10,47 +10,52 @@
 # builds, due to inadequate locking.
 
 pkgname=hdf5
-pkgver=1.10.4
+pkgver=1.10.5
 pkgrel=0
 pkgdesc="HDF5 is a data model, library, and file format for storing and managing data"
 url="http://www.hdfgroup.org/HDF5/"
 arch="all"
 license="custom"
+options="!check" # test suite takes a very long time
 depends_dev="zlib-dev"
-makedepends="$depends_dev"
-subpackages="$pkgname-dev $pkgname-doc"
+makedepends="cmake $depends_dev"
+subpackages="$pkgname-static $pkgname-dev $pkgname-doc"
 source="http://www.hdfgroup.org/ftp/HDF5/current18/src/$pkgname-$pkgver.tar.bz2"
 source="https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${pkgver%.*}/hdf5-$pkgver/src/hdf5-$pkgver.tar.bz2"
 
-builddir="$srcdir/$pkgname-$pkgver"
+builddir="$srcdir/$pkgname-$pkgver/build"
+
+prepare() {
+	mkdir -p "$builddir"
+	default_prepare
+}
 
 build() {
-	cd "$builddir"
-	./configure \
-		--build=$CBUILD \
-		--host=$CHOST \
-		--prefix=/usr \
-		--sysconfdir=/etc \
-		--mandir=/usr/share/man \
-		--infodir=/usr/share/info \
-		--localstatedir=/var \
-		--disable-threadsafe \
-		--enable-cxx \
-		--enable-direct-vfd
+	if [ "$CBUILD" != "$CHOST" ]; then
+		CMAKE_CROSSOPTS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
+	fi
+
+	cmake \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_SHARED_LIBS=True \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+		-DCMAKE_C_FLAGS="$CFLAGS" \
+		${CMAKE_CROSSOPTS} ..
+
 	make
 }
 
+check() {
+	make test
+}
+
 package() {
-	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 	install -d "$pkgdir"/usr/share/licenses/"$pkgname"
-	install -c -m 0644 COPYING "$pkgdir"/usr/share/licenses/"$pkgname"/COPYING
+	mv "$pkgdir"/usr/share/COPYING "$pkgdir"/usr/share/licenses/"$pkgname"/COPYING
+	rm "$pkgdir"/usr/share/*.txt
 }
 
-dev() {
-	mkdir -p "$subpkgdir"/usr/share
-	mv "$pkgdir"/usr/share/hdf5_examples/ "$subpkgdir"/usr/share
-	default_dev
-}
-
-sha512sums="0393208a310dc2de93b9f5cb250f0e7c33c1573639ffe20b5ec6d5fd0771d31ffaff311a1aba3512fa40f38a687600ee64d572301d49e0fc410bacf82da2ecb7  hdf5-1.10.4.tar.bz2"
+sha512sums="769e43b8672e26fe24ed68da0228c010d3d9bc950ca09f0bc60707911a2f26f2f8415c8abc8ec06e07667148d8cdb3b0c7b3e7860d9b19739629c5dfd5ce73d4  hdf5-1.10.5.tar.bz2"


### PR DESCRIPTION
Now uses CMake to build in order to provide cmake exports. 