### PR TITLE
testing/shairport-sync: upgrade to 3.3.1

### DIFF
--- a/testing/shairport-sync/APKBUILD
+++ b/testing/shairport-sync/APKBUILD
@@ -1,14 +1,14 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer:
 pkgname=shairport-sync
-pkgver=3.2.2
-pkgrel=2
+pkgver=3.3.1
+pkgrel=0
 pkgdesc="AirTunes emulator. Shairport Sync adds multi-room capability with Audio Synchronisation"
 url="https://github.com/mikebrady/shairport-sync"
 arch="all"
 license="custom"
 depends="avahi"
-makedepends="autoconf automake libtool alsa-lib-dev libdaemon-dev popt-dev
+makedepends="autoconf automake libtool alsa-lib-dev popt-dev
 	openssl-dev soxr-dev avahi-dev libconfig-dev"
 subpackages="$pkgname-doc $pkgname-openrc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/mikebrady/$pkgname/archive/$pkgver.tar.gz
@@ -48,5 +48,5 @@ package() {
 	install -m 755 -D "$srcdir"/$pkgname.initd "$pkgdir"/etc/init.d/$pkgname
 }
 
-sha512sums="a034961d6e9e15dc29c7ceccf4be9e4f66a9038334556d209e8a24dc6444d1e9da20225089e3aa1274dba1565ee6a6b276e65a4e4247cdd4bfb614d1d19d2176  shairport-sync-3.2.2.tar.gz
+sha512sums="4a619f55d6a01077e92b63ee891dbb1573dd328000bbbedc5fad3f1ef525c3865f4dbdcfae2c021c5584e0350f0e837f0fb22586019f9722aa4d0b66c8a14b5c  shairport-sync-3.3.1.tar.gz
 aeead51ef0f17d360bb1e2d2ae897974ef507ef56db84e6aeb79d8ec522c3bb9336f01ff4150e70fecfebf9808dd7190cb2839e287cf0ef6e1886504c1f1edc6  shairport-sync.initd"


### PR DESCRIPTION
Remove libdaemon dependency since it's handled by openrc.