### PR TITLE
main/open-iscsi: add required sysmacros.h header

### DIFF
--- a/main/open-iscsi/APKBUILD
+++ b/main/open-iscsi/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=open-iscsi
 pkgver=2.0.874
-pkgrel=2
+pkgrel=3
 pkgdesc="High performance, transport independent, multi-platform iSCSI initiator"
 url="https://www.open-iscsi.com"
 arch="all"
@@ -16,6 +16,7 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/open-iscsi/open-iscsi/archiv
 	iscsid.conf
 	musl-fixes.patch
 	ldflags.patch
+	open-iscsi-include-sysmacros.patch
 	static-inline.patch
 	"
 builddir="$srcdir"/$pkgname-$pkgver
@@ -51,4 +52,5 @@ sha512sums="66d8a52b6401229d51873f1ee0f4e7259a8ed584800403a41741c7eeedc0ec21a2b1
 3686d31c5642e611c0c0c61f0f42a33030a74b518a2a108f004b9bd34b2b98d8e29ee2416a5b9cc447ab0449bdc94158b2323d977e7b7d2930dd4dcf0866da68  iscsid.conf
 9120d8e0a594f7337eb748ef655ebe915356fc4519b2cb58d9a6a5a2002059c0e9eb31e33e3e8b2242ae2fb9538a5233d17cdf0afd50c56aef3922335ebcd7d3  musl-fixes.patch
 9b2edc90c397fc86a91ac124308561b376adeb10ee794b40faa43b5ec34a672004f4881e03689632e8c05c587ee311918fa58d25e2a0442cf05359dd4659f712  ldflags.patch
+ea04b541f100e621e21e00c20d4a6be9f799dc5dd872d1f84a4e203171dfd3efc3e5b6a8374ff200ee69bed04180a41dfe7226621f6d133091c3b086210c9f28  open-iscsi-include-sysmacros.patch
 4ea344f018107450e288ae87cd12ff31cc69fb38127aa090b89226b1d622f7a9bd6f7ed13dabecc72af311a98eff5eb05973162d0b4bedd6d357399fca421b7b  static-inline.patch"

--- a/main/open-iscsi/open-iscsi-include-sysmacros.patch
+++ b/main/open-iscsi/open-iscsi-include-sysmacros.patch
@@ -1,0 +1,20 @@
+--- a/iscsiuio/src/unix/libs/bnx2x.c
++++ b/iscsiuio/src/unix/libs/bnx2x.c
+@@ -47,6 +47,7 @@
+ #include <sys/mman.h>
+ #include <sys/ioctl.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <sys/user.h>
+ #include <fcntl.h>
+--- a/iscsiuio/src/unix/libs/bnx2.c
++++ b/iscsiuio/src/unix/libs/bnx2.c
+@@ -42,6 +42,7 @@
+ #include <arpa/inet.h>
+ #include <sys/mman.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <sys/user.h>
+ #include <fcntl.h>


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of open-iscsi fails with:
```
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: ../../src/unix/libs/lib_iscsiuio_hw_cnic.a(bnx2.o): in function `bnx2_open':
bnx2.c:(.text+0xf74): undefined reference to `minor'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: ../../src/unix/libs/lib_iscsiuio_hw_cnic.a(bnx2x.o): in function `bnx2x_open':
bnx2x.c:(.text+0x162c): undefined reference to `minor'

```

Explicitly including sys/sysmacros.h fixes the issue.