### PR TITLE
testing/retroarch: fix s390x

### DIFF
--- a/testing/retroarch/APKBUILD
+++ b/testing/retroarch/APKBUILD
@@ -15,6 +15,7 @@ builddir="$srcdir/$_pkgname-$pkgver"
 options="!check" # No tests
 
 build() {
+	CFLAGS="$CFLAGS -I/usr/include/directfb"
 	./configure \
 		--prefix=/usr \
 		--enable-dynamic \


### PR DESCRIPTION
Include directfb header path explicitly