### PR TITLE
testing/libglvnd: new aport

### DIFF
--- a/testing/libglvnd/APKBUILD
+++ b/testing/libglvnd/APKBUILD
@@ -1,0 +1,48 @@
+# Contributor: Russ Webber <russ@rw.id.au>
+# Maintainer: Russ Webber <russ@rw.id.au>
+pkgname=libglvnd
+pkgver=1.1.1
+pkgrel=0
+pkgdesc="libglvnd is a vendor-neutral dispatch layer for arbitrating OpenGL API calls between multiple vendors."
+url="https://github.com/NVIDIA/libglvnd"
+arch="all"
+license="custom"
+options="!check"	# test suite requires an Xorg display
+provides="mesa-gl mesa-egl mesa-gles"
+makedepends="automake autoconf libtool python libxext-dev libx11-dev xorgproto"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-nvidia"
+source="libglvnd-$pkgver.tar.gz::https://github.com/NVIDIA/libglvnd/archive/v$pkgver.tar.gz
+				https://gitlab.com/nvidia/opengl/raw/ubuntu16.04/glvnd/runtime/10_nvidia.json
+				COPYING"
+builddir="$srcdir/libglvnd-$pkgver"
+
+build() {
+	./autogen.sh
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var
+	make
+}
+
+check() {
+	make check
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+	install -Dm644 "$srcdir/COPYING" "$pkgdir"/usr/share/licenses/$pkgname/COPYING
+}
+
+nvidia() {
+	arch="noarch"
+	depends="libglvnd"
+	install -Dm644 "$srcdir/10_nvidia.json" "$subpkgdir/etc/glvnd/egl_vendor.d/10_nvidia.json"
+}
+
+sha512sums="f64a481be002b108bc45147f9ecddc97561d09b15dd2fee82e76642f8d298f5b21458042dea3083ade650181d5f937bf550bba2914fbf46a774990abdbc56883  libglvnd-1.1.1.tar.gz
+03aaeb46b99175bf402aa08529385ec48eb029deef5afb1be82cc7ae6a342bebfd25bc50d2d643751737d52156555d88dd1bde0eacd2b6862cac2c02c2f6e215  10_nvidia.json
+085be7058af8f4f9a9bb540fec3e74b77cb92cca8fc3e8f4a8dd4cd404acc2e700f8b141f17818c056d76d1085ec63a33a52f13c49b902689ae000ff1a0944bf  COPYING"

--- a/testing/libglvnd/COPYING
+++ b/testing/libglvnd/COPYING
@@ -1,0 +1,26 @@
+Copyright (c) 2013, NVIDIA CORPORATION.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+unaltered in all copies or substantial portions of the Materials.
+Any additions, deletions, or changes to the original source files
+must be clearly indicated in accompanying documentation.
+
+If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the
+work of the Khronos Group."
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.


### PR DESCRIPTION
https://github.com/NVIDIA/libglvnd
libglvnd is a vendor-neutral dispatch layer for arbitrating OpenGL API calls between multiple vendors.

Part of my work to get OpenGL routing through Alpine linux with Docker Nvidia runtime. I haven't been successful yet, but this package seems to compile fine so my issues might lie elsewhere.