### PR TITLE
community/php7-pecl-redis: upgrade to 5.0.0

### DIFF
--- a/community/php7-pecl-redis/APKBUILD
+++ b/community/php7-pecl-redis/APKBUILD
@@ -2,13 +2,13 @@
 # Maintainer: Fabio Ribeiro <fabiorphp@gmail.com>
 pkgname=php7-pecl-redis
 _pkgreal=redis
-pkgver=4.3.0
-pkgrel=2
+pkgver=5.0.0
+pkgrel=0
 pkgdesc="PHP extension for interfacing with Redis - PECL"
 url="https://pecl.php.net/package/redis"
 arch="all"
 license="PHP-3.01"
-depends="php7-common php7-pecl-igbinary php7-session"
+depends="php7-common php7-pecl-igbinary php7-session php7-json"
 makedepends="php7-dev autoconf re2c"
 source="$pkgname-$pkgver.tgz::https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir/$_pkgreal-$pkgver"
@@ -39,4 +39,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$confdir"/20_$_pkgreal.ini
 }
 
-sha512sums="30ce5863540485463704e6f90cff3a8d1f5bda34360c987e848ab290c8240f323b6eb2df1e90cc4c0922b3413652132d937488943f5db4e242c460c592da54ca  php7-pecl-redis-4.3.0.tgz"
+sha512sums="e1ea05ea526228a8ed65aa697342ed709f2690db8d49f27bdd3c161e4ca74fd635817a74fb6f540044458f39bc848820efbd040e044f3e98d2e1c56d8af41f2a  php7-pecl-redis-5.0.0.tgz"


### PR DESCRIPTION
Ref https://pecl.php.net/package-changelog.php?package=redis&release=5.0.0

PS It depends on `php7-json` because it supposed to be bundled https://www.php.net/manual/en/extensions.membership.php#extensions.membership.bundled