### PR TITLE
main/curl: fix missing nghttp2 symbols

### DIFF
--- a/main/curl/APKBUILD
+++ b/main/curl/APKBUILD
@@ -87,7 +87,7 @@ prepare() {
 }
 
 build() {
-	./configure \
+	configure_flags="\
 		--build=$CBUILD \
 		--host=$CHOST \
 		--prefix=/usr \
@@ -96,11 +96,22 @@ build() {
 		--enable-static \
 		--without-libidn \
 		--without-libidn2 \
-		--with-nghttp2 \
 		--disable-ldap \
 		--with-pic \
-		--without-libssh2 # https://bugs.alpinelinux.org/issues/10222
+		--without-libssh2" # https://bugs.alpinelinux.org/issues/10222
+
+	# Despite using CFLAGS="-DNGHTTP2_STATICLIB" as said in
+	# https://github.com/curl/curl/issues/2516#issuecomment-383545545
+	# we still cannot link statically due to nghttp2 missing symbols,
+	# so we built libcurl.a without, to at least being able to link statically.
+
+	./configure $configure_flags --without-nghttp2
 	make
+	mv ./lib/.libs/libcurl.a .
+
+	./configure $configure_flags --with-nghttp2
+	make
+	mv libcurl.a ./lib/.libs/libcurl.a
 }
 
 check() {


### PR DESCRIPTION
nghttp2 symbols are missing when statically linking against libcurl.a, so we remove it in the static archive.

Follow up of https://github.com/alpinelinux/aports/pull/6264