### PR TITLE
scripts/bootstrap.sh: Changes required to bootstrap ARM on x86

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -101,10 +101,10 @@ for PKG in fortify-headers linux-headers musl libc-dev pkgconf zlib \
 	   gmp mpfr3 mpc1 isl cloog gcc \
 	   openrc alpine-conf alpine-baselayout alpine-keys alpine-base build-base \
 	   attr libcap patch sudo acl fakeroot tar \
-	   pax-utils lzip abuild openssh \
-	   ncurses libcap-ng util-linux libaio lvm2 popt xz \
+	   pax-utils lzip abuild ncurses libedit openssh \
+	   libcap-ng util-linux libaio lvm2 popt xz \
 	   json-c argon2 cryptsetup kmod lddtree mkinitfs \
-	   community/go libffi community/ghc \
+	   libffi \
 	   $KERNEL_PKG ; do
 
 	CHOST=$TARGET_ARCH BOOTSTRAP=bootimage APKBUILD=$(apkbuildname $PKG) abuild -r


### PR DESCRIPTION
Introduce changes required to perform successful bootstrap of v3.10 ARMv7 environment on x86_64 hosts.