### PR TITLE
[3.8] main/mariadb: security upgrade to 10.2.26

### DIFF
--- a/main/mariadb/APKBUILD
+++ b/main/mariadb/APKBUILD
@@ -5,7 +5,7 @@
 # Contributor: TBK <alpine@jjtc.eu>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mariadb
-pkgver=10.2.24
+pkgver=10.2.26
 pkgrel=0
 pkgdesc="A fast SQL database server"
 url="https://www.mariadb.org/"
@@ -34,6 +34,12 @@ source="https://downloads.mariadb.org/interstitial/mariadb-$pkgver/source/mariad
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   10.2.26.r0:
+#     - CVE-2019-2805
+#     - CVE-2019-2740
+#     - CVE-2019-2739
+#     - CVE-2019-2737
+#     - CVE-2019-2758
 #   10.2.24.r0:
 #     - CVE-2019-2614
 #     - CVE-2019-2627
@@ -332,7 +338,7 @@ _server_utils() {
 		"$subpkgdir"/usr/bin/
 }
 
-sha512sums="bd0e8c506e94f063b6cfbb1e7e872b4fdbe9ab704e07ff3af1e1efabb89daa39fec3b06ec5294d9a19fdc680da082d095cd3c5f9e4c4ee6f9ee5ae0514d6bb6f  mariadb-10.2.24.tar.gz
+sha512sums="1eaac1c1dda1017b64249d39d872729d3140d81653240c54f688f64440b1775e5f3a7c5a8486075fa1799411dfb0c2c09b7c1dbb46d95675572d90127048c124  mariadb-10.2.26.tar.gz
 06751768cb00d2e433655635c38d267ef25084a5830ff40e719ac579223c7192dc34b43f919ab6faf480094632327511cbd22456064dde2d04dc15648b9e3b9f  mariadb.initd
 81d2a95bfbce35fab6e1780f4201320e5621f470591020d707801dcf31f5fad3cb5d7b781a186b2914c6559a8fdc8f13e31e7cdde0af360ad56cedf80e491bc0  ppc-remove-glibc-dep.patch
 70da971aa78815495098205bcbd28428430aa83c3f1050fec0231ca86af9d9def2d2108a48ee08d86812c8dc5ad8ab1ef4e17a49b4936ed5187ae0f6a7ef8f63  pcre.cmake.patch"


### PR DESCRIPTION
https://github.com/alpinelinux/aports/pull/9806