### PR TITLE
main/argon2: upgrade to 20190702

### DIFF
--- a/main/argon2/APKBUILD
+++ b/main/argon2/APKBUILD
@@ -3,8 +3,8 @@
 # Maintainer: Corey Oliver <coreyjonoliver@gmail.com>
 pkgname=argon2
 _pkgname=phc-winner-argon2
-pkgver=20171227
-pkgrel=2
+pkgver=20190702
+pkgrel=0
 pkgdesc="The password hash Argon2, winner of PHC"
 url="https://github.com/P-H-C/phc-winner-argon2"
 arch="all"
@@ -33,5 +33,5 @@ package() {
 	sed -i -e "s/@UPSTREAM_VER@/${pkgver}/" "$pkgdir"/usr/lib/pkgconfig/libargon2.pc
 }
 
-sha512sums="9c9e1a3905e61ac6913d1e073c104477e419ddd0506adc4487e88e98d19165ed8901fe8bb11246ed0cc71b3523c190da9692d5926642f86be09c3e67510afe4d  argon2-20171227.tar.gz
+sha512sums="0a4cb89e8e63399f7df069e2862ccd05308b7652bf4ab74372842f66bcc60776399e0eaf979a7b7e31436b5e6913fe5b0a6949549d8c82ebd06e0629b106e85f  argon2-20190702.tar.gz
 299d72d3cd6a9d8167e69b2cefc8f854e1c3abd0897e44acdc78bb5c6fdb62eee6b75e2deeb51f9c46bda543b61268fe7b89adc274c624609d4cec39294b81d8  libargon2.pc"


### PR DESCRIPTION
Ref https://github.com/P-H-C/phc-winner-argon2/releases

PHP adds dependency https://github.com/alpinelinux/aports/pull/9267