### PR TITLE
testing/procs: upgrade to 0.8.8

### DIFF
--- a/testing/procs/APKBUILD
+++ b/testing/procs/APKBUILD
@@ -1,13 +1,13 @@
 # Contributor: Chloe Kudryavtsev <toast@toastin.space>
 # Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=procs
-pkgver=0.8.7
+pkgver=0.8.8
 pkgrel=0
 pkgdesc="A modern replacement for ps written in Rust"
 url="https://github.com/dalance/procs"
 arch="x86_64" # limited by rust/cargo
 license="MIT"
-options="!check net" # abuild specifically causes tests to segfault
+options="net"
 makedepends="cargo"
 source="$pkgname-$pkgver.tar.gz::https://github.com/dalance/procs/archive/v$pkgver.tar.gz"
 
@@ -29,4 +29,4 @@ package() {
 	install -Dm755 target/release/"$pkgname" "$pkgdir"/usr/bin/"$pkgname"
 }
 
-sha512sums="2f0645c08b86f48a81d0d2055317954365f2b290b3b1cf56cea60e28c21800f907b9fc802b0832decd3f62b009c9faff82158611c4fb0044da4a28d2b50f0d3b  procs-0.8.7.tar.gz"
+sha512sums="166ce8b954c8dd59de4398cc8903b77522629db315274050402c32046e48285d63a9904a2b5403ab235e8a4a728aa1438894a95353c896564d745531abbd0908  procs-0.8.8.tar.gz"


### PR DESCRIPTION
Also re-enable tests, since upstream fixed the segfault issue.