### PR TITLE
Ganglia

### DIFF
--- a/testing/ganglia-web/APKBUILD
+++ b/testing/ganglia-web/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Zach McGrew <zmcgrew@gmail.com>
+# Maintainer:
+pkgname="ganglia-web"
+pkgver="3.7.5"
+pkgrel=0
+pkgdesc="Web visualisation for Ganglia monitoring tool"
+url="https://github.com/ganglia/ganglia-web/wiki"
+arch="noarch"
+license="BSD-3-Clause"
+depends="ganglia"
+makedepends="rsync"
+# Package just copies a directory to specified location -- No tests
+options="!check"
+install="$pkgname.pre-install $pkgname.post-install"
+pkggroups="www-data"
+source="$pkgname-$pkgver.tar.gz::https://github.com/ganglia/ganglia-web/archive/$pkgver.tar.gz"
+
+package() {
+	make \
+		DESTDIR="$pkgdir" \
+		APACHE_USER=ganglia \
+		APACHE_GROUP=www-data \
+		GDESTDIR=/var/www/ganglia \
+		GMETAD_ROOTDIR=/var/lib/ganglia \
+		GWEB_STATEDIR=/var/lib/ganglia \
+		install
+
+	install -dm755 -o ganglia -g www-data "$pkgdir/var/lib/ganglia/conf"
+	install -dm775 -o ganglia -g www-data "$pkgdir/var/lib/ganglia/dwoo/"
+	install -dm775 -o ganglia -g www-data "$pkgdir/var/lib/ganglia/dwoo/cache"
+	install -dm775 -o ganglia -g www-data "$pkgdir/var/lib/ganglia/dwoo/compiled"
+	install -Dm644 COPYING "$pkgdir/usr/share/licenses/$pkgname/COPYING"
+}
+
+sha512sums="3df0c8dc51d411d29beb00bcd66d617115ad72a576bec25ce7e4e96ba9f2d7099daa1e6f738cfcc6cab60e9af72303e8af51eeaa2ade2fa219ac075106f2e521  ganglia-web-3.7.5.tar.gz"

--- a/testing/ganglia-web/ganglia-web.post-install
+++ b/testing/ganglia-web/ganglia-web.post-install
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cat <<EOF
+Make sure that your php open_basedir includes
+/var/www and /var/lib/ganglia.
+EOF
+

--- a/testing/ganglia-web/ganglia-web.pre-install
+++ b/testing/ganglia-web/ganglia-web.pre-install
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+addgroup -S -g 82 www-data 2>/dev/null
+
+exit 0

--- a/testing/ganglia/APKBUILD
+++ b/testing/ganglia/APKBUILD
@@ -1,0 +1,100 @@
+# Contributor: Zach McGrew <zmcgrew@gmail.com>
+# Maintainer:
+pkgname="ganglia"
+pkgver="3.7.2"
+pkgrel=0
+pkgdesc="Ganglia is a scalable distributed monitoring system for high-performance computing systems"
+pkggroups="ganglia"
+pkgusers="ganglia"
+url="http://ganglia.info/"
+arch="all"
+license="BSD-3-Clause"
+depends="python2
+	rrdtool"
+depends_dev="
+	autoconf
+	automake
+	libtool
+	libtirpc-dev
+	rrdtool-dev
+	apr-dev
+	confuse-dev
+	protobuf-c-dev
+	expat-dev
+	pcre-dev
+	zlib-dev
+	rpcgen
+	linux-headers"
+makedepends="$depends_dev"
+install="$pkgname.pre-install"
+subpackages="$pkgname-dev $pkgname-doc $pkgname-openrc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/ganglia/monitor-core/archive/$pkgver.tar.gz
+	gmond.initd
+	gmetad.initd
+	riemann.proto::https://raw.githubusercontent.com/aphyr/riemann-java-client/2.5.0/src/main/proto/riemann/proto.proto
+	uid.patch
+	runstatedir.patch
+	"
+builddir="$srcdir/monitor-core-$pkgver"
+
+prepare() {
+	./bootstrap
+	default_prepare
+
+	cd "$srcdir"
+	protoc-c --c_out="$builddir/gmetad" riemann.proto
+}
+
+build() {
+	# Required to work around Sun RPC (ONC/RPC) library errors
+	LDFLAGS=-ltirpc \
+	CFLAGS=-I/usr/include/tirpc \
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr \
+		--libdir=/usr/lib \
+		--sysconfdir=/etc/ganglia \
+		--mandir=/usr/share/man \
+		--localstatedir=/var \
+		--enable-gexec \
+		--enable-status \
+		--with-gmetad \
+		--with-riemann \
+		--with-python=/usr/bin/python2
+	make
+}
+
+check() {
+	make check
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+
+	install -m755 -D "$srcdir"/gmond.initd \
+		"$pkgdir"/etc/init.d/gmond
+
+	install -m755 -D "$srcdir"/gmetad.initd \
+		"$pkgdir"/etc/init.d/gmetad
+
+	# Install Python modules
+	mkdir -p "$pkgdir/usr/lib/$pkgname/python_modules"
+	find "gmond/python_modules" -name *.py \
+		-exec cp \{\} "$pkgdir/usr/lib/$pkgname/python_modules/" \;
+	cp -R "gmond/python_modules/conf.d" "$pkgdir/etc/$pkgname/"
+
+	msg2 "Generating default gmond.conf"
+	./gmond/gmond --default_config > "$pkgdir/etc/$pkgname/gmond.conf"
+
+	install -dm755 -o ganglia -g ganglia "$pkgdir/var/lib/ganglia/"
+	install -dm755 -o ganglia -g ganglia "$pkgdir/var/lib/ganglia/rrds"
+	install -Dm644 COPYING "$pkgdir/usr/share/licenses/${pkgname}/COPYING"
+}
+
+sha512sums="7e7988e8c24340937afb4400e537fb097b5600ffd36e2505c10d230f92776f8b8ece055afb2dbc1d7d08a44f1107590996eca6474321615dfa39e0597159df42  ganglia-3.7.2.tar.gz
+b6cd6384037ee54727eeec8fbc71f17455e84b652ece86bf0ec4f96854fd63ef65b26b90c0147b2a1dc739a102e5f625c63567e8700856246ebabbc116639429  gmond.initd
+76000ce18f9ab2f3202d0ca0695737ee2e5479da24071dd20e442e340fd36c0a29c2578e7e3cabe54648cd0b82ed15e969f31c9d578ba1d05100116f813ab520  gmetad.initd
+c76a2b53bf306787a25f529e4d72db6bf9b0b1ea54486bb841150bd138f6d188aaf6481ac287fbc8d3ff15c0f33d755d30fbc863aa4c26d7a87551bc7f200a85  riemann.proto
+e9e78bbb45ebeeb7617499cd92a9173051b7949b625e4aca543a46d073919dcd1b5b1921fe92b6253b868ef345ce49e186dd44a8a12e77117b84678d7d538c82  uid.patch
+101f053d90e4a47c0792ae83d678338e9cd3cfcf8f40c882235e55a6f994ebfe78b00a211b52ba73b3f9f23a1bd53274476fe9901c7f04c88000ffe207f71810  runstatedir.patch"

