### PR TITLE
main/openssh: use ldns

### DIFF
--- a/main/openssh/APKBUILD
+++ b/main/openssh/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=openssh
 pkgver=8.0_p1
 _myver=${pkgver%_*}${pkgver#*_}
-pkgrel=0
+pkgrel=1
 pkgdesc="Port of OpenBSD's free SSH release"
 url="https://www.openssh.com/portable.html"
 arch="all"
@@ -12,7 +12,7 @@ license="BSD"
 options="!check suid" # FIXME: tests fails. disable for now
 depends="openssh-client openssh-sftp-server openssh-server"
 makedepends_build="linux-pam-dev"
-makedepends_host="openssl-dev zlib-dev libedit-dev linux-headers"
+makedepends_host="openssl-dev ldns-dev zlib-dev libedit-dev linux-headers"
 makedepends="$makedepends_build $makedepends_host"
 # Add more packages support here e.g. kerberos
 _pkgsupport=""
@@ -85,6 +85,7 @@ build() {
 		--with-privsep-user=sshd \
 		--with-md5-passwords \
 		--with-ssl-engine \
+		--with-ldns \
 		--with-libedit \
 		"
 	# now we build "vanilla" openssh


### PR DESCRIPTION
Other distributions, e.g. Arch Linux also built openssh with ldns by default. Doing so fixes a segfault when trying to verify SSH host keys using DNS records.

---

Fixes https://gitlab.alpinelinux.org/alpine/aports/issues/8323