### PR TITLE
main/alpine-baselayout: improve color_prompt

### DIFF
--- a/main/alpine-baselayout/color_prompt
+++ b/main/alpine-baselayout/color_prompt
@@ -4,7 +4,7 @@ NORMAL="\[\e[0m\]"
 RED="\[\e[1;31m\]"
 GREEN="\[\e[1;32m\]"
 if [ "$USER" = root ]; then
-	PS1="$RED\h [$NORMAL\w$RED]# $NORMAL"
+	PS1="$RED\u$NORMAL@$RED\H [$NORMAL\w$RED]$NORMAL# "
 else
-	PS1="$GREEN\h [$NORMAL\w$GREEN]\$ $NORMAL"
+	PS1="$GREEN\u$NORMAL@$GREEN\H [$NORMAL\w$GREEN]$NORMAL\$ "
 fi


### PR DESCRIPTION
This commit will alter color_prompt in order to display the default $PS1
prompt in the form of 'user@hostname' instead of 'hostname' alone.

It will also display the full hostname rather than just the hostname up
to the first '.' character.