### PR TITLE
testing/docker-volume-local-persist: add openrc subpackage

### DIFF
--- a/testing/docker-volume-local-persist/APKBUILD
+++ b/testing/docker-volume-local-persist/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=docker-volume-local-persist
 pkgver=1.3.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Local Persist Volume Plugin for Docker"
 url="https://github.com/CWSpear/local-persist"
 arch="all"
@@ -9,8 +9,11 @@ license="MIT"
 depends="docker"
 makedepends="go glide"
 install=""
-subpackages=""
-source="docker-local-persist-$pkgver.tar.gz::https://github.com/CWSpear/local-persist/archive/v$pkgver.tar.gz"
+subpackages="$pkgname-openrc"
+source="
+	docker-local-persist-$pkgver.tar.gz::https://github.com/CWSpear/local-persist/archive/v$pkgver.tar.gz
+	docker-volume-local-persist.initd
+	"
 builddir="$srcdir/local-persist-$pkgver"
 
 build() {
@@ -22,9 +25,11 @@ build() {
 }
 
 package() {
-	cd "$builddir"
-	install -Dm755 bin/local-persist \
+	install -Dm755 "$builddir"/bin/local-persist \
 		"$pkgdir"/usr/bin/docker-volume-local-persist
+	install -Dm755 "$srcdir"/docker-volume-local-persist.initd \
+		"$pkgdir"/etc/init.d/docker-volume-local-persist
 }
 
-sha512sums="43a061c937c84eaab817dc62e4be5adfee960e357a2eea504e87c8e5fda32f5a835dc6d145f7d787f4907cd592a04c0159455d8d28d40e158f5a93c4e4fc060a  docker-local-persist-1.3.0.tar.gz"
+sha512sums="43a061c937c84eaab817dc62e4be5adfee960e357a2eea504e87c8e5fda32f5a835dc6d145f7d787f4907cd592a04c0159455d8d28d40e158f5a93c4e4fc060a  docker-local-persist-1.3.0.tar.gz
+806b53e97b52d7ec2517cd978ddce6de14321519a64a4f309e3ea233f77b0c6cb1c9ec6bd9431ebe6d1eef83c7fe6ab2b8720bc4e552b64f3741a1fcd0df4bac  docker-volume-local-persist.initd"

--- a/testing/docker-volume-local-persist/docker-volume-local-persist.initd
+++ b/testing/docker-volume-local-persist/docker-volume-local-persist.initd
@@ -1,0 +1,14 @@
+#!/sbin/openrc-run
+
+name="docker-volume-local-persist"
+description="Docker Volume plugin local-persist"
+command="/usr/bin/docker-volume-local-persist"
+DOCKER_VOLUME_ERRFILE="/var/log/docker-volume-err.log"
+DOCKER_VOLUME_OUTFILE="/var/log/docker-volume-out.log"
+start_stop_daemon_args="--background \
+    --stderr \"${DOCKER_VOLUME_ERRFILE}\" --stdout \"${DOCKER_VOLUME_OUTFILE}\""
+
+depend() {
+    before docker
+    wants docker
+}


### PR DESCRIPTION
Added an init script to the `docker-volume-local-persist` package

The file was copied from [this discussion on bug 7616](https://bugs.alpinelinux.org/issues/7616#note-3) but was never implemented for some reason