### PR TITLE
testing/minio: upgrade to 20190705

### DIFF
--- a/testing/minio/APKBUILD
+++ b/testing/minio/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
 # Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=minio
-_pkgver='RELEASE.2019-06-27T21-13-50Z'
+_pkgver='RELEASE.2019-07-05T21-20-21Z'
 pkgver=${_pkgver#*.}
 pkgver=${pkgver%T*}
 pkgver=0.${pkgver//-}
@@ -20,7 +20,7 @@ source="
 	$pkgname-$pkgver.tar.gz::https://github.com/minio/minio/archive/$_pkgver.tar.gz
 	"
 builddir="$srcdir/src/github.com/minio/$pkgname"
-options="!check net" # pkg/disk fails with "disk_test.go:42: Unexpected FSType UNKNOWN"
+options="net"
 subpackages="$pkgname-openrc"
 
 export GOPATH="$srcdir"
@@ -39,7 +39,12 @@ build() {
 }
 
 check() {
-	go test -tags kqueue ./...
+	# pkg/disk: doesn't know what btrfs is
+	# pkg/s3select: fails on 32bit systems
+	GO111MODULE=on go test -tags kqueue $(go list ./... | grep -v \
+		-e pkg/disk \
+		-e pkg/s3select
+		)
 }
 
 package() {
@@ -58,4 +63,4 @@ cleanup_srcdir() {
 
 sha512sums="6427a225d4e6c51cc5de077ccd29ddf52556722cf958e83e480df1c5882aa4fa7daebfeb970e80f8f9c3176594d8e427e8c8dbf268ce945647a11bdf1e69affd  minio.initd
 ed9790fbadfb38e4d660eb1befd87e803d70dec04d936e8cd26def4a9c21240bb7cae8750ae3395aa4761e6738b9e346c86ba57761cfde30efe46d2cb459a7e4  minio.confd
-2ac9af7fddf2152fd19afc984828a439df9878f57519d7a9ad29b3946e43afb257fddda4556fe85a3ebc49c24dffe4c3c789a83ee7c7039ca33c89dd7acf42d1  minio-0.20190627.tar.gz"
+2ea480af1f627c8752932c52214b9e4b2c7387314d5338e2cbec5f755c42893e88dc03aa310874a2445e9df4e2c70b833ae2f832ec8b1a31a241a7a0db95bb4f  minio-0.20190705.tar.gz"


### PR DESCRIPTION
Also:
- enable tests
- filter out the failing test

The test fails due to not knowing the fstype.
This may be purely because my builder is btrfs.