### PR TITLE
main/bind: security upgrade to 9.14.3

### DIFF
--- a/main/bind/APKBUILD
+++ b/main/bind/APKBUILD
@@ -4,14 +4,14 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: tcely <bind+aports@tcely.33mail.com>
 pkgname=bind
-pkgver=9.14.1
+pkgver=9.14.3
 _ver=${pkgver%_p*}
 _p=${pkgver#*_p}
 _major=${pkgver%%.*}
 [ "$_p" != "$pkgver" ] && _ver="${_ver}-P$_p"
-pkgrel=1
+pkgrel=0
 pkgdesc="The ISC DNS server"
-url="https://www.isc.org"
+url="https://www.isc.org/"
 arch="all"
 license="MPL-2.0"
 pkgusers="named"
@@ -60,6 +60,8 @@ source="
 builddir="$srcdir/$pkgname-$_ver"
 
 # secfixes:
+#   9.14.3-r0:
+#     - CVE-2019-6471
 #   9.14.1-r0:
 #     - CVE-2019-6467
 #     - CVE-2018-5743
@@ -244,7 +246,7 @@ libs() {
 #gpg_signature_extensions="sha512.asc"
 #gpgfingerprints="good:AE3F AC79 6711 EC59 FC00  7AA4 74BB 6B9A 4CBB 3D38"
 
-sha512sums="560944951b6c6a2801967813597440f7ffb3687adf455ea27751d5976954643b9ea86d0da4661caf4fa9673c1d5c1ce7f34cce94a8edfa95eb60dd1cf7839c56  bind-9.14.1.tar.gz
+sha512sums="46974be2adea512c58b82184566ea5e8a9faf67aeb78ea33356861f0a7edce37eac05c21e8fbbc7f7db4e87404fe71ed59d9eac46e6e4758d95139a21891f437  bind-9.14.3.tar.gz
 2b32d1e7f62cd1e01bb4fdd92d15460bc14761b933d5acc463a91f5ecd4773d7477c757c5dd2738e8e433693592cf3f623ffc142241861c91848f01aa84640d6  bind.plugindir.patch
 7167dccdb2833643dfdb92994373d2cc087e52ba23b51bd68bd322ff9aca6744f01fa9d8a4b9cd8c4ce471755a85c03ec956ec0d8a1d4fae02124ddbed6841f6  bind.so_bsdcompat.patch
 ca779f52a0a96d774bbc4dbb4e62d136f483ce528693ac73b844435be73500d8495bfddce34534825b5f6fa3197601e3175918a076428bab52bbc33c509a816e  named.initd


### PR DESCRIPTION
https://lists.isc.org/pipermail/bind-announce/2019-June/001129.html