### PR TITLE
[3.7] main/libcroco: fix a few CVEs

### DIFF
--- a/main/libcroco/APKBUILD
+++ b/main/libcroco/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libcroco
 pkgver=0.6.12
-pkgrel=0
+pkgrel=1
 pkgdesc="GNOME CSS2 parsing and manipulation toolkit"
 url="http://www.gnome.org"
 arch="all"
@@ -9,11 +9,20 @@ license="LGPL"
 subpackages="$pkgname-dev"
 depends=
 makedepends="glib-dev libxml2-dev"
-source="https://download.gnome.org/sources/$pkgname/0.6/$pkgname-$pkgver.tar.xz"
+source="https://download.gnome.org/sources/$pkgname/0.6/$pkgname-$pkgver.tar.xz
+	CVE-2017-7960.patch
+	CVE-2017-7961.patch
+	CVE-2017-8871-and-CVE-2017-8834.patch
+	"
+
+# secfixes:
+#   0.6.12-r1:
+#     - CVE-2017-7960
+#     - CVE-2017-7961
+#     - CVE-2017-8871
+#     - CVE-2017-8834
 
 depends_dev="glib-dev libxml2-dev pkgconfig"
-
-builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
 	cd "$builddir"
@@ -28,6 +37,9 @@ build() {
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install || return 1
+	make DESTDIR="$pkgdir" install
 }
-sha512sums="af9a171d5ccded255b57f170576e67155f12fa0f61ab3e379e907975f77afc37e82e22772c6019b2897cffc15b2425faf3ccfda92b1a45b23eda2519debabeb6  libcroco-0.6.12.tar.xz"
+sha512sums="af9a171d5ccded255b57f170576e67155f12fa0f61ab3e379e907975f77afc37e82e22772c6019b2897cffc15b2425faf3ccfda92b1a45b23eda2519debabeb6  libcroco-0.6.12.tar.xz
+e6a799e5547c60a317602aa5b537b27ecbc47de84ceb9ef109586370406cd8151c7ab1e7c27f346becf3c10f0524bfc7ac98dcf3160089880c2ac189ee4e7176  CVE-2017-7960.patch
+a1820039d23793ac53ba3acb771f487fe7fed839b298734435e168fecb5cd8b2b20b2fd08b4f827d0ed7eb0b5e76c9290ba912533b95acbf1be7cda5fd604da6  CVE-2017-7961.patch
+568ad8205f5c2ab1eb949ef664671069fad5991e43992e35092738c1a741289303dba343c8002caec817d1c27fe5645dc2a861573fb4d91074aef59ff41f3d27  CVE-2017-8871-and-CVE-2017-8834.patch"

