### PR TITLE
testing/xdg-desktop-portal-kde: take over maintainership

### DIFF
--- a/testing/xdg-desktop-portal-kde/APKBUILD
+++ b/testing/xdg-desktop-portal-kde/APKBUILD
@@ -1,14 +1,14 @@
 # Contributor: Rasmus Thomsen <oss@cogitri.dev>
-# Maintainer: Rasmus Thomsen <oss@cogitri.dev>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=xdg-desktop-portal-kde
 pkgver=5.16.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Qt/KF5 implementation of xdg-desktop-portal"
 url="https://phabricator.kde.org/source/xdg-desktop-portal-kde"
 arch="all"
 license="GPL-3.0-or-later"
-makedepends="cmake qt5-qtbase-dev glib-dev kio-dev kwayland-dev libepoxy-dev
-	pipewire-dev kcoreaddons xdg-desktop-portal extra-cmake-modules cups-dev"
+makedepends="extra-cmake-modules qt5-qtbase-dev glib-dev kio-dev kwayland-dev libepoxy-dev
+	pipewire-dev kcoreaddons xdg-desktop-portal cups-dev"
 subpackages="$pkgname-lang"
 source="https://download.kde.org/stable/plasma/$pkgver/xdg-desktop-portal-kde-$pkgver.tar.xz"
 
@@ -20,7 +20,7 @@ build() {
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DBUILD_SHARED_LIBS=True \
-		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
 		-DCMAKE_C_FLAGS="$CFLAGS" \
 		${CMAKE_CROSSOPTS} .


### PR DESCRIPTION
It's part of the Plasma stack which I already maintain, so I'll maintain this one too. Agreed upon by @Cogitri on IRC.

Also set build type to `RelWithDebInfo` like all the other KDE packages.