### PR TITLE
testing/procs: new aport

### DIFF
--- a/testing/procs/APKBUILD
+++ b/testing/procs/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Chloe Kudryavtsev <toast@toastin.space>
+# Maintainer: Chloe Kudryavtsev <toast@toastin.space>
+pkgname=procs
+pkgver=0.8.7
+pkgrel=0
+pkgdesc="A modern replacement for ps written in Rust"
+url="https://github.com/dalance/procs"
+arch="x86_64" # limited by rust/cargo
+license="MIT"
+options="!check net" # abuild specifically causes tests to segfault
+makedepends="cargo"
+source="$pkgname-$pkgver.tar.gz::https://github.com/dalance/procs/archive/v$pkgver.tar.gz"
+
+export CARGO_HOME="$srcdir"/cargo
+
+build() {
+	cargo build \
+		--release \
+		--verbose
+}
+
+check() {
+	cargo test --all \
+		--release \
+		--verbose
+}
+
+package() {
+	install -Dm755 target/release/"$pkgname" "$pkgdir"/usr/bin/"$pkgname"
+}
+
+sha512sums="2f0645c08b86f48a81d0d2055317954365f2b290b3b1cf56cea60e28c21800f907b9fc802b0832decd3f62b009c9faff82158611c4fb0044da4a28d2b50f0d3b  procs-0.8.7.tar.gz"


### PR DESCRIPTION
A modern replacement for ps written in Rust

re: tests
In the following scenarios, tests pass:
- running by hand on real hardware
- running by hand in an alpine container

However, the moment abuild is involved, tests will segfault on test 3.
I couldn't figure out why exactly this happens.
I have a hunch that it has something to do with stdout handling, but it's hard to verify.