### PR TITLE
testing/py3-treq: new aport

### DIFF
--- a/testing/py3-treq/APKBUILD
+++ b/testing/py3-treq/APKBUILD
@@ -1,0 +1,24 @@
+# Contributor: Leo <thinkabit.ukim@gmail.com>
+# Maintainer: Leo <thinkabit.ukim@gmail.com>
+pkgname=py3-treq
+pkgver=18.6.0
+pkgrel=0
+pkgdesc="py3-requests-like API build on top of Twisted's HTTP client"
+options="!check" # Requires unpackaged httpbin
+url="https://github.com/twisted/treq"
+arch="noarch"
+license="MIT"
+depends="python3 py3-incremental py3-requests py3-six py3-twisted py3-attrs"
+makedepends="py3-setuptools"
+source="$pkgname-$pkgver.tar.gz::https://github.com/twisted/treq/archive/release-$pkgver.tar.gz"
+builddir="$srcdir/treq-release-$pkgver"
+
+build() {
+	python3 setup.py build
+}
+
+package() {
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+
+sha512sums="1d0d793725647c6b451853f166436040e49095fca43f6c74053f3ba18ec8f8ae0095ed78c7d141cc95dfba9674339ac44262943225bec7be0f0cb05253758688  py3-treq-18.6.0.tar.gz"


### PR DESCRIPTION
https://github.com/twisted/treq
py3-requests-like API build on top of Twisted's HTTP client