### PR TITLE
add raspi2png

### DIFF
--- a/testing/raspi2png/APKBUILD
+++ b/testing/raspi2png/APKBUILD
@@ -1,0 +1,23 @@
+# Maintainer: signageOS <dev@signageos.io>
+pkgname="raspi2png"
+pkgver="0.1"
+_commitid=5008e64ead4e1d3a6496ec98e800a695629a3a2e
+pkgrel=0
+pkgdesc="Utility to take a snapshot of the raspberry pi screen and save it as a PNG file"
+url="https://github.com/AndrewFromMelbourne/raspi2png"
+arch="armhf"
+license="MIT"
+makedepends="libpng-dev raspberrypi-dev"
+options="!check"
+source="raspi2png-$pkgver.tar.gz::https://github.com/AndrewFromMelbourne/raspi2png/archive/$_commitid.tar.gz"
+builddir="$srcdir/"$pkgname-$_commitid
+
+build() {
+	make
+}
+
+package() {
+	mkdir -p $pkgdir/usr/bin
+	cp raspi2png $pkgdir/usr/bin/raspi2png
+}
+sha512sums="8b7023f904aa96a99ef0b68714acb67c34d2e2806c8c40774fdde02f282fb54ee7eded760c4547db9add78127585aaa07fb80985c188faa130c3fc860788139a  raspi2png-0.1.tar.gz"


### PR DESCRIPTION
Great tool for making screenshots on Raspberry Pi. Definitely useful to have in the repo.

https://github.com/AndrewFromMelbourne/raspi2png