### PR TITLE
community/rust: build on arm{hf,v7}, aarch64 & ppc64le

### DIFF
--- a/community/rust/APKBUILD
+++ b/community/rust/APKBUILD
@@ -10,7 +10,7 @@ _bootver=1.34.0
 pkgrel=0
 pkgdesc="The Rust Programming Language"
 url="https://www.rust-lang.org"
-arch="x86_64"
+arch="x86_64 armv7 armhf ppc64le x86"
 license="Apache-2.0 AND MIT"
 
 # gcc is needed at runtime just for linking. Someday rustc might invoke
@@ -23,8 +23,6 @@ depends="$pkgname-stdlib=$pkgver-r$pkgrel gcc llvm-libunwind-dev musl-dev"
 #   prebuilt rustc and cargo) is 8cb3112594f10a8cee5b5412c28a846acb63167f.
 # * libffi-dev is needed just because we compile llvm with LLVM_ENABLE_FFI.
 makedepends="
-	rust-bootstrap>=$_bootver
-	cargo-bootstrap
 	cmake
 	curl-dev
 	file
@@ -37,13 +35,25 @@ makedepends="
 	python2
 	tar
 	zlib-dev
-	"
+	coreutils
+"
+
+case "$CARCH" in
+	x86_64)
+		makedepends="$makedepends
+			rust-bootstrap=>$_bootver
+			cargo-bootstrap
+		"
+		;;
+esac
+
 # XXX: This is a hack to allow this abuild to depend on itself. Adding "rust"
 # to makedepends would not work, because abuild implicitly removes $pkgname
 # and $subpackages from the abuild's dependencies.
 provides="rust-bootstrap=$pkgver-r$pkgrel"
 # This is needed for -src that contains some testing binaries.
-options="!archcheck"
+# Disable tests for now, while we use foreign triplets
+options="!archcheck !check"
 subpackages="
 	$pkgname-dbg
 	$pkgname-stdlib
@@ -58,6 +68,11 @@ subpackages="
 	cargo-doc:_cargo_doc:noarch
 	"
 source="https://static.rust-lang.org/dist/rustc-$pkgver-src.tar.gz
+	https://exp.exqa.de/alpine-rust/rust-armhf-$pkgver.tar.xz
+	https://exp.exqa.de/alpine-rust/rust-armv7-$pkgver.tar.xz
+	rust-aarch64-$pkgver.tar.xz::https://exp.exqa.de/alpine-rust/rust-aarch64-$pkgver.tar.xz.new
+	https://exp.exqa.de/alpine-rust/rust-ppc64le-$pkgver.tar.xz
+	https://exp.exqa.de/alpine-rust/rust-x86-$pkgver.tar.xz
 	musl-fix-static-linking.patch
 	musl-fix-linux_musl_base.patch
 	llvm-with-ffi.patch
@@ -72,31 +87,90 @@ source="https://static.rust-lang.org/dist/rustc-$pkgver-src.tar.gz
 	cargo-tests-ignore-resolving_minimum_version_with_transitive_deps.patch
 	check-rustc
 	cargo-skip-broken-tests.patch
+	link-musl-dynamically.patch
+	musl-dont-use-crt-static.patch
 	"
 builddir="$srcdir/rustc-$pkgver-src"
 
-_rlibdir="usr/lib/rustlib/$CTARGET/lib"
+# We have to add new arches in multiple steps:
+# 1. Compile with the upstream triplets, compiling alpine's triplets in
+# 2. Compile again, now with our triplets selected as build/target, now that
+#    rustc knows about them
+case "$CARCH" in
+	armv7)
+		export LD_LIBRARY_PATH="$srcdir/rust-armv7/lib"
+		export PATH="$srcdir/rust-armv7/bin:$PATH"
+		_build="armv7-unknown-linux-musleabihf"
+		_target="$_build"
+		;;
+	armhf)
+		export LD_LIBRARY_PATH="$srcdir/rust-armhf/lib"
+		export PATH="$srcdir/rust-armhf/bin:$PATH"
+		_build="arm-unknown-linux-musleabihf"
+		_target="$_build"
+		;;
+	aarch64)
+		export LD_LIBRARY_PATH="$srcdir/rust-aarch64/usr/lib"
+		export PATH="$srcdir/rust-aarch64/usr/bin:$PATH"
+		_build="aarch64-unknown-linux-musl"
+		_target="$_build"
+		;;
+	ppc64le)
+		export LD_LIBRARY_PATH="$srcdir/rust-ppc64le/lib"
+		export PATH="$srcdir/rust-ppc64le/bin:$PATH"
+		_build="powerpc64le-unknown-linux-musl"
+		_target="$_build"
+		;;
+	x86)
+		export LD_LIBRARY_PATH="$srcdir/rust-x86/lib"
+		export PATH="$srcdir/rust-x86/bin:$PATH"
+		_build="i686-unknown-linux-musl"
+		_target="$_build"
+		;;
+	*)
+		_build="$CBUILD"
+		_target="$CTARGET"
+		;;
+esac
+
+_rlibdir="usr/lib/rustlib/$_target/lib"
 _sharedir="usr/share/rust"
 
 ldpath="/$_rlibdir"
 
 export RUST_BACKTRACE=1
