### PR TITLE
community/pdns: security upgrade to 4.1.10

### DIFF
--- a/community/pdns/APKBUILD
+++ b/community/pdns/APKBUILD
@@ -5,7 +5,7 @@
 # Contributor: Fabian Zoske <fabian@zoske.it>
 # Maintainer:  Matt Smith <mcs@darkregion.net>
 pkgname=pdns
-pkgver=4.1.8
+pkgver=4.1.10
 pkgrel=0
 pkgdesc="PowerDNS Authoritative Server"
 url="https://www.powerdns.com/"
@@ -41,6 +41,9 @@ source="https://downloads.powerdns.com/releases/$pkgname-$pkgver.tar.bz2
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   4.1.10-r0:
+#     - CVE-2019-10162
+#     - CVE-2019-10163
 #   4.1.7-r0:
 #     - CVE-2019-3871
 #   4.1.5-r0:
@@ -135,6 +138,6 @@ backend_remote()        { _mv_backend remote; }
 backend_sqlite3()       { _mv_backend gsqlite3 sqlite; }
 #backend_tinydns()       { _mv_backend tinydns; }
 
-sha512sums="1113745cdaa8fba591c176721893fb478e976861beee0cb6c0240e5afa6b68c9afae286579036b2ed77fffe76ca1e6f103cda915f8b7b875bcdc1253931ad935  pdns-4.1.8.tar.bz2
+sha512sums="59a7a52468f6daae8de01bb2b08d812906ef58047026369895341cfff253a5b9ba29d6a6b43a822f1632641eec34fa1afa6fbb5b0ba5e72ecce8e61787892136  pdns-4.1.10.tar.bz2
 3a55547e1b6407e7d2faa6e02982ed903c2364381af1b7eeb626ae3a8b0e32558dd79bf31c982b134414e5636d4868c1f3660ac523f25d2440ed6f7b436843bf  pdns.initd
 3f809f3257680c3e496fa6a4c86c8a636db5d9d5b92aef96fe54c29b8266ee590deb792d13205cc171e27307fa73295dd3b101b09102fd66a2393a7cdbf9dd27  pdns.conf"


### PR DESCRIPTION
https://blog.powerdns.com/2019/06/21/powerdns-authoritative-server-4-0-8-and-4-1-10-released/