### PR TITLE
main/mozjs60: security upgrade to 60.7.2

### DIFF
--- a/main/mozjs60/APKBUILD
+++ b/main/mozjs60/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Rasmus Thomsen <oss@cogitri.dev>
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=mozjs60
-pkgver=60.7.0
+pkgver=60.7.2
 _majver=${pkgver%%.*}
 pkgrel=0
 pkgdesc="standalone mozilla javascript engine"
@@ -19,6 +19,11 @@ source="https://ftp.mozilla.org/pub/firefox/releases/${pkgver}esr/source/firefox
 	"
 builddir="$srcdir"/firefox-$pkgver
 _builddir="$builddir/js/src"
+
+# secfixes:
+#   60.7.2-r0:
+#     - CVE-2019-11708
+#     - CVE-2019-11707
 
 build() {
 	cd "$_builddir"
@@ -63,7 +68,7 @@ package() {
 	rm -f "$pkgdir"/usr/lib/*.ajs
 }
 
-sha512sums="c2152857f5f1c816a12fcf5c450268025ee47ee9299ae3355650d86c7c97191b731123a4964154222ca5ba1edc44fee0d1d5f803ae9515841283ecaff6dc9a55  firefox-60.7.0esr.source.tar.xz
+sha512sums="1258b0bf231b1b5c96b7063f2529ad9cd312cbd043b1d732abbc439093b41833361bbec3b740f3cf70299734035aa0a7db87c6b7b1537b9619b94bebf9b5c22b  firefox-60.7.2esr.source.tar.xz
 adaacd6e087a07bd4ded598f6a66ee00c67c9092bb93d88729668516f6f00f497ad8ece1866680e6c371e4705e0f9194ade41ea3a986f793bd972c92029cf03a  0001-silence-sandbox-violations.patch
 bc91c2fb15eb22acb8acc36d086fb18fbf6f202b4511d138769b5ecaaed4a673349c55f808270c762616fafa42e3b01e74dc0af1dcbeea1289e043926e2750c8  fix-musl-build.patch
 4782794a0f409f767293fb5f61a9ad58985e05197538975ed8f7372bfae6921a3b9bcbbbfcf8ce2843cdfe8ee799d08cee71a6391ed5ae939f051d13038b0960  fix-soname-lib.patch


### PR DESCRIPTION
CVE-2019-11707
CVE-2019-11708