### PR TITLE
community/docker: upgrade to 19.03.1

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: Jake Buchholz <tomalok@gmail.com>
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 pkgname=docker
-pkgver=19.03.0
-_gitcommit=aeac9490dc54c1d48b3d7ae9a46f5a19b78dcd3a	# https://github.com/docker/docker-ce/commits/v$pkgver
+pkgver=19.03.1
+_gitcommit=74b1e89e8ac68948be88fe0aa1e2767ae28659fe	# https://github.com/docker/docker-ce/commits/v$pkgver
 _ver=${pkgver/_/-}-ce
 pkgrel=1
 pkgdesc="Pack, ship and run any application as a lightweight container"
@@ -20,10 +20,12 @@ _libnetwork_ver=fc5a7d91d54cc98f64fc28f9e288b46a0bee756c
 _cobra_ver="0.0.3"
 
 # secfixes:
+#   19.03.1:
+#   - CVE-2019-14271
 #   18.09.8:
-#     - CVE-2019-13509
+#   - CVE-2019-13509
 #   18.09.7:
-#     - CVE-2018-15664
+#   - CVE-2018-15664
 
 subpackages="
 	$pkgname-engine:engine
@@ -211,7 +213,7 @@ cli_vim() {
 	done
 }
 
-sha512sums="ae843ef3d634b5e8e9e3e03890269aaa4edd01d9d2f5a8a6343c8c224a79f5df7c47aad6c59ea45b6aaac6aa0b0348d9ac54b76f037be742c0b4ed9dd160010b  docker-19.03.0.tar.gz
+sha512sums="92b4e5fe2bbf96a261d290ca807550af45146be9d21680940bd6aa45d9127ae8ddbc706df4056f1720ed6975a2a92004f1789fae4109c50206904ad827d4bf2e  docker-19.03.1.tar.gz
 dea31fd82ab2d445fbd39fe15550a91f7e489a06f6dedd32ea1925f7e9a7971952d26b874f9687249609a0d204ea35da357e0a957b819df2026a0cf8109cb354  libnetwork-fc5a7d91d54cc98f64fc28f9e288b46a0bee756c.tar.gz
 c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 d796e6dcab6443a84064f3439dde46bc7e1989e1b52910b3e80a0af0ae1ddd288f0306a24c8d31032e24f5fd4218d2f25614752021355441f118ba2b524cfbd1  docker-openrc-fixes.patch"


### PR DESCRIPTION
Fix for CVE-2019-14271
Release notes: https://github.com/docker/docker-ce/releases/tag/v19.03.1