### PR TITLE
[3.9] main/ansible: security upgrade to 2.7.12

### DIFF
--- a/main/ansible/APKBUILD
+++ b/main/ansible/APKBUILD
@@ -3,15 +3,16 @@
 # Contributor: Takuya Noguchi <takninnovationresearch@gmail.com>
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=ansible
-pkgver=2.7.0
-pkgrel=1
+pkgver=2.7.12
+pkgrel=0
 pkgdesc="A configuration-management, deployment, task-execution, and multinode orchestration framework"
 url="https://ansible.com"
 arch="noarch"
 license="GPL-3.0-or-later"
 _py=py3
 depends="python3 $_py-yaml $_py-paramiko $_py-jinja2 $_py-markupsafe $_py-crypto"
-makedepends="python2-dev py-setuptools"
+makedepends="python3-dev py3-setuptools"
+options="!check" # not included in release tarball
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://releases.ansible.com/ansible/$pkgname-$pkgver.tar.gz
 	add-lxc-container_shell-option.patch
@@ -20,8 +21,23 @@ source="$pkgname-$pkgver.tar.gz::https://releases.ansible.com/ansible/$pkgname-$
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   2.7.12-r0:
+#     - CVE-2019-101562
+#   2.7.8-r0:
+#     - CVE-2019-38287
+#   2.7.5-r0:
+#     - CVE-2018-16876
+#   2.7.3-r0:
+#     - CVE 2018-16859
+#   2.7.1-r0:
+#     - CVE-2018-16837
 #   2.6.3-r0:
 #     - CVE-2018-10875
+
+prepare() {
+	# Windows-only scripts
+	rm -r examples/scripts
+}
 
 build() {
 	cd "$builddir"
@@ -42,5 +58,5 @@ package() {
 	install -m644 README.rst "$pkgdir"/usr/share/doc/$pkgname
 }
 
-sha512sums="a5e0e0b87bb2fa8fbc76825733a5c6afe642d4602be80466e5f28324e90be4487fd1c300e567a164222f171bd9eac65b7b36ca9b6fe4bebfcbd2c24dd60049ad  ansible-2.7.0.tar.gz
+sha512sums="0ab68af8239f6d4d2a13bd38a09fe6f3c700231e7c83df0af77c70ea62faebd0d45e1ff316963c6c72931608d49a79b98e8d3ddc6f4c8b826aabe87dc71cc6f9  ansible-2.7.12.tar.gz
 e1bd1affec585abf4556d1f2598df2689c2341fc0ddaec3eadc0a9c6df5725b8ab97092771f2c57da6ecaa72ae1bb5e5ccce55db8c4d74bfc785f611dd5b8c32  add-lxc-container_shell-option.patch"


### PR DESCRIPTION
This fixes CVE-2019-101562, CVE-2019-38287, CVE-2018-16876, CVE 2018-16859, CVE-2018-16837