### PR TITLE
testing/k3s: upgrade to 0.6.0

### DIFF
--- a/testing/k3s/APKBUILD
+++ b/testing/k3s/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=k3s
-pkgver=0.5.0
-pkgrel=1
+pkgver=0.6.0
+pkgrel=0
 pkgdesc="Lightweigt Kubernetes. 5 less than k8s."
 url="https://k3s.io"
 arch="all"
@@ -10,9 +10,8 @@ license="Apache-2.0"
 options="!check" # No test suite from upstream
 depends="containerd"
 makedepends="go linux-headers"
-install=""
 subpackages="$pkgname-doc $pkgname-openrc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/rancher/k3s/archive/v$pkgver.tar.gz
+source="$pkgname-$pkgver.tar.gz::https://github.com/rancher/k3s/archive/$pkgver.tar.gz
 	k3s.initd
 	k3s.confd
 	"
@@ -52,13 +51,12 @@ package() {
 	install -m755 -D hyperkube \
 		"$pkgdir"/usr/bin/hypercube
 
-	install -m644 -D -t "$pkgdir"/usr/share/licenses/$pkgname LICENSE
 	install -m644 -D -t "$pkgdir"/usr/share/doc/$pkgname README.md
 
 	install -m755 -D "$srcdir"/k3s.initd "$pkgdir"/etc/init.d/k3s
 	install -m644 -D "$srcdir"/k3s.confd "$pkgdir"/etc/conf.d/k3s
 }
 
-sha512sums="10fa2eba818105024ee130d75b01cbb0aec0ed2472118510399ae05e78f171b47d85587ba3dbd8a1f2fcd6cc5f971cfb38eff0efa2b00404f98d87cb1f2e8521  k3s-0.5.0.tar.gz
+sha512sums="76d019e5b259e6d1b9967c2b27909d537321f2949c40dc89aa487ee10f4990a6a9bf7b4369dc8547696ac6ba594d2e69a158e44c6ba06fea3245f8fa4a76a18c  k3s-0.6.0.tar.gz
 9501422f1bf5375555116cbeedb32de32109153396699bde1300ce01156c3e57fe3fb14a57f7de1dce47c955e5e6d61de7fea181a07b407f5b452006bc58991c  k3s.initd
 dda2fc70e884ef439fece8f850d798f98d07cd431f0b8b79183f192b35f68fc7c633d3c790aae7b86ca57331212a7bb2f783131b752a4e1e71ef918469e6b944  k3s.confd"


### PR DESCRIPTION
- https://github.com/rancher/k3s/releases 0.6.0
- Source URL update
- License remove
- Remove of unused install=