### PR TITLE
testing/libzim: upgrade to 5.0.1

### DIFF
--- a/testing/libzim/APKBUILD
+++ b/testing/libzim/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=libzim
-pkgver=5.0.0
-pkgrel=2
+pkgver=5.0.1
+pkgrel=0
 pkgdesc="Reference implementation of the ZIM file format"
 url="https://openzim.org/"
 arch="all"
@@ -14,11 +14,8 @@ makedepends="meson
 	     libexecinfo-dev
 	     icu-dev
 	     xapian-core-dev
-	     gtest-dev
-	     python3-dev
-	     cython
 	    "
-checkdepends="gtest"
+checkdepends="gtest gtest-dev python3-dev cython3"
 subpackages="$pkgname-dev $pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/openzim/$pkgname/archive/$pkgver.tar.gz"
 
@@ -34,7 +31,7 @@ build() {
 }
 
 check() {
-	SKIP_BIG_MEMORY_TEST=1 ninja -C output test
+	ninja -C output test
 }
 
 package() {
@@ -43,4 +40,4 @@ package() {
 	install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
 }
 
-sha512sums="b1d5bee583364dcd7967e3b826afb08bea25a11512b7a522cb74cde25ae304d4b7f65354ec2160599d145c5b67ba26109e281482021ba1d8d88a1041c0c785d9  libzim-5.0.0.tar.gz"
+sha512sums="56845ff14e80800b145305c89e1fc47fbb5210df32886e42b5dec0a1dd4bc9f725cd82a9aa6e46935baefc9cde33e329cb8bb7eb4978c892cec3158d02adc604  libzim-5.0.1.tar.gz"


### PR DESCRIPTION
- https://github.com/openzim/libzim/releases 5.0.1
- Move gtest-dev, python3-dev, and cython from makedepends to checkdepends
- Replace cython by cython3 in checkdepends
- Remove SKIP_BIG_MEMORY_TEST=1 from check()