### PR TITLE
community/xe-guest-utilities upgrade to 7.14.0

### DIFF
--- a/community/xe-guest-utilities/APKBUILD
+++ b/community/xe-guest-utilities/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Ian Bashford <ianbashford@gmail.com>
 # Maintainer: Ian Bashford <ianbashford@gmail.com>
 pkgname=xe-guest-utilities
-pkgver=7.13.0
+pkgver=7.14.0
 pkgrel=0
 pkgdesc="XenServer guest tools"
 url="https://github.com/xenserver/xe-guest-utilities"
@@ -18,6 +18,7 @@ builddir="$srcdir"/$pkgname-$pkgver
 
 build() {
 	cd "$builddir"
+	go get golang.org/x/sys/unix
 	make
 }
 
@@ -37,5 +38,5 @@ udev() {
 	install -m644 -D "${builddir}/build/stage/${udev_dir}/${filename}" "${subpkgdir}/${udev_dir}/${filename}"
 }
 
-sha512sums="003c901e6897ba1ceb17665d99785749fc020e0ebc165155f06518b816f406b4276d7b9ce26c992ff2758fa3e6e03c05fbb83f7ddc976aeebef47d1cb5df2d39  xe-guest-utilities-7.13.0.tar.gz
+sha512sums="4d20e9e0a60f42b977ed1af43d8f5ff8f8d05aa4fe37eca5c14a26010c616c705587c6a33b0e085c39ae6d6bc0e8ae8f16baafb20972f78b1167b0a9676504ca  xe-guest-utilities-7.14.0.tar.gz
 3e898b473f6e71ecc5b820717df0a460b31756b68f4bb9bf454df39f430e64ca5e33582c03bfea044d93f49937883fe9b6807c31dee72307750de670bfca8bcd  xe-guest-utilities.initd"


### PR DESCRIPTION
Release adds support for xenstore-ls
import of golang.org/x/sys/unix added to APKBUILD to support this feature