### PR TITLE
community/dunst: add dbus-dev dependency to fix build

### DIFF
--- a/community/dunst/APKBUILD
+++ b/community/dunst/APKBUILD
@@ -9,7 +9,7 @@ url="http://knopwob.org/dunst/"
 arch="all"
 license="BSD-3-Clause"
 makedepends="gtk+2.0-dev libxscrnsaver-dev libxinerama-dev
-	libxrandr-dev libnotify-dev"
+	libxrandr-dev libnotify-dev dbus-dev"
 checkdepends="dbus librsvg"
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/dunst-project/dunst/archive/v$pkgver.tar.gz"


### PR DESCRIPTION
Build breaks with error:
Error: Makefile:25: *** "Failed to query pkg-config for package 'dbus-1'!".  Stop.

The Makefile uses pkg-conf and requires /usr/lib/pkgconfig/dbus-1.pc provided by the dbus-dev package. Add this as a Make dependancy to fix.
