### PR TITLE
testing/minio-client: upgrade to 0.20190703

### DIFF
--- a/testing/minio-client/APKBUILD
+++ b/testing/minio-client/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=minio-client
 _pkgname=mc
-_pkgver='RELEASE.2019-06-27T21-31-45Z'
+_pkgver='RELEASE.2019-07-03T18-14-53Z'
 pkgver=${_pkgver#*.}
 pkgver=${pkgver%T*}
 pkgver=0.${pkgver//-}
@@ -13,7 +13,7 @@ license="Apache-2.0"
 makedepends="go"
 source="$_pkgname-$_pkgver.tar.gz::https://github.com/minio/$_pkgname/archive/$_pkgver.tar.gz"
 builddir="$srcdir/src/github.com/minio/$_pkgname"
-options="!check net" # tests seem to lag behind code
+options="net"
 
 export GOPATH="$srcdir"
 export CGO_ENABLED=0
@@ -30,7 +30,10 @@ build() {
 }
 
 check() {
-	GO111MODULE=on go test -tags kqueue ./...
+	# mc/cmd is disabled, seems to be outdated and fails on all my systems
+	GO111MODULE=on go test -tags kqueue $(go list ./... | grep -v \
+		-e cmd \
+		)
 }
 
 package() {
@@ -42,4 +45,4 @@ cleanup_srcdir() {
 	go clean -modcache
 	default_cleanup_srcdir
 }
-sha512sums="2fde68a51d4dfc0c4d7c4733e87430f7338285fd8bedb43e941f5c54d28c04f7b1184694c873e42ed4215453ddee02398ee6f8493b54439e7e25a39320cebebb  mc-RELEASE.2019-06-27T21-31-45Z.tar.gz"
+sha512sums="8d364c7b884a1930a300b9e608618b2ea659463bf62fe5280ec6cf0bce26d2a99a52161c71d526ff01ba9efd2de45816321610a21d9eaff6c414bdec8164fca5  mc-RELEASE.2019-07-03T18-14-53Z.tar.gz"


### PR DESCRIPTION
Also:
- re-enable tests
- disable the specific set that's failing

It's not particularly trivial in Go, you basically have to filter out
the name.
This passes in my environment though.