### PR TITLE
testing/php7-pecl-swoole: enable ppc64le and s390x via libucontext

### DIFF
--- a/testing/php7-pecl-swoole/APKBUILD
+++ b/testing/php7-pecl-swoole/APKBUILD
@@ -2,19 +2,22 @@
 pkgname=php7-pecl-swoole
 _pkgreal=swoole
 pkgver=4.4.3
-pkgrel=0
+pkgrel=1
 pkgdesc="Event-driven asynchronous and concurrent networking engine with high performance for PHP."
 url="https://pecl.php.net/package/swoole"
-arch="all !ppc64le !s390x" # Fails to build
+arch="all"
 license="Apache-2.0"
 depends="php7-openssl php7-sockets"
-makedepends="php7-dev autoconf re2c openssl-dev nghttp2-dev"
+makedepends="php7-dev autoconf re2c openssl-dev nghttp2-dev libucontext-dev"
 source="https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
 builddir="$srcdir"/$_pkgreal-$pkgver
 subpackages="$pkgname-dev"
 
 build() {
 	cd "$builddir"
+	case "$CARCH" in
+		ppc64le|s390x) export LDFLAGS="$LDFLAGS -lucontext" ;;
+	esac
 	phpize7
 	./configure --prefix=/usr \
 		--with-php-config=php-config7 \


### PR DESCRIPTION
Trying approach from https://github.com/swoole/swoole-src/issues/2692#issuecomment-518059106