### PR TITLE
testing/skim: upgrade to 0.6.8

### DIFF
--- a/testing/skim/APKBUILD
+++ b/testing/skim/APKBUILD
@@ -1,13 +1,14 @@
 # Contributor: Chloe Kudryavtsev <toast@toastin.space>
 # Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=skim
-pkgver=0.6.7
+pkgver=0.6.8
 pkgrel=0
 pkgdesc="Fuzzy finder in rust"
 url="https://github.com/lotabout/skim"
 arch="x86_64" # limited by rust/cargo
 license="MIT"
 makedepends="cargo"
+options="net"
 subpackages="
 	$pkgname-doc
 	$pkgname-tmux::noarch
@@ -21,7 +22,6 @@ subpackages="
 source="$pkgname-$pkgver.tar.gz::https://github.com/lotabout/skim/archive/v$pkgver.tar.gz"
 
 export CARGO_HOME="$srcdir"/cargo
-export RUSTFLAGS="-C target-feature=-crt-static"
 
 build() {
 	cargo build \
@@ -114,4 +114,4 @@ zshkey() {
 	mv "$pkgdir"/usr/share/skim/key-bindings.zsh "$subpkgdir"/usr/share/skim
 }
 
-sha512sums="05aee9fc9a59cd28c7ec713a6cd70fd03d349441572b33611975cc685964aad042ad1d32c500e0d30abd56fc7fcb3b2a06135122460b2b1c5992ea3608e3fb11  skim-0.6.7.tar.gz"
+sha512sums="52da7ace0882e991f621b49368d81389af6ff24a79dc7e86dff45855c4caee2c61453c8209174b0da1dc4dfd604f0dd8da20d217a2ce6136a8ab94b9ebb22950  skim-0.6.8.tar.gz"


### PR DESCRIPTION
Also:
1. Add "net" option for rootbld builds
2. Remove redundant feature flag