### PR TITLE
[3.9] community/webkit2gtk: upgrade to 2.24.2

### DIFF
--- a/community/webkit2gtk/APKBUILD
+++ b/community/webkit2gtk/APKBUILD
@@ -1,13 +1,15 @@
+# Contributor: Rasmus Thomsen <oss@cogitri.dev>
 # Contributor: Sergei Lukin <sergej.lukin@gmail.com>
 # Contributor: Jiri Horner <laeqten@gmail.com>
 # Maintainer: Jiri Horner <laeqten@gmail.com>
 pkgname=webkit2gtk
-pkgver=2.22.7
+pkgver=2.24.2
 pkgrel=0
 pkgdesc="Portable web rendering engine WebKit for GTK+"
 url="https://webkitgtk.org/"
-arch="all"
-license="LGPL-2.0-or-later BSD-2-Clause"
+# Not enough RAM on 32-bit arches, x86 works due to using x86_64 kernel on builders
+arch="all !armv7 !armhf"
+license="LGPL-2.0-or-later AND BSD-2-Clause"
 options="!check" # 2.20.3-r1 no idea why gtest is removed in prepare
 makedepends="
 	bison
@@ -35,6 +37,8 @@ makedepends="
 	libxslt-dev
 	libxt-dev
 	mesa-dev
+	openjpeg-dev
+	openjpeg-tools
 	pango-dev
 	paxmark
 	python2
@@ -42,15 +46,29 @@ makedepends="
 	sqlite-dev
 	"
 replaces="webkit"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
+options="!check" # upstream doesn't package them in release tarballs: Tools/Scripts/run-gtk-tests: Command not found
+subpackages="$pkgname-dev $pkgname-lang"
 source="https://webkitgtk.org/releases/webkitgtk-$pkgver.tar.xz
 	fix-fast-memory-disabled.patch
 	fix_armv6l.patch
 	musl-fixes.patch
+	fix-openjpeg.patch
 	"
 builddir="$srcdir/webkitgtk-$pkgver"
 
 # secfixes:
+#   2.24.1-r0:
+#     - CVE-2019-6251
+#     - CVE-2019-8506
+#     - CVE-2019-8524
+#     - CVE-2019-8535
+#     - CVE-2019-8536
+#     - CVE-2019-8544
+#     - CVE-2019-8551
+#     - CVE-2019-8558
+#     - CVE-2019-8559
+#     - CVE-2019-8563
+#     - CVE-2019-11070
 #   2.22.7-r0:
 #     - CVE-2018-4437
 #     - CVE-2019-6212
@@ -81,38 +99,45 @@ builddir="$srcdir/webkitgtk-$pkgver"
 #     - CVE-2017-2371
 #     - CVE-2017-2373
 
-prepare() {
-	default_prepare
-	cd "$builddir"
-	rm -r Source/ThirdParty/gtest/
-}
-
 build() {
 	local _archopt=
 	case "$CARCH" in
-		armhf) _archopt="-DUSE_LD_GOLD=OFF -DENABLE_JIT=OFF -DUSE_SYSMEM_MALLOC=ON";;
+		x86) export CFLAGS="$CFLAGS -msse2"
+			_archopt="-DENABLE_JIT=OFF"
+		;;
+		armhf) _archopt="-DUSE_LD_GOLD=OFF -DENABLE_JIT=OFF -DENABLE_C_LOOP=ON";;
+		armv7) _archopt="-DENABLE_JIT=OFF -DENABLE_C_LOOP=ON";;
 		aarch64) _archopt="-DUSE_LD_GOLD=OFF";;
-		ppc64le) _archopt="-DENABLE_JIT=OFF -DUSE_SYSMTE_MALLOC=ON";;
-		s390x) _archopt="-DUSE_LD_GOLD=OFF -DENABLE_JIT=OFF -DUSE_SYSMEM_MALLOC=ON";;
+		ppc64le) _archopt="-DENABLE_JIT=OFF -DENABLE_C_LOOP=ON";;
+		s390x) _archopt="-DUSE_LD_GOLD=OFF -DENABLE_JIT=OFF -ENABLE_C_LOOP=ON";;
 	esac
 
-	cd "$builddir"
 	mkdir build
 	cd build
-	cmake -DPORT=GTK \
+	cmake \
+		-DPORT=GTK \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_SKIP_RPATH=ON \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DLIB_INSTALL_DIR=/usr/lib \
 		-DLIBEXEC_INSTALL_DIR=/usr/lib/webkit2gtk-4.0 \
-		-DENABLE_GTKDOC=ON \
+		-DENABLE_GTKDOC=OFF \
 		-DENABLE_GEOLOCATION=OFF \
 		-DENABLE_PLUGIN_PROCESS_GTK2=OFF \
 		-DENABLE_SAMPLING_PROFILER=OFF \
-		-DUSE_WOFF2=OFF\
+		-DENABLE_MINIBROWSER=ON \
+		-DUSE_WOFF2=OFF \
 		$_archopt \
 		..
