### PR TITLE
Fix wpa_supplicant and re-enable it in NetworkManager again

### DIFF
--- a/community/networkmanager/APKBUILD
+++ b/community/networkmanager/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=networkmanager
 pkgver=1.18.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Network Management daemon"
 url="https://wiki.gnome.org/Projects/NetworkManager"
 arch="all !s390x" # Limited by iwd
 license="GPL-2.0-or-later"
-depends="dhcpcd iptables dbus iwd"
+depends="dhcpcd iptables dbus"
 install="$pkgname.pre-install $pkgname.pre-upgrade"
 makedepends="$depends_dev
 	curl-dev
@@ -99,11 +99,11 @@ package() {
 	mv "$pkgdir/usr/share/doc/NetworkManager" "$pkgdir/usr/share/doc/$pkgname"
 	cat > "$pkgdir"/usr/share/doc/$pkgname/README.alpine <<EOF
 To modify system network connections without the root password: add your user account to the 'plugdev' group, or use Polkit.
-EOF
 
-	cat > "$pkgdir"/etc/NetworkManager/conf.d/iwd.conf <<-EOF
-	[device]
-	wifi.backend=iwd
+To use iwd instead of the default wpa_supplicant install iwd, start its service and add the following to your /etc/NetworkManager/NetworkManager.conf:
+
+[device]
+wifi.backend=iwd
 EOF
 }
 

--- a/community/networkmanager/networkmanager.pre-install
+++ b/community/networkmanager/networkmanager.pre-install
@@ -2,6 +2,8 @@
 
 addgroup -S plugdev 2>/dev/null
 
-printf "  *\n  * To setup system connections, regular users must either use Polkit for authentication or be a member of the 'plugdev' group."
+printf "  *\n  * To setup system connections, regular users must be member of 'plugdev' group.\n  *\n"
+printf "  *\n  * To control WiFi devices, enable wpa_supplicant service: 'rc-update add wpa_supplicant default'\n"
+printf "  * then reboot the system or restart 'wpa_supplicant' and 'networkmanager' services respectively.\n  *\n"
 
 exit 0

--- a/main/wpa_supplicant/wpa_supplicant.initd
+++ b/main/wpa_supplicant/wpa_supplicant.initd
@@ -5,7 +5,14 @@
 command=/sbin/wpa_supplicant
 : ${wpa_supplicant_conf:=/etc/wpa_supplicant/wpa_supplicant.conf}
 wpa_supplicant_if=${wpa_supplicant_if:+-i}$wpa_supplicant_if
-command_args="$wpa_supplicant_args -B -c$wpa_supplicant_conf $wpa_supplicant_if"
+
+# Run in dbus mode if no config file is found
+if [ -f "${wpa_supplicant_conf}" ]; then
+	command_args="$wpa_supplicant_args -B -c$wpa_supplicant_conf $wpa_supplicant_if"
+else
+	command_args="$wpa_supplicant_args -B -u"
+fi
+
 name="WPA Supplicant Daemon"
 
 depend()


### PR DESCRIPTION
This makes wpa_supplicant run in dbus mode if no config file has been created for it, fixing the networkmanager integration. This config has been used for a long time in postmarketOS and works fine.

It also removes the iwd dependency from networkmanager again so wpa_supplicant is used because iwd doesn't support as many chipsets as wpa_supplicant and it doesn't run on older kernels.

Ping @Cogitri 