### PR TITLE
testing/tarantool: enable on armhf

### DIFF
--- a/testing/tarantool/APKBUILD
+++ b/testing/tarantool/APKBUILD
@@ -8,10 +8,10 @@ pkgrel=7
 pkgdesc="Lua application server integrated with a database management system"
 url="https://tarantool.org"
 # x86, aarch64: fails to build
-# armhf: zstd not available (fails to build)
+# # armhf: zstd not available (fails to build)
 # ppc64le: not supported by LuaJIT w/o patches
 # s390x: not supported by LuaJIT
-arch="x86_64"
+arch="x86_64 armhf"
 license="BSD-2-Clause MIT Public-Domain"
 pkgusers="$pkgname"
 pkggroups="$pkgname"


### PR DESCRIPTION
zstd is now available, let's try it!