### PR TITLE
main/mt-st: add required sysmacros.h header

### DIFF
--- a/main/mt-st/APKBUILD
+++ b/main/mt-st/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=mt-st
 pkgver=1.1
-pkgrel=4
+pkgrel=5
 pkgdesc="Linux SCSI tape driver aware magnetic tape control"
 url="http://www.ibiblio.org/pub/linux/system/backup/"
 arch="all"
@@ -11,6 +11,7 @@ makedepends='linux-headers'
 install=
 subpackages="$pkgname-doc"
 source="http://www.ibiblio.org/pub/linux/system/backup/$pkgname-$pkgver.tar.gz
+	mt-st-include-sysmacros.patch
 	musl-path_max.patch"
 
 _builddir="$srcdir"/$pkgname-$pkgver
@@ -39,9 +40,6 @@ package() {
 	 MANDIR=$pkgdir/usr/share/man install || return 1
 }
 
-md5sums="fdd5f5ec673c9f630a102ceff7612774  mt-st-1.1.tar.gz
-06a7d26b71480105465c8b84303071fe  musl-path_max.patch"
-sha256sums="945cb4f3d9957dabe768f5941a9148b746396836c797b25f020c84319ba8170d  mt-st-1.1.tar.gz
-3ca59c3b94b0af048ad2811bf9f2f3b46542964e1952a118b7932bd850a5c86f  musl-path_max.patch"
 sha512sums="5fd11c430219c9c2d98f7567433a59c689e6f1bf9a2aaa13eb8df58569c1d70417965a4a62b5c9d0fc7e4e520ecb8d745911d18c3e2652c6aaedb94850743fdb  mt-st-1.1.tar.gz
+621711dc38436285f98f587a43393c505a101c1a99d3c2b652660cef98c6532813620d6f34fa7ca55fe2e13383e6b5c4930dad5996b4007262a6fdea449c18a7  mt-st-include-sysmacros.patch
 207f355497930cb466f5e3ad9601098381da1555709f9dafdbc85efcd5ea9cb8299e22c54b34b12d8fb9880dec75c3f625b3065438f7284bbcdef21b4de82555  musl-path_max.patch"

--- a/main/mt-st/mt-st-include-sysmacros.patch
+++ b/main/mt-st/mt-st-include-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/mt.c
++++ b/mt.c
+@@ -19,6 +19,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
+ #include <sys/utsname.h>


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of mt-st fails with:
```
mt.c:(.text+0xc4): undefined reference to `minor'
```
Explicitly including sys/sysmacros.h fixes the issue.