### PR TITLE
[3.8] main/binutils: fix multiple vulnerabilities

### DIFF
--- a/main/binutils/APKBUILD
+++ b/main/binutils/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=binutils
 pkgver=2.30
-pkgrel=5
+pkgrel=6
 pkgdesc="Tools necessary to build programs"
 url="https://www.gnu.org/software/binutils/"
 depends=""
@@ -16,6 +16,15 @@ source="http://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.bz2
 	binutils-ld-fix-static-linking.patch
 	gold-mips.patch
 	allow-R_AARCH64_ABS16-and.patch
+	CVE-2018-7208.patch
+	CVE-2018-6543.patch
+	CVE-2018-7643.patch
+	CVE-2018-6759.patch
+	CVE-2018-7642.patch
+	CVE-2018-7569.patch
+	CVE-2018-6872.patch
+	CVE-2018-7568.patch
+	CVE-2018-8945.patch
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -28,6 +37,17 @@ fi
 # secfixes:
 #   2.28-r1:
 #   - CVE-2017-7614
+#   2.30-r6:
+#   - CVE-2018-7208
+#   - CVE-2018-6543
+#   - CVE-2018-7643
+#   - CVE-2018-6759
+#   - CVE-2018-7642
+#   - CVE-2018-7570
+#   - CVE-2018-7569
+#   - CVE-2018-6872
+#   - CVE-2018-7568
+#   - CVE-2018-8945
 
 build() {
 	local _sysroot=/
@@ -109,7 +129,16 @@ gold() {
 }
 
 sha512sums="c3ce91aa20f058ec589bf18c722bf651331b394db6378900cc813cc0eea3a331a96584d5ae090630b627369510397dccc9edfcd43d4aeefc99579f277a05c72c  binutils-2.30.tar.bz2
-5d8ebbcae2c8d3b2075fb06ace3c52ff6bb0ec96989873fbe302019a15d91f6e85e9e38a6d8eb09bd9aefa7723665108a3a62a6fc1cafb07b1eba2a96d19c9e3  allow-R_AARCH64_ABS16-and.patch
 29791af5a09387d16fc4272dc7a10f71aed5a13187187af533bbe365506d6e6b581030d3f9bb4b7d8e300fb29b8b37b5f48027d86e33a8395b1a6d2dfb2d895a  fix-powerpc64-out-ot-line-save-restore.patch
 ecee33b0e435aa704af1c334e560f201638ff79e199aa11ed78a72f7c9b46f85fbb227af5748e735fd681d1965fcc42ac81b0c8824e540430ce0c706c81e8b49  binutils-ld-fix-static-linking.patch
-f55cf2e0bf82f97583a1abe10710e4013ecf7d64f1da2ef8659a44a06d0dd8beaf58dab98a183488ea137f03e32d62efc878d95f018f836f8cec870bc448556f  gold-mips.patch"
+f55cf2e0bf82f97583a1abe10710e4013ecf7d64f1da2ef8659a44a06d0dd8beaf58dab98a183488ea137f03e32d62efc878d95f018f836f8cec870bc448556f  gold-mips.patch
+5d8ebbcae2c8d3b2075fb06ace3c52ff6bb0ec96989873fbe302019a15d91f6e85e9e38a6d8eb09bd9aefa7723665108a3a62a6fc1cafb07b1eba2a96d19c9e3  allow-R_AARCH64_ABS16-and.patch
+13d68a99c63ba82c301c51e0747897cb0ee0e199606f1e285d02b5035a2309eabb057fd372fe3ff5bad48119a6ed7968385d0ce2ead776c72a77f4174d2ca777  CVE-2018-7208.patch
+6218beebc64299236073dc69acf6b1959b51abe55f3137b847c7bf66a76d030e5fa40fa2771cc8987559680c87f5c7e7eb5f8026cc62a6ea6f301a3b17e5fad4  CVE-2018-6543.patch
+da7efaea69795bec35324748929befd504edf11454bca5cdd4a408ae144cd8783e45088277d5a2460a7cbd0f19222270f4249fc71bcf5359d1d96ade7ce8f6b1  CVE-2018-7643.patch
+3a424369a49b5f970569748a9405c2927bfc5a300bced5ba1d2e9ce95757225d1727f8d05fbfb7771f7e88e67eaa895d9bece58a5004ef3ce2a83b43fc6f4452  CVE-2018-6759.patch
+a75552fc21209b34a62af9861f8ce25fe01f4dfec13a14918b2d77dfda77b49983abddc4cd0f1ae2901ef385731e56f98fe603911c9a757584b4dc7e45534efa  CVE-2018-7642.patch
+9ecb0bcf73f2c6e6f41875557ad0ac77e968ee4e7de0fd69d3a989109b2d648fe2441da720befa5c975d25cc8241570914229897ccdc3b6e6ff05e424a01fe1c  CVE-2018-7569.patch
+cef3d0a50eda9296359f60feec7feb91610b500c74d0c42517a7f10b5b8b228257dbb6af55cf480d17d6532acb5dca708db1928aa4c6bf2d5c57b7a180a3d08a  CVE-2018-6872.patch
+b73a5fe747f6a967ba4bcfeca59286f1d7b1324841860d31dd914eb96ab61dd5241cb8b6a8491e29aa9ccd63d46bee92e8635f6d4c49b7da46593d43cdbc2e55  CVE-2018-7568.patch
+3578788a75e720aa17e92bf28074ee8bee764a7a6335ef6a1d766b83a67aae27bf806f1354cd919fc69bfb5e9c6579cd01449156c188ac45f1e16e33d10b986a  CVE-2018-8945.patch"

--- a/main/binutils/CVE-2018-6543.patch
+++ b/main/binutils/CVE-2018-6543.patch
@@ -1,0 +1,28 @@
+X-Git-Url: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blobdiff_plain;f=binutils%2Fobjdump.c;h=d8dca90f40c87c9bfd437c374f123ba5625a5b1d;hp=6c4d936b266a29a2cab7292978ec8f725b4cf1aa;hb=f2023ce7e8d70b0155cc6206c901e185260918f0;hpb=35f48e217ab6f909510bf9ca07325ec16122ae88
+
+diff --git a/binutils/objdump.c b/binutils/objdump.c
+index 6c4d936..d8dca90 100644
+--- a/binutils/objdump.c
++++ b/binutils/objdump.c
+@@ -2466,6 +2466,7 @@ load_specific_debug_section (enum dwarf_section_display_enum debug,
+   struct dwarf_section *section = &debug_displays [debug].section;
+   bfd *abfd = (bfd *) file;
+   bfd_byte *contents;
++  bfd_size_type amt;
+ 
+   if (section->start != NULL)
+     {
+@@ -2480,9 +2481,11 @@ load_specific_debug_section (enum dwarf_section_display_enum debug,
+   section->num_relocs = 0;
+   section->address = bfd_get_section_vma (abfd, sec);
+   section->size = bfd_get_section_size (sec);
+-  section->start = contents = malloc (section->size + 1);
++  amt = section->size + 1;
++  section->start = contents = malloc (amt);
+   section->user_data = sec;
+-  if (section->start == NULL
++  if (amt == 0
++      || section->start == NULL
+       || !bfd_get_full_section_contents (abfd, sec, &contents))
+     {
+       free_debug_section (debug);

--- a/main/binutils/CVE-2018-6759.patch
+++ b/main/binutils/CVE-2018-6759.patch
@@ -1,0 +1,86 @@
+From 64e234d417d5685a4aec0edc618114d9991c031b Mon Sep 17 00:00:00 2001
+From: Nick Clifton <nickc@redhat.com>
+Date: Tue, 6 Feb 2018 15:48:29 +0000
+Subject: [PATCH] Prevent attempts to call strncpy with a zero-length field by
+ chacking the size of debuglink sections.
+
+	PR 22794
+	* opncls.c (bfd_get_debug_link_info_1): Check the size of the
+	section before attempting to read it in.
+	(bfd_get_alt_debug_link_info): Likewise.
+---
+diff --git a/bfd/opncls.c b/bfd/opncls.c
+index 458f06e..16b568c 100644
+--- a/bfd/opncls.c
++++ b/bfd/opncls.c
+@@ -1179,6 +1179,7 @@ bfd_get_debug_link_info_1 (bfd *abfd, void *crc32_out)
+   bfd_byte *contents;
+   unsigned int crc_offset;
+   char *name;
++  bfd_size_type size;
+ 
+   BFD_ASSERT (abfd);
+   BFD_ASSERT (crc32_out);
+@@ -1188,6 +1189,12 @@ bfd_get_debug_link_info_1 (bfd *abfd, void *crc32_out)
+   if (sect == NULL)
+     return NULL;
+ 
++  size = bfd_get_section_size (sect);
++
++  /* PR 22794: Make sure that the section has a reasonable size.  */
++  if (size < 8 || size >= bfd_get_size (abfd))
++    return NULL;
++
+   if (!bfd_malloc_and_get_section (abfd, sect, &contents))
+     {
+       if (contents != NULL)
+@@ -1197,10 +1204,10 @@ bfd_get_debug_link_info_1 (bfd *abfd, void *crc32_out)
+ 
+   /* CRC value is stored after the filename, aligned up to 4 bytes.  */
+   name = (char *) contents;
+-  /* PR 17597: avoid reading off the end of the buffer.  */
+-  crc_offset = strnlen (name, bfd_get_section_size (sect)) + 1;
++  /* PR 17597: Avoid reading off the end of the buffer.  */
++  crc_offset = strnlen (name, size) + 1;
+   crc_offset = (crc_offset + 3) & ~3;
+-  if (crc_offset + 4 > bfd_get_section_size (sect))
++  if (crc_offset + 4 > size)
+     return NULL;
+ 
+   *crc32 = bfd_get_32 (abfd, contents + crc_offset);
+@@ -1261,6 +1268,7 @@ bfd_get_alt_debug_link_info (bfd * abfd, bfd_size_type *buildid_len,
+   bfd_byte *contents;
+   unsigned int buildid_offset;
+   char *name;
++  bfd_size_type size;
+ 
+   BFD_ASSERT (abfd);
+   BFD_ASSERT (buildid_len);
+@@ -1271,6 +1279,10 @@ bfd_get_alt_debug_link_info (bfd * abfd, bfd_size_type *buildid_len,
+   if (sect == NULL)
+     return NULL;
+ 
++  size = bfd_get_section_size (sect);
++  if (size < 8 || size >= bfd_get_size (abfd))
++    return NULL;
++
+   if (!bfd_malloc_and_get_section (abfd, sect, & contents))
+     {
+       if (contents != NULL)
+@@ -1280,11 +1292,11 @@ bfd_get_alt_debug_link_info (bfd * abfd, bfd_size_type *buildid_len,
+ 
+   /* BuildID value is stored after the filename.  */
+   name = (char *) contents;
+-  buildid_offset = strnlen (name, bfd_get_section_size (sect)) + 1;
++  buildid_offset = strnlen (name, size) + 1;
+   if (buildid_offset >= bfd_get_section_size (sect))
+     return NULL;
+ 
+-  *buildid_len = bfd_get_section_size (sect) - buildid_offset;
++  *buildid_len = size - buildid_offset;
+   *buildid_out = bfd_malloc (*buildid_len);
+   memcpy (*buildid_out, contents + buildid_offset, *buildid_len);
+ 
+-- 
+2.9.3
+

--- a/main/binutils/CVE-2018-6872.patch
+++ b/main/binutils/CVE-2018-6872.patch
@@ -1,0 +1,15 @@
+X-Git-Url: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blobdiff_plain;f=bfd%2Felf.c;h=db1e076b554a83be5db6234c11e89d26805fb527;hp=dedf35feb3c468d020025b3528a2c6544107db04;hb=ef135d4314fd4c2d7da66b9d7b59af4a85b0f7e6;hpb=a9479dc051ab00f311c04cdd5b299a70739f67ed
+
+diff --git a/bfd/elf.c b/bfd/elf.c
+index dedf35f..db1e076 100644
+--- a/bfd/elf.c
++++ b/bfd/elf.c
+@@ -11012,6 +11012,8 @@ elf_parse_notes (bfd *abfd, char *buf, size_t size, file_ptr offset,
+      align is less than 4, we use 4 byte alignment.   */
+   if (align < 4)
+     align = 4;
++  if (align != 4 && align != 8)
++    return FALSE;
+ 
+   p = buf;
+   while (p < buf + size)

--- a/main/binutils/CVE-2018-7208.patch
+++ b/main/binutils/CVE-2018-7208.patch
@@ -1,0 +1,16 @@
+X-Git-Url: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blobdiff_plain;f=bfd%2Fcoffgen.c;h=4f90eaddd9cf6d5ae77848043493f305a96bb26d;hp=b2410873d0c9fc9ccd6d44870ec8204dcf3bfbc2;hb=eb77f6a4621795367a39cdd30957903af9dbb815;hpb=0d5e2f6abee322730eea6d7c175ae24631d3b089
+
+diff --git a/bfd/coffgen.c b/bfd/coffgen.c
+index b241087..4f90ead 100644
+--- a/bfd/coffgen.c
++++ b/bfd/coffgen.c
+@@ -1555,7 +1555,8 @@ coff_pointerize_aux (bfd *abfd,
+     }
+   /* A negative tagndx is meaningless, but the SCO 3.2v4 cc can
+      generate one, so we must be careful to ignore it.  */
+-  if (auxent->u.auxent.x_sym.x_tagndx.l > 0)
++  if ((unsigned long) auxent->u.auxent.x_sym.x_tagndx.l
++      < obj_raw_syment_count (abfd))
+     {
+       auxent->u.auxent.x_sym.x_tagndx.p =
+ 	table_base + auxent->u.auxent.x_sym.x_tagndx.l;

--- a/main/binutils/CVE-2018-7568.patch
+++ b/main/binutils/CVE-2018-7568.patch
@@ -1,0 +1,41 @@
+X-Git-Url: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blobdiff_plain;f=bfd%2Fdwarf1.c;h=f272ea831157dc16283774edb933492ca8d3cf48;hp=71bc57bfdf825092c3449ba8810b0efa7b54bb8b;hb=eef104664efb52965d85a28bc3fc7c77e52e48e2;hpb=0d329c0a83a23cebb86fbe0ebddd780dc0df2424
+
+diff --git a/bfd/dwarf1.c b/bfd/dwarf1.c
+index 71bc57b..f272ea8 100644
+--- a/bfd/dwarf1.c
++++ b/bfd/dwarf1.c
+@@ -213,6 +213,7 @@ parse_die (bfd *	     abfd,
+   /* Then the attributes.  */
+   while (xptr + 2 <= aDiePtrEnd)
+     {
++      unsigned int   block_len;
+       unsigned short attr;
+ 
+       /* Parse the attribute based on its form.  This section
+@@ -255,12 +256,24 @@ parse_die (bfd *	     abfd,
+ 	  break;
+ 	case FORM_BLOCK2:
+ 	  if (xptr + 2 <= aDiePtrEnd)
+-	    xptr += bfd_get_16 (abfd, xptr);
++	    {
++	      block_len = bfd_get_16 (abfd, xptr);
++	      if (xptr + block_len > aDiePtrEnd
++		  || xptr + block_len < xptr)
++		return FALSE;
++	      xptr += block_len;
++	    }
+ 	  xptr += 2;
+ 	  break;
+ 	case FORM_BLOCK4:
+ 	  if (xptr + 4 <= aDiePtrEnd)
+-	    xptr += bfd_get_32 (abfd, xptr);
++	    {
++	      block_len = bfd_get_32 (abfd, xptr);
++	      if (xptr + block_len > aDiePtrEnd
++		  || xptr + block_len < xptr)
++		return FALSE;
++	      xptr += block_len;
++	    }
+ 	  xptr += 4;
+ 	  break;
+ 	case FORM_STRING:

--- a/main/binutils/CVE-2018-7569.patch
+++ b/main/binutils/CVE-2018-7569.patch
@@ -1,0 +1,78 @@
+X-Git-Url: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blobdiff_plain;f=bfd%2Fdwarf2.c;h=ca22db766c54a0ee8c35199b5110b03d9f7524d8;hp=2413542b84b20554f9f6e58edd03880b81cc6171;hb=12c963421d045a127c413a0722062b9932c50aa9;hpb=116acb2c268c89c89186673a7c92620d21825b25
+
+diff --git a/bfd/dwarf2.c b/bfd/dwarf2.c
+index 2413542..ca22db7 100644
+--- a/bfd/dwarf2.c
++++ b/bfd/dwarf2.c
+@@ -623,14 +623,24 @@ read_8_bytes (bfd *abfd, bfd_byte *buf, bfd_byte *end)
+ }
+ 
+ static bfd_byte *
+-read_n_bytes (bfd *abfd ATTRIBUTE_UNUSED,
+-	      bfd_byte *buf,
+-	      bfd_byte *end,
+-	      unsigned int size ATTRIBUTE_UNUSED)
++read_n_bytes (bfd_byte *           buf,
++	      bfd_byte *           end,
++	      struct dwarf_block * block)
+ {
+-  if (buf + size > end)
+-    return NULL;
+-  return buf;
++  unsigned int  size = block->size;
++  bfd_byte *    block_end = buf + size;
++
++  if (block_end > end || block_end < buf)
++    {
++      block->data = NULL;
++      block->size = 0;
++      return end;
++    }
++  else
++    {
++      block->data = buf;
++      return block_end;
++    }
+ }
+ 
+ /* Scans a NUL terminated string starting at BUF, returning a pointer to it.
+@@ -1128,8 +1138,7 @@ read_attribute_value (struct attribute *  attr,
+ 	return NULL;
+       blk->size = read_2_bytes (abfd, info_ptr, info_ptr_end);
+       info_ptr += 2;
+-      blk->data = read_n_bytes (abfd, info_ptr, info_ptr_end, blk->size);
+-      info_ptr += blk->size;
++      info_ptr = read_n_bytes (info_ptr, info_ptr_end, blk);
+       attr->u.blk = blk;
+       break;
+     case DW_FORM_block4:
+@@ -1139,8 +1148,7 @@ read_attribute_value (struct attribute *  attr,
+ 	return NULL;
+       blk->size = read_4_bytes (abfd, info_ptr, info_ptr_end);
+       info_ptr += 4;
+-      blk->data = read_n_bytes (abfd, info_ptr, info_ptr_end, blk->size);
+-      info_ptr += blk->size;
++      info_ptr = read_n_bytes (info_ptr, info_ptr_end, blk);
+       attr->u.blk = blk;
+       break;
+     case DW_FORM_data2:
+@@ -1180,8 +1188,7 @@ read_attribute_value (struct attribute *  attr,
+       blk->size = _bfd_safe_read_leb128 (abfd, info_ptr, &bytes_read,
+ 					 FALSE, info_ptr_end);
+       info_ptr += bytes_read;
+-      blk->data = read_n_bytes (abfd, info_ptr, info_ptr_end, blk->size);
+-      info_ptr += blk->size;
++      info_ptr = read_n_bytes (info_ptr, info_ptr_end, blk);
+       attr->u.blk = blk;
+       break;
+     case DW_FORM_block1:
+@@ -1191,8 +1198,7 @@ read_attribute_value (struct attribute *  attr,
+ 	return NULL;
+       blk->size = read_1_byte (abfd, info_ptr, info_ptr_end);
+       info_ptr += 1;
+-      blk->data = read_n_bytes (abfd, info_ptr, info_ptr_end, blk->size);
+-      info_ptr += blk->size;
++      info_ptr = read_n_bytes (info_ptr, info_ptr_end, blk);
+       attr->u.blk = blk;
+       break;
+     case DW_FORM_data1:

--- a/main/binutils/CVE-2018-7642.patch
+++ b/main/binutils/CVE-2018-7642.patch
@@ -1,0 +1,21 @@
+X-Git-Url: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blobdiff_plain;f=bfd%2Faoutx.h;h=525e5603ec90c296e086091327aa0c472cf06e41;hp=4cadbfbd2fad64e0417c37bb316e3b63f202b3ae;hb=116acb2c268c89c89186673a7c92620d21825b25;hpb=889be5dbd230ee47a90d4a83f682b13ed7e3faae
+
+diff --git a/bfd/aoutx.h b/bfd/aoutx.h
+index 4cadbfb..525e560 100644
+--- a/bfd/aoutx.h
++++ b/bfd/aoutx.h
+@@ -2289,10 +2289,12 @@ NAME (aout, swap_std_reloc_in) (bfd *abfd,
+   if (r_baserel)
+     r_extern = 1;
+ 
+-  if (r_extern && r_index > symcount)
++  if (r_extern && r_index >= symcount)
+     {
+       /* We could arrange to return an error, but it might be useful
+-	 to see the file even if it is bad.  */
++	 to see the file even if it is bad.  FIXME: Of course this
++	 means that objdump -r *doesn't* see the actual reloc, and
++	 objcopy silently writes a different reloc.  */
+       r_extern = 0;
+       r_index = N_ABS;
+     }

--- a/main/binutils/CVE-2018-7643.patch
+++ b/main/binutils/CVE-2018-7643.patch
@@ -1,0 +1,28 @@
+X-Git-Url: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blobdiff_plain;f=binutils%2Fdwarf.c;h=17896e61107eb53afac4b47820d2b18cf2398a9d;hp=6aca9b79942b5593b6ab445795d5b50b8f973bed;hb=d11ae95ea3403559f052903ab053f43ad7821e37;hpb=0cb7c7b0bb79be910e261f3d30c58ace6b0d06d1
+
+diff --git a/binutils/dwarf.c b/binutils/dwarf.c
+index 6aca9b7..17896e6 100644
+--- a/binutils/dwarf.c
++++ b/binutils/dwarf.c
+@@ -6810,6 +6817,13 @@ display_debug_ranges (struct dwarf_section *section,
+ 	  continue;
+ 	}
+ 
++      if (next < section_begin || next >= finish)
++	{
++	  warn (_("Corrupt offset (%#8.8lx) in range entry %u\n"),
++		(unsigned long) offset, i);
++	  continue;
++	}
++
+       if (dwarf_check != 0 && i > 0)
+ 	{
+ 	  if (start < next)
+@@ -6825,6 +6839,7 @@ display_debug_ranges (struct dwarf_section *section,
+ 		    (unsigned long) (next - section_begin), section->name);
+ 	    }
+ 	}
++
+       start = next;
+       last_start = next;
+ 

--- a/main/binutils/CVE-2018-8945.patch
+++ b/main/binutils/CVE-2018-8945.patch
@@ -1,0 +1,52 @@
+From 95a6d23566165208853a68d9cd3c6eedca840ec6 Mon Sep 17 00:00:00 2001
+From: Nick Clifton <nickc@redhat.com>
+Date: Tue, 8 May 2018 12:51:06 +0100
+Subject: [PATCH] Prevent a memory exhaustion failure when running objdump on a
+ fuzzed input file with corrupt string and attribute sections.
+
+	PR 22809
+	* elf.c (bfd_elf_get_str_section): Check for an excessively large
+	string section.
+	* elf-attrs.c (_bfd_elf_parse_attributes): Issue an error if the
+	attribute section is larger than the size of the file.
+---
+ bfd/ChangeLog   | 8 ++++++++
+ bfd/elf-attrs.c | 9 +++++++++
+ bfd/elf.c       | 1 +
+ 3 files changed, 18 insertions(+)
+
+diff --git a/bfd/elf-attrs.c b/bfd/elf-attrs.c
+index dfdf1a5..b353309 100644
+--- a/bfd/elf-attrs.c
++++ b/bfd/elf-attrs.c
+@@ -438,6 +438,15 @@ _bfd_elf_parse_attributes (bfd *abfd, Elf_Internal_Shdr * hdr)
+   /* PR 17512: file: 2844a11d.  */
+   if (hdr->sh_size == 0)
+     return;
++  if (hdr->sh_size > bfd_get_file_size (abfd))
++    {
++      /* xgettext:c-format */
++      _bfd_error_handler (_("%pB: error: attribute section '%pA' too big: %#llx"),
++			  abfd, hdr->bfd_section, (long long) hdr->sh_size);
++      bfd_set_error (bfd_error_invalid_operation);
++      return;
++    }
++
+   contents = (bfd_byte *) bfd_malloc (hdr->sh_size + 1);
+   if (!contents)
+     return;
+diff --git a/bfd/elf.c b/bfd/elf.c
+index 21bc4e7..3e8d510 100644
+--- a/bfd/elf.c
++++ b/bfd/elf.c
+@@ -298,6 +298,7 @@ bfd_elf_get_str_section (bfd *abfd, unsigned int shindex)
+       /* Allocate and clear an extra byte at the end, to prevent crashes
+ 	 in case the string table is not terminated.  */
+       if (shstrtabsize + 1 <= 1
++	  || shstrtabsize > bfd_get_file_size (abfd)
+ 	  || bfd_seek (abfd, offset, SEEK_SET) != 0
+ 	  || (shstrtab = (bfd_byte *) bfd_alloc (abfd, shstrtabsize + 1)) == NULL)
+ 	shstrtab = NULL;
+-- 
+2.9.3
+


### PR DESCRIPTION
This fixes CVE-2018-6543, CVE-2018-6759, CVE-2018-6872, CVE-2018-7208, CVE-2018-7568,
CVE-2018-7569, CVE-2018-7642, CVE-2018-7643, CVE-2018-8945

ref #8959