### PR TITLE
testing/kde-cli-tools: fix build type

### DIFF
--- a/testing/kde-cli-tools/APKBUILD
+++ b/testing/kde-cli-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=kde-cli-tools
 pkgver=5.16.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Tools based on KDE Frameworks 5 to better interact with the system"
 arch="all !ppc64le !s390x" # Limited by plasma-workspace -> libksysguard -> qt5-qtwebengine
 url="https://cgit.kde.org/kde-cli-tools"
@@ -16,7 +16,7 @@ options="!check" # Broken
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make


### PR DESCRIPTION
`RelWithDebugInfo` isn't a valid build target, should be `RelWithDebInfo`.