### PR TITLE
testing/minio: upgrade to 0.20190619

### DIFF
--- a/testing/minio/APKBUILD
+++ b/testing/minio/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
 # Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=minio
-_pkgver='RELEASE.2019-06-15T23-07-18Z'
+_pkgver='RELEASE.2019-06-19T18-24-42Z'
 pkgver=${_pkgver#*.}
 pkgver=${pkgver%T*}
 pkgver=0.${pkgver//-}
@@ -56,6 +56,6 @@ cleanup_srcdir() {
 	default_cleanup_srcdir
 }
 
-sha512sums="1e48f298a28e400d378a08816b617a134357f52dd66bbf9ec5bc8467cf7202a917d9a162a95f40617feb191b13834fd92ab920b04b436d2df55a2cd4adc4b062  minio.initd
+sha512sums="6427a225d4e6c51cc5de077ccd29ddf52556722cf958e83e480df1c5882aa4fa7daebfeb970e80f8f9c3176594d8e427e8c8dbf268ce945647a11bdf1e69affd  minio.initd
 ed9790fbadfb38e4d660eb1befd87e803d70dec04d936e8cd26def4a9c21240bb7cae8750ae3395aa4761e6738b9e346c86ba57761cfde30efe46d2cb459a7e4  minio.confd
-88b4ec5232e44f7f574a8576b74d878eaac2024679491c7fe44865f12b5b1b5a005f629bda6ebc1750c0700676ad077583628f5a5e83d511c93da4dacf31fa91  RELEASE.2019-06-15T23-07-18Z.tar.gz"
+25d4ed521481b08b50c10825a5a0cc47a3e36adc6d6945c4febe8848045c4909e92d674ded7681deb1eb25d5f1d3626d2f050cde99b368418b449a419673b66c  RELEASE.2019-06-19T18-24-42Z.tar.gz"

--- a/testing/minio/minio.initd
+++ b/testing/minio/minio.initd
@@ -21,5 +21,5 @@ start_pre() {
 
 healthcheck() {
     [ -x /usr/bin/curl ] || return 0
-    /usr/bin/curl -q "$address"/minio/health/ready
+    /usr/bin/curl -q "${address:-localhost:9000}"/minio/health/ready
 }


### PR DESCRIPTION
Also improve healthcheck.
When conf.d does not define an `$address`, curl will try to query a file
(`/minio/health/ready`), which obviously will always fail.
By default, minio will listen on 0.0.0.0:9000, so default to localhost.