### PR TITLE
community/rawtherapee: Provided support for aarch64

### DIFF
--- a/community/rawtherapee/APKBUILD
+++ b/community/rawtherapee/APKBUILD
@@ -5,7 +5,7 @@ pkgver=5.6
 pkgrel=0
 pkgdesc="Powerful cross-platform raw image processing program"
 url="https://rawtherapee.com"
-arch="x86 x86_64 ppc64le"
+arch="x86 x86_64 ppc64le aarch64"
 license="GPL-3.0-or-later"
 makedepends="bzip2-dev cmake exiv2-dev expat-dev fftw-dev glib-dev gtk+3.0-dev
 	gtk-engines-dev gtkmm3-dev lcms2-dev lensfun-dev libcanberra-dev


### PR DESCRIPTION
Architecture specific support is provided for aarch64.

