### PR TITLE
[3.9] main/bind: security upgrade to 9.12.4_p2 (CVE-2019-6471)

### DIFF
--- a/main/bind/APKBUILD
+++ b/main/bind/APKBUILD
@@ -3,12 +3,12 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=bind
-pkgver=9.12.4_p1
+pkgver=9.12.4_p2
 _ver=${pkgver%_p*}
 _p=${pkgver#*_p}
 _major=${pkgver%%.*}
 [ "$_p" != "$pkgver" ] && _ver="${_ver}-P$_p"
-pkgrel=1
+pkgrel=0
 pkgdesc="The ISC DNS server"
 url="http://www.isc.org"
 arch="all"
@@ -51,6 +51,8 @@ source="
 builddir="$srcdir/$pkgname-$_ver"
 
 # secfixes:
+#   9.12.4_p2-r0:
+#     - CVE-2019-6471
 #   9.12.4_p1-r0:
 #     - CVE-2018-5743
 #     - CVE-2019-6467
@@ -199,7 +201,7 @@ tools() {
 	done
 }
 
-sha512sums="1c07f6e10cb9fd499c4231e8290da94da1f5f4294c664635eac82bdb10be9a01119208fe2c15f5d28f50e3c2cdec7b553851b7676b65792f3f21de071587297d  bind-9.12.4-P1.tar.gz
+sha512sums="069fb0684a9e223cf81cc6485accde9d9495e541550e54636742601cc281f04fa58143e1b8d6afe0a8d08f13681fbb12d8bcc843349f47627c0a21bff24144bf  bind-9.12.4-P2.tar.gz
 d3b0329f48bd296988d8854ec4c7738c611d96e13c0439326a9cf801bc41a9504b1e0673f06fd66c5e36949192c6968d512d53a91d5d5fa96783c8b2c6ec88e3  Replace-atomic-operations.patch
 7167dccdb2833643dfdb92994373d2cc087e52ba23b51bd68bd322ff9aca6744f01fa9d8a4b9cd8c4ce471755a85c03ec956ec0d8a1d4fae02124ddbed6841f6  bind.so_bsdcompat.patch
 ca779f52a0a96d774bbc4dbb4e62d136f483ce528693ac73b844435be73500d8495bfddce34534825b5f6fa3197601e3175918a076428bab52bbc33c509a816e  named.initd


### PR DESCRIPTION
https://github.com/ventz/docker-bind/issues/19

(@tcely)