### PR TITLE
community/networkmanager: enable iwd by default

### DIFF
--- a/community/networkmanager/APKBUILD
+++ b/community/networkmanager/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=networkmanager
 pkgver=1.18.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Network Management daemon"
 url="https://wiki.gnome.org/Projects/NetworkManager"
 arch="all"
 license="GPL-2.0-or-later"
-depends="dhcpcd iptables dbus"
+depends="dhcpcd iptables dbus iwd"
 install="$pkgname.pre-install $pkgname.pre-upgrade"
 makedepends="$depends_dev
 	curl-dev
@@ -97,11 +97,11 @@ package() {
 	mkdir -p "$pkgdir/usr/share/apk-tools/$pkgname"
 	# post-install message
 	mv "$pkgdir/usr/share/doc/NetworkManager" "$pkgdir/usr/share/doc/$pkgname"
-	cat > $pkgdir/usr/share/doc/$pkgname/README.alpine <<EOF
+	cat > "$pkgdir"/usr/share/doc/$pkgname/README.alpine <<EOF
 To modify system network connections without the root password: add your user account to the 'plugdev' group, or use Polkit.
+EOF
 
-To use iwd instead of the default wpa_supplicant install iwd, start its service and the following to your /etc/NetworkManager/NetworkManager.conf:
-
+	cat > "$pkgdir"/etc/NetworkManager/conf.d/iwd.conf <<EOF
 [device]
 wifi.backend=iwd
 EOF

--- a/community/networkmanager/networkmanager.pre-install
+++ b/community/networkmanager/networkmanager.pre-install
@@ -2,8 +2,6 @@
 
 addgroup -S plugdev 2>/dev/null
 
-printf "  *\n  * To setup system connections, regular users must be member of 'plugdev' group.\n  *\n"
-printf "  *\n  * To control WiFi devices, enable wpa_supplicant service: 'rc-update add wpa_supplicant default'\n"
-printf "  * then reboot the system or restart 'wpa_supplicant' and 'networkmanager' services respectively.\n  *\n"
+printf "  *\n  * To setup system connections, regular users must either use Polkit for authentication or be a member of the 'plugdev' group."
 
 exit 0


### PR DESCRIPTION
wpa_supplicant on NM has been broken on Alpine for some time now (not showing
any SSIDs in the WiFi overview). As such enabling iwd by default allows WiFi
to function for all users again.