### PR TITLE
main/audit: update to 2.8.5

### DIFF
--- a/main/audit/0003-all-get-rid-of-strndupa.patch
+++ b/main/audit/0003-all-get-rid-of-strndupa.patch
@@ -32,36 +32,6 @@ index 058f544..f61d204 100644
  	ptr = audit_strsplit(tmp);
  	if (ptr) {
  		// Optionally grab the node - may or may not be included
-diff --git a/src/auditd.c b/src/auditd.c
-index cd49758..2de065a 100644
---- a/src/auditd.c
-+++ b/src/auditd.c
-@@ -185,7 +185,7 @@ static void child_handler2( int sig )
- 
- static int extract_type(const char *str)
- {
--	const char *tptr, *ptr2, *ptr = str;
-+	const char *ptr2, *ptr = str;
- 	if (*str == 'n') {
- 		ptr = strchr(str+1, ' ');
- 		if (ptr == NULL)
-@@ -194,12 +194,12 @@ static int extract_type(const char *str)
- 	}
- 	// ptr should be at 't'
- 	ptr2 = strchr(ptr, ' ');
--	// get type=xxx in a buffer
--	tptr = strndupa(ptr, ptr2 - ptr);
-+
- 	// find =
--	str = strchr(tptr, '=');
--	if (str == NULL)
-+	str = strchr(ptr, '=');
-+	if (str == NULL || str >= ptr2)
- 		return -1; // Malformed - bomb out
-+
- 	// name is 1 past
- 	str++;
- 	return audit_name_to_msg_type(str);
 diff --git a/src/ausearch-lol.c b/src/ausearch-lol.c
 index 29d0a32..3a2e5e8 100644
 --- a/src/ausearch-lol.c

--- a/main/audit/APKBUILD
+++ b/main/audit/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Tycho Andersen <tycho@docker.com>
 pkgname=audit
-pkgver=2.8.4
+pkgver=2.8.5
 pkgrel=0
 pkgdesc="User space tools for 2.6 kernel auditing"
 url="http://people.redhat.com/sgrubb/audit/"
@@ -56,8 +56,8 @@ static() {
 	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib/
 }
 
-sha512sums="5795c565effab995cee447a2dc457ef6a6f15201fb185d7104992ac373a3cb5cfc865dd661c0896a895c96f452eff392d455064d0eead55cd7364d96e0d15c4a  audit-2.8.4.tar.gz
+sha512sums="7d416aaa21c1a167f8e911ca82aecbaba804424f3243f505066c43ecc4a62a34feb2c27555e99d3268608404793dccca0f828c63670e3aa816016fb493f8174a  audit-2.8.5.tar.gz
 b7851d4c3c6d7d35f2e822273c17ab530ac24301c414da7f0c7578b7a182692ecd01b51cb50ea04adba4b43987f27020f8f411aec23b3bda0af4d4b6e9fbae5d  0002-auparse-remove-use-of-rawmemchr.patch
-c380c04fc1939903eea9919d5a918f58725177adee1fe7dbe81e33905bad2f561dc35cae9f3d79aa6f00245cf33cdd50cef5e2b58f4fa5b8cd0cfad59af7137a  0003-all-get-rid-of-strndupa.patch
+f3f2c4ee745e99877c981d889c5cbb0379d073a9b7634c1480ae603a21a13045f9978b51f8cb53c8d0ba414d249bb859af7bca7e302c464b3fc3c6463ecca762  0003-all-get-rid-of-strndupa.patch
 1b48c248db5d34f148f9c79f8b2a6acbf61c729230341b861f5e331bbfb0c8356305a09eb2cc5c82c14c4fd9a13c7c13957e1ed493834b8b3b9ee38978e4c31f  auditd.initd
 69d8777772ded7a8c0db2bcf84961b121bb355fa0d4ba0e14e311f8a8bfe665cbd2b7ac632d73477f9dfa9a6eec357a7ed458fe9b3e7b5ede75b166f3f092ab7  auditd.confd"


### PR DESCRIPTION
ref: http://people.redhat.com/sgrubb/audit/ChangeLog

the fix of **src/auditd.c** is no longer required