### PR TITLE
main/tiny-ec2-bootstrap: upgrade to 1.3.0

### DIFF
--- a/main/tiny-ec2-bootstrap/APKBUILD
+++ b/main/tiny-ec2-bootstrap/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Mike Crute <mike@crute.us>
 # Maintainer: Mike Crute <mike@crute.us>
 pkgname=tiny-ec2-bootstrap
-pkgver=1.2.0
+pkgver=1.3.0
 pkgrel=0
 pkgdesc="A tiny EC2 instance bootstrapper that uses instance metadata"
 url="https://github.com/mcrute/tiny-ec2-bootstrap"
@@ -17,4 +17,4 @@ package() {
 	make install PREFIX=$pkgdir
 }
 
-sha512sums="a653dd56ac7cc887077d83d1e01c6e2b58550548293e848a456b74a45b2d0061ed3a4188e9a4eb3aaf23ee96d22b00f4e0610d044d640e036591dc43b4681a63  tiny-ec2-bootstrap-1.2.0.tar.gz"
+sha512sums="fd0423921a420d71264348fc1e748933b4686c9d16efaf46f131992d38e01a27dbc946a4a0ce704ea216c0e1fe5cf822d5b2201bdf81e3b7ccd7f57a2ebdc69e  tiny-ec2-bootstrap-1.3.0.tar.gz"


### PR DESCRIPTION
Upgrades tiny-ec2-bootstrap to 1.3.0 which adds support for customizing the image username.

Release of: mcrute/tiny-ec2-bootstrap#3 and mcrute/tiny-ec2-bootstrap#4