### PR TITLE
main/bluez: package btmgmt tool

### DIFF
--- a/main/bluez/APKBUILD
+++ b/main/bluez/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=bluez
 pkgver=5.50
-pkgrel=3
+pkgrel=4
 pkgdesc="Tools for the Bluetooth protocol stack"
 url="http://www.bluez.org/"
 arch="all"
@@ -11,7 +11,7 @@ replaces="udev"
 makedepends="dbus-dev libusb-compat-dev eudev-dev json-c-dev
 	libical-dev readline-dev glib-dev linux-headers
 	autoconf automake libtool ell-dev"
-subpackages="$pkgname-dev $pkgname-doc $pkgname-libs $pkgname-bccmd $pkgname-btmon $pkgname-cups
+subpackages="$pkgname-dev $pkgname-doc $pkgname-libs $pkgname-bccmd $pkgname-btmgmt $pkgname-btmon $pkgname-cups
 	$pkgname-deprecated $pkgname-hid2hci $pkgname-meshctl $pkgname-obexd"
 source="https://www.kernel.org/pub/linux/bluetooth/bluez-$pkgver.tar.xz
 	bluetooth.initd
@@ -64,6 +64,11 @@ bccmd() {
 	pkgdesc="Bluez utility for the CSR BCCMD interface"
 	mkdir -p "$subpkgdir"/usr/bin
 	mv "$pkgdir"/usr/bin/bccmd "$subpkgdir"/usr/bin/
+}
+
+btmgmt() {
+	pkgdesc="Bluez tool for the Bluetooth Management API"
+	install -Dm755 "$builddir"/tools/btmgmt "$subpkgdir"/usr/bin/btmgmt
 }
 
 btmon() {


### PR DESCRIPTION
This is not installed by default because upstream does not consider it a "stable" tool (i.e. its usage can change anytime).

However, it is a very useful tool for debugging Bluetooth problems, or to change the Bluetooth MAC address, since no other tool exists to talk to the Bluetooth Management API.