### PR TITLE
main/musl: security fix in i386 math asm

### DIFF
--- a/main/musl/0001-x87-float-stack-imbalance.patch
+++ b/main/musl/0001-x87-float-stack-imbalance.patch
@@ -1,0 +1,198 @@
+From f3ed8bfe8a82af1870ddc8696ed4cc1d5aa6b441 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Mon, 5 Aug 2019 18:41:47 -0400
+Subject: fix x87 stack imbalance in corner cases of i386 math asm
+
+commit 31c5fb80b9eae86f801be4f46025bc6532a554c5 introduced underflow
+code paths for the i386 math asm, along with checks on the fpu status
+word to skip the underflow-generation instructions if the underflow
+flag was already raised. unfortunately, at least one such path, in
+log1p, returned with 2 items on the x87 stack rather than just 1 item
+for the return value. this is a violation of the ABI's calling
+convention, and could cause subsequent floating point code to produce
+NANs due to x87 stack overflow. if floating point results are used in
+flow control, this can lead to runaway wrong code execution.
+
+rather than reviewing each "underflow already raised" code path for
+correctness, remove them all. they're likely slower than just
+performing the underflow code unconditionally, and significantly more
+complex.
+
+all of this code should be ripped out and replaced by C source files
+with inline asm. doing so would preclude this kind of error by having
+the compiler perform all x87 stack register allocation and stack
+manipulation, and would produce comparable or better code. however
+such a change is a much larger project.
+---
+ src/math/i386/asin.s   | 10 ++--------
+ src/math/i386/atan.s   |  7 ++-----
+ src/math/i386/atan2.s  |  5 +----
+ src/math/i386/atan2f.s |  5 +----
+ src/math/i386/atanf.s  |  7 ++-----
+ src/math/i386/exp.s    | 10 ++--------
+ src/math/i386/log1p.s  |  7 ++-----
+ src/math/i386/log1pf.s |  7 ++-----
+ 8 files changed, 14 insertions(+), 44 deletions(-)
+
+diff --git a/src/math/i386/asin.s b/src/math/i386/asin.s
+index a9f691bf..920d967a 100644
+--- a/src/math/i386/asin.s
++++ b/src/math/i386/asin.s
+@@ -7,13 +7,10 @@ asinf:
+ 	cmp $0x01000000,%eax
+ 	jae 1f
+ 		# subnormal x, return x with underflow
+-	fnstsw %ax
+-	and $16,%ax
+-	jnz 2f
+ 	fld %st(0)
+ 	fmul %st(1)
+ 	fstps 4(%esp)
+-2:	ret
++	ret
+ 
+ .global asinl
+ .type asinl,@function
+@@ -30,11 +27,8 @@ asin:
+ 	cmp $0x00200000,%eax
+ 	jae 1f
+ 		# subnormal x, return x with underflow
+-	fnstsw %ax
+-	and $16,%ax
+-	jnz 2f
+ 	fsts 4(%esp)
+-2:	ret
++	ret
+ 1:	fld %st(0)
+ 	fld1
+ 	fsub %st(0),%st(1)
+diff --git a/src/math/i386/atan.s b/src/math/i386/atan.s
+index d73137b2..a26feae1 100644
+--- a/src/math/i386/atan.s
++++ b/src/math/i386/atan.s
+@@ -10,8 +10,5 @@ atan:
+ 	fpatan
+ 	ret
+ 		# subnormal x, return x with underflow
+-1:	fnstsw %ax
+-	and $16,%ax
+-	jnz 2f
+-	fsts 4(%esp)
+-2:	ret
++1:	fsts 4(%esp)
++	ret
+diff --git a/src/math/i386/atan2.s b/src/math/i386/atan2.s
+index a7d2979b..1fa0524d 100644
+--- a/src/math/i386/atan2.s
++++ b/src/math/i386/atan2.s
+@@ -10,8 +10,5 @@ atan2:
+ 	cmp $0x00200000,%eax
+ 	jae 1f
+ 		# subnormal x, return x with underflow
+-	fnstsw %ax
+-	and $16,%ax
+-	jnz 1f
+ 	fsts 4(%esp)
+-1:	ret
++	ret
+diff --git a/src/math/i386/atan2f.s b/src/math/i386/atan2f.s
+index 14b88ce5..0b264726 100644
+--- a/src/math/i386/atan2f.s
++++ b/src/math/i386/atan2f.s
+@@ -10,10 +10,7 @@ atan2f:
+ 	cmp $0x01000000,%eax
+ 	jae 1f
+ 		# subnormal x, return x with underflow
+-	fnstsw %ax
+-	and $16,%ax
+-	jnz 1f
+ 	fld %st(0)
+ 	fmul %st(1)
+ 	fstps 4(%esp)
+-1:	ret
++	ret
+diff --git a/src/math/i386/atanf.s b/src/math/i386/atanf.s
+index 8caddefa..893beac5 100644
+--- a/src/math/i386/atanf.s
++++ b/src/math/i386/atanf.s
+@@ -10,10 +10,7 @@ atanf:
+ 	fpatan
+ 	ret
+ 		# subnormal x, return x with underflow
+-1:	fnstsw %ax
+-	and $16,%ax
+-	jnz 2f
+-	fld %st(0)
++1:	fld %st(0)
+ 	fmul %st(1)
+ 	fstps 4(%esp)
+-2:	ret
++	ret
+diff --git a/src/math/i386/exp.s b/src/math/i386/exp.s
+index c7aa5b6e..df87c497 100644
+--- a/src/math/i386/exp.s
++++ b/src/math/i386/exp.s
+@@ -7,13 +7,10 @@ expm1f:
+ 	cmp $0x01000000,%eax
+ 	jae 1f
+ 		# subnormal x, return x with underflow
+-	fnstsw %ax
+-	and $16,%ax
+-	jnz 2f
+ 	fld %st(0)
+ 	fmul %st(1)
+ 	fstps 4(%esp)
+-2:	ret
++	ret
+ 
+ .global expm1l
+ .type expm1l,@function
+@@ -30,11 +27,8 @@ expm1:
+ 	cmp $0x00200000,%eax
+ 	jae 1f
+ 		# subnormal x, return x with underflow
+-	fnstsw %ax
+-	and $16,%ax
+-	jnz 2f
+ 	fsts 4(%esp)
+-2:	ret
++	ret
+ 1:	fldl2e
+ 	fmulp
+ 	mov $0xc2820000,%eax
+diff --git a/src/math/i386/log1p.s b/src/math/i386/log1p.s
+index 6b6929c7..354f391a 100644
+--- a/src/math/i386/log1p.s
++++ b/src/math/i386/log1p.s
+@@ -16,9 +16,6 @@ log1p:
+ 	fyl2x
+ 	ret
+ 		# subnormal x, return x with underflow
+-2:	fnstsw %ax
+-	and $16,%ax
+-	jnz 1f
+-	fsts 4(%esp)
++2:	fsts 4(%esp)
+ 	fstp %st(1)
+-1:	ret
++	ret
+diff --git a/src/math/i386/log1pf.s b/src/math/i386/log1pf.s
+index c0bcd30f..4d3484cd 100644
+--- a/src/math/i386/log1pf.s
++++ b/src/math/i386/log1pf.s
+@@ -16,10 +16,7 @@ log1pf:
+ 	fyl2x
+ 	ret
+ 		# subnormal x, return x with underflow
+-2:	fnstsw %ax
+-	and $16,%ax
+-	jnz 1f
+-	fxch
++2:	fxch
+ 	fmul %st(1)
+ 	fstps 4(%esp)
+-1:	ret
++	ret
+-- 
+cgit v1.2.1
+

