### PR TITLE
testing/minio: upgrade to 0.20190627

### DIFF
--- a/testing/minio/APKBUILD
+++ b/testing/minio/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
 # Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=minio
-_pkgver='RELEASE.2019-06-19T18-24-42Z'
+_pkgver='RELEASE.2019-06-27T21-13-50Z'
 pkgver=${_pkgver#*.}
 pkgver=${pkgver%T*}
 pkgver=0.${pkgver//-}
@@ -17,10 +17,10 @@ makedepends="go"
 source="
 	minio.initd
 	minio.confd
-	https://github.com/minio/minio/archive/$_pkgver.tar.gz
+	$pkgname-$pkgver.tar.gz::https://github.com/minio/minio/archive/$_pkgver.tar.gz
 	"
 builddir="$srcdir/src/github.com/minio/$pkgname"
-options="!check" # pkg/disk fails with "disk_test.go:42: Unexpected FSType UNKNOWN"
+options="!check net" # pkg/disk fails with "disk_test.go:42: Unexpected FSType UNKNOWN"
 subpackages="$pkgname-openrc"
 
 export GOPATH="$srcdir"
@@ -58,4 +58,4 @@ cleanup_srcdir() {
 
 sha512sums="6427a225d4e6c51cc5de077ccd29ddf52556722cf958e83e480df1c5882aa4fa7daebfeb970e80f8f9c3176594d8e427e8c8dbf268ce945647a11bdf1e69affd  minio.initd
 ed9790fbadfb38e4d660eb1befd87e803d70dec04d936e8cd26def4a9c21240bb7cae8750ae3395aa4761e6738b9e346c86ba57761cfde30efe46d2cb459a7e4  minio.confd
-25d4ed521481b08b50c10825a5a0cc47a3e36adc6d6945c4febe8848045c4909e92d674ded7681deb1eb25d5f1d3626d2f050cde99b368418b449a419673b66c  RELEASE.2019-06-19T18-24-42Z.tar.gz"
+2ac9af7fddf2152fd19afc984828a439df9878f57519d7a9ad29b3946e43afb257fddda4556fe85a3ebc49c24dffe4c3c789a83ee7c7039ca33c89dd7acf42d1  minio-0.20190627.tar.gz"


### PR DESCRIPTION
Also:
1. Explicitly name the source tarball, since it can cause conflicts.
2. Enable the "net" option for rootbld.