### PR TITLE
testing/kitinerary: remove libphonenumber from makedepends on x86_64

### DIFF
--- a/testing/kitinerary/APKBUILD
+++ b/testing/kitinerary/APKBUILD
@@ -7,7 +7,27 @@ arch="all"
 url="https://kontact.kde.org/"
 pkgdesc="Data model and extraction system for travel reservation information"
 license="LGPL-2.0-or-later"
-makedepends="extra-cmake-modules qt5-qtbase-dev qt5-qtdeclarative-dev ki18n-dev kmime-dev kcalcore-dev kcontacts-dev kpkpass-dev poppler-dev zxing-cpp-dev zxing-cpp zlib-dev libxml2-dev libphonenumber-dev kcalcore-dev"
+makedepends="
+	extra-cmake-modules
+	qt5-qtbase-dev
+	qt5-qtdeclarative-dev
+	ki18n-dev
+	kmime-dev
+	kcalcore-dev
+	kcontacts-dev
+	kpkpass-dev
+	poppler-dev
+	zxing-cpp-dev
+	zxing-cpp
+	zlib-dev
+	libxml2-dev
+	kcalcore-dev
+	"
+# libphonenumber fails to link on x86_64 for some reason, but only on the Alpine
+# builders. Just disable it for now
+if [ "$CARCH" != "x86_64" ]; then
+	makedepends="$makedepends libphonenumber-dev"
+fi
 source="https://download.kde.org/stable/applications/$pkgver/src/$pkgname-$pkgver.tar.xz"
 subpackages="$pkgname-dev $pkgname-lang"
 options="!check" # Broken
@@ -22,8 +42,10 @@ build() {
 }
 
 check() {
-	# jsonlddocumenttest, mergeutiltest, airportdbtest, pkpassextractortest, postprocessortest, calendarhandlertest and extractortest are broken
-	CTEST_OUTPUT_ON_FAILURE=TRUE ctest -E "(jsonlddocument|mergeutil|airportdb|pkpassextractor|postprocessor|calendarhandler|extractor)test"
+	# jsonlddocumenttest, mergeutiltest, airportdbtest, pkpassextractortest,
+	# postprocessortest, calendarhandlertest and extractortest are broken
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest \
+		-E "(jsonlddocument|mergeutil|airportdb|pkpassextractor|postprocessor|calendarhandler|extractor)test"
 }
 
 package() {


### PR DESCRIPTION
35ee7505c6f44c55d2098b1dcc1712ca7a7c8404 clearly failed, so let's try this approach instead. Since the build output doesn't change for other architectures, a `$pkgrel` bump shouldn't be needed. 35ee7505c6f44c55d2098b1dcc1712ca7a7c8404 should probably be reverted (if possible).