### PR TITLE
[3.10] main/keyutils: link libkeyutils.so to ../../lib/libkeyutils.so.1

### DIFF
--- a/main/keyutils/APKBUILD
+++ b/main/keyutils/APKBUILD
@@ -2,16 +2,14 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=keyutils
 pkgver=1.6
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux Key Management Utilities"
 url="http://people.redhat.com/~dhowells/keyutils/"
 arch="all"
 options="!check"  # Test suite requires RPM.
 license="GPL-2.0-or-later LGPL-2.0-or-later"
-depends=""
 makedepends="file linux-headers"
-install=""
-subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
+subpackages="$pkgname-dev:_dev $pkgname-doc $pkgname-libs"
 source="https://people.redhat.com/~dhowells/keyutils/keyutils-$pkgver.tar.bz2"
 
 build() {
@@ -38,6 +36,12 @@ libs() {
 	pkgdesc="Key utilities library"
 	mkdir -p "$subpkgdir"
 	mv "$pkgdir"/lib "$subpkgdir"/
+}
+
+_dev() {
+	# Fix for #10662
+	ln -fs ../../lib/libkeyutils.so.1 "$pkgdir"/usr/lib/libkeyutils.so
+	default_dev
 }
 
 sha512sums="ee50da165099ea26904066d24b27c5165cb1eb78df6768cba3a534aa318a5c8d926ec6e5322a38c8cedaa768cd79bdcb26ef918aa8447df2e5dfbbe7b8f200ff  keyutils-1.6.tar.bz2"


### PR DESCRIPTION
Fixes https://gitlab.alpinelinux.org/alpine/aports/issues/10662