### PR TITLE
main/cramfs: add required sysmacros.h header

### DIFF
--- a/main/cramfs/APKBUILD
+++ b/main/cramfs/APKBUILD
@@ -1,14 +1,15 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cramfs
 pkgver=1.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Linux filesystem designed to be simple, small, and to compress things well"
 arch="all"
 url="https://sourceforge.net/projects/cramfs/"
 license='GPL'
 depends=
 makedepends="zlib-dev linux-headers"
-source="https://downloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.gz"
+source="https://downloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.gz
+	mkcramfs-include-sysmacros.patch"
 
 build() {
 	cd "$srcdir/$pkgname-$pkgver"
@@ -21,4 +22,5 @@ package() {
 	install mkcramfs cramfsck "$pkgdir"/sbin
 }
 
-sha512sums="6c18dbe32df57f7d132fb2a59a917ad381156ca1f720c1ad0997ca81c62e82fd43ebb0339c5a66d5b144a72ce5c7ae93596522fe2698259f2b68c31db26e3b63  cramfs-1.1.tar.gz"
+sha512sums="6c18dbe32df57f7d132fb2a59a917ad381156ca1f720c1ad0997ca81c62e82fd43ebb0339c5a66d5b144a72ce5c7ae93596522fe2698259f2b68c31db26e3b63  cramfs-1.1.tar.gz
+4cb3b50f76181775634a4cdf5d2d06ea90978f7059e0390e97f58c58896afee76e04e1df4e44f254285d7c80a76c3b053c36aa03b2e4cb3b9621c8aacd21368b  mkcramfs-include-sysmacros.patch"

--- a/main/cramfs/mkcramfs-include-sysmacros.patch
+++ b/main/cramfs/mkcramfs-include-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/mkcramfs.c
++++ b/mkcramfs.c
+@@ -23,6 +23,7 @@
+  */
+ 
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <stdio.h>
+ #include <sys/stat.h>
+ #include <unistd.h>


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of cramfs fails with error:
```
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: /tmp/cchndpjP.o: in function `main':
mkcramfs.c:(.text.startup+0x6c0): undefined reference to `major'
```
Explicitly including sys/sysmacros.h header fixes this. 