### PR TITLE
testing/dolphin-emu: new aport

### DIFF
--- a/testing/dolphin-emu/APKBUILD
+++ b/testing/dolphin-emu/APKBUILD
@@ -1,0 +1,112 @@
+# Contributor: Bart Ribbers <bribbers@disroot.org>
+# Maintainer: Bart Ribbers <bribbers@disroot.org>
+pkgname=dolphin-emu
+_pkgname=dolphin
+pkgver=5.0_git20190707
+pkgrel=0
+_commit="398aa2a9f976169c4ac8228f0969971f3e2ba2f3"
+ # Upstream doesn't actively support non 64-bit platforms and they're too slow
+ # to emulate any games anyway
+arch="x86_64 aarch64 ppc64le s390x"
+url="https://dolphin-emu.org"
+pkgdesc="A Gamecube / Wii emulator"
+license="GPL-2.0-or-later"
+depends="mbedtls"
+makedepends="
+	cmake
+	ninja
+	mesa-dev
+	mesa-egl
+	ffmpeg-dev
+	libevdev-dev
+	eudev-dev
+	pugixml-dev
+	zlib-dev
+	lzo-dev
+	libpng-dev
+	sfml-dev
+	libusb-dev
+	miniupnpc-dev
+	mbedtls-dev
+	curl-dev
+	hidapi-dev
+	libx11-dev
+	qt5-qtbase-dev
+	libxi-dev
+	bluez-dev
+	pulseaudio-dev
+	vulkan-headers
+	"
+# The following dependencies are required, but atm not supported for using system wide libraries
+# minizip-dev xxhash-dev soundtouch-dev gtest-dev
+source="$pkgname-$_commit.tar.gz::https://github.com/dolphin-emu/$_pkgname/archive/$_commit.tar.gz
+	add-missing-x11-includes.patch
+	fix-compilation-without-xrandr-support.patch
+	"
+subpackages="$pkgname-doc $pkgname-lang"
+builddir="$srcdir/$_pkgname-$_commit"
+
+prepare() {
+	default_prepare
+
+	# Make sure we never use non-system libraries except the ones that are not
+	# supported being used system-wide by removing them from the Externals
+	# folder
+
+	KEEP_SOURCES="
+		Bochs_disasm
+		FreeSurround
+		cpp-optparse
+		fmt
+		glslang
+		imgui
+		xxhash
+		minizip
+		soundtouch
+		cubeb
+		gtest
+		picojson
+		enet
+	"
+
+	# Move the libraries we want to keep out of the externals folder
+	for s in $KEEP_SOURCES; do
+		mv -v "Externals/$s" .
+	done
+
+	# Remove the rest
+	rm -r Externals/*
+
+	# Move them back
+	for s in $KEEP_SOURCES; do
+		mv -v "$s" "Externals/"
+	done
+
+	mkdir "$builddir"/build
+}
+
+build() {
+	cd "$builddir"/build
+	cmake "$builddir" \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_GENERATOR=Ninja \
+		-DUSE_DISCORD_PRESENCE=OFF \
+		-DUSE_SHARED_ENET=ON \
+		-DDISTRIBUTOR="alpinelinux.org"
+	ninja
+}
+
+check() {
+	CTEST_OUTPUT_ON_FAILURE=TRUE ctest
+}
+
+package() {
+	DESTDIR="$pkgdir" ninja -C build install
+
+	install -Dm 644 Data/51-usb-device.rules -t "$pkgdir"/usr/lib/udev/rules.d/
+}
+
+sha512sums="c6bd84e6840b83d84cadf0e8deb0f34780bc56f642fdf84a5480a9e0600bf677b2ad3214a861771f1108c176c21cd36e6086809c3de9b8572b1f18197e91be4d  dolphin-emu-398aa2a9f976169c4ac8228f0969971f3e2ba2f3.tar.gz
+eb7c31b5aa790a0839642da296ded70b543c4e2e7ab910b491367c8258065f0a976fa155e8a782ece745e842a0bf743e7c13d1cf1061255b672d7b7d47fde44a  add-missing-x11-includes.patch
+1ed5851dd03db8e76ec9aa8194e4014bc951b1f363133db0dc43098aaab43f507bb9b97e55b50a9d5793b7b5b75cf5100881bdd1d5b80c0ada0192e104099ec4  fix-compilation-without-xrandr-support.patch"

--- a/testing/dolphin-emu/add-missing-x11-includes.patch
+++ b/testing/dolphin-emu/add-missing-x11-includes.patch
@@ -1,0 +1,21 @@
+From ac17ff1e4400b80ce0be64911bf1c4f1ac548c34 Mon Sep 17 00:00:00 2001
+From: Shiz <hi@shiz.me>
+Date: Sat, 29 Jun 2019 02:21:47 +0200
+Subject: [PATCH] Core: add missing X11 includes
+
+---
+ Source/Core/DolphinNoGUI/PlatformX11.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Source/Core/DolphinNoGUI/PlatformX11.cpp b/Source/Core/DolphinNoGUI/PlatformX11.cpp
+index af8993a4a58..dfa1c0729d3 100644
+--- a/Source/Core/DolphinNoGUI/PlatformX11.cpp
++++ b/Source/Core/DolphinNoGUI/PlatformX11.cpp
+@@ -18,6 +18,7 @@
+ 
+ #include <X11/Xatom.h>
+ #include <X11/Xlib.h>
++#include <X11/Xutil.h>
+ #include <X11/keysym.h>
+ #include "UICommon/X11Utils.h"
+ #include "VideoCommon/RenderBase.h"

--- a/testing/dolphin-emu/fix-compilation-without-xrandr-support.patch
+++ b/testing/dolphin-emu/fix-compilation-without-xrandr-support.patch
@@ -1,0 +1,34 @@
+From 7bb9f502cf4505d7f30b8f0a3303e05464fafe44 Mon Sep 17 00:00:00 2001
+From: Shiz <hi@shiz.me>
+Date: Sat, 29 Jun 2019 02:31:24 +0200
+Subject: [PATCH] Core/UICommon: fix compilation without X RandR support
+
+---
+ Source/Core/UICommon/UICommon.cpp | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/Source/Core/UICommon/UICommon.cpp b/Source/Core/UICommon/UICommon.cpp
+index 935d07b043f..27fe62307d1 100644
+--- a/Source/Core/UICommon/UICommon.cpp
++++ b/Source/Core/UICommon/UICommon.cpp
+@@ -367,16 +367,15 @@ bool TriggerSTMPowerEvent()
+   return true;
+ }
+ 
+-#if defined(HAVE_XRANDR) && HAVE_X11
+-void EnableScreenSaver(Window win, bool enable)
+-#else
++#if !defined(HAVE_XRANDR) || !HAVE_XRANDR
+ void EnableScreenSaver(bool enable)
+-#endif
++{
++#else
++void EnableScreenSaver(Window win, bool enable)
+ {
+   // Inhibit the screensaver. Depending on the operating system this may also
+   // disable low-power states and/or screen dimming.
+ 
+-#if defined(HAVE_X11) && HAVE_X11
+   if (Config::Get(Config::MAIN_DISABLE_SCREENSAVER))
+   {
+     X11Utils::InhibitScreensaver(win, !enable);


### PR DESCRIPTION
Several options make it crash still (PulseAudio Dolby Pro Logic II Decoder, any Shader Compilation option other than Synchronous, etc), but at least it runs with default settings. Will try to fix the other crashes later.

CC @Shizmob as you helped getting it to compile