### PR TITLE
testing/php7-pecl-grpc: upgrade to 1.22.0

### DIFF
--- a/testing/php7-pecl-grpc/APKBUILD
+++ b/testing/php7-pecl-grpc/APKBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
 pkgname=php7-pecl-grpc
 _pkgreal=grpc
-pkgver=1.21.3
-pkgrel=1
+pkgver=1.22.0
+pkgrel=0
 pkgdesc="PHP extension provide a concrete implementation of the gRPC protocol, layered over HTTP/2."
 url="https://pecl.php.net/package/grpc"
 arch="all !s390x !ppc64le"
@@ -32,4 +32,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/50_$_pkgreal.ini
 }
 
-sha512sums="ca262827382ef252307f90f1548d28d6bd9fffbd9bb37eccb3611c69001a4e2e50eb24e8785012dc89bb5c01481b01fba82501d8851742f705901e2e3ec8c55e  grpc-1.21.3.tgz"
+sha512sums="c80cc85e99c419d6a89cb91a2c968d554bf677818492680f6794da207476020288d3fe03ad6867029f5b0719a8720b71adfade1562b7222fe90eb2986c20c8f6  grpc-1.22.0.tgz"


### PR DESCRIPTION
Could be upgraded independently of the rest https://pecl.php.net/package-changelog.php?package=gRPC&release=1.22.0

Related to https://github.com/alpinelinux/aports/pull/9161