### PR TITLE
community/firefox-esr: upgrade to 60.7.1

### DIFF
--- a/community/firefox-esr/APKBUILD
+++ b/community/firefox-esr/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor:
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox-esr
-pkgver=60.7.0
-pkgrel=2
+pkgver=60.7.1
+pkgrel=0
 pkgdesc="Firefox web browser - Extended Support Release"
 url="https://www.mozilla.org/en-US/firefox/organizations/"
 # limited by rust and cargo
@@ -80,6 +80,8 @@ _mozappdir=/usr/lib/firefox
 ldpath="$_mozappdir"
 
 # secfixes:
+#   60.7.1-r0:
+#     - CVE-2019-11707
 #   60.7.0-r0:
 #     - CVE-2019-9815
 #     - CVE-2019-9816
@@ -263,7 +265,7 @@ __EOF__
 	rm -f "$pkgdir"/${_mozappdirdev}/sdk/lib/libxul.so
 }
 
-sha512sums="c2152857f5f1c816a12fcf5c450268025ee47ee9299ae3355650d86c7c97191b731123a4964154222ca5ba1edc44fee0d1d5f803ae9515841283ecaff6dc9a55  firefox-60.7.0esr.source.tar.xz
+sha512sums="597e2872f6fb1959f0945d18b4d56add786dfd031c4cb99e76c5bd01d28c9c4705acc6bbdf8a0b6fcf9105e3f028403d6b79fe7e6d9218c97d743828afeb4087  firefox-60.7.1esr.source.tar.xz
 0b3f1e4b9fdc868e4738b5c81fd6c6128ce8885b260affcb9a65ff9d164d7232626ce1291aaea70132b3e3124f5e13fef4d39326b8e7173e362a823722a85127  stab.h
 845209a7f831c069a1c1d20f88e388423656f7c2f0915b5e7cfb7f47947883d4f9eb2f887b6f10ac5d75d0b323b495b693ec21cd2208ee5071283089bc023f07  fix-rust.patch
 2f4f15974d52de4bb273b62a332d13620945d284bbc6fe6bd0a1f58ff7388443bc1d3bf9c82cc31a8527aad92b0cd3a1bc41d0af5e1800e0dcbd7033e58ffd71  fix-fortify-system-wrappers.patch


### PR DESCRIPTION
See https://www.mozilla.org/en-US/security/advisories/mfsa2019-18