+
+	# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=923476
+	make JavaScriptCore-4-gir
 	make
+}
+
+check() {
+	cd "$builddir"/build
+	make check
 }
 
 package() {
@@ -122,7 +147,8 @@ package() {
 	paxmark -m "$pkgdir"/usr/lib/webkit2gtk-4.0/WebKitWebProcess
 }
 
-sha512sums="c11f60b14f279752bb75efce4b69cbfd75e854bfb16772edc3b24d28eff2fb65090e03f24c1cfaf1f27668e017d877e04d5210560da70568029c5af33a916126  webkitgtk-2.22.7.tar.xz
-9d7de4755c21d2573103dde326bb86ba37d54032627cb1bd362138906ac1d6a1dc48d4e548f29e29dc507831bae833ac5a8d2cf7fdb3d6a9d5bd5fb06f222b00  fix-fast-memory-disabled.patch
-f8fad1450d87f1cb195818cddb8a2307616916612e4676a4d71a20d58864d1c153550e4465a128e04f136c437518a4b90f1fa685ef6519fa8054637760635c72  fix_armv6l.patch
-922957ae400853bcfd5bff2c4e5b98a8351227a0b3b759dc34913ea5c8437e852899467a293cd2fb7a67f65022c4e99506f2be3c54fbcd74f038eb98ac02189e  musl-fixes.patch"
+sha512sums="8376167cfc4530886a2ac644ab84ff1021a63f6236d7be9eeb9e0ecade8bad5384b652dfe3720fdd31cddb39df6c935f859f1c0a59f42d7c71998992c4a9ffaa  webkitgtk-2.24.2.tar.xz
+e1537b9937af1cb936669d405993a52204cb9968b8b3161cb12a3f3f1343c260088c9490fcd7a7deeab6dbabdb5f7ce7e6cb2f857b9f0a4205aba6db2b11fb20  fix-fast-memory-disabled.patch
+c567eeac3c5f87b12711b40269946be0996df7fd73790d46fed64100c79240fbc965200ba702ef73a091e08ef9c949aebced62a7e4f5aab4f9b657d7dd808802  fix_armv6l.patch
+d0d5e37822644cab071e33d325affd1ce5948b414f6f54d695e6b4a7bffadecd25c0df6dc1cb63e70127499f5a8da43b02286a3518b2488b5da32c622df45d97  musl-fixes.patch
+c517c012f5630ef6be5be7d9592c5e042a070f849a141859edefa7984acb98dbd0d718fe6613cd35ba3b7d8530beebcc7408fd077cd914ed335c5e524e9e746a  fix-openjpeg.patch"

--- a/community/webkit2gtk/fix-fast-memory-disabled.patch
+++ b/community/webkit2gtk/fix-fast-memory-disabled.patch
@@ -1,6 +1,6 @@
---- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp.orig	2017-09-14 10:03:40.908890971 +0200
-+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp	2017-09-14 10:04:17.084859537 +0200
-@@ -112,7 +112,11 @@ void unregisterCode(void* start, void* e
+--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
++++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+@@ -118,7 +118,11 @@ void unregisterCode(void* start, void* e
  
  bool fastMemoryEnabled()
  {

--- a/community/webkit2gtk/fix-openjpeg.patch
+++ b/community/webkit2gtk/fix-openjpeg.patch
@@ -1,0 +1,11 @@
+--- a/Source/WebCore/platform/image-decoders/jpeg2000/JPEG2000ImageDecoder.cpp
++++ b/Source/WebCore/platform/image-decoders/jpeg2000/JPEG2000ImageDecoder.cpp
+@@ -28,7 +28,7 @@
+ 
+ #if USE(OPENJPEG)
+ 
+-#include <openjpeg.h>
++#include <openjpeg-2.3/openjpeg.h>
+ 
+ namespace WebCore {
+ 

--- a/community/webkit2gtk/fix_armv6l.patch
+++ b/community/webkit2gtk/fix_armv6l.patch
@@ -2,9 +2,9 @@ Fix code emitted for armv6l to not use movw/movt but ldr.
 See https://bugs.webkit.org/show_bug.cgi?id=131612
 and https://bugs.webkit.org/show_bug.cgi?id=141288
 
---- a/Source/JavaScriptCore/offlineasm/arm.rb	2015-07-22 14:37:57.000000000 +0200
-+++ b/Source/JavaScriptCore/offlineasm/arm.rb	2015-08-08 00:31:21.011824644 +0200
-@@ -473,8 +473,16 @@
+--- a/Source/JavaScriptCore/offlineasm/arm.rb
++++ b/Source/JavaScriptCore/offlineasm/arm.rb
+@@ -537,8 +537,16 @@
                  $asm.puts "mov #{armFlippedOperands(operands)}"
              end
          when "mvlbl"

--- a/community/webkit2gtk/musl-fixes.patch
+++ b/community/webkit2gtk/musl-fixes.patch
@@ -1,5 +1,3 @@
-diff --git a/Source/JavaScriptCore/runtime/MachineContext.h b/Source/JavaScriptCore/runtime/MachineContext.h
-index 836d755..4a0518a 100644
 --- a/Source/JavaScriptCore/runtime/MachineContext.h
 +++ b/Source/JavaScriptCore/runtime/MachineContext.h
 @@ -188,7 +188,7 @@ static inline void*& stackPointerImpl(mcontext_t& machineContext)
@@ -47,11 +45,10 @@ index 836d755..4a0518a 100644
  
  // The following sequence depends on glibc's sys/ucontext.h.
  #if CPU(X86)
-diff --git a/Source/JavaScriptCore/runtime/Options.h b/Source/JavaScriptCore/runtime/Options.h
-index 27396d2..23a7b9e 100644
+
 --- a/Source/JavaScriptCore/runtime/Options.h
 +++ b/Source/JavaScriptCore/runtime/Options.h
-@@ -144,9 +144,9 @@ constexpr bool enableWebAssemblyStreamingApi = false;
+@@ -138,9 +138,9 @@ constexpr bool enableWebAssemblyStreamingApi = false;
      \
      v(bool, reportMustSucceedExecutableAllocations, false, Normal, nullptr) \
      \
@@ -64,8 +61,7 @@ index 27396d2..23a7b9e 100644
      \
      v(bool, crashIfCantAllocateJITMemory, false, Normal, nullptr) \
      v(unsigned, jitMemoryReservationSize, 0, Normal, "Set this number to change the executable allocation size in ExecutableAllocatorFixedVMPool. (In bytes.)") \
-diff --git a/Source/ThirdParty/ANGLE/src/compiler/preprocessor/ExpressionParser.cpp b/Source/ThirdParty/ANGLE/src/compiler/preprocessor/ExpressionParser.cpp
-index c0f8b9c..1074cce 100644
+
 --- a/Source/ThirdParty/ANGLE/src/compiler/preprocessor/ExpressionParser.cpp
 +++ b/Source/ThirdParty/ANGLE/src/compiler/preprocessor/ExpressionParser.cpp
 @@ -836,7 +836,7 @@ int yydebug;
@@ -86,8 +82,7 @@ index c0f8b9c..1074cce 100644
  #   define yystpcpy stpcpy
  #  else
  /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-diff --git a/Source/ThirdParty/ANGLE/src/compiler/translator/glslang_tab.cpp b/Source/ThirdParty/ANGLE/src/compiler/translator/glslang_tab.cpp
-index 14cd536..6084d64 100644
+
 --- a/Source/ThirdParty/ANGLE/src/compiler/translator/glslang_tab.cpp
 +++ b/Source/ThirdParty/ANGLE/src/compiler/translator/glslang_tab.cpp
 @@ -1975,7 +1975,7 @@ int yydebug;
@@ -108,11 +103,10 @@ index 14cd536..6084d64 100644
  #   define yystpcpy stpcpy
  #  else
  /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-diff --git a/Source/WTF/wtf/Platform.h b/Source/WTF/wtf/Platform.h
-index 67cfa93..341a9f5 100644
+
 --- a/Source/WTF/wtf/Platform.h
 +++ b/Source/WTF/wtf/Platform.h
-@@ -697,7 +697,7 @@
+@@ -710,7 +710,7 @@
  #define HAVE_CFNETWORK_STORAGE_PARTITIONING 1
  #endif
  
@@ -121,8 +115,6 @@ index 67cfa93..341a9f5 100644
  #define HAVE_MACHINE_CONTEXT 1
  #endif
  
-diff --git a/Source/WebCore/xml/XPathGrammar.cpp b/Source/WebCore/xml/XPathGrammar.cpp
-index 31df1c0..bc569c1 100644
 --- a/Source/WebCore/xml/XPathGrammar.cpp
 +++ b/Source/WebCore/xml/XPathGrammar.cpp
 @@ -966,7 +966,7 @@ int yydebug;


### PR DESCRIPTION
* Disable armv7/armhf, due to using a 32-bit kernel these arches can't allocate
  enough memory during compilation for the massive compilation units webkit2gtk
  does. We'll have to wait for 2.26.x to allow compilation without unified sources
  to upgrade these arches.
* Disable GTK_DOC, which fails to build
* Disable system malloc on some arches. There were typos in the options anyway,
  so they haven't done anything anyway. System malloc is discouraged by upstream
  since bmalloc not only performs better it also has some security related
  advantages.

fixes the following CVEs:

* CVE-2019-6251
* CVE-2019-8506
* CVE-2019-8524
* CVE-2019-8535
* CVE-2019-8536
* CVE-2019-8544
* CVE-2019-8551
* CVE-2019-8558
* CVE-2019-8559
* CVE-2019-8563
* CVE-2019-11070

Co-authored-by: TBK <tbk@jjtc.eu>