### PR TITLE
testing/howard-bc: bump to 2.1.0

### DIFF
--- a/testing/howard-bc/APKBUILD
+++ b/testing/howard-bc/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Gavin D. Howard <yzena.tech@gmail.com>
 pkgname=howard-bc
 _pkgname=bc
-pkgver=2.0.3
+pkgver=2.1.0
 pkgrel=0
 pkgdesc="POSIX bc with GNU extensions"
 url="https://github.com/gavinhoward/bc"
@@ -25,4 +25,4 @@ package() {
 	make install
 }
 
-sha512sums="1eabc44a33c08e1cc20c7112843e18544860dc8621cf655c2453858d64b720cada4835ab6142110f296c4d6ad82e77725e603fd11b84b61b073efccc9f6a1c45  howard-bc-2.0.3.tar.xz"
+sha512sums="d117c0433b08d7bf4986ff49a39b6cbd1048399e74a3781ba48b27008d18c1cedfaca79c1d0510919b194bc593699ba99a736c377815cb3659cec772b45b1cd1  howard-bc-2.1.0.tar.xz"


### PR DESCRIPTION
This bc is now complete. It is still actively maintained, but this is the last release with new features. Bug fixes and new translations will still be added in the future.