### PR TITLE
[3.7] community/pdns: security upgrade to 4.0.8

### DIFF
--- a/community/pdns/APKBUILD
+++ b/community/pdns/APKBUILD
@@ -4,7 +4,7 @@
 # Contributor: Daniel Isaksen <d@duniel.no>
 # Maintainer:  Matt Smith <mcs@darkregion.net>
 pkgname=pdns
-pkgver=4.0.7
+pkgver=4.0.8
 pkgrel=0
 pkgdesc="PowerDNS Authoritative Server"
 url="https://www.powerdns.com/"
@@ -31,6 +31,9 @@ source="https://downloads.powerdns.com/releases/pdns-$pkgver.tar.bz2
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   4.0.8-r0:
+#     - CVE-2019-10162
+#     - CVE-2019-10163
 #   4.0.7-r0:
 #     - CVE-2019-3871
 #   4.0.6-r0:
@@ -85,6 +88,6 @@ _mv_backend() {
 		"$subpkgdir"/usr/lib/pdns/pdns/
 }
 
-sha512sums="2e7f8b0f530780a665c43a95c0c0396ef71520a9f94fb6a446774812539c7aaf5191a71fc1d2a22b46b19f1b445be79e5dcd958f554afedc9a354cc8c903ea7b  pdns-4.0.7.tar.bz2
+sha512sums="4d2902fb06a4c3f1af9cd1d8a13e7cdcc144110e4347a285ec61d9547ac2191fb946d24b9e90842504948b2836450eac38150f92cd74ba09c28f4766630f566d  pdns-4.0.8.tar.bz2
 3f5b202c56408168ddbf81b47f5c48ca65de91ada88751213a06a1096334b89176c5a6a58f3c6a893a2d15b51ece9f2a64d7d2ea836220a3e45fe362969c6cfa  pdns.initd
 c8f8d152c4d29660aa56a9dbfd0d268474f9bd26993ad9e7d8ef54725d02a02e27c1a11adc67bf40f5dd871a677648d45fa76222a063907e0dfb2420111d5dc8  pdns.conf"


### PR DESCRIPTION
#9064