### PR TITLE
mongo-c-driver, mongo-cxx-driver: fix depends_dev

### DIFF
--- a/testing/mongo-c-driver/APKBUILD
+++ b/testing/mongo-c-driver/APKBUILD
@@ -1,12 +1,13 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=mongo-c-driver
 pkgver=1.14.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Client library written in C for MongoDB"
 url="https://github.com/mongodb/mongo-c-driver"
 arch="all"
 license="Apache-2.0"
 makedepends="openssl-dev snappy-dev zlib-dev libtool py3-sphinx cmake"
+depends_dev="libbson-dev"
 subpackages="
 	$pkgname-static:_static
 	libbson-static:_libbson_static

--- a/testing/mongo-cxx-driver/APKBUILD
+++ b/testing/mongo-cxx-driver/APKBUILD
@@ -9,7 +9,7 @@ url="http://mongocxx.org/"
 arch="all"
 license="Apache-2.0"
 makedepends="cmake mongo-c-driver-dev libbson-dev openssl-dev python3 snappy-dev"
-subpackages="$pkgname-dev:_dev libbsoncxx libbsoncxx-dev"
+subpackages="libbsoncxx-dev $pkgname-dev:_dev libbsoncxx"
 depends_dev="libbsoncxx-dev"
 source="mongo-cxx-driver-$pkgver.tar.gz::https://github.com/mongodb/mongo-cxx-driver/archive/$_commit.tar.gz
 	01-dont-build-mongo-tests.patch"

--- a/testing/mongo-cxx-driver/APKBUILD
+++ b/testing/mongo-cxx-driver/APKBUILD
@@ -3,14 +3,14 @@
 pkgname="mongo-cxx-driver"
 pkgver="3.4.0"
 _commit="131fa1a67acd45c0eebcbdcfee42b212af8d2e80" # master compiles with GCC8.3/CXX17
-pkgrel=0
+pkgrel=1
 pkgdesc="C++ driver for MongoDB"
 url="http://mongocxx.org/"
 arch="all"
 license="Apache-2.0"
 makedepends="cmake mongo-c-driver-dev libbson-dev openssl-dev python3 snappy-dev"
 subpackages="$pkgname-dev:_dev libbsoncxx libbsoncxx-dev"
-depends_dev="libbson-dev"
+depends_dev="libbsoncxx-dev"
 source="mongo-cxx-driver-$pkgver.tar.gz::https://github.com/mongodb/mongo-cxx-driver/archive/$_commit.tar.gz
 	01-dont-build-mongo-tests.patch"
 builddir="$srcdir/mongo-cxx-driver-$_commit"


### PR DESCRIPTION
Should no longer need to specify libbson[cxx]-dev as an explicit makedep.

EDIT: Actually:

```
/usr/lib # ldd libmongocxx.so.0.0.0 
        /lib/ld-musl-x86_64.so.1 (0x7faddbd73000)
        libmongoc-1.0.so.0 => /usr/lib/libmongoc-1.0.so.0 (0x7faddbc54000)
        libbson-1.0.so.0 => /usr/lib/libbson-1.0.so.0 (0x7faddbc15000)
        libbsoncxx.so._noabi => /usr/lib/libbsoncxx.so._noabi (0x7faddbbf5000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x7faddbaa0000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x7faddba8c000)
        libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7faddbd73000)
        libssl.so.1.1 => /lib/libssl.so.1.1 (0x7faddba0c000)
        libcrypto.so.1.1 => /lib/libcrypto.so.1.1 (0x7faddb78e000)
        libsnappy.so.1 => /usr/lib/libsnappy.so.1 (0x7faddb782000)
        libz.so.1 => /lib/libz.so.1 (0x7faddb56b000)
```

but:
```
mongo-cxx-driver-3.4.0-r0 depends on:
so:libbson-1.0.so.0
so:libc.musl-x86_64.so.1
so:libgcc_s.so.1
so:libmongoc-1.0.so.0
so:libstdc++.so.6
```

So, we're not correctly finding the libbsoncxx.so._noabi dependency...

Should we add it explicitly or fix the underlying issue?
