### PR TITLE
community/unison: Enable aarch64 Support

### DIFF
--- a/community/unison/APKBUILD
+++ b/community/unison/APKBUILD
@@ -9,8 +9,7 @@ pkgrel=0
 pkgdesc="Efficient file-synchronization tool"
 url="https://www.cis.upenn.edu/~bcpierce/unison/"
 # ocaml is not built for x86, armhf, s390x
-# ocaml-lablgtk is not built for aarch64
-arch="all !x86 !armhf !armv7 !aarch64 !s390x"
+arch="all !x86 !armhf !armv7 !s390x"
 license="GPL-3.0+"
 makedepends="ocaml ocaml-lablgtk-dev linux-headers emacs-nox bash"
 subpackages="$pkgname-gui"


### PR DESCRIPTION
Architecture specific support is provided for aarch64.