### PR TITLE
main/atop: add required sysmacros.h header

### DIFF
--- a/main/atop/APKBUILD
+++ b/main/atop/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=atop
 pkgver=2.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Resource-specific view of processes"
 url="https://www.atoptool.nl/"
 arch="all"
@@ -11,6 +11,7 @@ subpackages="$pkgname-doc"
 source="https://www.atoptool.nl/download/atop-$pkgver.tar.gz
 	atop-bb-compat.patch
 	atop-daily-bb.patch
+	atop-include-macros.patch
 	atop.initd"
 options="suid"
 
@@ -44,4 +45,5 @@ package() {
 sha512sums="51cc868545403cab439a66cc38fe9324c6ff7537e6dad5271fa3f0a22cbad471b0e15186d4f78f0080129301ba0a59e0c1cd1cc694bc3a4f982118a8d0cae429  atop-2.3.0.tar.gz
 165e5f17f1a752f8663a774d72476eac5693f93922b32fa198f09233ca6dfde2d6c63b10c31d0388ac9f10d210e7067787f30ef25e0ef9419a1520486f290b15  atop-bb-compat.patch
 078e76315a6336a63e03873ec4c76e2c0d2698879840bfad5c57db266a15abd521dde9f720f0ddf482b4e2a18cac9d869e0c08994cfe5ef9a3343603e3858a11  atop-daily-bb.patch
+f30c9e6051332af8c8cafcd881f89a0e2d2a8e1d84eee8ac0c8c6b58f3ae3431fcf9c40dea6d03e271f8969802de449d33b4323c13045bdb38a539732c81a8b6  atop-include-macros.patch
 172c9d367b936427ccbbbd1140c7808ec8ffe3194b3557ba024820dac8fa68c9919f7dc34d332e91283fde64d731db7bdbfee3c2d6caad3cd291e0f1c227cb03  atop.initd"

--- a/main/atop/atop-include-macros.patch
+++ b/main/atop/atop-include-macros.patch
@@ -1,0 +1,10 @@
+--- a/photosyst.c
++++ b/photosyst.c
+@@ -152,6 +152,7 @@
+ static const char rcsid[] = "$Id: photosyst.c,v 1.38 2010/11/19 07:40:40 gerlof Exp $";
+ 
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <unistd.h>


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of atop fails with error:
```
photosyst.c:1465:19: error: called object 'major' is not a function or function pointer
     dmp->major  = major(statbuf.st_rdev);
```
To fix this add the include of sys/sysmacros.h explicitly to atop source.