### PR TITLE
community/udisks2: add dependency on dbus

### DIFF
--- a/community/udisks2/APKBUILD
+++ b/community/udisks2/APKBUILD
@@ -3,11 +3,12 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=udisks2
 pkgver=2.8.3
-pkgrel=0
+pkgrel=1
 pkgdesc="A Disk Manager"
 url="https://www.freedesktop.org/wiki/Software/udisks/"
 arch="all"
 license="GPL-2.0-or-later"
+depends="dbus"
 depends_dev="gobject-introspection-dev polkit-dev libatasmart-dev
 	libgudev-dev acl-dev"
 makedepends="$depends_dev glib-dev intltool gtk-doc linux-headers libblockdev-dev
@@ -19,7 +20,6 @@ source="https://github.com/storaged-project/udisks/releases/download/udisks-$pkg
 builddir="$srcdir"/udisks-$pkgver
 
 build() {
-	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -38,12 +38,10 @@ build() {
 }
 
 check() {
-	cd "$builddir"
 	make check
 }
 
 package() {
-	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 	rm -f "$pkgdir"/usr/lib/*.a
 }


### PR DESCRIPTION
It depends on dbus to run services.

Fixes https://gitlab.alpinelinux.org/alpine/aports/issues/9922