### PR TITLE
community/docker: update to 18.09.7

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: Jake Buchholz <tomalok@gmail.com>
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 pkgname=docker
-pkgver=18.09.6
-_gitcommit=481bc7715621adba10752357e0d537c8dc86507d	# https://github.com/docker/docker-ce/commits/v$pkgver
+pkgver=18.09.7
+_gitcommit=2d0083d657f82c47044c8d3948ba434b622fe2fd	# https://github.com/docker/docker-ce/commits/v$pkgver
 _ver=${pkgver/_/-}-ce
 pkgrel=0
 pkgdesc="Pack, ship and run any application as a lightweight container"
@@ -15,8 +15,12 @@ makedepends="go go-md2man btrfs-progs-dev bash linux-headers coreutils lvm2-dev 
 install="$pkgname.pre-install"
 
 # from https://github.com/docker/docker-ce/blob/v$pkgver/components/engine/vendor.conf
-_libnetwork_ver=872f0a83c98add6cae255c8859e29532febc0039
+_libnetwork_ver=e7933d41e7b206756115aa9df5e0599fc5169742
 _cobra_ver="0.0.3"
+
+# secfixes:
+#   18.09.7:
+#     - CVE-2018-15664
 
 subpackages="
 	$pkgname-engine:engine
@@ -205,8 +209,8 @@ cli_vim() {
 	done
 }
 
-sha512sums="f05fc78f5891fa0308878690576e245eebb1e72f306f5b629b0e82dc96a04812202a2393ee6fd352bc59a1c5d29d398f0d6cddf545d57b483a051d14d7a0ee28  docker-18.09.6.tar.gz
-c8e8544a3d8d44dc0f309aa3520a2cf62cee374a06d40473542078de94d88cb484c0dca1cee7ad89fb312c969af1694c848f464d04d61df5a9888058e21a485e  libnetwork-872f0a83c98add6cae255c8859e29532febc0039.tar.gz
+sha512sums="7d06ab01673b5931a8dde1d2fcebf442d1a107c98c95cd8fe3b886c123b48470950601782fe0c83e7537a1e856069e79a096b9f4523fea7984fd3e773b243b66  docker-18.09.7.tar.gz
+0a833510df0029999bfc05c23445a58a8b2ff165c0fb2fd5c411498d1e89b5b1990d2778b32346dd2b6d61c166ff707c6277a5d1937db6345c77d3825eb59875  libnetwork-e7933d41e7b206756115aa9df5e0599fc5169742.tar.gz
 c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 33155a79799cc6c0520a030e1a9bdba60441776d612e5e255574b23bbce1c7a8e5d868284b05a8a92704be6bbb7db905388564e867986a705acbe4884ac58584  docker-openrc-fixes.patch
 9b24dc0c50904c3d12bb04c1a7df169651043ddbc258018647010a5aa01d8a19ad54d10ca79dce6d6283c81f4fa0cc8de417f6180dd824c5a588b22b23546cb5  docker-openrc-busybox-ash.patch"


### PR DESCRIPTION
Fix: CVE-2018-15664 symlink-exchange attack with directory traversal.

More release details at https://github.com/docker/docker-ce/releases/tag/v18.09.7