### PR TITLE
main/protobuf: upgrade to 3.10.0

### DIFF
--- a/main/protobuf/APKBUILD
+++ b/main/protobuf/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=protobuf
 _gemname=google-protobuf
-pkgver=3.9.2
+pkgver=3.10.0
 _tstver=5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081
 pkgrel=0
 pkgdesc="Library for extensible, efficient structure packing"
@@ -152,7 +152,7 @@ dev() {
 	default_dev
 }
 
-sha512sums="510349ddc59b4e53087b5247ca8784e9f852d66d755e1b014c6214e14c003f31dd336a724e9eb87a5b85a70e22793eb3211744c85a514b24b687346563717bec  protobuf-3.9.2.tar.gz
+sha512sums="0dcba6d21486fdc162f57119754b47b4a2fb605af878d5b96a32df55895321535cffb5b804566fd90ee7c36e20106d0cd4f5d9f3c652dc9c4dfca96be41a1977  protobuf-3.10.0.tar.gz
 623b077b3334958fafcbc34aa85891883277994af33be530efd903f47738a3e3562001cbf3b6da1a5e7d03803c5bd51bcc1fab81490db85d5a4f2b15e7de1495  googletest-5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081.tar.gz
 875592bc5dc5efe9087ea1b340673f54c984ecd5aa3b110a2da136bdc28009af7ce1a9c57f4747ff809fc02eb6c39a0209c277177172af467a54172d9700188a  musl-fix.patch
 495ba43f1e43e49caee6f44bb7e8e1cc52d46b158b946598c2b296a9efa07fd9abadc8649c3751aad34d26380dcdef782239449cbc5fd7654df144d249dd9de2  trim-rakefile.patch"


### PR DESCRIPTION
Ref https://github.com/protocolbuffers/protobuf/releases/tag/v3.9.0

https://abi-laboratory.pro/?view=timeline&l=protobuf