### PR TITLE
community/php7: add argon2 support

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -27,7 +27,7 @@
 pkgname=php7
 _pkgreal=php
 pkgver=7.3.6
-pkgrel=0
+pkgrel=1
 _apiver=20180731
 _suffix=${pkgname#php}
 # Is this package the default (latest) PHP version?
@@ -48,6 +48,7 @@ _depends_mysqli="$pkgname-mysqlnd $pkgname-openssl"
 makedepends="
 	$depends_dev
 	apache2-dev
+	argon2-dev
 	aspell-dev
 	bison
 	bzip2-dev
@@ -315,6 +316,7 @@ _build() {
 		--enable-opcache=shared \
 		--with-openssl=shared  \
 			--with-system-ciphers \
+		--with-password-argon2 \
 		--enable-pcntl=shared \
 		--with-pcre-regex=/usr \
 			$without_pcre_jit \


### PR DESCRIPTION
Closes https://bugs.alpinelinux.org/issues/10649

```
checking for Argon2 support... yes
```