### PR TITLE
testing/cockroach: bump to 19.1.3

### DIFF
--- a/testing/cockroach/APKBUILD
+++ b/testing/cockroach/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Joe Holden <jwh@zorins.us>
 # Maintainer: Joe Holden <jwh@zorins.us>
 pkgname=cockroach
-pkgver=19.1.2
+pkgver=19.1.3
 pkgrel=0
 pkgdesc="The open source, cloud-native SQL database."
 url="https://cockroachlabs.com"
@@ -27,9 +27,9 @@ build() {
 package() {
 	install -m755 -D ${srcdir}/${pkgname}.initd ${pkgdir}/etc/init.d/${pkgname}
 	install -m644 -D ${srcdir}/${pkgname}.confd ${pkgdir}/etc/conf.d/${pkgname}
-	install -m750 -o ${pkgusers} -g ${pkggroups} -D src/github.com/cockroachdb/${pkgname}/${pkgname}oss ${pkgdir}/usr/sbin/${pkgname}
+	install -m755 -o ${pkgusers} -g ${pkggroups} -D src/github.com/cockroachdb/${pkgname}/${pkgname}oss ${pkgdir}/usr/sbin/${pkgname}
 }
-sha512sums="48b2bbc08b3c2e87b6b099e515d718bc437c658cf911fa088cceb680beae12ac39a3539a24373c9f9b199e3088a215e3f015c086a1904a63f156c554fd45a280  cockroach-v19.1.2.tar.gz
+sha512sums="acb44e9f340b90eda1575318c1099e5ccc5ed8fbfec40399c2d0349b30c91abee732c079c81391a6372985cd671305f9bf5e0ae5a6b470ec24f44683ade35b6c  cockroach-v19.1.3.tar.gz
 94264601b5b8516d87072017d40ba293d17320c706ad7a2e3c49f1af2b1030071e33cf3353adce26c634d284d0be4e41f2f9a9749c5071e9f0921ed03429f4cf  cockroach.initd
 7039d17eb3c251d941bc73af2264c9618b59f8301165764371bf1539c46366d35496b2c00ea134731fd1ca9a0b362f9ba331b03aa62339f75e14504af9eb44f9  cockroach.confd
 fe611479ba32a01a1ee7770170c54570cb4ac558fb756c44c90f9e31d59a5da74af81adf1e100e723d3956aea96748955919e5b000ee91d8f8fcb26cc678556f  01_no_githooks.patch"


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/releases/tag/v19.1.3