### PR TITLE
main/libuv: upgrade to 1.30.1

### DIFF
--- a/main/libuv/APKBUILD
+++ b/main/libuv/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libuv
-pkgver=1.29.1
+pkgver=1.30.1
 pkgrel=0
 pkgdesc="Cross-platform asychronous I/O"
 url="https://libuv.org"
@@ -53,4 +53,4 @@ package() {
 		"$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 
-sha512sums="0813a57d7da28c1665824be69321f133050656171d294bb0cb5a83bab7b7c8eef2d6690bdcff2f44727a6f6d6b9b977a66586efb5d59ed280f78be72c71110d3  libuv-v1.29.1.tar.gz"
+sha512sums="a27c808d437b0e5000cd0018cf3a11d49869bf4cb4a9955d3825fa002465f87a78ad8d0e83e3ea829561d9fbf8f6332c213c1c94bfb5557843864b3ddcd0d715  libuv-v1.30.1.tar.gz"


### PR DESCRIPTION
- https://github.com/libuv/libuv/releases 1.30.1

ABI compatible https://abi-laboratory.pro/?view=timeline&l=libuv