### PR TITLE
community/pulseaudio: enable missing avahi support for zeroconf

### DIFF
--- a/community/pulseaudio/APKBUILD
+++ b/community/pulseaudio/APKBUILD
@@ -5,7 +5,7 @@
 # Maintainer: Leo <thinkabit.ukim@gmail.com>
 pkgname=pulseaudio
 pkgver=12.2
-pkgrel=3
+pkgrel=4
 pkgdesc="A featureful, general-purpose sound server"
 url="http://www.freedesktop.org/wiki/Software/PulseAudio"
 arch="all !s390x"
@@ -57,7 +57,8 @@ build() {
 		--disable-rpath \
 		--disable-esound \
 		--disable-hal-compat \
-		--enable-x11
+		--enable-x11 \
+		--enable-avahi
 
 	sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
 
@@ -130,6 +131,8 @@ jack() {
 
 zeroconf() {
 	pkgdesc="Pulseaudio zeroconf support"
+	depends="avahi"
+
 	mkdir -p "$subpkgdir"/usr/lib/pulse-$pkgver/modules
 	mv "$pkgdir"/usr/lib/pulse-$pkgver/modules/*avahi*.so \
 		"$pkgdir"/usr/lib/pulse-$pkgver/modules/*zeroconf*.so \


### PR DESCRIPTION
CC @maxice8 

Avahi support is required for pulseaudio-zeroconf to find any devices. Using this setup (and after starting the `avahi-daemon` service), I was able to use my networked speakers on my RPi from my laptop.