### PR TITLE
main/git: enable support for nanoseconds

### DIFF
--- a/main/git/APKBUILD
+++ b/main/git/APKBUILD
@@ -11,7 +11,7 @@
 #   - CVE-2017-1000117
 pkgname=git
 pkgver=2.22.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Distributed version control system"
 url="https://www.git-scm.com/"
 arch="all"
@@ -57,7 +57,6 @@ prepare() {
 		NO_SVN_TESTS=YesPlease
 		NO_REGEX=YesPlease
 		USE_LIBPCRE2=YesPlease
-		NO_NSEC=YesPlease
 		NO_SYS_POLL_H=1
 		CFLAGS=$CFLAGS
 	EOF


### PR DESCRIPTION
musl does support `stat.st_mtimespec.tv_nsec` nowadays. This
configuration option has been present in this APKBUILD forever and I am
assuming it was added when alpine used a libc which didn't support it.

See also: https://gitlab.alpinelinux.org/alpine/aports/issues/10542