### PR TITLE
main/wpa_supplicant: security upgrade to 2.9

### DIFF
--- a/main/wpa_supplicant/APKBUILD
+++ b/main/wpa_supplicant/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=wpa_supplicant
-pkgver=2.8
-pkgrel=1
+pkgver=2.9
+pkgrel=0
 pkgdesc="A utility providing key negotiation for WPA wireless networks"
 url="https://w1.fi/wpa_supplicant/"
 arch="all"
@@ -109,7 +109,7 @@ package() {
 		"$pkgdir"/etc/conf.d/wpa_cli
 }
 
-sha512sums="b37d254d32a4b7a1f95fcb18ec1be0ffb9d025e0b21c42c53acc4cd839be355df1b125b32cc073f9fe09b746807321e23dbe25dc2fc8a7cafa1e71add69f245b  wpa_supplicant-2.8.tar.gz
+sha512sums="37a33f22cab9d27084fbef29856eaea0f692ff339c5b38bd32402dccf293cb849afd4a870cd3b5ca78179f0102f4011ce2f3444a53dc41dc75a5863b0a2226c8  wpa_supplicant-2.9.tar.gz
 2758109ccdd7d13e3839fc640ff2c321d5474d62a9dfce40ceb3c89e09b5cd6fe8b5f2f3184380513dc0e10f166669965e92005c0288c3f0814fd084d9673932  wpa_supplicant.initd
 cbfc6b80cb47d4e33415018054a0d8ba39acbadbc3e44776afa918cc4c1e4d36ed3dd809b3448332575ac4fa0b82ad77d7530563f0b9f5e1374a5deea73a3b93  wpa_supplicant.confd
 c3db077fa78dd296d90d07626cb4e684f87618a77ffd51c1ae04b47be7bc0db1e9a3e0f7442acef21c081f6bb782f150cbbd3d0bf245d6ab43f19da3899b53b9  wpa_cli.confd


### PR DESCRIPTION
https://w1.fi/security/2019-6/sae-eap-pwd-side-channel-attack-update.txt