### PR TITLE
testing/rtrlib: update to 0.7.0

### DIFF
--- a/testing/rtrlib/APKBUILD
+++ b/testing/rtrlib/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Christian Franke <nobody@nowhere.ws>
 pkgname=rtrlib
-pkgver=0.6.3
+pkgver=0.7.0
 pkgrel=0
 pkgdesc="An open-source C implementation of the RPKI/Router Protocol client"
 url="https://github.com/rtrlib/rtrlib"
@@ -33,4 +33,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="0dea41716f261b9538f366a02002afe5fd8f04f555bc4266c04a4290499c76c61a38b70e730911c5ac796ddff2ee73d56357f2c5917040e9a4f0892aee3028d2  rtrlib-0.6.3.tar.gz"
+sha512sums="e1c78ce92d066308c1c4fbb6575c2f0dc0f6840c16be90e27bd0da184cab7d0fa4dd1cff3677eda5f1720184756e02765e5abd267b0da0d183082721fee2ffd8  rtrlib-0.7.0.tar.gz"


### PR DESCRIPTION
There has been a new upstream release: https://github.com/rtrlib/rtrlib/releases/tag/v0.7.0