### PR TITLE
main/parted: included needed sysmacros.h header

### DIFF
--- a/main/parted/APKBUILD
+++ b/main/parted/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=parted
 pkgver=3.2
-pkgrel=9
+pkgrel=10
 pkgdesc="Utility to create, destroy, resize, check and copy partitions"
 url="https://www.gnu.org/software/parted/parted.html"
 arch="all"
@@ -12,6 +12,7 @@ makedepends="readline-dev ncurses-dev lvm2-dev bash util-linux-dev"
 source="ftp://ftp.gnu.org/pub/gnu/$pkgname/$pkgname-$pkgver.tar.xz
 	fix-includes.patch
 	fix-libintl-header-s390x.patch
+	parted-include-sysmacros.patch
 	make-tests.patch
 	skip-duplicate-bsd-test-on-s390x.patch
 	"
@@ -45,5 +46,6 @@ package() {
 sha512sums="4e37dbdd6f5032c9ebfec43704f6882379597d038167b9c4d04053efa083c68a705196713864451fa9e11d32777e16c68982877945c5efd9ea5f8252cb20e1c4  parted-3.2.tar.xz
 55ee63c218d1867c0f2c596e7c3eec5c42af160181456cc551fe3d432eabed0ac2dd3a3955ff0c375f76aeec8071e7f55a32834b87a0d39b8ef30361f671bfdd  fix-includes.patch
 444a7e2fb3235dfd218f6b71fb25adde107d001f638d988ee1fa79686d8efee94a9499e27bdfdd75f9718760b448938b70a90a74285b93a39338d21f4ab4c9dc  fix-libintl-header-s390x.patch
+ba86cd2591d8e920e474faf28a32f9eaca9482e168c53eae5d392276aefaf6c46b66a0d5fc4a18b7186bf38f7288bd79de8ba8019c1cd38a5e2102904ce75723  parted-include-sysmacros.patch
 d0b08148f1b8020d8948780c281b2334d5d0acc5850d0a36bccab536bc91d91f5692021712d18d653699895e2c0b847b8bf9e6061d29c1e054f71fd440bc6f1e  make-tests.patch
 d19ad61cffb6434f1433c2da29dc6c137076125ddd23936ca26298db5d120dc8ec64788556599a1a8522d10630bca48258d7dfa9fd633551b791275bdc2c68d0  skip-duplicate-bsd-test-on-s390x.patch"

--- a/main/parted/parted-include-sysmacros.patch
+++ b/main/parted/parted-include-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/libparted/arch/linux.c
++++ b/libparted/arch/linux.c
+@@ -38,6 +38,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/utsname.h>        /* for uname() */
+ #include <scsi/scsi.h>
+ #include <assert.h>


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of parted failed with:
```
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: ../libparted/.libs/libparted.so: undefined reference to `minor'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: ../libparted/.libs/libparted.so: undefined reference to `major'
collect2: error: ld returned 1 exit status
```
Explicitly including sys/sysmacros.h fixes the issue.