### PR TITLE
community/clsync: Enable aarch64 

### DIFF
--- a/community/clsync/APKBUILD
+++ b/community/clsync/APKBUILD
@@ -5,7 +5,7 @@ pkgver=0.4.2
 pkgrel=1
 pkgdesc="File live sync daemon based on inotify"
 url="https://github.com/xaionaro/clsync"
-arch="x86 x86_64"
+arch="x86 x86_64 aarch64"
 license="GPL-3.0-or-later"
 depends=""
 depends_dev="glib-dev fts-dev libcap-dev libexecinfo-dev linux-headers musl-dev"
@@ -26,17 +26,35 @@ prepare() {
 build() {
 	cd "$builddir"
 
-	./configure \
-		CFLAGS="$CFLAGS -lfts -lexecinfo" \
-		--build=$CBUILD \
-		--host=$CHOST \
-		--prefix=/usr \
-		--sysconfdir=/etc \
-		--mandir=/usr/share/man \
-		--localstatedir=/var \
-		--enable-capabilities \
-		--enable-seccomp \
-		--disable-debug
+	case "$CARCH" in
+	aarch64)
+		./configure \
+			CFLAGS="$CFLAGS -lfts -lexecinfo" \
+			--build=$CBUILD \
+			--host=$CHOST \
+			--prefix=/usr \
+			--sysconfdir=/etc \
+			--mandir=/usr/share/man \
+			--localstatedir=/var \
+			--enable-capabilities \
+			--disable-seccomp \
+			--disable-debug
+		;;
+	*)
+		./configure \
+			CFLAGS="$CFLAGS -lfts -lexecinfo" \
+			--build=$CBUILD \
+			--host=$CHOST \
+			--prefix=/usr \
+			--sysconfdir=/etc \
+			--mandir=/usr/share/man \
+			--localstatedir=/var \
+			--enable-capabilities \
+			--enable-seccomp \
+			--disable-debug
+		;;
+	esac
+
 	make
 }
 

--- a/community/clsync/APKBUILD
+++ b/community/clsync/APKBUILD
@@ -15,6 +15,7 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/xaionaro/$pkgname/archive/v$
 	musl-fix.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 options="!check"  # upstream does not provide tests
+seccomp=""
 
 prepare() {
 	default_prepare
@@ -28,19 +29,10 @@ build() {
 
 	case "$CARCH" in
 	aarch64)
-		./configure \
-			CFLAGS="$CFLAGS -lfts -lexecinfo" \
-			--build=$CBUILD \
-			--host=$CHOST \
-			--prefix=/usr \
-			--sysconfdir=/etc \
-			--mandir=/usr/share/man \
-			--localstatedir=/var \
-			--enable-capabilities \
-			--disable-seccomp \
-			--disable-debug
-		;;
+		seccomp="disable-seccomp" ;;
 	*)
+		seccomp="enable-seccomp" ;;
+	esac
 		./configure \
 			CFLAGS="$CFLAGS -lfts -lexecinfo" \
 			--build=$CBUILD \
@@ -50,10 +42,8 @@ build() {
 			--mandir=/usr/share/man \
 			--localstatedir=/var \
 			--enable-capabilities \
-			--enable-seccomp \
+			--$seccomp \
 			--disable-debug
-		;;
-	esac
 
 	make
 }


### PR DESCRIPTION
Architecture specific support is provided for aarch64.


