### PR TITLE
main/jfsutils: add required sysmacros.h header

### DIFF
--- a/main/jfsutils/APKBUILD
+++ b/main/jfsutils/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=jfsutils
 pkgver=1.1.15
-pkgrel=1
+pkgrel=2
 pkgdesc="JFS filesystem utilities"
 url="http://jfs.sourceforge.net"
 arch="all"
@@ -13,6 +13,7 @@ makedepends="e2fsprogs-dev" # is pulled in externally.
 subpackages="$pkgname-doc"
 source="http://jfs.sourceforge.net/project/pub/jfsutils-$pkgver.tar.gz
 	musl-fix-includes.patch
+	jfsutils-include-sysmacros.patch
 	missing-stdinth.patch"
 
 _builddir="$srcdir"/$pkgname-$pkgver
@@ -43,12 +44,7 @@ package() {
 	make -j1 LDCONFIG=: DESTDIR="${pkgdir}" install || return 1
 }
 
-md5sums="8809465cd48a202895bc2a12e1923b5d  jfsutils-1.1.15.tar.gz
-cd086dc5682094b81c25fa64ed820aca  musl-fix-includes.patch
-da6e6be4d89d5652d9c1e99424634e42  missing-stdinth.patch"
-sha256sums="244a15f64015ce3ea17e49bdf6e1a0fb4f9af92b82fa9e05aa64cb30b5f07a4d  jfsutils-1.1.15.tar.gz
-163754388fb2f8c7525b14d1f9cb07e35b91d0ff8f5964df20c3f042305f42d4  musl-fix-includes.patch
-cabb017038bccfcec5ff55b820105b1fefe679c122a03f2d186f5be8e33ca4d7  missing-stdinth.patch"
 sha512sums="fa8ba7f4997471da3e6ea7239564f3395046222cfbb2b10e37b24ad0bd107b7eadbb51ce328d89d193034360b4035ca5e0e5b0b416a74483d7a2c0a2b9c65858  jfsutils-1.1.15.tar.gz
 fb0d7348e2e13a6a9c3a987d161e0cf05363649515366ef49a45e3580b8f6135fce8465b99ff8a351231d970371c00bea6ceb9edb1d0f24da20d261b06ec85bd  musl-fix-includes.patch
+dd634072847158520ae1eb1b624884cd4fdf6847c468335d8cb784f82f0fa09814c3756014f373b19fa3a5d19a95128964c2b6a12aac7ea6da6b7714646765d4  jfsutils-include-sysmacros.patch
 a8e2332f2dec37affa8404b31e7e68399d815d450422ad342243c51d117e4d7ef4aaa0e30d1389380a81ed076a7ef1e1d41fcf260fa05ce4d823aa779628982d  missing-stdinth.patch"

--- a/main/jfsutils/jfsutils-include-sysmacros.patch
+++ b/main/jfsutils/jfsutils-include-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/libfs/devices.c
++++ b/libfs/devices.c
+@@ -38,6 +38,7 @@
+ #endif
+ 
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <sys/ioctl.h>
+ #if defined(__DragonFly__)


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of jfsutils fails with:
```
devices.c:(.text+0x51c): undefined reference to `major'

```
Explicitly including sys/sysmacros.h fixes the issue.