### PR TITLE
main/iproute2: upgrade to 5.1.0

### DIFF
--- a/main/iproute2/APKBUILD
+++ b/main/iproute2/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=iproute2
-pkgver=4.20.0
-pkgrel=1
+pkgver=5.1.0
+pkgrel=0
 pkgdesc="IP Routing Utilities"
 url="https://www.linuxfoundation.org/collaborate/workgroups/networking/iproute2"
 arch="all"
@@ -26,7 +26,6 @@ prepare() {
 }
 
 build() {
-	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -38,7 +37,6 @@ build() {
 }
 
 package() {
-	cd "$builddir"
 	make -j1 DESTDIR="$pkgdir" install
 }
 
@@ -54,6 +52,6 @@ bashcomp() {
 	rmdir -p "$pkgdir"/usr/share 2>/dev/null || true
 }
 
-sha512sums="ed29638c864062e199152c7b3b24b6495987ca6f79cc9ab1b529dab37a8a840fa2b5858d5db2b94eeefa1c0d72ff666a790107e27d11a597b189bfb7a01a4b8b  iproute2-4.20.0.tar.xz
+sha512sums="5c8319b040bd0ba98cf1225b2a77efafc662741344c53877ee38cf108ca01906b03328e4f9b00b7557e301c6e64bca4e42e92af477b4d657bcbff5120c0c4e87  iproute2-5.1.0.tar.xz
 24fc2a901650e11f80bcaa82c839e70c21aafdf3c5b8a357d932d066a0b98ae2ec8379fc17a0a16a1b5b4fa5edc131179c10fc02e55d6101701df5a09966912c  fix-install-errors.patch
 2e3558caddf814da8c4d78c74eddb7a659d6f94b93de5396bdd995e2333e3cd656f9c936ac7a5a86d0477abc27a92550582575ab4ed19fc2ec0d9b6699cd612c  musl-fixes.patch"


### PR DESCRIPTION
I tried to get `check()` running, but was unsuccessful (it does a lot of weird things, like hardcode `sudo` and so on; it would never run on the builders).

However, I ran the tests by hand.
Only one failed, and only because I ran it in a container (it tried to unload modules, which is the part that failed).