--- a/main/libcroco/CVE-2017-7960.patch
+++ b/main/libcroco/CVE-2017-7960.patch
@@ -1,0 +1,59 @@
+From 898e3a8c8c0314d2e6b106809a8e3e93cf9d4394 Mon Sep 17 00:00:00 2001
+From: Ignacio Casal Quinteiro <qignacio@amazon.com>
+Date: Sun, 16 Apr 2017 13:13:43 +0200
+Subject: [PATCH] input: check end of input before reading a byte
+
+When reading bytes we weren't check that the index wasn't
+out of bound and this could produce an invalid read which
+could deal to a security bug.
+---
+ src/cr-input.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/src/cr-input.c b/src/cr-input.c
+index 49000b1..3b63a88 100644
+--- a/src/cr-input.c
++++ b/src/cr-input.c
+@@ -256,7 +256,7 @@ cr_input_new_from_uri (const gchar * a_file_uri, enum CREncoding a_enc)
+                  *we should  free buf here because it's own by CRInput.
+                  *(see the last parameter of cr_input_new_from_buf().
+                  */
+-                buf = NULL ;
++                buf = NULL;
+         }
+ 
+  cleanup:
+@@ -404,6 +404,8 @@ cr_input_get_nb_bytes_left (CRInput const * a_this)
+ enum CRStatus
+ cr_input_read_byte (CRInput * a_this, guchar * a_byte)
+ {
++        gulong nb_bytes_left = 0;
++
+         g_return_val_if_fail (a_this && PRIVATE (a_this)
+                               && a_byte, CR_BAD_PARAM_ERROR);
+ 
+@@ -413,6 +415,12 @@ cr_input_read_byte (CRInput * a_this, guchar * a_byte)
+         if (PRIVATE (a_this)->end_of_input == TRUE)
+                 return CR_END_OF_INPUT_ERROR;
+ 
++        nb_bytes_left = cr_input_get_nb_bytes_left (a_this);
++
++        if (nb_bytes_left < 1) {
++                return CR_END_OF_INPUT_ERROR;
++        }
++
+         *a_byte = PRIVATE (a_this)->in_buf[PRIVATE (a_this)->next_byte_index];
+ 
+         if (PRIVATE (a_this)->nb_bytes -
+@@ -477,7 +485,6 @@ cr_input_read_char (CRInput * a_this, guint32 * a_char)
+                 if (*a_char == '\n') {
+                         PRIVATE (a_this)->end_of_line = TRUE;
+                 }
+-
+         }
+ 
+         return status;
+-- 
+2.21.0
+
+

--- a/main/libcroco/CVE-2017-7961.patch
+++ b/main/libcroco/CVE-2017-7961.patch
@@ -1,0 +1,43 @@
+From 9ad72875e9f08e4c519ef63d44cdbd94aa9504f7 Mon Sep 17 00:00:00 2001
+From: Ignacio Casal Quinteiro <qignacio@amazon.com>
+Date: Sun, 16 Apr 2017 13:56:09 +0200
+Subject: [PATCH] tknzr: support only max long rgb values
+
+This fixes a possible out of bound when reading rgbs which
+are longer than the support MAXLONG
+---
+ src/cr-tknzr.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/cr-tknzr.c b/src/cr-tknzr.c
+index 1a7cfeb..1548c35 100644
+--- a/src/cr-tknzr.c
++++ b/src/cr-tknzr.c
+@@ -1279,6 +1279,11 @@ cr_tknzr_parse_rgb (CRTknzr * a_this, CRRgb ** a_rgb)
+         status = cr_tknzr_parse_num (a_this, &num);
+         ENSURE_PARSING_COND ((status == CR_OK) && (num != NULL));
+ 
++        if (num->val > G_MAXLONG) {
++                status = CR_PARSING_ERROR;
++                goto error;
++        }
++
+         red = num->val;
+         cr_num_destroy (num);
+         num = NULL;
+@@ -1298,6 +1303,11 @@ cr_tknzr_parse_rgb (CRTknzr * a_this, CRRgb ** a_rgb)
+                 status = cr_tknzr_parse_num (a_this, &num);
+                 ENSURE_PARSING_COND ((status == CR_OK) && (num != NULL));
+ 
++                if (num->val > G_MAXLONG) {
++                        status = CR_PARSING_ERROR;
++                        goto error;
++                }
++
+                 PEEK_BYTE (a_this, 1, &next_bytes[0]);
+                 if (next_bytes[0] == '%') {
+                         SKIP_CHARS (a_this, 1);
+-- 
+2.21.0
+
+

--- a/main/libcroco/CVE-2017-8871-and-CVE-2017-8834.patch
+++ b/main/libcroco/CVE-2017-8871-and-CVE-2017-8834.patch
@@ -1,0 +1,29 @@
+From deda38539f5b25616aa294d8b19d33ebf8e175ff Mon Sep 17 00:00:00 2001
+From: Mike Gorse <mgorse@alum.wpi.edu>
+Date: Thu, 2 May 2019 10:54:43 -0500
+Subject: [PATCH] cr_utils_read_char_from_utf8_buf: move past invalid UTF-8
+
+Otherwise, the offending character is never consumed, possibly leading
+to an infinite loop.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=782647
+---
+ src/cr-utils.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/cr-utils.c b/src/cr-utils.c
+index 2420cec..6cf4849 100644
+--- a/src/cr-utils.c
++++ b/src/cr-utils.c
+@@ -505,6 +505,7 @@ cr_utils_read_char_from_utf8_buf (const guchar * a_in,
+ 
+         } else {
+                 /*BAD ENCODING */
++                nb_bytes_2_decode = 1;
+                 goto end;
+         }
+ 
+-- 
+2.20.1
+
+


### PR DESCRIPTION
- CVE-2017-7960
- CVE-2017-7961
- CVE-2017-8834
- CVE-2017-8871

Fixes https://gitlab.alpinelinux.org/alpine/aports/issues/10566