### PR TITLE
community/wine: Provided support for aarch64

### DIFF
--- a/community/wine/APKBUILD
+++ b/community/wine/APKBUILD
@@ -10,7 +10,7 @@ _pkgver=${pkgver/_/-}
 pkgrel=1
 pkgdesc="A compatibility layer for running Windows programs"
 url="https://www.winehq.org"
-arch="x86 x86_64"
+arch="x86 x86_64 aarch64"
 license="LGPL-2.0-or-later"
 # As of 2.0.3 most of the tests fails
 options="!check"


### PR DESCRIPTION
Architecture specific support is provided for aarch64.

