### PR TITLE
[3.10] community/exempi: security upgrade to 2.5.1

### DIFF
--- a/community/exempi/APKBUILD
+++ b/community/exempi/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=exempi
-pkgver=2.5.0
-pkgrel=1
+pkgver=2.5.1
+pkgrel=0
 pkgdesc="A library to parse XMP metadata"
 url="https://libopenraw.freedesktop.org/wiki/Exempi/"
 arch="all"
@@ -10,6 +10,10 @@ license="BSD-3-Clause"
 makedepends="expat-dev zlib-dev boost-dev"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-libs"
 source="https://libopenraw.freedesktop.org/download/exempi-$pkgver.tar.bz2"
+
+# secfixes:
+#   2.5.1-r0:
+#     - CVE-2018-12648
 
 prepare() {
 	default_prepare
@@ -35,4 +39,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="1d042ffe3c3daadf937c4938e7892d52c4835275065e159f7991ddc9f533424fb6cd7d607600c3381440020db9dfa06af5ae15168d7a8012358fa5c8ac453bba  exempi-2.5.0.tar.bz2"
+sha512sums="97f2a688e1f92e219d0b68b077608112373cf3e6cbfe4141bbb9c3d1f416926bfd568957c1d0a081b95b524cbd500da0b7bca0ce45e1e8611818f66bcb1b6518  exempi-2.5.1.tar.bz2"


### PR DESCRIPTION
This fixes CVE-2018-12648