### PR TITLE
main/imagemagick: security upgrade to 7.0.8-59

### DIFF
--- a/main/imagemagick/APKBUILD
+++ b/main/imagemagick/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
 _pkgname=ImageMagick
-pkgver=7.0.8.56
+pkgver=7.0.8.59
 pkgrel=0
 _pkgver=${pkgver%.*}-${pkgver##*.}
 _abiver=7
@@ -134,5 +134,5 @@ _perlmagick_doc() {
 	make -j1 DESTDIR="$subpkgdir" doc_vendor_install
 }
 
-sha512sums="204249136db3449bff07600b4438d0f880e4014c0ba8663d17b041e098b4732a2bce97fe58f37654404e7c2730194ef500670f19f9cf89d3fc6b46215ece80a1  ImageMagick-7.0.8-56.tar.gz
+sha512sums="518557ca23035fa78c34a475123c77381ab413de6bec2a85d71f299b41ff51a213fb4a2cb605409428a499bbb9154f72ad28c709214c72f3a3963110f33ac64e  ImageMagick-7.0.8-59.tar.gz
 58afb2da075a6208b6a990ff297b3a827d260687c3355198a8b4d987e1596c0b0cd78aff6f0be0e1896e537fbe44a3d467473183f5f149664ea6e6fb3d3291a9  disable-avaraging-tests.patch"


### PR DESCRIPTION
Issue without CVE: https://github.com/ImageMagick/ImageMagick/commit/64ede28ec07c7ac95cdd70d5340c86bd06dbcda7