### PR TITLE
Testing/Clisp: Fixed clisp compilation on x86_64

### DIFF
--- a/testing/clisp/APKBUILD
+++ b/testing/clisp/APKBUILD
@@ -1,12 +1,12 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
-# Maintainer:
+# Maintainer: Will Sinatra <wpsinatra@gmail.com>
 pkgname=clisp
 pkgver=2.49
-pkgrel=3
+pkgrel=4
 pkgdesc="ANSI Common Lisp interpreter, compiler and debugger"
 url="https://clisp.sourceforge.io/"
-arch="" # Fails to build on x86_64
+arch="x86_64"
 license="GPL-2.0-only"
 depends_dev="libsigsegv-dev ffcall ncurses-dev"
 makedepends="$depends_dev"
@@ -27,6 +27,7 @@ build() {
 		--with-ffcall \
 		--with-dynamic-ffi \
 		--without-dynamic-modules \
+		--disable-mmap \
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
 		"$builddir"
@@ -37,9 +38,5 @@ package() {
 	make -j1 DESTDIR="$pkgdir" install
 }
 
-md5sums="1962b99d5e530390ec3829236d168649  clisp-2.49.tar.bz2
-a8456d6a45340e091055b58c306022ef  no-page.h.patch"
-sha256sums="8132ff353afaa70e6b19367a25ae3d5a43627279c25647c220641fed00f8e890  clisp-2.49.tar.bz2
-2d3bd8dde82e5cdf0a3825a0b67df110e20e19541308509d1165029c589b3d0a  no-page.h.patch"
 sha512sums="eef66fc85199a2c283b616db61bf67ff103eeb0f19fa907da48994dc790b6f5f8d0c74fb3bd723c6b827c0ff3cfd89fa6ba67934fc669ed5d5249044b5140d81  clisp-2.49.tar.bz2
 86273c5d5d05a8d41ab6311192e0c757d3f7fe4d78546590830aa00f8c2f170fcb08f66ea739ae8834cec00cdf0f6a20824eb6a3d0f6df97be405c26b1cc5d39  no-page.h.patch"


### PR DESCRIPTION
Added --disable-mmap to package build, which allowed clisp to compile thereafter. Added myself as a maintainer to prevent the package from becoming unmaintained in the future.