### PR TITLE
testing/py-biopython: new aport

### DIFF
--- a/testing/py3-biopython/APKBUILD
+++ b/testing/py3-biopython/APKBUILD
@@ -1,0 +1,24 @@
+# Contributor: Charles Pritchard <chuck@jumis.com>
+# Maintainer: Charles Pritchard <chuck@jumis.com>
+pkgname=py3-biopython
+_pkgname=biopython
+pkgver=1.74
+pkgrel=0
+pkgdesc="Python tools for computational molecular biology."
+url="http://biopython.org/"
+arch="all"
+license="BSD-3-Clause"
+depends="py3-numpy python3"
+makedepends="py3-setuptools py-numpy-dev python3-dev"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver"
+
+build() {
+	python3 setup.py build
+}
+
+package() {
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+sha512sums="a5611b993e383d76d2fdc9be22481624180748f06f107e603a062c51b7ca7cf8603d6d97e11d64cd011ae7bd2696c8bf3659b9c625c84c479164a6171d5e8415  biopython-1.74.tar.gz"


### PR DESCRIPTION
depends on numpy