### PR TITLE
main/nginx: fix http-geoip2 bug

### DIFF
--- a/main/nginx/APKBUILD
+++ b/main/nginx/APKBUILD
@@ -19,7 +19,7 @@ pkgname=nginx
 # NOTE: Upgrade only to even-numbered versions (e.g. 1.14.z, 1.16.z)!
 # Odd-numbered versions are mainline (development) versions.
 pkgver=1.16.1
-pkgrel=0
+pkgrel=1
 # Revision of nginx-tests to use for check().
 _tests_hgrev=40e5f2a0a238
 _njs_ver=0.3.4
@@ -151,7 +151,9 @@ _rtmp_provides="$pkgname-rtmp"  # for backward compatibility
 _add_module "http-vod" "1.24" "https://github.com/kaltura/nginx-vod-module"
 
 _add_module "http-geoip2" "3.2" "https://github.com/leev/ngx_http_geoip2_module"
-_http_geoip2_so="ngx_http_geoip2_module.so ngx_stream_geoip2_module.so"
+
+_add_module "stream-geoip2" "3.2" "https://github.com/leev/ngx_http_geoip2_module"
+_stream_geoip2_depends="$pkgname-mod-stream"
 
 prepare() {
 	local file; for file in $source; do
@@ -314,7 +316,8 @@ _module() {
 
 	local soname; for soname in $sonames; do
 		mv "$pkgdir"/$_modules_dir/$soname ./$_modules_dir/$soname
-		echo "load_module \"modules/$soname\";" > ./etc/nginx/modules/$name.conf
+		rm -f "$pkgdir"/$_modules_dir/${soname}.old
+		echo "load_module \"modules/$soname\";" >> ./etc/nginx/modules/$name.conf
 	done
 }
 
@@ -340,4 +343,5 @@ c31c46344d49704389722325a041b9cd170fa290acefe92cfc572c07f711cd3039de78f28df48ca7
 8adb7453c27748f4e685e3352e9b318b408da818754dc5b6244e908423941a8ba337561104f6e481f2553cbc0e334dcea73b57f8e810a9d6e974bb69ff8859e5  nginx-upstream-fair-0.1.3.tar.gz
 4a0af5e9afa4deb0b53de8de7ddb2cfa6430d372e1ef9e421f01b509548bd134d427345442ac1ce667338cc2a1484dc2ab732e316e878ac7d3537dc527d5f922  nginx-rtmp-module-1.2.1.tar.gz
 daa9b23858937e57f1bcd5f4400b33155ab4e0e455eea01d80eec5285fc85bd10db63d80a1560f1fea51914a4eb4c59cc54110b7e4de208adbf52ea691cfd6d9  nginx-vod-module-1.24.tar.gz
+84b26955234e29dbfbf2431b652fcc453c5e86b95f837296df4f3d6c730e3e0773223dae890eebfc9b5763f46082bde6f38d6505b8bf78133b89e7297016cc5d  ngx_http_geoip2_module-3.2.tar.gz
 84b26955234e29dbfbf2431b652fcc453c5e86b95f837296df4f3d6c730e3e0773223dae890eebfc9b5763f46082bde6f38d6505b8bf78133b89e7297016cc5d  ngx_http_geoip2_module-3.2.tar.gz"


### PR DESCRIPTION
Currently, there are ~3~2 bugs in the nginx package (and modules)

1) Nginx is loading `ngx_stream_geoip2_module.so` before `ngx_stream_module.so` and that prevents nginx from starting with error `nginx: [emerg] dlopen() "/var/lib/nginx/modules/ngx_stream_geoip2_module.so" failed (Error relocating /var/lib/nginx/modules/ngx_stream_geoip2_module.so: ngx_stream_add_variable: symbol not found) in /etc/nginx/modules/http_geoip2.conf:1`
2) When there is more than one so defined for a module, the line `echo "load_module \"modules/$soname\";" > ./etc/nginx/modules/$name.conf` only writes the last so listed into the conf file, so `ngx_http_geoip2_module.so` is not being loaded
~3) sha512sum for the package `lua-nginx-module-0.10.15.tar.gz` has changed, so nginx currently doesn't build with abuild~ fixed in #10076 

This PR fixes these issues by
1) Splitting stream-geoip2 from http-geoip2 into its own package, and loading the stream-geoip2 conf after stream (alphabetical)
2) Fixing the echo line to append into conf file
~3) Updating the sha512sum for the lua nginx module~ fixed in #10076 

Note: Splitting stream-geoip2 into a new package is a somewhat hacky method because we are pulling the same github repo twice and building it twice (once for http-geoip2 and once for stream-geoip2). Each build results in two so's one for http and one for stream. After the second build the first pair are renamed ${soname}.old so I added a line `rm -f "$pkgdir"/$_modules_dir/${soname}.old` to remove these duplicate files before packaging.