### PR TITLE
main/imagemagick: Fix install location for PerlMagick modules

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
 pkgver=7.0.8.49
-pkgrel=1
+pkgrel=2
 _pkgver=${pkgver%.*}-${pkgver##*.}
 _abiver=7
 pkgdesc="Collection of tools and libraries for many image formats"
@@ -58,7 +58,7 @@ build() {
 		--with-modules \
 		--with-xml \
 		--with-perl \
-		--with-perl-options=PREFIX=/usr \
+		--with-perl-options="PREFIX=/usr INSTALLDIRS=vendor" \
 		$_pic
 	make
 }
@@ -94,7 +94,7 @@ _perlmagick() {
 	pkgdesc="PerlMagick Perl Modules for ImageMagick"
 	mkdir -p "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/lib/perl5 "$subpkgdir"/usr/lib/
-	chrpath -d "$subpkgdir"/usr/lib/perl5/site_perl/auto/Image/Magick/Q16HDRI/Q16HDRI.so
+	chrpath -d "$subpkgdir"/usr/lib/perl5/vendor_perl/auto/Image/Magick/Q16HDRI/Q16HDRI.so
 }
 
 _perlmagick_doc() {


### PR DESCRIPTION
Original code puts perl modules in /usr/lib/perl5/site_perl which is not in the @INC for perl.  This puts it in /usr/lib/perl5/vendor_perl which is the location for packaged modules.

Sorry I did not catch this previously.
