### PR TITLE
main/findutils: add required sysmacros.h header

### DIFF
--- a/main/findutils/APKBUILD
+++ b/main/findutils/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Michael Mason <ms13sp@gmail.com>
 pkgname=findutils
 pkgver=4.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU utilities for finding files"
 url="https://www.gnu.org/software/findutils/"
 arch="all"
@@ -15,6 +15,7 @@ install=
 subpackages="$pkgname-doc"
 source="https://ftp.gnu.org/pub/gnu/$pkgname/$pkgname-$pkgver.tar.gz
 	localename-test-fix.patch
+	findutils-include-sysmacros.patch
 	"
 options="!checkroot"
 
@@ -44,4 +45,5 @@ package() {
 }
 
 sha512sums="41fcd4197c1efbd77f7420e5754e2cf9332dfef19f90c65a8fa1844bb4bc5d529c8393ee0ff979a054e9ac65ff71d7fe3921ea079f9960843412fc9a71f8afd4  findutils-4.6.0.tar.gz
-39fc0bc7602dd5300cf0b5488a7d14b6d00e05fedd6067ff45a229e65ff020d0003c0bb8e43807d9874afeb39c1dae6d612182caeb7de76156e1bc6ceb50adfc  localename-test-fix.patch"
+39fc0bc7602dd5300cf0b5488a7d14b6d00e05fedd6067ff45a229e65ff020d0003c0bb8e43807d9874afeb39c1dae6d612182caeb7de76156e1bc6ceb50adfc  localename-test-fix.patch
+552d48cdb444568ded2a097e2b7b5851d730edb7e58e7b7740a6c6781d0e5b6bb269bb2429f5147f4004a50647ce16705eb390919b4652dcf1dfbded7ebfc03a  findutils-include-sysmacros.patch"

--- a/main/findutils/findutils-include-sysmacros.patch
+++ b/main/findutils/findutils-include-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/gl/lib/mountlist.c	2019-07-31 15:56:05.495945881 +0000
++++ b/gl/lib/mountlist.c	2019-07-31 15:56:43.444754951 +0000
+@@ -59,6 +59,7 @@
+ #ifdef MOUNTED_GETMNTENT1       /* 4.3BSD, SunOS, HP-UX, Dynix, Irix.  */
+ # include <mntent.h>
+ # include <sys/types.h>
++# include <sys/sysmacros.h>
+ # if !defined MOUNTED
+ #  if defined _PATH_MOUNTED     /* GNU libc  */
+ #   define MOUNTED _PATH_MOUNTED


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of findutils fails with:
```
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: ../gl/lib/libgnulib.a(mountlist.o): in function `read_file_system_list':
mountlist.c:(.text+0x3e8): undefined reference to `makedev' 
```

Explicitly including sys/sysmacros.h fixes the issue.