### PR TITLE
testing/k3s: upgrade to 0.6.1

### DIFF
--- a/testing/k3s/APKBUILD
+++ b/testing/k3s/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=k3s
-pkgver=0.6.0
+pkgver=0.6.1
 pkgrel=0
 pkgdesc="Lightweigt Kubernetes. 5 less than k8s."
 url="https://k3s.io"
@@ -55,6 +55,6 @@ package() {
 	install -m644 -D "$srcdir"/k3s.confd "$pkgdir"/etc/conf.d/k3s
 }
 
-sha512sums="76d019e5b259e6d1b9967c2b27909d537321f2949c40dc89aa487ee10f4990a6a9bf7b4369dc8547696ac6ba594d2e69a158e44c6ba06fea3245f8fa4a76a18c  k3s-0.6.0.tar.gz
+sha512sums="41cae0809f3bb82906c98c31c8069b012ae965e21a2bf8bb9bc544bccc1793fa9aa14161ebea73e26f4b67f16ec703031921037c6c65a7f46d34328f41c1a80e  k3s-0.6.1.tar.gz
 9501422f1bf5375555116cbeedb32de32109153396699bde1300ce01156c3e57fe3fb14a57f7de1dce47c955e5e6d61de7fea181a07b407f5b452006bc58991c  k3s.initd
 dda2fc70e884ef439fece8f850d798f98d07cd431f0b8b79183f192b35f68fc7c633d3c790aae7b86ca57331212a7bb2f783131b752a4e1e71ef918469e6b944  k3s.confd"


### PR DESCRIPTION
- https://github.com/rancher/k3s/releases 0.6.1