--- a/main/musl/0002-x87-float-stack-imbalance.patch
+++ b/main/musl/0002-x87-float-stack-imbalance.patch
@@ -1,0 +1,35 @@
+From 6818c31c9bc4bbad5357f1de14bedf781e5b349e Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Mon, 5 Aug 2019 19:57:07 -0400
+Subject: fix build regression in i386 asm for atan2, atan2f
+
+commit f3ed8bfe8a82af1870ddc8696ed4cc1d5aa6b441 inadvertently removed
+labels that were still needed.
+---
+ src/math/i386/atan2.s  | 2 +-
+ src/math/i386/atan2f.s | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/math/i386/atan2.s b/src/math/i386/atan2.s
+index 1fa0524d..76b95f31 100644
+--- a/src/math/i386/atan2.s
++++ b/src/math/i386/atan2.s
+@@ -11,4 +11,4 @@ atan2:
+ 	jae 1f
+ 		# subnormal x, return x with underflow
+ 	fsts 4(%esp)
+-	ret
++1:	ret
+diff --git a/src/math/i386/atan2f.s b/src/math/i386/atan2f.s
+index 0b264726..c9408a90 100644
+--- a/src/math/i386/atan2f.s
++++ b/src/math/i386/atan2f.s
+@@ -13,4 +13,4 @@ atan2f:
+ 	fld %st(0)
+ 	fmul %st(1)
+ 	fstps 4(%esp)
+-	ret
++1:	ret
+-- 
+cgit v1.2.1
+

--- a/main/musl/APKBUILD
+++ b/main/musl/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=musl
 pkgver=1.1.23
-pkgrel=1
+pkgrel=2
 pkgdesc="the musl c library (libc) implementation"
 url="http://www.musl-libc.org/"
 arch="all"
@@ -18,6 +18,8 @@ nolibc) ;;
 *)	subpackages="$subpackages $pkgname-utils";;
 esac
 source="http://www.musl-libc.org/releases/musl-$pkgver.tar.gz
+	0001-x87-float-stack-imbalance.patch
+	0002-x87-float-stack-imbalance.patch
 	handle-aux-at_base.patch
 
 	ldconfig
@@ -158,6 +160,8 @@ compat() {
 }
 
 sha512sums="a2278de9903852b08352d3e734a39d4616caa602496997ba843e8fea0e1c481761776745faf04536a149d1c4af416b68df681b6fbc9ae2de8794e18c2e853b09  musl-1.1.23.tar.gz
+bbe309259d0bf08b51ecf1d3a8928ebb84faa8d9e770d25c9c1bb65df7ebb148e994b93416e55ce19a1f69ba251d9a48f1f135f00d49efc476bbe5950c99763f  0001-x87-float-stack-imbalance.patch
+1fd81026940174b45454fbeb9f9e5c7df1695a76dc5ced0d1d0abb47e930f4c0035be8ffca370c72c186bc613639839e313b8cc64ae0fa95f098ff4c51a41a11  0002-x87-float-stack-imbalance.patch
 6a7ff16d95b5d1be77e0a0fbb245491817db192176496a57b22ab037637d97a185ea0b0d19da687da66c2a2f5578e4343d230f399d49fe377d8f008410974238  handle-aux-at_base.patch
 8d3a2d5315fc56fee7da9abb8b89bb38c6046c33d154c10d168fb35bfde6b0cf9f13042a3bceee34daf091bc409d699223735dcf19f382eeee1f6be34154f26f  ldconfig
 062bb49fa54839010acd4af113e20f7263dde1c8a2ca359b5fb2661ef9ed9d84a0f7c3bc10c25dcfa10bb3c5a4874588dff636ac43d5dbb3d748d75400756d0b  __stack_chk_fail_local.c


### PR DESCRIPTION
Pending CVE request: https://www.openwall.com/lists/musl/2019/08/06/1