### PR TITLE
community/docker: enable seccomp support

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -5,13 +5,14 @@ pkgname=docker
 pkgver=18.09.7
 _gitcommit=2d0083d657f82c47044c8d3948ba434b622fe2fd	# https://github.com/docker/docker-ce/commits/v$pkgver
 _ver=${pkgver/_/-}-ce
-pkgrel=0
+pkgrel=1
 pkgdesc="Pack, ship and run any application as a lightweight container"
 url="http://www.docker.io/"
 arch="all"
 license="Apache-2.0"
 depends="docker-engine docker-cli"
-makedepends="go go-md2man btrfs-progs-dev bash linux-headers coreutils lvm2-dev libtool"
+makedepends="go go-md2man btrfs-progs-dev bash linux-headers coreutils lvm2-dev libtool
+	libseccomp-dev"
 install="$pkgname.pre-install"
 
 # from https://github.com/docker/docker-ce/blob/v$pkgver/components/engine/vendor.conf
@@ -44,7 +45,7 @@ source="
 _dockerdir="$srcdir"/docker-$_ver
 _cli_builddir="$_dockerdir"/components/cli
 _daemon_builddir="$_dockerdir"/components/engine
-_buildtags=""
+_buildtags="seccomp"
 
 _libnetwork_builddir="$srcdir"/libnetwork-$_libnetwork_ver
 


### PR DESCRIPTION
@tomalok

Fixes https://gitlab.alpinelinux.org/alpine/aports/issues/9028