### PR TITLE
[3.7] main/sdl2: security upgrade to 2.0.10

### DIFF
--- a/main/sdl2/APKBUILD
+++ b/main/sdl2/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: August Klein <amatcoder@gmail.com>
 # Maintainer: August Klein <amatcoder@gmail.com>
 pkgname=sdl2
-pkgver=2.0.7
-pkgrel=3
+pkgver=2.0.10
+pkgrel=0
 pkgdesc="A development library designed to provide low level access to audio, keyboard, mouse, joystick and graphics"
 url="http://www.libsdl.org"
 arch="all"
@@ -15,6 +15,19 @@ subpackages="$pkgname-dev"
 source="https://www.libsdl.org/release/SDL2-$pkgver.tar.gz
 	fix-directfb-include.patch"
 builddir="$srcdir/SDL2-$pkgver"
+
+# secfixes:
+#   2.0.10-r0:
+#     - CVE-2019-7572
+#     - CVE-2019-7573
+#     - CVE-2019-7574
+#     - CVE-2019-7575
+#     - CVE-2019-7576
+#     - CVE-2019-7578
+#     - CVE-2019-7635
+#     - CVE-2019-7636
+#     - CVE-2019-7637
+#     - CVE-2019-7638
 
 build() {
 	cd "$builddir"
@@ -43,6 +56,5 @@ package() {
 	cd "$builddir"
 	make DESTDIR="$pkgdir" install
 }
-
-sha512sums="eed5477843086a0e66552eb197a5c4929134522bc366d873732361ea0df5fb841ef7e2b1913e21d1bae69e6fd3152ee630492e615c58cbe903e7d6e47b587410  SDL2-2.0.7.tar.gz
-f57a7a7b89f11934835b5693d104354be1107ddd31d34f6cfc07cf480b0811d775c95685f6b6b20c6154f03744ed976c8092973ddb6e87773969b8394e852c24  fix-directfb-include.patch"
+sha512sums="f49b869362699b3282f6e82920e59c7fac581bcbf955f18a81cc126293c08093a90df7fcb39517cc8bc32708d2213fe645a42b655d6d811c1386efebb3d3c798  SDL2-2.0.10.tar.gz
+126fe6f072e7f45c0d8db710904ffc2a3382fa1403d34a4f9c656e1deca633147b1e5273ce9dfd148af2694cd472ab045129ff50e9ebbb0a888125253710a805  fix-directfb-include.patch"

--- a/main/sdl2/fix-directfb-include.patch
+++ b/main/sdl2/fix-directfb-include.patch
@@ -14,14 +14,3 @@ index 2d18afb..6416e2f 100644
  /* Set up for C function definitions, even when using C++ */
  #ifdef __cplusplus
  extern "C" {
-@@ -79,10 +84,6 @@ struct SDL_SysWMinfo;
- 
- #endif /* defined(SDL_VIDEO_DRIVER_X11) */
- 
--#if defined(SDL_VIDEO_DRIVER_DIRECTFB)
--#include <directfb.h>
--#endif
--
- #if defined(SDL_VIDEO_DRIVER_COCOA)
- #ifdef __OBJC__
- @class NSWindow;


### PR DESCRIPTION
closes #10341