### PR TITLE
main/gcc: Add libstdc++-dev subpackage

### DIFF
--- a/main/gcc/APKBUILD
+++ b/main/gcc/APKBUILD
@@ -114,7 +114,7 @@ fi
 
 _languages=c
 if $LANG_CXX; then
-	subpackages="$subpackages libstdc++:libcxx:$CTARGET_ARCH g++$_target:gpp"
+	subpackages="$subpackages libstdc++:libcxx:$CTARGET_ARCH libstdc++-dev:libcxx_dev:$CTARGET_ARCH g++$_target:gpp"
 	_languages="$_languages,c++"
 fi
 if $LANG_OBJC; then
@@ -414,6 +414,14 @@ libcxx() {
 
 	mkdir -p "$subpkgdir"/usr/lib
 	mv "$pkgdir"/usr/${_target:+$CTARGET/}lib/libstdc++.so.* "$subpkgdir"/usr/lib/
+}
+
+libcxx_dev() {
+	pkgdesc="GNU C++ standard runtime library (development files)"
+	depends=libstdc++
+
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/${_target:+$CTARGET/}lib/libstdc++*.a "$subpkgdir"/usr/lib/
 }
 
 gpp() {


### PR DESCRIPTION
When compiling a program statically, installing `libstdc++` isn't enough. `g++` has to be added to to have `libstdc++.a`. I noticed it in https://github.com/j8r/dockerfiles/issues/4.