### PR TITLE
main/partimage: add required sysmacros.h header

### DIFF
--- a/main/partimage/APKBUILD
+++ b/main/partimage/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=partimage
 pkgver=0.6.9
-pkgrel=7
+pkgrel=8
 pkgdesc="Saves partitions having a supported filesystem to an image file"
 options="!check" # No testsuite
 url="http://www.partimage.org"
@@ -13,6 +13,7 @@ subpackages="$pkgname-doc"
 source="https://downloads.sourceforge.net/project/$pkgname/stable/$pkgver/$pkgname-$pkgver.tar.bz2
 	partimage-0.6.9-zlib-1.2.6.patch
 	partimage-0.6.9-common.patch
+	partimage-include-sysmacros.patch
 	Use-SSLv3-by-default.patch
 	openssl-1.1.patch
 	"
@@ -41,5 +42,6 @@ package() {
 sha512sums="252885921b23933fdcdf0bb6efa4b82066b08ca95cc653296912d384ae875b421c1d39f347a90115315139176d4eab4a930c24919c2d38cf00ed29c764cd14d9  partimage-0.6.9.tar.bz2
 f6feaf6967620ca5512aec50ada13e1b3676976ee2e04cebb3cd64c991ec8be47b337cd99c2656b3a1c77ce4ea25661784a8217f6d8325fd346f1d15463392ce  partimage-0.6.9-zlib-1.2.6.patch
 39faba3b75302c0fb04e343b3854549c06447e28040f9c49a83d595533901e3c6af252a18d8db0394cbaabc7c9c1bde014f2d423cab80dadb6ea5322dc19a381  partimage-0.6.9-common.patch
+bffd175117aa18f558521b0b33eeeb287b88e0c64e69209802e49f9284da72a7443eeb47b62de928f198e20ff0c06d86ffe3bb29fdb5119adf7bc9aa39b608f3  partimage-include-sysmacros.patch
 580d9ef868b423fd77282839f619239f92789e202fc25cb2ee409ecc43424f89bd5d31314a6aba183ef36a61b427cb24a0ca1f62f53235b5bc60f574c5469a1b  Use-SSLv3-by-default.patch
 bd1bc43bed6d6829ea8d15ff8b278807815de776c8f4fe1a86a1c3695dd3c8cadc155e5bcaf7f030ca8d0fac10ad3ad48a52a29cde15832511ae52fcc307edb6  openssl-1.1.patch"

--- a/main/partimage/partimage-include-sysmacros.patch
+++ b/main/partimage/partimage-include-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/src/client/misc.cpp
++++ b/src/client/misc.cpp
+@@ -40,6 +40,7 @@
+ 
+ #include <ctype.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/ioctl.h>
+ #include <sys/mount.h>
+ #include <sys/time.h>


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of partimage fails with:
```
misc.cpp: In function 'int checkInodeForDevice(char*, char*)':
misc.cpp:1683:103: error: expected ';' before ')' token
       nRes = mknod(szDevice, S_IFBLK | S_IREAD | S_IWRITE | S_IRGRP | S_IROTH, makedev(nMajor, nMinor));
                                                                                                       ^  
```
Explicitly including sys/sysmacros.h fixes the issue.