### PR TITLE
testing/firefox: enable wayland capabilities

### DIFF
--- a/testing/firefox/APKBUILD
+++ b/testing/firefox/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox
 pkgver=68.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Firefox web browser"
 url="https://www.firefox.com/"
 # limited by rust and cargo
@@ -107,7 +107,7 @@ build() {
 		--disable-updater \
 		\
 		--enable-alsa \
-		--enable-default-toolkit=cairo-gtk3 \
+		--enable-default-toolkit=cairo-gtk3-wayland \
 		--enable-official-branding \
 		--enable-optimize="$CFLAGS -O2" \
 		--enable-startup-notification \


### PR DESCRIPTION
This doesn't change anything for Xorg sessions, but for Wayland sessions it makes
use of the GDK Wayland backend (if set by the session, e.g. via GDK_BACKEND=wayland),
which enables things like fractional scaling and different scaling factors across
different monitors