### PR TITLE
[3.9] community/docker: update to 18.09.7

### DIFF
--- a/community/containerd/APKBUILD
+++ b/community/containerd/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=containerd
 
 # NOTE: containerd's Makefile tries to get REVISION from git, but we're building from a tarball.
-_commit=9754871865f7fe2f4e74d43e2fc7ccd237edcbce
-pkgver=1.2.2
+_commit=85f6aa58b8a3170aec9824568f7a31832878b603
+pkgver=1.2.7
 pkgrel=0
 pkgdesc="An open and reliable container runtime"
 url="https://containerd.io"
@@ -16,6 +16,10 @@ makedepends="btrfs-progs-dev go go-md2man libseccomp-dev"
 subpackages="$pkgname-doc"
 source="containerd-$pkgver.tar.gz::https://github.com/containerd/containerd/archive/v$pkgver.tar.gz"
 builddir="$srcdir/src/github.com/containerd/containerd"
+
+# secfixes:
+#   1.2.6:
+#     - CVE-2019-9946
 
 build() {
 	cd "$srcdir"
@@ -42,4 +46,4 @@ package() {
 	install -Dm644 "$builddir"/man/*.5 "$pkgdir"/usr/share/man/man5/
 }
 
-sha512sums="0fdd8799c5afb75074b6f00d5191e983ff570b323242665055c73b2e7a6bdd74a745e287f4f7b675dde26e8bf083c144104151e794ad24d2a8f6f39ae2ee6fff  containerd-1.2.2.tar.gz"
+sha512sums="b96ca236d28933c1bf309fc7204af7d2c356e19af394d5c2274a178c8f15298faf6ca9bb8e7d04acb7c3c9c41035446643a8df0103017f7ed0320bfc37cb8ca9  containerd-1.2.7.tar.gz"

--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -1,30 +1,36 @@
+# Contributor: Eivind Uggedal <eu@eju.no>
 # Contributor: Jake Buchholz <tomalok@gmail.com>
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
-
 pkgname=docker
-pkgver=18.09.1
-_gitcommit=4c52b901c6cb019f7552cd93055f9688c6538be4	# https://github.com/docker/docker-ce/commits/v$pkgver
+pkgver=18.09.7
+_gitcommit=2d0083d657f82c47044c8d3948ba434b622fe2fd	# https://github.com/docker/docker-ce/commits/v$pkgver
 _ver=${pkgver/_/-}-ce
 pkgrel=0
 pkgdesc="Pack, ship and run any application as a lightweight container"
 url="http://www.docker.io/"
 arch="all"
 license="Apache-2.0"
-depends="ca-certificates containerd iptables tini-static"
+depends="docker-engine docker-cli"
 makedepends="go go-md2man btrfs-progs-dev bash linux-headers coreutils lvm2-dev libtool"
 install="$pkgname.pre-install"
 
-# https://github.com/docker/docker-ce/blob/v$pkgver/components/engine/hack/dockerfile/install/proxy.installer
-_libnetwork_ver=2cfbf9b1f98162a55829a21cc603c76072a75382
+# from https://github.com/docker/docker-ce/blob/v$pkgver/components/engine/vendor.conf
+_libnetwork_ver=e7933d41e7b206756115aa9df5e0599fc5169742
 _cobra_ver="0.0.3"
 
+# secfixes:
+#   18.09.7:
+#     - CVE-2018-15664
+
 subpackages="
-	$pkgname-bash-completion:bashcomp:noarch
-	$pkgname-fish-completion:fishcomp:noarch
-	$pkgname-zsh-completion:zshcomp:noarch
-	$pkgname-vim:vim:noarch
-	$pkgname-doc
-	$pkgname-openrc
+	$pkgname-engine:engine
+	$pkgname-openrc:engine_openrc:noarch
+	$pkgname-cli:cli
+	$pkgname-doc:cli_doc:noarch
+	$pkgname-bash-completion:cli_bashcomp:noarch
+	$pkgname-fish-completion:cli_fishcomp:noarch
+	$pkgname-zsh-completion:cli_zshcomp:noarch
+	$pkgname-vim:cli_vim:noarch
 	"
 
 source="
@@ -114,71 +120,87 @@ build() {
 	./man/md2man-all.sh -q
 }
 
-check() {
-	cd "$_cli_builddir"/build
-        ./docker --version
-	cd "$_daemon_builddir"/bundles/dynbinary-daemon
-	./dockerd --version
+# docker itself is a meta package
+package() {
+	mkdir -p "$pkgdir"
 }
 
-package() {
-	cd "$_dockerdir"
-	local ver=$(cat VERSION)
+engine() {
+	pkgdesc="Docker Engine (dockerd)"
+	depends="ca-certificates containerd iptables tini-static"
+
+	install -Dm755 "$_daemon_builddir"/bundles/dynbinary-daemon/dockerd \
+		"$subpkgdir"/usr/bin/dockerd
+
+	install -Dm755 "$_libnetwork_builddir"/docker-proxy \
+		"$subpkgdir"/usr/bin/docker-proxy
+
+	# symlink externally provided tini-static binary
+	ln -s /sbin/tini-static "$subpkgdir"/usr/bin/docker-init
+}
+
+engine_openrc() {
+	pkgdesc="OpenRC init scripts for Docker"
+	depends=""
+	install_if="openrc $pkgname-engine=$pkgver-r$pkgrel"
+
+	install -Dm755 "$_daemon_builddir"/contrib/init/openrc/docker.initd \
+		"$subpkgdir"/etc/init.d/docker
+	install -Dm644 "$_daemon_builddir"/contrib/init/openrc/docker.confd \
+		"$subpkgdir"/etc/conf.d/docker
+}
+
+cli() {
+	pkgdesc="Docker CLI"
+	depends="ca-certificates"
 
 	# 'build/docker' is a symlink to 'docker-linux-$arch' e.g. 'docker-linux-amd64'
 	install -Dm755 "$_cli_builddir"/build/docker \
-		"$pkgdir"/usr/bin/docker
-
-	install -Dm755 "$_daemon_builddir"/bundles/dynbinary-daemon/dockerd \
-		"$pkgdir"/usr/bin/dockerd
-
-	install -Dm755 "$_libnetwork_builddir"/docker-proxy \
-		"$pkgdir"/usr/bin/docker-proxy
-
-	# symlink externally provided tini-static binary
-	ln -s /sbin/tini-static "$pkgdir"/usr/bin/docker-init
-
-	install -Dm755 "$_daemon_builddir"/contrib/init/openrc/docker.initd \
-		"$pkgdir"/etc/init.d/docker
-	install -Dm644 "$_daemon_builddir"/contrib/init/openrc/docker.confd \
-		"$pkgdir"/etc/conf.d/docker
-
-	mkdir -p "$pkgdir"/usr/share/man/man1
-	install -Dm644 "$_cli_builddir"/man/man1/* \
-		"$pkgdir"/usr/share/man/man1
+		"$subpkgdir"/usr/bin/docker
 }
 
-bashcomp() {
+cli_doc() {
+	pkgdesc="Documentation for Docker"
+	depends=""
+	install_if="docs $pkgname-cli=$pkgver-r$pkgrel"
+
+	mkdir -p "$subpkgdir"/usr/share/man/man1
+	gzip -9 "$_cli_builddir"/man/man1/*
+	install -Dm644 "$_cli_builddir"/man/man1/* \
+		"$subpkgdir"/usr/share/man/man1
+}
+
+cli_bashcomp() {
 	pkgdesc="Bash completion for Docker"
 	depends=""
-	install_if="$pkgname=$pkgver-r$pkgrel bash-completion"
+	install_if="bash-completion $pkgname-cli=$pkgver-r$pkgrel"
 
 	install -Dm644 "$_cli_builddir"/contrib/completion/bash/$pkgname \
 		"$subpkgdir"/usr/share/bash-completion/completions/$pkgname
 }
 
-fishcomp() {
+cli_fishcomp() {
 	pkgdesc="Fish shell completion for Docker"
 	depends=""
-	install_if="$pkgname=$pkgver-r$pkgrel fish"
+	install_if="fish<3 $pkgname-cli=$pkgver-r$pkgrel" # fish above version 3 has docker completion
 
 	install -Dm644 "$_cli_builddir"/contrib/completion/fish/$pkgname.fish \
 		"$subpkgdir"/usr/share/fish/completions/$pkgname.fish
 }
 
-zshcomp() {
-	pkgdesc="Zsh completion for $pkgname"
+cli_zshcomp() {
+	pkgdesc="Zsh completion for Docker"
 	depends=""
-	install_if="$pkgname=$pkgver-r$pkgrel zsh"
+	install_if="zsh $pkgname-cli=$pkgver-r$pkgrel"
 
 	install -Dm644 "$_cli_builddir"/contrib/completion/zsh/_$pkgname \
 		"$subpkgdir"/usr/share/zsh/site-functions/_$pkgname
 }
 
-vim() {
+cli_vim() {
+	pkgdesc="Vim syntax for Docker"
 	depends=""
-	pkgdesc="Vim syntax for $pkgname"
-	install_if="vim $pkgname=$pkgver-r$pkgrel"
+	install_if="vim $pkgname-cli=$pkgver-r$pkgrel"
 
 	local f=
 	for f in ftdetect/dockerfile.vim syntax/dockerfile.vim; do
@@ -187,8 +209,8 @@ vim() {
 	done
 }
 
-sha512sums="9813d3bd41eff63a089495a976226b93d5d43544530aea0ebce78b96e6b4b38389fe3ad1117f1ca95c38727047a24211ad2c2b44217935c26ffb5496cf90407e  docker-18.09.1.tar.gz
-9256eedc6ed530506e4e61673a9f45397274093dd61105097d5c650796f0afebc8ad7c550d2dc3cacf94426e3872a2b764906bca46fc907a21b865314c8927d4  libnetwork-2cfbf9b1f98162a55829a21cc603c76072a75382.tar.gz
+sha512sums="7d06ab01673b5931a8dde1d2fcebf442d1a107c98c95cd8fe3b886c123b48470950601782fe0c83e7537a1e856069e79a096b9f4523fea7984fd3e773b243b66  docker-18.09.7.tar.gz
+0a833510df0029999bfc05c23445a58a8b2ff165c0fb2fd5c411498d1e89b5b1990d2778b32346dd2b6d61c166ff707c6277a5d1937db6345c77d3825eb59875  libnetwork-e7933d41e7b206756115aa9df5e0599fc5169742.tar.gz
 c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 33155a79799cc6c0520a030e1a9bdba60441776d612e5e255574b23bbce1c7a8e5d868284b05a8a92704be6bbb7db905388564e867986a705acbe4884ac58584  docker-openrc-fixes.patch
 9b24dc0c50904c3d12bb04c1a7df169651043ddbc258018647010a5aa01d8a19ad54d10ca79dce6d6283c81f4fa0cc8de417f6180dd824c5a588b22b23546cb5  docker-openrc-busybox-ash.patch"

--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -2,41 +2,36 @@
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 
 pkgname=runc
-
-# NOTE: using explicit post-1.0.0_rc6 commit, for CVE-2019-5736
-# (https://nvd.nist.gov/vuln/detail/CVE-2019-5736).  This commit is more recent
-# than the one specified by containerd
-# (https://github.com/containerd/containerd/blob/v1.2.2/vendor.conf)
-_commit=6635b4f0c6af3810594d2770f662f34ddc15b40d
-
-pkgver=1.0.0_rc6
-pkgrel=1
 pkgdesc="CLI tool for spawning and running containers according to the OCI specification"
 url="https://www.opencontainers.org"
+
+_commit=425e105d5a03fabd737a126ad93d62a9eeede87f
+pkgver=1.0.0_rc8
+pkgrel=0
+
+_ver=v${pkgver/_rc/-rc}
+# if we're building against an explicit commit beyond pkgver, use this instead:
+#_ver=${_commit}
+
 arch="all"
 license="Apache-2.0"
 makedepends="go go-md2man libseccomp-dev libtool"
 subpackages="$pkgname-doc"
-source="runc-$_commit.tar.gz::https://github.com/opencontainers/runc/archive/$_commit.tar.gz"
+source="runc-$_ver.tar.gz::https://github.com/opencontainers/runc/archive/$_ver.tar.gz"
 builddir="$srcdir/src/github.com/opencontainers/runc"
 
 # secfixes:
-#   1.0.0_rc6-r1:
+#   1.0.0_rc7:
 #     - CVE-2019-5736
 
 build() {
 	cd "$srcdir"
 	export GOPATH="$PWD"
-	mkdir -p $(dirname "$builddir")
-	ln -s "$PWD/$pkgname-$_commit" "$builddir"
+	mkdir -p "$(dirname "$builddir")"
+	ln -s "$PWD/$pkgname-${_ver#v}" "$builddir"
 	cd "$builddir"
 	make COMMIT="$_commit"
 	make man
-}
-
-check() {
-	cd "$builddir"
-	./runc --version
 }
 
 package() {
@@ -46,4 +41,4 @@ package() {
 	install -Dm644 "$builddir"/man/man8/* "$pkgdir"/usr/share/man/man8/
 }
 
-sha512sums="37bb09463df4742b0ea5b1f079f609642ab5621707674844ffef06f733703ec1d09b52a180ccb2d66c284c56ba242f7a1b70ba4c4c45722bf85fd2fd924bb9df  runc-6635b4f0c6af3810594d2770f662f34ddc15b40d.tar.gz"
+sha512sums="4bf464acc87b6d687010f0c070d96e171d91e46c45b84b5570c6f607e7d06777d2d83b2ead87ac4aa761e34afc68a3d9be9ab25107d499e8f41cb68647e23541  runc-v1.0.0-rc8.tar.gz"


### PR DESCRIPTION
(Also updates to `containerd` and `runc` dependencies.)

Fix: CVE-2018-15664 symlink-exchange attack with directory traversal.

More release details at https://github.com/docker/docker-ce/releases/tag/v18.09.7