### PR TITLE
community/nodejs-current: upgrade to 12.6.0

### DIFF
--- a/community/nodejs-current/APKBUILD
+++ b/community/nodejs-current/APKBUILD
@@ -20,7 +20,7 @@
 #
 pkgname=nodejs-current
 # The current stable version, i.e. non-LTS.
-pkgver=12.5.0
+pkgver=12.6.0
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - current stable version"
 url="https://nodejs.org/"
@@ -93,6 +93,6 @@ package() {
 	rm "$pkgdir"/usr/bin/npm "$pkgdir"/usr/bin/npx
 }
 
-sha512sums="101aea1b49368905177425c3e47382fb41a83aecba3be9b490f0a4a062bc70ae25be52af17daeb1b9a71247384bf8394da6a4eb97b062803bf70cec357f415c4  node-v12.5.0.tar.gz
+sha512sums="57efcfa512626d624cd940d7e111a4c3f8a21c068b564246a8f98c8643ceab6f23a885e2dd983d326a3c3b9ee322388bfda501bdec85070264be3f146f8841d9  node-v12.6.0.tar.gz
 7634ae88ec660867361e0d909f3bf038270524f8e399d8a5f46ce63cc0f21529bdf3165246da263f0a848fd10dd3a2c5877a04864f35bc4c77556d3ac4eb6196  dont-run-gyp-files-for-bundled-deps.patch
 9f60928b53447f9590c7065bcdbdd4065d10a06e8451531615791a3bd7d14f9114807e5446e0ec00e2cb7a11a277050345e34636b199db2979d7f022b31ffde4  link-with-libatomic-on-mips32.patch"


### PR DESCRIPTION
Ref https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.6.0