### PR TITLE
main/bind: add previous ISC signing key

### DIFF
--- a/main/bind/APKBUILD
+++ b/main/bind/APKBUILD
@@ -243,8 +243,12 @@ libs() {
 	default_libs
 }
 
-#gpg_signature_extensions="sha512.asc"
-#gpgfingerprints="good:AE3F AC79 6711 EC59 FC00  7AA4 74BB 6B9A 4CBB 3D38"
+
+gpg_signature_extensions="sha512.asc"
+gpgfingerprints="
+	good:AE3F AC79 6711 EC59 FC00  7AA4 74BB 6B9A 4CBB 3D38
+	BE0E 9748 B718 253A 28BB  89FF F1B1 1BF0 5CF0 2E57
+	"
 
 sha512sums="f5f4dc9b6a1d60838b59ce57ad37dc1e51fa26719aa203405a73850780f06bdc6ecea71c762efd464f946bdcce5a7c324de98caea36d2fe2781cce116fcd4932  bind-9.14.4.tar.gz
 2b32d1e7f62cd1e01bb4fdd92d15460bc14761b933d5acc463a91f5ecd4773d7477c757c5dd2738e8e433693592cf3f623ffc142241861c91848f01aa84640d6  bind.plugindir.patch


### PR DESCRIPTION
Without this TOFU unknown entry, a release signed with the older key
prompts for a trust decision. Avoiding the prompt is desirable.

Also, format GPG details so they are easier to check manually.

Used:
```
$ gpg --verify bind-*.asc bind-*.tar.gz
$ awk \
    '/gpgfingerprints=/,/(^|[^=])["'\'']$/ {print;}' \
    APKBUILD
```