### PR TITLE
testing/mutter: enable remote-desktop capabilities

### DIFF
--- a/testing/mutter/APKBUILD
+++ b/testing/mutter/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=mutter
 pkgver=3.32.2
-pkgrel=1
+pkgrel=2
 pkgdesc="clutter-based window manager and compositor"
 url="https://wiki.gnome.org/Projects/Mutter/"
 arch="all !s390x" # limited by gnome-settings-daemon
@@ -11,7 +11,7 @@ depends="xkeyboard-config zenity gsettings-desktop-schemas xorg-server-xwayland"
 makedepends="gnome-desktop-dev libcanberra-dev upower-dev json-glib-dev
 	libxkbcommon-dev libxkbfile-dev wayland-protocols clutter-dev cogl-dev
 	libgudev-dev libinput-dev gnome-common itstool libxml2-utils
-	libxcomposite-dev libxdamage-dev elogind-dev meson py3-setuptools
+	libxcomposite-dev libxdamage-dev elogind-dev meson pipewire-dev
 	gnome-settings-daemon-dev libice-dev libsm-dev startup-notification-dev
 	xorg-server"
 options="!check" # Can't be run with release builds
@@ -32,7 +32,7 @@ build() {
 		-Dnative_backend=true \
 		-Dintrospection=true \
 		-Dxwayland_path=/usr/bin/Xwayland \
-		-Dremote_desktop=false \
+		-Dremote_desktop=true \
 		. output
 	ninja -C output
 }


### PR DESCRIPTION
Now that pipewire is packaged we can enable it

Needs #8954