### PR TITLE
testing/sddm: fix build type

### DIFF
--- a/testing/sddm/APKBUILD
+++ b/testing/sddm/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=sddm
 pkgver=0.18.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Simple Desktop Display Manager"
 url="https://github.com/sddm/sddm/"
 arch="all"
@@ -21,7 +21,7 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/sddm/$pkgname/archive/v$pkgv
 
 build() {
 	cmake \
-		-DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_MAN_PAGES=ON \


### PR DESCRIPTION
`RelWithDebugInfo` isn't a valid build target, should be `RelWithDebInfo`.