### PR TITLE
testing/plasma-applet-weather-plugin: add missing depends

### DIFF
--- a/community/qt5-qtxmlpatterns/APKBUILD
+++ b/community/qt5-qtxmlpatterns/APKBUILD
@@ -6,12 +6,12 @@ _ver=${pkgver/_/-}
 _ver=${_ver/beta0/beta}
 _ver=${_ver/rc0/rc}
 _V=${_ver/rc/RC}
-pkgrel=0
+pkgrel=1
 pkgdesc="Qt5 - QtXmlPatterns component"
 url="http://qt-project.org/"
 arch="all"
 license="LGPL-2.0 with exceptions or GPL-3.0 with exceptions"
-makedepends="qt5-qtbase-dev"
+makedepends="qt5-qtbase-dev qt5-qtdeclarative-dev"
 subpackages="$pkgname-dev"
 
 case $pkgver in
@@ -24,17 +24,14 @@ builddir="$srcdir"/$_pkgname-${_V%-*}
 builddir="$srcdir"/$_pkgname-$_V
 
 build() {
-	cd "$builddir"
 	qmake-qt5 && make
 }
 
 check() {
-	cd "$builddir"
 	make check
 }
 
-package() {
-	cd "$builddir"
+package() {	
 	make install INSTALL_ROOT="$pkgdir"
 }
 

--- a/testing/plasma-applet-weather-widget/APKBUILD
+++ b/testing/plasma-applet-weather-widget/APKBUILD
@@ -2,11 +2,12 @@
 # Maintainer: Bart Ribbers <bribbers@disroot.org>
 pkgname=plasma-applet-weather-widget
 pkgver=1.6.10
-pkgrel=0
+pkgrel=1
 arch="all"
 url="https://www.linux-apps.com/content/show.php/Weather+Widget?content=169572"
 pkgdesc="Plasmoid for showing weather information from yr.no and Open Weather Map servers"
 license="GPL-2.0-only"
+depends="qt5-qtxmlpatterns qt5-qtdeclarative-dev"
 makedepends="extra-cmake-modules qt5-qtbase-dev plasma-framework-dev"
 source="$pkgname-$pkgver.tar.gz::https://github.com/kotelnik/$pkgname/archive/v$pkgver.tar.gz"
 subpackages="$pkgname-lang"


### PR DESCRIPTION
`plasma-applet-weather-plugin` needs `qt5-qtxmlpatterns` with QML support, so build it with `qt5-qtdeclarative`. When someone doesn't want the QML part of `qt5-qtxmlpatterns`, they can just not install `qt5-qtdeclarative`.