### PR TITLE
add mongo-cxx-driver

### DIFF
--- a/testing/mongo-cxx-driver/01-dont-build-mongo-tests.patch
+++ b/testing/mongo-cxx-driver/01-dont-build-mongo-tests.patch
@@ -1,0 +1,13 @@
+diff --git a/src/mongocxx/CMakeLists.txt b/src/mongocxx/CMakeLists.txt
+index b0a2828ff..73d082480 100644
+--- a/src/mongocxx/CMakeLists.txt
++++ b/src/mongocxx/CMakeLists.txt
+@@ -194,7 +194,7 @@ if(MONGOCXX_BUILD_STATIC)
+     mongocxx_install(mongocxx_static)
+ endif()
+ 
+-add_subdirectory(test)
++# add_subdirectory(test)
+ 
+ set_local_dist (src_mongocxx_DIST_local
+    CMakeLists.txt

--- a/testing/mongo-cxx-driver/APKBUILD
+++ b/testing/mongo-cxx-driver/APKBUILD
@@ -1,0 +1,81 @@
+# Contributor: Russ Webber <russ@rw.id.au>
+# Maintainer: Russ Webber <russ@rw.id.au>
+pkgname="mongo-cxx-driver"
+pkgver="3.4.0"
+_commit="131fa1a67acd45c0eebcbdcfee42b212af8d2e80" # master compiles with GCC8.3/CXX17
+pkgrel=0
+pkgdesc="C++ driver for MongoDB"
+url="http://mongocxx.org/"
+arch="all"
+license="Apache-2.0"
+makedepends="cmake mongo-c-driver-dev libbson-dev openssl-dev python3 snappy-dev"
+subpackages="$pkgname-dev:_dev libbsoncxx libbsoncxx-dev"
+depends_dev="libbson-dev"
+source="mongo-cxx-driver-$pkgver.tar.gz::https://github.com/mongodb/mongo-cxx-driver/archive/$_commit.tar.gz
+	01-dont-build-mongo-tests.patch"
+builddir="$srcdir/mongo-cxx-driver-$_commit"
+
+prepare() {
+	mkdir -p "$builddir/build"
+	default_prepare
+}
+
+build() {
+	cd "$builddir/build"
+	if [ "$CBUILD" != "$CHOST" ]; then
+		CMAKE_CROSSOPTS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
+	fi
+	cmake \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_SHARED_LIBS=True \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+		-DCMAKE_C_FLAGS="$CFLAGS" \
+		-DCMAKE_CXX_STANDARD=17 \
+		-DBSONCXX_POLY_USE_STD=ON \
+		${CMAKE_CROSSOPTS} ..
+	make
+}
+
+check() {
+	# mongo tests require a running server, so they are disabled.
+	# libbsoncxx tests are still ran
+	cd "$builddir/build"
+	make test
+}
+
+package() {
+	cd "$builddir/build"
+	make DESTDIR="$pkgdir" install
+	rm -rf "$pkgdir"/usr/share/mongo-cxx-driver/
+}
+
+libbsoncxx() {
+	pkgdesc="Building, parsing, and iterating BSON documents using C++"
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/libbsoncxx.so.* "$subpkgdir"/usr/lib/
+}
+
+_dev() {
+	default_dev
+
+	# libbsoncxx pkg-config files
+	mkdir -p "$pkgdir"/usr/lib/pkgconfig
+	mv "$subpkgdir"/usr/lib/pkgconfig/libbsoncxx.pc "$pkgdir"/usr/lib/pkgconfig
+
+	# libbsoncxx solink
+	mkdir -p "$pkgdir"/usr/lib
+	mv "$subpkgdir"/usr/lib/libbsoncxx.so "$pkgdir"/usr/lib
+
+	# libbsoncxx cmake file
+	mkdir -p "$pkgdir"/usr/lib/cmake
+	mv "$subpkgdir"/usr/lib/cmake/libbsoncxx-* "$pkgdir"/usr/lib/cmake
+
+	# libbsoncxx include files
+	mkdir -p "$pkgdir"/usr/include
+	mv "$subpkgdir"/usr/include/bsoncxx "$pkgdir"/usr/include
+}
+
+sha512sums="271807e0906ba82912c1249571e3784e600c80f0aeb7d5dc927a5784fe3584b35f830677c1634afa1818310243d4b1ae694f32e44c7c36641a4904e4236756e4  mongo-cxx-driver-3.4.0.tar.gz
+2d5aa9adb75e3e9244f8b4b2769b0e3f6c92aff8b8f04bd55a0eb2c788e5e4ff24487e94c6680f37d485cd989ec4219edef942b2592e05b80c187611e225ba4f  01-dont-build-mongo-tests.patch"


### PR DESCRIPTION
Requires https://github.com/alpinelinux/aports/pull/9486

Added the CXX driver which is also Apache 2.0 licensed.