### PR TITLE
main/mdadm: add required sysmacros.h header

### DIFF
--- a/main/mdadm/APKBUILD
+++ b/main/mdadm/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mdadm
 pkgver=4.1
-pkgrel=0
+pkgrel=1
 pkgdesc="a tool for managing Linux Software RAID arrays"
 url="http://neil.brown.name/blog/mdadm"
 arch="all"
@@ -16,6 +16,7 @@ source="https://www.kernel.org/pub/linux/utils/raid/$pkgname/$pkgname-$pkgver.ta
 	$pkgname.confd
 	$pkgname-raid.initd
 	no-werror.patch
+	mdadm-include-sysmacros.patch
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -54,4 +55,5 @@ sha512sums="f9bff760795ba7361f19fd1cbc02efedcdaa4b0125b99cf1369e78f30e5c12812675
 ca5f4e3ff5b284102b44e818d11622e1889066e3d18edce2d62c1a44ee8f4cfdc0979121c0462a916c638423c5ebc706c46aa996a7c4f68e030589adc62803f4  mdadm.initd
 7d45bf489ef93a4f217ffcf72311eb661b8de7fbf63a5344697252c0d3a684b0123ff60efa5f218da4eb4cda7c88d91c2ef3625d5e44a588e3e1210cb60b0ab9  mdadm.confd
 37022593ba090eb0690669b99d6386152242c017c1e608cea7b5420b7a6f754b377e916e4f81e2abf9941e791db78b5820e63db0e706d5de8b35e796678e921c  mdadm-raid.initd
-794d6c31fbc0a9ef2f56d7b0afdb94490f0b677414d4f2b1b5104a51c4f39948491fc21aaa30ca75c90c9f056369317f48ea2f78e04ee740327114bee5d959b4  no-werror.patch"
+794d6c31fbc0a9ef2f56d7b0afdb94490f0b677414d4f2b1b5104a51c4f39948491fc21aaa30ca75c90c9f056369317f48ea2f78e04ee740327114bee5d959b4  no-werror.patch
+e711c15fada5fc98984f43f90a8ab3b6a2a20e9b91c56b5672fdb0ea127b61934b2f0c6ca986bd91c96c56b66f46326cb616101a62e4bfebe3a2b0d33ed2465c  mdadm-include-sysmacros.patch"

--- a/main/mdadm/mdadm-include-sysmacros.patch
+++ b/main/mdadm/mdadm-include-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/mdadm.h
++++ b/mdadm.h
+@@ -34,6 +34,7 @@
+ #endif
+ 
+ #include	<sys/types.h>
++#include	<sys/sysmacros.h>
+ #include	<sys/stat.h>
+ #include	<stdint.h>
+ #include	<stdlib.h>


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of mdadm fails with:
```
util.c:1622:8: error: called object 'major' is not a function or function pointer
   (int)major(st.st_rdev), (int)minor(st.st_rdev));
        ^~~~~                                                   
```
Explicitly including sys/sysmacros.h fixes the issue.