### PR TITLE
[3.7] main/mariadb: security upgrade to 10.1.41 

### DIFF
--- a/main/mariadb/APKBUILD
+++ b/main/mariadb/APKBUILD
@@ -4,7 +4,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mariadb
-pkgver=10.1.40
+pkgver=10.1.41
 pkgrel=0
 pkgdesc="A fast SQL database server"
 url="https://www.mariadb.org/"
@@ -23,6 +23,11 @@ source="https://downloads.mariadb.org/interstitial/mariadb-$pkgver/source/mariad
 	"
 
 # secfixes:
+#   10.1.41-r0:
+#     - CVE-2019-2805
+#     - CVE-2019-2740
+#     - CVE-2019-2739
+#     - CVE-2019-2737
 #   10.1.40-r0:
 #     - CVE-2019-2614
 #     - CVE-2019-2627
@@ -249,6 +254,6 @@ mysql() { _compat mysql mariadb; }
 _compat_client() { _compat mysql-client mariadb-client; }
 _compat_bench() { _compat mysql-bench mariadb-client; }
 
-sha512sums="6b946189c69905f1a23a96d34720f1592353e0095455bf452bba31d53c90143d088f0fd997cac3da0a779840bb6ae6cc30b45144cba474463a8e3a6978a8a8f3  mariadb-10.1.40.tar.gz
+sha512sums="4a18b06fda49c5c3627b4e7cd32fb460e73762273a0c3d09098e34c71e63caa8fad03cdd92ae4a391cdfdb3719934688f0bdf312fa4af7ac3b9e5f5d90f404be  mariadb-10.1.41.tar.gz
 06751768cb00d2e433655635c38d267ef25084a5830ff40e719ac579223c7192dc34b43f919ab6faf480094632327511cbd22456064dde2d04dc15648b9e3b9f  mariadb.initd
 a352661d19becae717c16ac67a0e47ed93787653851a75d27e7764133b31dc02e18c38dbbce6d3138e4db08da616dfc75a0141865cd042cef669d6afe4463127  ppc-remove-glibc-dep.patch"


### PR DESCRIPTION
https://github.com/alpinelinux/aports/pull/9806