### PR TITLE
community/php7-phalcon: upgrade to 3.4.4

### DIFF
--- a/community/php7-phalcon/APKBUILD
+++ b/community/php7-phalcon/APKBUILD
@@ -3,9 +3,9 @@
 pkgname=php7-phalcon
 _pkgext=phalcon
 _pkgreal=cphalcon
-pkgver=3.4.3
+pkgver=3.4.4
 _pkgver=${pkgver/_rc/RC}
-pkgrel=2
+pkgrel=0
 pkgdesc="High performance, full-stack PHP framework delivered as a C extension"
 url="https://github.com/phalcon/cphalcon"
 arch="all"
@@ -35,4 +35,4 @@ package() {
 	echo "extension=$_pkgext.so" > "$pkgdir"/etc/php7/conf.d/$_pkgext.ini
 }
 
-sha512sums="dc48055aaab412fa48987624d6813f7d6f375a743b77e64464aab165e2a06988e5714c4262a1cc175f16079b08f6941b77c0a86b5a39c4ae41c51d80e85b930c  php7-phalcon-3.4.3.tar.gz"
+sha512sums="0c09e36b8e81e4eb7e5e85100e555226439bf5b927fb39de7289d8fcd91deda70082b2692a1273a0410d9a0020cb36218654f7b8c42c06a200b0f638d1006e63  php7-phalcon-3.4.4.tar.gz"


### PR DESCRIPTION
Ref https://github.com/phalcon/cphalcon/releases/tag/v3.4.4

PS needs backport because fix segfaults for updated php