### PR TITLE
[3.9] main/py-django: security upgrade to 1.11.23

### DIFF
--- a/main/py-django/APKBUILD
+++ b/main/py-django/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=py-django
 _pkgname=Django
-pkgver=1.11.22
+pkgver=1.11.23
 pkgrel=0
 pkgdesc="A high-level Python Web framework"
 url="http://djangoproject.com/"
@@ -16,6 +16,11 @@ source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname
 builddir="$srcdir"/$_pkgname-$pkgver
 
 # secfixes:
+#   1.11.23-r0:
+#     - CVE-2019-14232
+#     - CVE-2019-14233
+#     - CVE-2019-14234
+#     - CVE-2019-14235
 #   1.11.22-r0:
 #     - CVE-2019-12781
 #   1.8.16-r0:
@@ -88,4 +93,4 @@ _py() {
 	done
 }
 
-sha512sums="687cba07c0549b18ef386df5663e968871b8fc950b9ddf4267f7e2f4ea43c98dc92e76fae39e07a0760b183653e38cdf9909cfaeca874e8230f24bd49ef95d6a  Django-1.11.22.tar.gz"
+sha512sums="c4c5d82e4ecf1a100637ac32eafd3fb0d7690ba5c0cb884846f31c434c0cb1282d94149e031c577d676570f3b331c2a320d58f34f40ac02deae089c4b61c65ea  Django-1.11.23.tar.gz"


### PR DESCRIPTION
ref #10706