### PR TITLE
community/tinc-pre: downgrade to 1.16pre

### DIFF
--- a/community/tinc-pre/APKBUILD
+++ b/community/tinc-pre/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=tinc-pre
-_realver="1.1pre17"
+_realver="1.1pre16"
 pkgver=${_realver/pre/.}
 pkgrel=1
 pkgdesc="Virtual Private Network (VPN) daemon (pre-release)"
@@ -10,13 +10,13 @@ url="http://tinc-vpn.org/"
 # armhf: tests fail
 # aarch64: FAIL: legacy-protocol.test
 # disable due to FAIL: legacy-protocol.test
-arch=   #"all !s390x !armhf !armv7 !aarch64"
+arch=x86_64   #"all !s390x !armhf !armv7 !aarch64"
 license="GPL-2.0"
 makedepends="linux-headers ncurses-dev readline-dev
 	zlib-dev lzo-dev openssl-dev texinfo
 	automake autoconf libtool bash"
 subpackages="$pkgname-doc"
-source="http://tinc-vpn.org/packages/tinc-$_realver.tar.gz
+source="https://tinc-vpn.org/packages/tinc-$_realver.tar.gz
 	tinc-1.1-fix-paths.patch
 	$pkgname.initd
 	$pkgname.confd
@@ -67,7 +67,7 @@ package() {
 		"$pkgdir"/etc/conf.d/tinc.networks
 }
 
-sha512sums="b966dbfa522e12ff6766c4deb54a9da29cddc15c3a1df0f0e084df27ee5f1421ffbebc0e29472b1bcd79ea8b41f8c0ef904172e333dcba0b85bafe4654a63b30  tinc-1.1pre17.tar.gz
+sha512sums="b32a0a734a4c8a91bad4cef4177cb45757c97c09dc179da1e3357f2fde48b3b0747587dbac31ecb5400e1553b6712d474a6a1808ac24bce1a3494c1842bb6c43  tinc-1.1pre16.tar.gz
 bb6f9a1fedf6ffab21f6bfa65c8d977b24453a5d667229eec995b979bbe8dcdaa0617f076a3d9081c4580068b385f7595b80856d5abcf9c928b866eb9c6f4910  tinc-1.1-fix-paths.patch
 59811c3e5241d08ebdfbd539556b7cee0dfaab89727ad503512c98f1a696fae143ecdf2682a652c5d71d077ed254ffe2e1c442b1c305c7e7ea94d9af9a1d385e  tinc-pre.initd
 f8d9354af5ebc07420ced98059262751bffef434b61c6333964338f327e2ac01ae676e375954efa794a1bccf8b939c78387b9fb7261f675f1237b0d946b529c9  tinc-pre.confd


### PR DESCRIPTION
1.17pre build failed on all platform. downgrade to 1.16 temporarily.