--- a/testing/ganglia/ganglia.pre-install
+++ b/testing/ganglia/ganglia.pre-install
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+addgroup -S ganglia 2>/dev/null
+adduser -S -D -H -s /bin/false -G ganglia -g ganglia ganglia 2>/dev/null
+
+exit 0

--- a/testing/ganglia/gmetad.initd
+++ b/testing/ganglia/gmetad.initd
@@ -1,0 +1,11 @@
+#!/sbin/openrc-run
+
+description="Ganglia monitoring daemon"
+command="/usr/sbin/${RC_SVCNAME}"
+command_args="--pid-file=/run/${RC_SVCNAME}.pid"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+depend() {
+	need net
+	after firewall
+}

--- a/testing/ganglia/gmond.initd
+++ b/testing/ganglia/gmond.initd
@@ -1,0 +1,11 @@
+#!/sbin/openrc-run
+
+description="Ganglia meta daemon"
+command="/usr/sbin/${RC_SVCNAME}"
+command_args="--pid-file=/run/${RC_SVCNAME}.pid"
+pidfile="/run/${RC_SVCNAME}.pid"
+
+depend() {
+	need net
+	after firewall
+}

--- a/testing/ganglia/runstatedir.patch
+++ b/testing/ganglia/runstatedir.patch
@@ -1,0 +1,7 @@
+--- a/scripts/fixconfig.in
++++ b/scripts/fixconfig.in
+@@ -27,3 +27,3 @@ sysconfdir="@sysconfdir@"
+ includedir="@includedir@"
+-runstatedir="@localstatedir@/run" # @runstatedir@ if autoconf >= 2.70
++runstatedir="/run" # @runstatedir@ if autoconf >= 2.70
+ if [ -d "@sysconfdir@/sysconfig" ]

--- a/testing/ganglia/uid.patch
+++ b/testing/ganglia/uid.patch
@@ -1,0 +1,33 @@
+--- a/configure
++++ b/configure
+@@ -1588,7 +1588,7 @@ Optional Features:
+ 
+   --enable-debug          turn on debugging output and compile options
+   --enable-gexec          turn on gexec support (platform-specific)
+-  --enable-setuid=USER    turn on setuid support (default setuid=nobody)
++  --enable-setuid=USER    turn on setuid support (default setuid=ganglia)
+   --enable-setgid=GROUP   turn on setgid support (default setgid=no)
+   --enable-pedantic       turn on pedantic mode during compile
+   --enable-memcheck       turn on memory checking during compile
+@@ -11152,7 +11152,7 @@ $as_echo "#define SUPPORT_GEXEC 0" >>confdefs.h
+ fi
+ 
+ 
+-setuid_user=nobody
++setuid_user=ganglia
+ # Check whether --enable-setuid was given.
+ if test "${enable_setuid+set}" = set; then :
+   enableval=$enable_setuid; if test x"$enableval" != xno; then no_setuid=0; setuid_user=$enableval ; fi
+--- a/gmetad/gmetad.conf.in
++++ b/gmetad/gmetad.conf.in
+@@ -99,8 +99,8 @@ data_source "my cluster" localhost
+ #-------------------------------------------------------------------------------
+ # User gmetad will setuid to (defaults to "nobody")
+ # default: "nobody"
+-# setuid_username "nobody"
+-#
++setuid_username "ganglia"
++
+ #-------------------------------------------------------------------------------
+ # Umask to apply to created rrd files and grid directory structure
+ # default: 0 (files are public)


### PR DESCRIPTION
This adds two new aports: ganglia and ganglia-web. Ganglia is used for monitoring large environments, such as HPC nodes. Ganglia-web is a php frontend that can display and leverage rrdtool to generate graphs from all of the data.