### PR TITLE
main/git: add missing perl-git dependency to perl-git-svn

### DIFF
--- a/main/git/APKBUILD
+++ b/main/git/APKBUILD
@@ -16,7 +16,6 @@ pkgdesc="Distributed version control system"
 url="https://www.git-scm.com/"
 arch="all"
 license="GPL-2.0-or-later"
-depends=""
 # we need tcl and tk to be built before git due to git-gui and gitk
 makedepends="zlib-dev openssl-dev curl-dev expat-dev perl-dev python2-dev
 	pcre2-dev asciidoc xmlto perl-error tcl tk"
@@ -45,7 +44,6 @@ source="https://www.kernel.org/pub/software/scm/git/git-$pkgver.tar.xz
 	git-daemon.initd
 	git-daemon.confd
 	"
-builddir="$srcdir/$pkgname-$pkgver"
 
 _gitcoredir=/usr/libexec/git-core
 
@@ -81,7 +79,7 @@ package() {
 
 _perl_git_svn() {
 	pkgdesc="Perl interface to Git::SVN"
-	depends="git=$pkgver-r$pkgrel"
+	depends="git=$pkgver-r$pkgrel perl-git=$pkgver-r$pkgrel"
 	local vendorlib
 
 	vendorlib=$(_perl_config vendorlib)


### PR DESCRIPTION
@ncopa

https://gitlab.alpinelinux.org/alpine/aports/issues/9125