### PR TITLE
WIP: testing/firefox: upgrade to 68.0

### DIFF
--- a/testing/firefox/APKBUILD
+++ b/testing/firefox/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor:
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox
-pkgver=67.0.4
+pkgver=68.0
 pkgrel=0
 pkgdesc="Firefox web browser"
 url="https://www.firefox.com/"
@@ -121,6 +121,7 @@ build() {
 		--enable-system-sqlite \
 		--enable-ffmpeg \
 		--enable-hardening \
+		--enable-rust-simd \
 		\
 		--with-system-bz2 \
 		--with-system-icu \
@@ -209,7 +210,7 @@ __EOF__
 	rm -f "$pkgdir"/${_mozappdirdev}/sdk/lib/libxul.so
 }
 
-sha512sums="42abc837b5808a55e68273db6aa45fa73f8fe1df3c9072c94d8d049b6803ce8758745cc0a68af64c4ce9f86e5dd3b3619824ba67fabddce428204605894d9ee7  firefox-67.0.4.source.tar.xz
+sha512sums="fcb6f6dd8069ca43b0b75cba4566f81c94535e66ddeb80fbdd4f47eaac2efc82d6e6bd36bf7cbebdc260a74886ba3f007a321d88fdf30731d3b669a38273f42e  firefox-68.0.source.tar.xz
 0b3f1e4b9fdc868e4738b5c81fd6c6128ce8885b260affcb9a65ff9d164d7232626ce1291aaea70132b3e3124f5e13fef4d39326b8e7173e362a823722a85127  stab.h
 2f4f15974d52de4bb273b62a332d13620945d284bbc6fe6bd0a1f58ff7388443bc1d3bf9c82cc31a8527aad92b0cd3a1bc41d0af5e1800e0dcbd7033e58ffd71  fix-fortify-system-wrappers.patch
 09bc32cf9ee81b9cc6bb58ddbc66e6cc5c344badff8de3435cde5848e5a451e0172153231db85c2385ff05b5d9c20760cb18e4138dfc99060a9e960de2befbd5  fix-fortify-inline.patch


### PR DESCRIPTION
This updates Firefox to 68.0.  
It also enables the `enable-rust-simd` flag as proposed in https://github.com/alpinelinux/aports/pull/8754#issuecomment-501457795

