### PR TITLE
[3.10] community/docker: upgrade to 18.09.8

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: Jake Buchholz <tomalok@gmail.com>
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 pkgname=docker
-pkgver=18.09.7
-_gitcommit=2d0083d657f82c47044c8d3948ba434b622fe2fd	# https://github.com/docker/docker-ce/commits/v$pkgver
+pkgver=18.09.8
+_gitcommit=0dd43dd87fd530113bf44c9bba9ad8b20ce4637f	# https://github.com/docker/docker-ce/commits/v$pkgver
 _ver=${pkgver/_/-}-ce
 pkgrel=0
 pkgdesc="Pack, ship and run any application as a lightweight container"
@@ -11,7 +11,8 @@ url="http://www.docker.io/"
 arch="all"
 license="Apache-2.0"
 depends="docker-engine docker-cli"
-makedepends="go go-md2man btrfs-progs-dev bash linux-headers coreutils lvm2-dev libtool"
+makedepends="go go-md2man btrfs-progs-dev bash linux-headers coreutils lvm2-dev libtool
+	libseccomp-dev"
 install="$pkgname.pre-install"
 
 # from https://github.com/docker/docker-ce/blob/v$pkgver/components/engine/vendor.conf
@@ -19,6 +20,8 @@ _libnetwork_ver=e7933d41e7b206756115aa9df5e0599fc5169742
 _cobra_ver="0.0.3"
 
 # secfixes:
+#   18.09.8:
+#     - CVE-2019-13509
 #   18.09.7:
 #     - CVE-2018-15664
 
@@ -44,7 +47,7 @@ source="
 _dockerdir="$srcdir"/docker-$_ver
 _cli_builddir="$_dockerdir"/components/cli
 _daemon_builddir="$_dockerdir"/components/engine
-_buildtags=""
+_buildtags="seccomp"
 
 _libnetwork_builddir="$srcdir"/libnetwork-$_libnetwork_ver
 
@@ -209,7 +212,7 @@ cli_vim() {
 	done
 }
 
-sha512sums="7d06ab01673b5931a8dde1d2fcebf442d1a107c98c95cd8fe3b886c123b48470950601782fe0c83e7537a1e856069e79a096b9f4523fea7984fd3e773b243b66  docker-18.09.7.tar.gz
+sha512sums="34cf91da732ebbde88f0c8cd39664130e6bd344b18d4643715a00e1c4062d0838a37650a8ee68fb371abd8f01910c7bdce1237af74a49cd63b5ed5382eaf00ed  docker-18.09.8.tar.gz
 0a833510df0029999bfc05c23445a58a8b2ff165c0fb2fd5c411498d1e89b5b1990d2778b32346dd2b6d61c166ff707c6277a5d1937db6345c77d3825eb59875  libnetwork-e7933d41e7b206756115aa9df5e0599fc5169742.tar.gz
 c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 33155a79799cc6c0520a030e1a9bdba60441776d612e5e255574b23bbce1c7a8e5d868284b05a8a92704be6bbb7db905388564e867986a705acbe4884ac58584  docker-openrc-fixes.patch


### PR DESCRIPTION
https://github.com/docker/docker-ce/releases/tag/v18.09.8
* Fix CVE-2019-13509 in DebugRequestMiddleware: unconditionally scrub data field.

Also, compile docker engine with seccomp.