### PR TITLE
[3.8] main/libebml: add secfixes comment for CVE-2019-13615

### DIFF
--- a/main/libebml/APKBUILD
+++ b/main/libebml/APKBUILD
@@ -13,6 +13,10 @@ makedepends="cmake"
 subpackages="$pkgname-dev"
 source="http://dl.matroska.org/downloads/$pkgname/$pkgname-$pkgver.tar.xz"
 
+# secfixes:
+#   1.3.6-r0:
+#     - CVE-2019-13615
+
 build() {
 	cd "$builddir"
 	if [ "$CBUILD" != "$CHOST" ]; then


### PR DESCRIPTION
ref #10697