### PR TITLE
testing/plasma-workspace: fiix build type

### DIFF
--- a/testing/plasma-workspace/APKBUILD
+++ b/testing/plasma-workspace/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=plasma-workspace
 pkgver=5.16.1
-pkgrel=0
+pkgrel=1
 pkgdesc="KDE Plasma Workspace"
 arch="all !ppc64le !s390x" # Limited by libksysguard -> qt5-qtwebengine
 url="https://www.kde.org/workspaces/plasmadesktop/"
@@ -16,7 +16,7 @@ subpackages="$pkgname-dev $pkgname-libs $pkgname-doc $pkgname-lang"
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib
 	make


### PR DESCRIPTION
`RelWithDebugInfo` isn't a valid build target, should be `RelWithDebInfo`.