### PR TITLE
[3.9] main/sdl2: security upgrade to 2.0.10

### DIFF
--- a/main/sdl2/APKBUILD
+++ b/main/sdl2/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: August Klein <amatcoder@gmail.com>
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=sdl2
-pkgver=2.0.9
+pkgver=2.0.10
 pkgrel=0
 pkgdesc="A development library designed to provide low level access to audio, keyboard, mouse, joystick and graphics"
 url="http://www.libsdl.org"
@@ -14,6 +14,19 @@ makedepends="alsa-lib-dev directfb-dev libxcursor-dev libxrandr-dev libxrender-d
 subpackages="$pkgname-dev"
 source="https://www.libsdl.org/release/SDL2-$pkgver.tar.gz"
 builddir="$srcdir/SDL2-$pkgver"
+
+# secfixes:
+#   2.0.10-r0:
+#     - CVE-2019-7572
+#     - CVE-2019-7573
+#     - CVE-2019-7574
+#     - CVE-2019-7575
+#     - CVE-2019-7576
+#     - CVE-2019-7578
+#     - CVE-2019-7635
+#     - CVE-2019-7636
+#     - CVE-2019-7637
+#     - CVE-2019-7638
 
 build() {
 	cd "$builddir"
@@ -43,4 +56,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="a78a4708b2bb5b35a7c7b7501eb3bd60a9aa3bb95a3d84e57763df4a377185e7312a94b66321eef7ca0d17255e4b402fc950e83ef0dbbd08f14ff1194107dc10  SDL2-2.0.9.tar.gz"
+sha512sums="f49b869362699b3282f6e82920e59c7fac581bcbf955f18a81cc126293c08093a90df7fcb39517cc8bc32708d2213fe645a42b655d6d811c1386efebb3d3c798  SDL2-2.0.10.tar.gz"


### PR DESCRIPTION
closes #10339