### PR TITLE
community/mtd-utils: upgrade to 2.1.1

### DIFF
--- a/community/mtd-utils/APKBUILD
+++ b/community/mtd-utils/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Olliver Schinagl <oliver@schinagl.nl>
-pkgname=mtd-utils
-pkgver=2.1.0
-pkgrel=1
+pkgname="mtd-utils"
+pkgver="2.1.1"
+pkgrel="0"
 pkgdesc="Utilities for handling MTD devices, and for dealing with FTL, NFTL JFFS2, etc."
 url="http://www.linux-mtd.infradead.org/"
 arch="all"
@@ -18,9 +18,9 @@ makedepends="
 	openssl-dev
 	util-linux-dev
 	zlib-dev
+	zstd-dev
 	"
 checkdepends="findutils"
-options="!check" # checks fail on builders
 _subpackages="
 	$pkgname-flash
 	$pkgname-jffs
@@ -30,12 +30,9 @@ _subpackages="
 	$pkgname-ubi
 	"
 subpackages="$pkgname-doc $_subpackages"
-_githash="1dba7944fe18978415a3ffc43932359a36b99b25"
+_githash="beb39b15e926747fe404376ceb148c1b56c998f6"
 source="
 	$pkgname-$pkgver.tar.gz::http://git.infradead.org/mtd-utils.git/snapshot/$_githash.tar.gz
-	0001-unittests-test_lib-Include-proper-header-for-_IOC_SI.patch
-	0002-unittests-libmtd_test-Include-fcntl-header.patch
-	0003-unittests-Define-the-use-of-_GNU_SOURCE.patch
 	"
 builddir="$srcdir/$pkgname-$(echo "$_githash" | cut -c1-7)"
 
@@ -126,7 +123,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="bb64b6cbdaee3c731ed1dc136064507fbfffe8a45879b0c4024a2b46d320875252f42af8dc268b30247ebb81a7a89b951e19a896bb415de38877c45b031e1081  mtd-utils-2.1.0.tar.gz
-70013f50fad529e94733cd86349d4efe4d99c5febd7c407ab3db0c2995fd6be0524b3ebc59537ff13a4be9a8f63100468a9faa8590ea4d84f79995398b0fd7d9  0001-unittests-test_lib-Include-proper-header-for-_IOC_SI.patch
-eb6d72e2810218c90044f562ec2d58543f42066ca4719ec5c1199dfdebeacacbde931b59ad12a39df7834fb2b8cef240bed839840c11b3cac9761dd44e63bca8  0002-unittests-libmtd_test-Include-fcntl-header.patch
-e29c485a96b959c26f39a0a05a78e2a562f2bda0a2acc7ed532b6ebda46139f9e4c88b4df0f9dc13051dd5aa50ad60f82880f3da412b59d46fca527a88a30f5d  0003-unittests-Define-the-use-of-_GNU_SOURCE.patch"
+sha512sums="ec5b0bb00ec97ca759fc1cca83af716fb24f9465d70d61c38cf5ab02e7e30b456d2c884ade6dc594dc37412bbb6100cb954bcb4f5a0caf35e6581a0652f6496d  mtd-utils-2.1.1.tar.gz"


### PR DESCRIPTION
Version bump of mtd-utils

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>