### PR TITLE
main/nettle: upgrade to 3.5.1

### DIFF
--- a/community/claws-mail/APKBUILD
+++ b/community/claws-mail/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=claws-mail
 pkgver=3.17.3
-pkgrel=6
+pkgrel=7
 pkgdesc="A GTK+ based e-mail client."
 url="https://www.claws-mail.org"
 arch="all"

--- a/community/filezilla/APKBUILD
+++ b/community/filezilla/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=filezilla
 pkgver=3.43.0
-pkgrel=0
+pkgrel=1
 pkgdesc="FTP Client"
 url="https://filezilla-project.org"
 arch="all"

--- a/community/libfilezilla/APKBUILD
+++ b/community/libfilezilla/APKBUILD
@@ -2,7 +2,7 @@
 # filezilla needs to be rebuilt when libfilezilla version changes, ABI is not stable
 pkgname=libfilezilla
 pkgver=0.17.1
-pkgrel=0
+pkgrel=1
 pkgdesc="C++ library for filezilla"
 url="https://filezilla-project.org"
 arch="all"

--- a/community/rdfind/APKBUILD
+++ b/community/rdfind/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=rdfind
 pkgver=1.4.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Redundant data find - a program that finds duplicate files"
 url="http://rdfind.pauldreik.se"
 arch="all"

--- a/main/aria2/APKBUILD
+++ b/main/aria2/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=aria2
 pkgver=1.34.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Download utility for HTTP(S), (S)FTP, Bittorrent, and Metalink"
 url="https://aria2.github.io/"
 arch="all"

--- a/main/dnsmasq/APKBUILD
+++ b/main/dnsmasq/APKBUILD
@@ -15,7 +15,7 @@
 #
 pkgname=dnsmasq
 pkgver=2.80
-pkgrel=3
+pkgrel=4
 pkgdesc="A lightweight DNS, DHCP, RA, TFTP and PXE server"
 url="http://www.thekelleys.org.uk/dnsmasq/"
 arch="all"

--- a/main/freeradius-client/APKBUILD
+++ b/main/freeradius-client/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer:  Natanael Copa <ncopa@alpinelinux.org>
 pkgname=freeradius-client
 pkgver=1.1.7
-pkgrel=2
+pkgrel=3
 pkgdesc="FreeRADIUS Client Software"
 url="https://freeradius.org/sub_projects/"
 arch="all"

--- a/main/gnutls/APKBUILD
+++ b/main/gnutls/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gnutls
 pkgver=3.6.8
-pkgrel=0
+pkgrel=1
 pkgdesc="A TLS protocol implementation"
 url="https://www.gnutls.org/"
 arch="all"

--- a/main/nettle/APKBUILD
+++ b/main/nettle/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=nettle
 pkgver=3.5.1
-pkgrel=0
+pkgrel=1
 pkgdesc="A low-level cryptographic library"
 url="http://www.lysator.liu.se/~nisse/nettle/"
 arch="all"

--- a/main/nettle/APKBUILD
+++ b/main/nettle/APKBUILD
@@ -2,19 +2,17 @@
 # Contributor: Fabian Affolter <fabian@affolter-engineering.ch>
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=nettle
-pkgver=3.4.1
-pkgrel=1
+pkgver=3.5.1
+pkgrel=0
 pkgdesc="A low-level cryptographic library"
 url="http://www.lysator.liu.se/~nisse/nettle/"
 arch="all"
 license="LGPL-2.0-or-later"
-depends=""
 depends_dev="gmp-dev"
 makedepends="$depends_dev m4"
 subpackages="$pkgname-dev $pkgname-utils"
 source="https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz
 	nettle-2.4-makefile.patch"
-builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	local _arch_opts=
@@ -36,6 +34,7 @@ build() {
 		--localstatedir=/var \
 		--enable-shared \
 		--disable-openssl \
+		--disable-static \
 		$_arch_opts
 	make
 	# strip comments in fields from .pc as it confuses pkgconf
@@ -59,5 +58,5 @@ utils() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="26aefbbe9927e90e28f271e56d2ba876611831222d0e1e1a58bdb75bbd50934fcd84418a4fe47b845f557e60a9786a72a4de2676c930447b104f2256aca7a54f  nettle-3.4.1.tar.gz
+sha512sums="f738121b9091cbe79435fb5d46b45cf6f10912320c233829356908127bab1cac6946ca56e022a832380c44f2c10f21d2feef64cb0f4f41e3da4a681dc0131784  nettle-3.5.1.tar.gz
 c7d9741a7a37d225f3f0db16d355e13b04cc0f1ac56882a6ff31ef15c1a1a0aee7a70cf1ec8bbf2c46b9b0dcec153da7a7aa6b8909a72d76dd4d669cbbaceaa4  nettle-2.4-makefile.patch"

--- a/main/qemu/APKBUILD
+++ b/main/qemu/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=qemu
 pkgver=4.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="QEMU is a generic machine emulator and virtualizer"
 url="http://qemu.org/"
 arch="all"

--- a/main/rtmpdump/APKBUILD
+++ b/main/rtmpdump/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=rtmpdump
 verbase=2.4
 pkgver=2.4_git20160909
-pkgrel=6
+pkgrel=7
 pkgdesc="A tool to download rtmp:// and rtmpe:// streams"
 url="http://rtmpdump.mplayerhq.hu/"
 arch="all"

--- a/main/xen/APKBUILD
+++ b/main/xen/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: 
 pkgname=xen
 pkgver=4.12.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Xen hypervisor"
 url="https://www.xenproject.org/"
 arch="x86_64 armhf aarch64" # enable armv7 when builds with gcc8

--- a/testing/epiphany/APKBUILD
+++ b/testing/epiphany/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=epiphany
 pkgver=3.32.3
-pkgrel=0
+pkgrel=1
 pkgdesc="A simple, clean, beautiful view of the web"
 options="!check" # Location entry test fails on builders
 url="https://wiki.gnome.org/Apps/Web"

--- a/testing/pike/APKBUILD
+++ b/testing/pike/APKBUILD
@@ -2,7 +2,7 @@
 pkgname=pike
 _pkgname=Pike
 pkgver=8.0.610
-pkgrel=1
+pkgrel=2
 pkgdesc="Pike Programing language"
 url="https://pike.lysator.liu.se"
 arch="x86_64"

--- a/testing/sequoia-sqv/APKBUILD
+++ b/testing/sequoia-sqv/APKBUILD
@@ -3,7 +3,7 @@
 _project="sequoia"
 pkgname="${_project}-sqv"
 pkgver="0.7.0"
-pkgrel=0
+pkgrel=1
 pkgdesc="A simple signature verification program"
 url="https://sequoia-pgp.org/"
 arch="x86_64" # limited by cargo

--- a/testing/stoken/APKBUILD
+++ b/testing/stoken/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=stoken
 pkgver=0.92
-pkgrel=0
+pkgrel=1
 pkgdesc="RSA SecurID-compatible software token for Linux/UNIX systems"
 url="http://stoken.sf.net"
 arch="all"


### PR DESCRIPTION
- [x] aria2
- [x] claws-mail
- [ ] dnsmasq
- [x] epiphany
- [x] filezilla
- [x] freeradius-client
- [x] gnutls
- [x] libfilezilla
- [x] pike
- [x] qemu
- [x] rdfind
- [x] rtmpdump
- [ ] sequoia-sqv
- [x] stoken
- [x] xen