### PR TITLE
community/filezilla: fix build break by adding wxgtk3-dev dependency

### DIFF
--- a/community/filezilla/APKBUILD
+++ b/community/filezilla/APKBUILD
@@ -6,7 +6,7 @@ pkgdesc="FTP Client"
 url="https://filezilla-project.org"
 arch="all"
 license="GPL-2.0-or-later"
-makedepends="libfilezilla-dev>=0.16.0 wxgtk-dev libidn-dev nettle-dev gnutls-dev
+makedepends="libfilezilla-dev>=0.16.0 wxgtk3-dev libidn-dev nettle-dev gnutls-dev
 	pugixml-dev xdg-utils gtk+2.0-dev sqlite-dev"
 subpackages="$pkgname-doc $pkgname-lang"
 source="https://download.filezilla-project.org/client/FileZilla_${pkgver}_src.tar.bz2"


### PR DESCRIPTION
Build fails with error:
```
Error:
checking for /usr/bin/wx-config-gtk3... no
configure: error:
        wxWidgets must be installed on your system
        but either the wx-config script couldn't be found or
        no compatible wxWidgets configuration has been installed.

        Compatible wxWidgets configurations are the unicode builds
        of wxGTK, wxMac and wxMSW.

        Please check that wx-config is in path, the directory
        where wxWidgets libraries are installed (returned by
        'wx-config --libs' command) is in LD_LIBRARY_PATH or
        equivalent variable and wxWidgets version is 3.0.4 or above.

>>> ERROR: filezilla: build failed
```
Adding explicit make dependancy on wxgtk3-dev to fix.
