### PR TITLE
community/pulseaudio: enable test, enable s390x, disable building doc

### DIFF
--- a/community/alsa-plugins/APKBUILD
+++ b/community/alsa-plugins/APKBUILD
@@ -6,7 +6,7 @@ pkgver=1.1.9
 pkgrel=0
 pkgdesc="Advanced Linux Sound Architecture (ALSA) plugins"
 url="https://www.alsa-project.org"
-arch="all !s390x"
+arch="all"
 license="GPL-2.0-or-later LGPL-2.1-or-later"
 makedepends="
 	alsa-lib-dev

--- a/community/pulseaudio/APKBUILD
+++ b/community/pulseaudio/APKBUILD
@@ -5,16 +5,16 @@
 # Maintainer: Leo <thinkabit.ukim@gmail.com>
 pkgname=pulseaudio
 pkgver=12.2
-pkgrel=3
+pkgrel=4
 pkgdesc="A featureful, general-purpose sound server"
 url="http://www.freedesktop.org/wiki/Software/PulseAudio"
-arch="all !s390x"
+arch="all"
 license="LGPL-2.1-or-later"
 makedepends="m4 automake libtool intltool bash dbus-dev libcap-dev alsa-lib-dev
 	bluez-dev speexdsp-dev avahi-dev openssl-dev eudev-dev libsndfile-dev
 	gtk+3.0-dev json-c-dev fftw-dev sbc-dev jack-dev libatomic_ops-dev gettext-dev
 	autoconf autoconf-archive libsm-dev libice-dev xcb-util-dev libx11-dev"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-bluez libpulse:_libpulse
+subpackages="$pkgname-dev $pkgname-bluez libpulse:_libpulse
 	libpulse-mainloop-glib:_libpulse_mainloop_glib $pkgname-alsa $pkgname-utils
 	$pkgname-jack $pkgname-zeroconf $pkgname-openrc
 	$pkgname-bash-completion:bashcomp:noarch $pkgname-zsh-completion:zshcomp:noarch"
@@ -26,7 +26,6 @@ source="https://freedesktop.org/software/pulseaudio/releases/pulseaudio-$pkgver.
 	b89d33bb182c42db5ad3987b0e91b7bf62f421e8.patch
 	300a1a96fa43ee456512843c671bdf1f9c75ca24.patch"
 
-options="!check" # Tests try to access nls stuff, which we disable
 
 prepare() {
 	default_prepare
@@ -60,6 +59,7 @@ build() {
 		--enable-x11
 
 	sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+	sed -i -e 's/SUBDIRS = src doxygen man po/SUBDIRS = src doxygen/g' Makefile
 
 	make
 }

--- a/testing/polybar/APKBUILD
+++ b/testing/polybar/APKBUILD
@@ -5,7 +5,7 @@ pkgver=3.3.1
 pkgrel=0
 pkgdesc="A fast and easy-to-use tool for creating status bars."
 url="https://polybar.github.io/"
-arch="all !s390x" # s390x lacks pulseaudio
+arch="all"
 license="MIT"
 makedepends="
 	alsa-lib-dev

--- a/testing/pulseaudio-qt/APKBUILD
+++ b/testing/pulseaudio-qt/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=pulseaudio-qt
 pkgver=1.1.0
 pkgrel=0
-arch="all !s390x" # Limited by pulseaudio
+arch="all"
 url="https://cgit.kde.org/pulseaudio-qt.git/"
 pkgdesc="Pulseaudio bindings for Qt"
 license="LGPL-2.1-only OR LGPL-3.0-only"


### PR DESCRIPTION
Building doc and translation (man, po) requires gettext. We now run
testsuites in the price of not having doc and translation.
Neither of --disable-nls, ENABLE_NLS=0, HAVE_GETTEXT=0, USE_NLS=no work.