### PR TITLE
main/squashfs-tools: add required sysmacros.h header

### DIFF
--- a/main/squashfs-tools/APKBUILD
+++ b/main/squashfs-tools/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=squashfs-tools
 pkgver=4.3
-pkgrel=5
+pkgrel=6
 pkgdesc="Tools for squashfs, a highly compressed read-only filesystem for Linux."
 url="http://squashfs.sourceforge.net"
 arch="all"
@@ -12,6 +12,7 @@ source="https://downloads.sourceforge.net/sourceforge/squashfs/squashfs$pkgver.t
 	fix-compat.patch
 	vla-overlow.patch
 	CVE-2015-4645.patch
+	squashfs-tools-include-sysmacros.patch
 	0001-mksquashfs-fix-rare-race-in-fragment-waiting-in-file.patch
 "
 
@@ -37,18 +38,9 @@ package() {
 	mkdir -p "$pkgdir"/sbin
 	cp -a mksquashfs unsquashfs "$pkgdir"/sbin
 }
-md5sums="d92ab59aabf5173f2a59089531e30dbf  squashfs4.3.tar.gz
-1bb2bed6830d32b76f1ca1b6c0349fcd  fix-compat.patch
-d34cb53db691f0fb58425bb5ab30f6d4  vla-overlow.patch
-c475b848e0c2e2b2eef3ddf2e3c23803  CVE-2015-4645.patch
-4434a07ea1607bf93178b9cbb73e15fb  0001-mksquashfs-fix-rare-race-in-fragment-waiting-in-file.patch"
-sha256sums="0d605512437b1eb800b4736791559295ee5f60177e102e4d4ccd0ee241a5f3f6  squashfs4.3.tar.gz
-249d10b4df7921fae5e0ab4c1f44f3346229f16851240d61a24e85006ed886e6  fix-compat.patch
-213f3f23576c99099305f717a279507913ab2b8df4dd8f502153e73b2d0a9df5  vla-overlow.patch
-ff71a62a435a9089b0fc95280aa3a8310b131653d37e55eed10a0f7d0100359b  CVE-2015-4645.patch
-4075a51f2e46c539a4184c832590a166ef60951f06a8b53652b2ebf2e2c62a01  0001-mksquashfs-fix-rare-race-in-fragment-waiting-in-file.patch"
 sha512sums="854ed7acc99920f24ecf11e0da807e5a2a162eeda55db971aba63a03f0da2c13b20ec0564a906c4b0e415bd8258b273a10208c7abc0704f2ceea773aa6148a79  squashfs4.3.tar.gz
 868e3923f98a7f8bb980fe8ab0d648e9ae9a55e324bea3830d6047aa348a4302dcb96d65bf59c6e04665891d822e18fad367a37c6704505b8492f64d749fc140  fix-compat.patch
 975d09d047f4122866e83c4322ce3a15795c051b850d14a85a615c3beef970378e5a620ee16058b9c5104c53f973f9b3804d96c3ba1ab4f622f1e096c04e0360  vla-overlow.patch
 77431a0a4a529ce63f1613a65a23af2fb8683a16d14ad1a5cfed3a9fac4df6a1212f081d1879ede188a25b77e860445058012131423c546657fb562069865d2c  CVE-2015-4645.patch
+7617182cc4698ace9d8f984e56a910f5727c82e66a6cf0024e1f1fe7d03acd45175cce96e3683732d40dd0d6fe854822e233f80fc615bf2ec8e27d423f0c1c60  squashfs-tools-include-sysmacros.patch
 1b2338a448ec8a2b75880ddc8c13f99392451847ab26277e1bc82b49a3a804796934e212dd1ba54a502940537a61891ee0103e913d0bda65cff0ca2827b8b41c  0001-mksquashfs-fix-rare-race-in-fragment-waiting-in-file.patch"

--- a/main/squashfs-tools/squashfs-tools-include-sysmacros.patch
+++ b/main/squashfs-tools/squashfs-tools-include-sysmacros.patch
@@ -1,0 +1,20 @@
+--- a/squashfs-tools/mksquashfs.c
++++ b/squashfs-tools/mksquashfs.c
+@@ -34,6 +34,7 @@
+ #include <stdio.h>
+ #include <stddef.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <errno.h>
+--- a/squashfs-tools/unsquashfs.c
++++ b/squashfs-tools/unsquashfs.c
+@@ -33,6 +33,7 @@
+ 
+ #include <sys/sysinfo.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/time.h>
+ #include <sys/resource.h>
+ #include <limits.h>


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of squashfs-tools fails with:
```
mksquashfs.c:987:24: error: called object 'major' is not a function or function pointer
   unsigned int major = major(buf->st_rdev);
                        ^~~~~                    
```
Explicitly including sys/sysmacros.h fixes the issue.