### PR TITLE
community/influxdb: upgrade to 1.7.7

### DIFF
--- a/community/influxdb/APKBUILD
+++ b/community/influxdb/APKBUILD
@@ -1,42 +1,44 @@
 # Contributor: Stefan Wagner <stw@bit-strickerei.de>
 # Maintainer: Stefan Wagner <stw@bit-strickerei.de>
+# Maintainer: Konstantin Kulikov <k.kulikov2@gmail.com>
 pkgname=influxdb
-pkgver=1.6.3
-pkgrel=1
+pkgver=1.7.7
+pkgrel=0
 pkgdesc="Scalable datastore for metrics, events, and real-time analytics"
 url="https://www.influxdata.com/time-series-platform/influxdb/"
-arch="all !aarch64"
+arch="all !aarch64 !x86"
 license="MIT"
-makedepends="go go-gdm python2 asciidoc xmlto"
-pkgusers="influxdb"
-pkggroups="influxdb"
+makedepends="go dep python2 asciidoc xmlto"
 install="$pkgname.pre-install"
-options="!check" # has no tests
 subpackages="$pkgname-doc $pkgname-openrc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/influxdata/$pkgname/archive/v$pkgver.tar.gz
 	influxdb.initd
-	influxdb.logrotate
+	influxdb.confd
 	"
 builddir="$srcdir/src/github.com/influxdata/$pkgname"
+
+export GOPATH="$srcdir"
+export GOCACHE="$srcdir/gocache"
 
 prepare() {
 	mkdir -p ${builddir%/*}
 	mv "$srcdir"/$pkgname-$pkgver "$builddir"/ || return 1
-	export GOPATH="$srcdir"
 	cd "$builddir"
-	gdm restore
+	dep ensure -v
 	default_prepare
 }
 
 build() {
-	export GOPATH="$srcdir"
-	cd "$builddir"
 	local path
 	for path in $(find ./cmd/* -maxdepth 0 -type d); do
-		go build -v -work -x -ldflags="-X main.version=$pkgver" \
+		go build -v -ldflags="-X main.version=$pkgver" \
 			-o ./bin/${path##*/} $path
 	done
 	make -C man
+}
+
+check() {
+	go test -short ./...
 }
 
 package() {
@@ -44,8 +46,8 @@ package() {
 	local path bindir
 	for path in $(find ./cmd/* -maxdepth 0 -type d); do
 		case "${path##*/}" in
-			influxd) bindir=sbin ;;
-			*) bindir=bin ;;
+		influxd) bindir=sbin ;;
+		*) bindir=bin ;;
 		esac
 		install -Dm755 ./bin/"${path##*/}" "$pkgdir"/usr/$bindir/"${path##*/}"
 	done
@@ -53,12 +55,12 @@ package() {
 	install -d "$pkgdir/usr/share/man/man1/"
 	install -Dm644 man/*.1 "$pkgdir/usr/share/man/man1/"
 
-	install -Dm644 "etc/config.sample.toml" "$pkgdir/etc/influxdb/influxdb.conf"
+	install -Dm644 "etc/config.sample.toml" "$pkgdir/etc/influxdb.conf"
 
 	install -Dm755 "$srcdir/$pkgname.initd" "$pkgdir/etc/init.d/$pkgname"
-	install -Dm644 "$srcdir/$pkgname.logrotate" "$pkgdir/etc/logrotate.d/$pkgname"
+	install -Dm644 "$srcdir/$pkgname.confd" "$pkgdir/etc/conf.d/$pkgname"
 }
 
-sha512sums="a6bca52223ae084a7d3feef20574b0f6d96105547a17e4cb2713bee18beb0fb31d096779a908d14ceec1510db93841cba5bfd26bc5e6961538351069f1a7a728  influxdb-1.6.3.tar.gz
-55d5776fde330001f254fed4b01163d576d1995c23b08ef64c3c33b7a53fa49c71092867a17149d3148af7a8e17dc4779481afe9dd54a86eeee16168dbb964e0  influxdb.initd
-5d754e3aeec912bae8f5bf2f84153d4ccc82918d9c728631e8b9ad6737fab3352af0ab63f46ac80aab6384d779bae5d321da0465f26fd8798a9694f7d79f879d  influxdb.logrotate"
+sha512sums="f8b74849f2de09b10de361d6008cab0e0291ea0978e3c89df5e758788d2dbfd5cc0b416bfaf3d14b04410a9cdff4ca7c96be6afadbf16490c0fbab599db3d643  influxdb-1.7.7.tar.gz
+04fb33ee5b3d60c3e8655cc20423885140b66e74a822866cfe05668e942d24116878b1815a48b07063c707bb600cf0ff390994f0321c881eed557abde016eeb9  influxdb.initd
+1db8790c84a9e193a6029291b2a83a6083d1ddcc330c2191c4da6bdcc6410d832288aee275605b4ca041c8855fe8a1340631444e901044659755db0146d6d3dc  influxdb.confd"

--- a/community/influxdb/influxdb.confd
+++ b/community/influxdb/influxdb.confd
@@ -1,0 +1,4 @@
+INFLUXDB_OPTS="-config /etc/influxdb.conf"
+
+# Uncomment to enable logging to syslog.
+#error_logger="logger -t $RC_SVCNAME"

--- a/community/influxdb/influxdb.initd
+++ b/community/influxdb/influxdb.initd
@@ -1,10 +1,10 @@
 #!/sbin/openrc-run
 
-pidfile=/run/influxdb.pid
-start_stop_daemon_args="--user influxdb --stderr /var/log/influxdb/influxdb.log"
+pidfile=/run/$RC_SVCNAME.pid
 command=/usr/sbin/influxd
-command_args="${EXTRA_OPTS}"
+command_args="${INFLUXDB_OPTS}"
 command_background="yes"
+command_user=influxdb:influxdb
 
 depend() {
 	need net
@@ -12,5 +12,5 @@ depend() {
 }
 
 start_pre() {
-	checkpath -d -o influxdb:influxdb -m755 /var/lib/influxdb /var/log/influxdb
+	checkpath -d -o influxdb:influxdb -m755 /var/lib/influxdb
 }

--- a/community/influxdb/influxdb.logrotate
+++ b/community/influxdb/influxdb.logrotate
@@ -1,8 +1,0 @@
-/var/log/influxdb/influxdb.log {
-	daily
-	missingok
-	copytruncate
-	rotate 7
-	compress
-	notifempty
-}

--- a/community/influxdb/influxdb.pre-install
+++ b/community/influxdb/influxdb.pre-install
@@ -1,10 +1,8 @@
 #!/bin/sh
 
-username=influxdb
-groupname="$username"
+name=influxdb
 
-addgroup -S "$groupname" 2>/dev/null
-adduser -S -D -H -h /var/lib/"$username" -s /sbin/nologin -G "$groupname" \
-	-g "$groupname" "$username" 2>/dev/null
+addgroup -S "$name" 2>/dev/null
+adduser -S -D -H -h "/var/lib/$name" -s /sbin/nologin -G "$name" -g "$name" "$name" 2>/dev/null
 
 exit 0


### PR DESCRIPTION
switch from gdm to dep
remove pkgusers/groups - they're unneeded at build time
enable tests
disable overly verbose build logging
add conf.d
move config to /etc/influxdb.conf
simplify init.d script
disable x86 arch - many tests fail, it most likely doesn't work or there's something wrong with builder