### PR TITLE
main/samba: security upgrade to 4.10.5

### DIFF
--- a/main/samba/APKBUILD
+++ b/main/samba/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=samba
-pkgver=4.10.4
-pkgrel=1
+pkgver=4.10.5
+pkgrel=0
 pkgdesc="Tools to access a server's filespace and printers via SMB"
 url="https://www.samba.org/"
 arch="all"
@@ -88,6 +88,9 @@ pkggroups="winbind"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   4.10.5-r0:
+#     - CVE-2019-12435
+#     - CVE-2019-12436
 #   4.10.3-r0:
 #     - CVE-2018-16860
 #   4.8.11-r0:
@@ -559,7 +562,7 @@ libs() {
 		"$pkgdir"/usr
 }
 
-sha512sums="10799f866b896903baaea5141af89cf442f3892d9c6f74b7acf217dd95abfe77b09f2bb001273cccf2e433bd2e845fad90651970952b4e18e8cd37bde956cf4e  samba-4.10.4.tar.gz
+sha512sums="82961791a43511aa42f0d648edd13f0533cb20e1d673903e6a1f6235b0df19dfc0755ab0c8e6d4518ca19c188968a38a6c8e8c80d05a20141c097fb0b3e2b795  samba-4.10.5.tar.gz
 188ed177d593906ac2ee532b40be20169f4379288480d71a79344702636208872fe50d54ec73f7c4477270f36c2c27308d1ae197b153b388ac4f3df9c8593347  domain.patch
 0d4fd9862191554dc9c724cec0b94fd19afbfd0c4ed619e4c620c075e849cb3f3d44db1e5f119d890da23a3dd0068d9873703f3d86c47b91310521f37356208b  getpwent_r.patch
 a99e771f28d787dc22e832b97aa48a1c5e13ddc0c030c501a3c12819ff6e62800ef084b62930abe88c6767d785d5c37e2e9f18a4f9a24f2ee1f5d9650320c556  musl_uintptr.patch


### PR DESCRIPTION
https://www.samba.org/samba/security/CVE-2019-12435.html
https://www.samba.org/samba/security/CVE-2019-12436.html