### PR TITLE
[3.10] community/elogind: depend on shadow

### DIFF
--- a/community/elogind/APKBUILD
+++ b/community/elogind/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Leo <thinkabit.ukim@gmail.com>
 pkgname=elogind
 pkgver=241.3
-pkgrel=0
+pkgrel=1
 pkgdesc="Standalone fork of systemd's elogind"
 url="https://github.com/elogind/elogind"
 arch="all"
 license="GPL-2.0-or-later LGPL-2.1-or-later"
-depends="dbus"
+depends="dbus shadow"
 options="!check" # Tests fail on builders
 makedepends="
 	meson
@@ -34,7 +34,7 @@ subpackages="
 	$pkgname-zsh-completion:zshcomp:noarch
 	$pkgname-bash-completion:bashcomp:noarch"
 source="
-	$pkgname-$pkgver.tar.gz::https://github.com/elogind/elogind/archive/v${pkgver}.tar.gz
+	$pkgname-$pkgver.tar.gz::https://github.com/elogind/elogind/archive/v$pkgver.tar.gz
 	reverse_DISABLE_BUFFER_in_cg_attach.patch
 	reverse_CLOSE_ON_EXEC_removal.patch"
 


### PR DESCRIPTION
shadow's login is required for elogind to pick up logins and assign
sessions.