### PR TITLE
main/lockfile-progs: add liblockfile-static dependency

### DIFF
--- a/main/lockfile-progs/APKBUILD
+++ b/main/lockfile-progs/APKBUILD
@@ -2,13 +2,13 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=lockfile-progs
 pkgver=0.1.18
-pkgrel=0
+pkgrel=1
 pkgdesc="Programs for locking and unlocking files and mailboxes"
 url="http://packages.debian.org/sid/lockfile-progs"
 arch="all"
 license="GPL"
 depends="liblockfile"
-makedepends="liblockfile-dev"
+makedepends="liblockfile-dev liblockfile-static"
 install=
 subpackages="$pkgname-doc"
 source="http://ftp.debian.org/debian/pool/main/l/lockfile-progs/${pkgname}_$pkgver.tar.gz"


### PR DESCRIPTION
After changes to liblockfile-static package with commit https://github.com/alpinelinux/aports/commit/2956bbd1c7d4d5298f72f265c06e1dbf76bbbea7#diff-9831cb082e6adbcf3151cbb2594eea55 building lockfile-progs fails with error:
```
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: cannot find -llockfile
```
Adding liblockfile-static as a make dependency will fix by making sure lockfile library is present. 