### PR TITLE
main/py-cryptography: upgrade to 2.7

### DIFF
--- a/main/py-cryptography/APKBUILD
+++ b/main/py-cryptography/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=py-cryptography
 _pkgname=${pkgname#py-}
-pkgver=2.6.1
-pkgrel=1
+pkgver=2.7
+pkgrel=0
 pkgdesc="A package which provides cryptographic recipes and primitives"
 url="https://pypi.python.org/pypi/cryptography"
 arch="all"
-license="Apache-2.0"
+license="Apache-2.0 OR BSD-3-Clause"
 depends="py-cffi py-idna py-asn1crypto py-six"
 makedepends="python2-dev python3-dev py-setuptools libffi-dev openssl-dev"
 subpackages="py3-$_pkgname:_py3 py2-$_pkgname:_py2"
@@ -53,4 +53,4 @@ _py3() {
 	_py python3
 }
 
-sha512sums="f14319e24d9dca52e74548cada5b78a6235f089ef875dbff4799e862f94da8b087f1b6e03e84dcef9fc7d7693c4a349c5f0cd54b8535806da777420ce8757d39  cryptography-2.6.1.tar.gz"
+sha512sums="fa420f44b038b6fe1983c6f2c6d830e2668017c26e1e125ad621e37ea627a927ffe64d0e987e0a26dcc260834f2ec817cccd22da03b892190f46cb6e8131a5a8  cryptography-2.7.tar.gz"


### PR DESCRIPTION
Looked at the setup.py/requirements.txt of all packages that
depend on py2-cryptography or py3-cryptography, only found that
docker-py depends on cryptography==2.3 which we already broke since we are on 2.7.