### PR TITLE
testing/minio-client: upgrade to 0.20190619

### DIFF
--- a/testing/minio-client/APKBUILD
+++ b/testing/minio-client/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=minio-client
 _pkgname=mc
-_pkgver='RELEASE.2019-06-12T20-35-20Z'
+_pkgver='RELEASE.2019-06-19T22-39-53Z'
 pkgver=${_pkgver#*.}
 pkgver=${pkgver%T*}
 pkgver=0.${pkgver//-}
@@ -11,9 +11,9 @@ url="https://minio.io/"
 arch="all"
 license="Apache-2.0"
 makedepends="go"
-source="https://github.com/minio/$_pkgname/archive/$_pkgver.tar.gz"
+source="$_pkgname-$_pkgver.tar.gz::https://github.com/minio/$_pkgname/archive/$_pkgver.tar.gz"
 builddir="$srcdir/src/github.com/minio/$_pkgname"
-options="!check" # tests seem to lag behind code
+options="!check net" # tests seem to lag behind code
 
 export GOPATH="$srcdir"
 export CGO_ENABLED=0
@@ -42,4 +42,4 @@ cleanup_srcdir() {
 	go clean -modcache
 	default_cleanup_srcdir
 }
-sha512sums="28bd395493036f49f384342953140660b0aaed845bca51a9f104f31133cfc82f2e50b93cbfd61db923dfa8d655dff881d9cf36e79a5a5e6abebbb236d4504d02  RELEASE.2019-06-12T20-35-20Z.tar.gz"
+sha512sums="9a28a76012017464a8279a3a2938a757fccceef3003b63ff58e290b1fd36cfa704a9be224b79f2f9d36dc6449b446914d6ae1129e4895e5639fa1963d03b3f18  mc-RELEASE.2019-06-19T22-39-53Z.tar.gz"


### PR DESCRIPTION
Also:
1. Set an explicit name for the archive, to avoid potential collisions
   with testing/minio.
2. Add "net" to options to allow for rootbld builds.