### PR TITLE
testing/gnome-settings-daemon: upgrade to 3.32.1

### DIFF
--- a/testing/gnome-settings-daemon/APKBUILD
+++ b/testing/gnome-settings-daemon/APKBUILD
@@ -1,26 +1,26 @@
+# Contributor: Rasmus Thomsen <oss@cogitri.dev>
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=gnome-settings-daemon
-pkgver=3.32.0
+pkgver=3.32.1
 pkgrel=0
 pkgdesc="GNOME settings daemon"
-url="https://www.gnome.org/"
+url="https://gitlab.gnome.org/GNOME/gnome-settings-daemon"
 arch="all !s390x"
-license="GPL"
-options="!check"
+options="!check" # needs unpackaged py-dbusmock
+license="GPL-2.0-only AND LGPL-2.1-only"
 depends_dev="gnome-desktop-dev libnotify-dev
 	libcanberra-dev colord-dev geoclue-dev
 	libgweather-dev geocode-glib-dev
 	pulseaudio-dev upower-dev libwacom-dev
 	cups-dev networkmanager-dev polkit-dev
 	lcms2-dev nss-dev"
-makedepends="$depends_dev libxml2-utils meson py3-setuptools"
+makedepends="$depends_dev libxml2-utils meson"
+checkdepends="py3-gobject3"
 depends="pulseaudio"
 subpackages="$pkgname-dev $pkgname-lang"
 source="https://download.gnome.org/sources/gnome-settings-daemon/${pkgver%.*}/gnome-settings-daemon-$pkgver.tar.xz"
-builddir="$srcdir/gnome-settings-daemon-$pkgver"
 
 build() {
-	cd "$builddir"
 	meson \
 		--prefix=/usr \
 		--sysconfdir=/etc \
@@ -31,8 +31,7 @@ build() {
 }
 
 package() {
-	cd "$builddir"
 	DESTDIR="$pkgdir" ninja -C output install
 }
 
-sha512sums="9b4c322ae063f62a934c730a4aed0de1486de60007dd84c31829f607e656cd90d03c0ddae0d0bb477dbc68f0313be06a6c566d54d111817177afb64b1784542a  gnome-settings-daemon-3.32.0.tar.xz"
+sha512sums="8d6aca1041cbd50d7dda67dc711269a51c4a5148d55dc63969f47c21bf309126f5d5cb13c1e6fa9e6498fbb30dc70fa7a049fead7d32c6a20d550da0ce8828c3  gnome-settings-daemon-3.32.1.tar.xz"


### PR DESCRIPTION
* Fix License&URL
* Modernize
* Remove py3-setuptools dep now that meson depends on it