### PR TITLE
main/gettext: add dependency on xz to prevent unpack errors

### DIFF
--- a/main/gettext/APKBUILD
+++ b/main/gettext/APKBUILD
@@ -3,14 +3,15 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=gettext
 pkgver=0.20.1
-pkgrel=0
+pkgrel=1
 pkgdesc="GNU locale utilities"
 url="https://www.gnu.org/software/gettext/gettext.html"
 arch="all"
 license="GPL-3.0+ AND LGPL-2.1+ AND MIT"
 # do _not_ add the optional dependencies on libcroco or glib
 # they depend on gettext and would introduce cyclic dependencies
-makedepends="perl ncurses-dev libxml2-dev libunistring-dev xz"
+depends="xz"
+makedepends="perl ncurses-dev libxml2-dev libunistring-dev"
 checkdepends="coreutils"
 source="https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.xz
 	skip-tests-musl.patch"


### PR DESCRIPTION
After commit https://github.com/alpinelinux/aports/commit/3f94dc69146a04b4c80b915ac5ee14fb4b2faecf to gettext, build of xz packages that use autoreconf fail with errors of type: 
```
>>> cogl: Unpacking /var/cache/distfiles/cogl-1.22.4.tar.xz...
/usr/bin/autopoint: line 494: xz: not found
tar: This does not look like a tar archive
tar: gettext-0.19: Not found in archive
tar: Exiting with failure status due to previous errors
autopoint: *** infrastructure files for version 0.19 not found; this is autopoint from GNU gettext-tools 0.20.1
autopoint: *** Stop.
```
 Adding xz as a dependency of gettext apk fixes this issue.

Packages that will fail to build because of this issue in main branch include:
cogl, consolekit2, fetchmail, gnokii, linux-pam, partimage, procps, upower