### PR TITLE
testing/plasma-meta: new aport

### DIFF
--- a/testing/plasma/APKBUILD
+++ b/testing/plasma/APKBUILD
@@ -1,0 +1,37 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=plasma
+pkgver=5.16.1
+pkgrel=0
+pkgdesc="Plasma (Base) meta package"
+url="https://kde.org/plasma-desktop"
+arch="noarch"
+options="!check" # No tests for a metapkg
+license="GPL-3.0-or-later"
+depends="
+	plasma-desktop
+	breeze
+	breeze-gtk
+	breeze-icons
+	systemsettings
+	sddm-breeze
+	sddm-kcm
+	plasma-pa
+	plasma-nm
+	kde-gtk-config
+	user-manager
+"
+subpackages="sddm-breeze:sddm_breeze"
+source="sddm.conf"
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+sddm_breeze() {
+	description="Set Breeze theme for SDDM"
+	depends="breeze sddm plasma-workspace"
+
+	install -Dm644 "$srcdir"/sddm.conf "$subpkgdir"/etc/sddm.conf
+}
+sha512sums="affbeec6d236bf09ae95b7bf478015ead9b5eabcffa8291107e34463bc3f7563c01d4e444e035b7eb575700e64c4da9f5079950b254b8c24b305845f031eb17f  sddm.conf"

--- a/testing/plasma/sddm.conf
+++ b/testing/plasma/sddm.conf
@@ -1,0 +1,3 @@
+[Theme]
+Current=breeze
+CursorTheme=breeze_cursors


### PR DESCRIPTION
Installing this package will give you a fully functional and complete Plasma desktop, with a pre-configured SDDM theme for Plasma.

Depends on:
- [x] #8860 
- [x] #8864
- [x] #8867
- [x] #8869
- [x] #8882