### PR TITLE
main/hostapd: security upgrade to 2.9

### DIFF
--- a/main/hostapd/APKBUILD
+++ b/main/hostapd/APKBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=hostapd
-pkgver=2.8
+pkgver=2.9
 pkgrel=0
 pkgdesc="daemon for wireless software access points"
-url="http://hostap.epitest.fi/hostapd/"
+url="https://w1.fi/hostapd/"
 arch="all"
 license="custom"
 makedepends="openssl-dev libnl3-dev linux-headers"
@@ -91,6 +91,6 @@ package() {
 		&& install -Dm644 hostapd_cli.1 \
 			"$pkgdir"/usr/share/man/man1/hostapd_cli
 }
-sha512sums="5a352517470912bcb87755a592238eac2d814a7089d4ba1ecb7969f172dbb746a4e9a6c0d47c0d7c4a6a86b04b14ac39147d729fdf3163371c1067490a4897aa  hostapd-2.8.tar.gz
+sha512sums="66c729380152db18b64520bda55dfa00af3b0264f97b5de100b81a46e2593571626c4bdcf900f0988ea2131e30bc8788f75d8489dd1f57e37fd56e8098e48a9c  hostapd-2.9.tar.gz
 b54b7c6aa17e5cb86a9b354a516eb2dbefb544df18471339c61d82776de447011a2ac290bea1e6c8beae4b6cebefafb8174683ea42fb773e9e8fe6c679f33ba3  hostapd.initd
 0882263bbd7c0b05bf51f51d66e11a23a0b8ca7da2a3b8a30166d2c5f044c0c134e6bccb1d02c9e81819ca8fb0c0fb55c7121a08fe7233ccaa73ff8ab9a238fe  hostapd.confd"


### PR DESCRIPTION
https://w1.fi/security/2019-6/sae-eap-pwd-side-channel-attack-update.txt