### PR TITLE
main/mariadb: security upgrade to 10.4.7

### DIFF
--- a/main/mariadb/APKBUILD
+++ b/main/mariadb/APKBUILD
@@ -6,7 +6,7 @@
 # Contributor: Marcel Haazen <marcel@haazen.xyz>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mariadb
-pkgver=10.4.6
+pkgver=10.4.7
 pkgrel=0
 pkgdesc="A fast SQL database server"
 url="https://www.mariadb.org/"
@@ -48,6 +48,12 @@ source="https://downloads.mariadb.org/interstitial/mariadb-$pkgver/source/mariad
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   10.4.7-r0:
+#     - CVE-2019-2805
+#     - CVE-2019-2740
+#     - CVE-2019-2739
+#     - CVE-2019-2737
+#     - CVE-2019-2758
 #   10.3.15-r0:
 #     - CVE-2019-2614
 #     - CVE-2019-2627
@@ -422,7 +428,7 @@ _plugin_rocksdb() {
 		"$subpkgdir"/usr/lib/mariadb/plugin/ha_rocksdb.so
 }
 
-sha512sums="b04c47f72de2473d7b5edd04b4785a1d7179bb1f429f30ba53ae6cfbbb413200d9803eff1072949b2e81fd7d2164ea34c68620d621d4181b913daa2293ae140c  mariadb-10.4.6.tar.gz
+sha512sums="cb8b5adaef1970b9c8f04db08c18660f8b3df87f699aa93c1bee9497b887ddf50fcf3a2aebbe21a5fc9dfcbd118d0192d7421512522d98eaf30a014822c2f7ce  mariadb-10.4.7.tar.gz
 c352969f6665b0ffa387f7b185a5dea7751f4b16c12c809627857b27321efa09159369d7dd5c852d6159a9f173cb895fb601f0c52a1fa6e3527899520030964c  mariadb.initd
 70da971aa78815495098205bcbd28428430aa83c3f1050fec0231ca86af9d9def2d2108a48ee08d86812c8dc5ad8ab1ef4e17a49b4936ed5187ae0f6a7ef8f63  pcre.cmake.patch
 e9ae4613f1d8c5f0a59b39a3548c46e50674ae78e7457d0e64c49f7e1573125c13634bbce7e29179bb8865a423171f852f43b96f7ef95619a95f02edcfc71efd  ppc-remove-glibc-dep.patch"


### PR DESCRIPTION
https://mariadb.com/kb/en/library/mariadb-server-releases/release-notes/release-notes-mariadb-104-series/mariadb-1047-release-notes/