### PR TITLE
testing/plasma-pa: re-enable

### DIFF
--- a/testing/plasma-pa/APKBUILD
+++ b/testing/plasma-pa/APKBUILD
@@ -4,7 +4,7 @@ pkgname=plasma-pa
 pkgver=5.16.2
 pkgrel=0
 pkgdesc="Plasma applet for audio volume management using PulseAudio"
-arch="" # Conflict between polkit-dev and polkit-elogind-dev
+arch="all !ppc64le !s390x" # Limited by plasma-workspace -> libksysguard -> qt5-qtwebengine
 url="https://www.kde.org/workspaces/plasmadesktop/"
 license="LGPL-2.1-only OR LGPL-3.0-only AND GPL-2.0-only"
 depends="pulseaudio kirigami2"
@@ -21,12 +21,10 @@ build() {
 }
 
 check() {
-	cd "$builddir"
 	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
 }
 
 package() {
-	cd "$builddir"
-	make DESTDIR="$pkgdir" install
+	DESTDIR="$pkgdir" make install
 }
 sha512sums="48ee899db002a946486d93bc81c0f046f6c6855a020d7557bb1625f116c61ef2d295e682401c77fa46bc2d7fdcd3d3337fe4c4df000b03718456bf20ef2ca4a1  plasma-pa-5.16.2.tar.xz"

--- a/testing/plasma/APKBUILD
+++ b/testing/plasma/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=plasma
 pkgver=5.16.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Plasma (Base) meta package"
 url="https://kde.org/plasma-desktop"
 arch="noarch !ppc64le !s390x" # Limited by plasma-workspace -> libksysguard -> qt5-qtwebengine
@@ -28,6 +28,7 @@ depends="
 	plasma-browser-integration
 	plasma-desktop
 	plasma-nm
+	plasma-pa
 	plasma-vault
 	plasma-workspace-wallpapers
 	polkit-kde-agent-1

--- a/testing/polkit-elogind/APKBUILD
+++ b/testing/polkit-elogind/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=polkit-elogind
 pkgver=0.116
-pkgrel=0
+pkgrel=1
 pkgdesc="Application development toolkit for controlling system-wide privileges (elogind variant)"
 url="https://www.freedesktop.org/wiki/Software/polkit/"
 arch="all"
@@ -66,6 +66,11 @@ package() {
 	chmod -R 700 "$pkgdir"/etc/polkit-1/rules.d "$pkgdir"/usr/share/polkit-1/rules.d
 	chmod 4755 "$pkgdir"/usr/lib/polkit-1/polkit-agent-helper-1
 	chmod 4755 "$pkgdir"/usr/bin/pkexec
+}
+
+dev() {
+	provides="polkit-dev"
+	default_dev
 }
 
 sha512sums="b66b01cc2bb4349de70147f41f161f0f6f41e7230b581dfb054058b48969ec57041ab05b51787c749ccfc36aa5f317952d7e7ba337b4f6f6c0a923ed5866c2d5  polkit-0.116.tar.gz


### PR DESCRIPTION
Previously there were Polkit conflicts because of networkmanager depending on `polkit-dev` but `polkit-qt-1` being built on `polkit-elogind-dev`.

Making `polkit-elogind-dev` provide `polkit-dev` fixes this issue, so `plasma-pa` can be re-enabled and added to the `plasma` meta package again.