### PR TITLE
community/py-gpiozero: upgrade to 1.5.1

### DIFF
--- a/community/py-gpiozero/APKBUILD
+++ b/community/py-gpiozero/APKBUILD
@@ -1,32 +1,51 @@
 # Contributor: ScrumpyJack <scrumpyjack@st.ilet.to>
 # Maintainer: ScrumpyJack <scrumpyjack@st.ilet.to>
 pkgname=py-gpiozero
-_pkgname=python-gpiozero
-pkgver=1.1.0
+_pkgname=gpiozero
+pkgver=1.5.1
 pkgrel=0
 pkgdesc="A simple interface to everyday GPIO components used with Raspberry Pi"
 url="http://gpiozero.readthedocs.org"
 arch="armhf armv7"
 license="BSD-3-Clause"
-depends="python2"
-depends_dev=""
-makedepends="python2-dev py-setuptools"
-install=""
-subpackages=""
-source="$_pkgname-$pkgver.tar.gz::https://github.com/RPi-Distro/${_pkgname}/archive/v${pkgver}.tar.gz"
+makedepends="python2-dev python3-dev py-setuptools"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="$_pkgname-$pkgver.tar.gz::https://github.com/gpiozero/gpiozero/archive/v${pkgver}.tar.gz"
 
-_builddir=${srcdir}/${_pkgname}-${pkgver}
+builddir=${srcdir}/${_pkgname}-${pkgver}
 
 build() {
-	cd "$_builddir"
-	python2 setup.py build || return 1
+	cd "$builddir"
+	python2 setup.py build
+	python3 setup.py build
 }
 
 package() {
-	cd "$_builddir"
-	python2 setup.py install --prefix=/usr --root="$pkgdir" || return 1
+	mkdir -p "$pkgdir"
 }
 
-md5sums="082fc277ab07fbf68397f75ed50ebb61  python-gpiozero-1.1.0.tar.gz"
-sha256sums="f68af12d203c998c6265ffd1f820236480639a044f64d6b81311575da8f62ced  python-gpiozero-1.1.0.tar.gz"
-sha512sums="e9519bf59d28da5b7c6771b49c99359ec2a0d6ae49433189d009c9be5af8c0e57b857265b1210a6cafdd88e71b3fa2d33d6b1d5ceae38371579f3478e96419e6  python-gpiozero-1.1.0.tar.gz"
+
+_py2() {
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	depends="$depends $python"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+
+
+sha512sums="73347ec887f6d6b58a09d8bfe604826df62cb9455fe2eab0de74e5130f7f9912a2f4caa25b1eaa80b50a5e1b1b4f712333facd1ff9405d53122f9602282fbf82  gpiozero-1.5.1.tar.gz"
+


### PR DESCRIPTION
community/py-gpiozero: upped version to 1.5.1 and made it compatible with both python2 and python3