### PR TITLE
security upgrade to 9.12.4_p2 (CVE-2019-6471)

### DIFF
--- a/main/bind/APKBUILD
+++ b/main/bind/APKBUILD
@@ -3,12 +3,12 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=bind
-pkgver=9.12.4_p1
+pkgver=9.12.4_p2
 _ver=${pkgver%_p*}
 _p=${pkgver#*_p}
 _major=${pkgver%%.*}
 [ "$_p" != "$pkgver" ] && _ver="${_ver}-P$_p"
-pkgrel=1
+pkgrel=0
 pkgdesc="The ISC DNS server"
 url="http://www.isc.org"
 arch="all"
@@ -51,6 +51,8 @@ source="
 builddir="$srcdir/$pkgname-$_ver"
 
 # secfixes:
+#   9.12.4_p2-r0:
+#     - CVE-2019-6471
 #   9.12.4_p1-r0:
 #     - CVE-2018-5743
 #     - CVE-2019-6467


### PR DESCRIPTION
@tcely https://github.com/ventz/docker-bind/issues/19