-export RUSTC_CRT_STATIC="false"
 # Convince libgit2-sys to use the distro libgit2.
 export LIBGIT2_SYS_USE_PKG_CONFIG=1
 
+# rust checksums files in vendor/, but we have to patch a few files...
+_clear_vendor_checksums() {
+	sed -i 's/\("files":{\)[^}]*/\1/' vendor/$1/.cargo-checksum.json
+}
+
 prepare() {
 	default_prepare
+
+	sed -i /LD_LIBRARY_PATH/d src/bootstrap/bootstrap.py
+
+	_clear_vendor_checksums libc
+	_clear_vendor_checksums lzma-sys
 
 	# Remove bundled dependencies.
 	rm -Rf src/llvm/
 }
 
 build() {
+	# Fails to compile libbacktrace-sys otherwise
+	case "$CARCH" in
+		x86)
+			export CFLAGS="$CFLAGS -fno-stack-protector"
+			;;
+	esac
+
 	./configure \
-		--build="$CBUILD" \
-		--host="$CTARGET" \
-		--target="$CTARGET" \
+		--build=${_build} \
+		--host=${_target} \
+		--target=${_target} \
 		--prefix="/usr" \
 		--release-channel="stable" \
 		--enable-local-rust \
@@ -109,9 +183,10 @@ build() {
 		--enable-llvm-link-shared \
 		--enable-option-checking \
 		--enable-locked-deps \
-		--enable-vendor
+		--enable-vendor \
+		--disable-full-bootstrap
 
-	./x.py build -v --jobs ${JOBS:-2}
+	./x.py build --jobs ${JOBS:-2}
 }
 
 check() {
@@ -143,9 +218,6 @@ package() {
 	# linked rustc/rustdoc against those under rustlib/, we can remove
 	# them. Read change-rpath-to-rustlib.patch for more info.
 	rm -r usr/lib/*.so
-
-	# These objects are for static linking with musl on non-musl systems.
-	rm $_rlibdir/crt*.o
 
 	# Shared objects should have executable flag.
 	chmod +x $_rlibdir/*.so
@@ -258,6 +330,11 @@ _mv() {
 }
 
 sha512sums="b23e6e221bf96e8621ea7aba2e8fc686c2ba1ae334072f13f1f0d4b0ae909632f511a9c62fdcc29c7467af931269020298f799064651b676e387dd3e6dfe6e8e  rustc-1.35.0-src.tar.gz
+34d25ac839b34ae859a3dc44f4fee85ab84b944c973a12982f089a778f7aa8bbea0285428646993821e3395cd75c7b25f626b02934812e14d8422c9c6005a8cd  rust-armhf-1.35.0.tar.xz
+50c391d141de432487058a56479fb72640319c040118680c532610454c007085caaa4b435c98be493040ee7fcf86b2451ee765e0cac8dbe7d8a6864a11b6812a  rust-armv7-1.35.0.tar.xz
+e22bccc770715aaf2a42ea2a09ef24df4f7939f2bdd529538a570db817dcd43e8f7e2ac45412970f1e2aed754d84043a950357e5045172ac64f3aca1c1e86f98  rust-aarch64-1.35.0.tar.xz
+f644f96d80d0fa5b068d826d6fbb9b3814c8ddab62e634283fb7f19fe48570cf248d1be2544d2065339780129f18db4c0a71970d0f597a0d198bd3208210b9ac  rust-ppc64le-1.35.0.tar.xz
+ee17396c183f55b2de74d23c6811cd0682ecdfc99ce80242a7022860d5d96f6331edd97afec511985c4808bfb4bd6d2ebc23d74e1d6fa6c69cf70472bda29ef2  rust-x86-1.35.0.tar.xz
 6713d0d0ccac6b17ed47e486c6d74d1f913887bf88d42527576188fa98063a33a1ea903967847d52126b996f965577f1311344d6e57063b1625221847290a0ed  musl-fix-static-linking.patch
 a2871fa75fb63570031eda80390461a137fe31ba82bf253caeabf3fb6673b4c80b535917dde139a300fb6d5f8c14fe09c8f7aaf4a506ef5e837540cf00aaa977  musl-fix-linux_musl_base.patch
 e40d41a6dc5d400d6672f1836cd5b9e00391f7beb52e872d87db76bc95a606ce6aaae737a0256a1e5fba77c83bb223818d214dbe87028d47be65fb43c101595c  llvm-with-ffi.patch
@@ -271,4 +348,6 @@ b7931281bfc1deb25c72494b4111500fe46c2e551ca32cafdfcc9a1bff657ca0b2bfaeea52260b46
 c2ccab15d48c11cc3af549a3944ca0d29cb3790345468f4f3779e5ac931554dea603e5523281fc391ba4a555ee468b516961c4cb8ecee007eadacf114f3d8758  bootstrap-tool-respect-tool-config.patch
 3d6f027088e1ec189ce864bf5ed150ccad8be5d9fc0973f1b4d202eec6eab865834403335a9f0765bbfa54638aed7f5d5f2183ba9dfeab9f5bc4ef48111a8427  cargo-tests-ignore-resolving_minimum_version_with_transitive_deps.patch
 c31fdfe8a9b3411576c75da46645cf0465b9053000a2ab49cf9b2f2733f679d6d33acbf236d67a20e14935d094a685453b7f1840180249f39d610fd0902c3125  check-rustc
-afca9b5524e270b6ddad4b2c99bba9a5f156a2411b04a9ca5802b185b50420de70555bb2526dcb4d5b12b29ff30afa2fe461d1de83b5345dd8e4ccf52e875c3f  cargo-skip-broken-tests.patch"
+afca9b5524e270b6ddad4b2c99bba9a5f156a2411b04a9ca5802b185b50420de70555bb2526dcb4d5b12b29ff30afa2fe461d1de83b5345dd8e4ccf52e875c3f  cargo-skip-broken-tests.patch
+78484210917af128a0fa1cfd762b937e2ff047764829e4ba5a10c1f4589bfb2420bf183b039ef88d8d9a2a60e5e150b7e1cd7e7aa1b1154baa2034d485a8a3bf  link-musl-dynamically.patch
+795194976763326c5e4a9eefc8b651b6d5fb533d2d000631ed48a92bafac90e9ca33b8d662e6c53ef109ea1a90c69def715d7d7154e3f9fb9035a58a313a7db3  musl-dont-use-crt-static.patch"

--- a/community/rust/link-musl-dynamically.patch
+++ b/community/rust/link-musl-dynamically.patch
@@ -1,0 +1,41 @@
+We don't need those, we provide musl ourselves.
+--- rustc-1.35.0-src/src/bootstrap/compile.rs
++++ rustc-1.35.0-src/src/bootstrap/compile.rs
+@@ -114,20 +114,7 @@ impl Step for Std {
+ fn copy_third_party_objects(builder: &Builder<'_>, compiler: &Compiler, target: Interned<String>) {
+     let libdir = builder.sysroot_libdir(*compiler, target);
+ 
+-    // Copies the crt(1,i,n).o startup objects
+-    //
+-    // Since musl supports fully static linking, we can cross link for it even
+-    // with a glibc-targeting toolchain, given we have the appropriate startup
+-    // files. As those shipped with glibc won't work, copy the ones provided by
+-    // musl so we have them on linux-gnu hosts.
+-    if target.contains("musl") {
+-        for &obj in &["crt1.o", "crti.o", "crtn.o"] {
+-            builder.copy(
+-                &builder.musl_root(target).unwrap().join("lib").join(obj),
+-                &libdir.join(obj),
+-            );
+-        }
+-    } else if target.ends_with("-wasi") {
++    if target.ends_with("-wasi") {
+         for &obj in &["crt1.o"] {
+             builder.copy(
+                 &builder.wasi_root(target).unwrap().join("lib/wasm32-wasi").join(obj),
+--- rustc-1.35.0-src/vendor/libc/src/unix/mod.rs
++++ rustc-1.35.0-src/vendor/libc/src/unix/mod.rs
+@@ -306,13 +306,6 @@ cfg_if! {
+     } else if #[cfg(feature = "use_std")] {
+         // cargo build, don't pull in anything extra as the libstd dep
+         // already pulls in all libs.
+-    } else if #[cfg(target_env = "musl")] {
+-        #[cfg_attr(feature = "rustc-dep-of-std",
+-                   link(name = "c", kind = "static",
+-                        cfg(target_feature = "crt-static")))]
+-        #[cfg_attr(feature = "rustc-dep-of-std",
+-                   link(name = "c", cfg(not(target_feature = "crt-static"))))]
+-        extern {}
+     } else if #[cfg(target_os = "emscripten")] {
+         #[link(name = "c")]
+         extern {}

--- a/community/rust/musl-dont-use-crt-static.patch
+++ b/community/rust/musl-dont-use-crt-static.patch
@@ -1,0 +1,13 @@
+We first have to build against upstream triplets, which by default use crt-static
+linking. This won't build though, so let's just disable it, we disable it in our
+triplets too.
+--- rustc-1.28.0-src/src/librustc_target/spec/linux_musl_base.rs.orig   2018-10-08 21:02:21.588611506 +0200
++++ rustc-1.28.0-src/src/librustc_target/spec/linux_musl_base.rs        2018-10-08 21:02:40.846454873 +0200
+@@ -61,7 +61,7 @@
+     base.post_link_objects_crt.push("crtn.o".to_string());
+
+     // These targets statically link libc by default
+-    base.crt_static_default = true;
++    base.crt_static_default = false;
+     // These targets allow the user to choose between static and dynamic linking.
+     base.crt_static_respected = true;


### PR DESCRIPTION
Also disable full bootstrapping. Since we always bootstrap from $pkgver minus one
we don't need it and it increases buildtime considerably.