### PR TITLE
[3.10] main/nsd: upgrade to 4.2.1

### DIFF
--- a/main/nsd/APKBUILD
+++ b/main/nsd/APKBUILD
@@ -1,9 +1,10 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Contributor: Matt Smith <mcs@darkregion.net>
 # Contributor: Leonardo Arena <rnalrd@alpinelinux.org>
+# Contributor: Iggy Jackson <iggy@theiggy.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nsd
-pkgver=4.1.27
+pkgver=4.2.0
 pkgrel=0
 pkgdesc="Authoritative only, high performance and simple DNS server"
 url="https://www.nlnetlabs.nl/projects/nsd"
@@ -46,5 +47,5 @@ package() {
 	rm -fr "$pkgdir"/var/run
 }
 
-sha512sums="9c75041f5a6213cdba7238c2e51fc73031f6f073e06587659f93992fed49418ee789642b25b5522d48642507050ac15021f385927eed81ce5ea649f974e66402  nsd-4.1.27.tar.gz
+sha512sums="caa14fcd599ddc631cb74c3a56e571044dae1deb2fa9bd6b062f143954f9207b64b42ab5eab917360161f96bae8711df932f3e18b58be98b3f7b640071e7e807  nsd-4.2.0.tar.gz
 0425f606bf102175adab6d198aeb692872576f9c0bfce11b9d9e4145595b4902e5ef3fe2c3ae5d832308f43282618494b8dd27eb76658e79df85cc7798008722  nsd.initd"

--- a/main/nsd/APKBUILD
+++ b/main/nsd/APKBUILD
@@ -4,7 +4,7 @@
 # Contributor: Iggy Jackson <iggy@theiggy.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nsd
-pkgver=4.2.0
+pkgver=4.2.1
 pkgrel=0
 pkgdesc="Authoritative only, high performance and simple DNS server"
 url="https://www.nlnetlabs.nl/projects/nsd"
@@ -47,5 +47,5 @@ package() {
 	rm -fr "$pkgdir"/var/run
 }
 
-sha512sums="caa14fcd599ddc631cb74c3a56e571044dae1deb2fa9bd6b062f143954f9207b64b42ab5eab917360161f96bae8711df932f3e18b58be98b3f7b640071e7e807  nsd-4.2.0.tar.gz
+sha512sums="8f40baf7cc72b72a84f3c4eb45847f03b2f91e47dd7f3dfc89270c774565a8cc692363cee3547b0a2a124e9c43b23eed8887f95ae55b2e63af96c65467b85796  nsd-4.2.1.tar.gz
 0425f606bf102175adab6d198aeb692872576f9c0bfce11b9d9e4145595b4902e5ef3fe2c3ae5d832308f43282618494b8dd27eb76658e79df85cc7798008722  nsd.initd"


### PR DESCRIPTION
**Summary**

* Bump version
* Add myself as a contributor

Backporting specifically for `Disable TLS1.0, TLS1.1 and weak ciphers` that was added in 4.2.0.

Not sure if this is considered too risky for `-stable`

@ncopa (hope it's okay to @ you since you are listed as maintainer, if not, feel free to let me know and I won't do it in the future)