### PR TITLE
[3.10] community/vault: security upgrade to 1.1.1

### DIFF
--- a/community/vault/APKBUILD
+++ b/community/vault/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Christian Kampka <christian@kampka.net>
 # Maintainer: Gennady Feldman <gena01@gmail.com>
 pkgname=vault
-pkgver=1.1.0
+pkgver=1.1.1
 pkgrel=0
 pkgdesc="Vault is a tool for securely accessing secrets"
 url="https://www.vaultproject.io/"
@@ -19,6 +19,10 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/hashicorp/$pkgname/archive/v
 	vault.hcl
 	vault.initd"
 builddir="$srcdir/src/github.com/hashicorp/$pkgname"
+
+# secfixes:
+#   1.1.1-r0:
+#     - CVE-2019-11075
 
 prepare() {
 	mkdir -p "$srcdir/src/github.com/hashicorp"
@@ -57,7 +61,7 @@ package() {
 	install -m750 -o vault -g vault -d "$pkgdir/var/lib/$pkgname"
 }
 
-sha512sums="b0bc32f438e8432d849aa896f610c9532fa923384d40749efe49985d64a91f4768a3309af449efd8c8ab4604ecdb2474c39999bfe196f0f876894f788618ae61  vault-1.1.0.tar.gz
+sha512sums="8922a32a3572cbaeb2dd5ade183e2b26338b49043031eb9d24cd8ab477183f8942e2856c8d3e67860f6d42e83043bd57af4b274ae5137cd946b2a285c8a16e01  vault-1.1.1.tar.gz
 0a2dc4d2deb42c77a225451a3c3cf68063435bc077495a6b207cfa2e2b446c9dba5ac726f9a7ec0be7f52e4519e7563c49561397750a069f5536fda66843ace4  bindata-filename.patch
 6f3f30e5c9d9dd5117f18fce0e669f0cd752a6be4910405d6b394f15273372731ee887a5ba4c700293e5b8bc2bf40fd69d4337156f77b03549d2dc2c0a666bec  vault.confd
 8c064aa5dcca84822c1fa85e9d0ff520df46f794b2e9c689a9b4f81f74279387b3aebc08b3ca26cf786c2fcf1a330e765bf5a511074c24f87e5346672346ba1c  vault.hcl


### PR DESCRIPTION
This fixes CVE-2019-11075.

The current 1.1.x version is 1.1.5. I wasn't sure if I should use that instead.