### PR TITLE
main/bzip2: Adding patch for CVE-2019-12900

### DIFF
--- a/main/bzip2/APKBUILD
+++ b/main/bzip2/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=bzip2
 pkgver=1.0.6
-pkgrel=6
+pkgrel=7
 pkgdesc="A high-quality data compression program"
 url="http://sources.redhat.com/bzip2"
 arch="all"
@@ -16,6 +16,7 @@ source="https://downloads.sourceforge.net/bzip2/bzip2-$pkgver.tar.gz
 	bzip2-1.0.3-no-test.patch
 	bzip2-1.0.4-POSIX-shell.patch
 	CVE-2016-3189.patch
+        CVE-2019-12900.patch
 	"
 
 # secfixes:
@@ -71,4 +72,5 @@ sha512sums="00ace5438cfa0c577e5f578d8a808613187eff5217c35164ffe044fbafdfec9e98f4
 b6810c73428f17245e0d7c2decd00c88986cd8ad1cfe4982defe34bdab808d53870ed92cb513b2d00c15301747ceb6ca958fb0e0458d0663b7d8f7c524f7ba4e  bzip2-1.0.2-progress.patch
 aefcafaaadc7f19b20fe023e0bd161127b9f32e0cd364621f6e5c03e95fb976e7e69e354ec46673a554392519532a3bfe56d982a5cde608c10e0b18c3847a030  bzip2-1.0.3-no-test.patch
 64ab461bf739c29615383750e7f260abb2d49df7eb23916940d512bd61fd9a37aaade4d8f6f94280c95fc781b8f92587ad4f3dda51e87dec7a92a7a6f8d8ae86  bzip2-1.0.4-POSIX-shell.patch
-cef6f448b661a775cc433f9636730e89c1285d07075536217657056be56e0a11e96f41f7c14f6ec59e235464b9ddd649a71fb8de1c60eda2fd5c2cdfbb6a8fdc  CVE-2016-3189.patch"
+cef6f448b661a775cc433f9636730e89c1285d07075536217657056be56e0a11e96f41f7c14f6ec59e235464b9ddd649a71fb8de1c60eda2fd5c2cdfbb6a8fdc  CVE-2016-3189.patch
+924992e381f701b43ac2e8bdeee46be0e592c8459acb55663c4a93127f6d5195271ede6aeedc66d09388f5c6e1c0caa792c6e19a38b469ee0294f0de8d273070  CVE-2019-12900.patch"

--- a/main/bzip2/APKBUILD
+++ b/main/bzip2/APKBUILD
@@ -20,6 +20,8 @@ source="https://downloads.sourceforge.net/bzip2/bzip2-$pkgver.tar.gz
 	"
 
 # secfixes:
+#   1.0.6-r7:
+#   - CVE-2019-12900
 #   1.0.6-r5:
 #   - CVE-2016-3189
 

--- a/main/bzip2/CVE-2019-12900.patch
+++ b/main/bzip2/CVE-2019-12900.patch
@@ -1,0 +1,11 @@
+--- a/decompress.c
++++ b/decompress.c
+@@ -287,7 +287,7 @@
+       GET_BITS(BZ_X_SELECTOR_1, nGroups, 3);
+       if (nGroups < 2 || nGroups > 6) RETURN(BZ_DATA_ERROR);
+       GET_BITS(BZ_X_SELECTOR_2, nSelectors, 15);
+-      if (nSelectors < 1) RETURN(BZ_DATA_ERROR);
++      if (nSelectors < 1 || nSelectors > BZ_MAX_SELECTORS) RETURN(BZ_DATA_ERROR);
+       for (i = 0; i < nSelectors; i++) {
+          j = 0;
+          while (True) {


### PR DESCRIPTION
Adding the upstream bzip2 security patch to fix the out of bounds security
vulnerability in bzip2.