### PR TITLE
testing/libb2: new aport

### DIFF
--- a/testing/libb2/APKBUILD
+++ b/testing/libb2/APKBUILD
@@ -1,0 +1,33 @@
+# Contributor: Leo <thinkabit.ukim@gmail.com>
+# Maintainer: Leo <thinkabit.ukim@gmail.com>
+pkgname=libb2
+pkgver=0.98.1
+pkgrel=0
+pkgdesc="C library providing BLAKE2b, BLAKE2s, BLAKE2bp, BLAKE2sp"
+url="https://blake2.net/"
+arch="all"
+license="CC0-1.0"
+subpackages="$pkgname-dev"
+source="https://github.com/BLAKE2/libb2/releases/download/v$pkgver/libb2-$pkgver.tar.gz"
+
+build() {
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--sysconfdir=/etc \
+		--mandir=/usr/share/man \
+		--localstatedir=/var \
+		--disable-static
+	make
+}
+
+check() {
+	make check
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="e760972173bb9ff3562843882abbe9042af09da63f37a5706921381be2d64cc4d333aec65e1e676d5a45ace913417536a1dc188c90b394c2f7b9cae654dbb108  libb2-0.98.1.tar.gz"


### PR DESCRIPTION
https://blake2.net/
C library providing BLAKE2b, BLAKE2s, BLAKE2bp, BLAKE2sp