### PR TITLE
main/socat: fix IP-SENDTO on musl

### DIFF
--- a/main/socat/0001-xiogetaddrinfo-support-SOCK_RAW.patch
+++ b/main/socat/0001-xiogetaddrinfo-support-SOCK_RAW.patch
@@ -1,0 +1,43 @@
+From dd103797da3a4bf8c662119b3ff717e0ca072cd7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6ren=20Tempel?= <soeren+git@soeren-tempel.net>
+Date: Mon, 12 Aug 2019 22:46:36 +0200
+Subject: [PATCH] xiogetaddrinfo: support SOCK_RAW
+
+The functions from xio-rawip.c call xiogetaddrinfo with this socktype.
+Unfortunately, xiogetaddrinfo silently discards it.
+
+For this reason IP-SENDTO function do not work with musl libc, e.g.
+Alpine Linux. On these systems socat aborts with the following error
+message:
+
+	socat - IP6-SENDTO:localhost:6
+	2019/08/12 22:48:34 socat[12846] E getaddrinfo("localhost", "NULL", {1,10,2,6}, {}): Unrecognized service
+
+This patches fixes this issue.
+---
+ xio-ip.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/xio-ip.c b/xio-ip.c
+index a2252b2..8aa414b 100644
+--- a/xio-ip.c
++++ b/xio-ip.c
+@@ -121,7 +121,7 @@ unsigned long res_opts() {
+    hostname.domain (fq hostname resolving to IPv4 or IPv6 address)
+  service: the port specification; may be numeric or symbolic
+  family: PF_INET, PF_INET6, or PF_UNSPEC permitting both
+- socktype: SOCK_STREAM, SOCK_DGRAM
++ socktype: SOCK_STREAM, SOCK_DGRAM, SOCK_RAW
+  protocol: IPPROTO_UDP, IPPROTO_TCP
+  sau: an uninitialized storage for the resulting socket address
+  returns: STAT_OK, STAT_RETRYLATER
+@@ -202,7 +202,8 @@ int xiogetaddrinfo(const char *node, const char *service,
+    if (node != NULL || service != NULL) {
+       struct addrinfo *record;
+ 
+-      if (socktype != SOCK_STREAM && socktype != SOCK_DGRAM) {
++      if (socktype != SOCK_STREAM && socktype != SOCK_DGRAM &&
++	  socktype != SOCK_RAW) {
+ 	 /* actual socket type value is not supported - fallback to a good one */
+ 	 socktype = SOCK_DGRAM;
+       }

--- a/main/socat/APKBUILD
+++ b/main/socat/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=socat
 pkgver=1.7.3.3
-pkgrel=0
+pkgrel=1
 pkgdesc="Multipurpose relay for binary protocols"
 # test  58 CHILDDEFAULT: child process default properties... FAILED:
 # ./socat -t 0.1  -u exec:./procan -
@@ -16,6 +16,7 @@ subpackages="$pkgname-doc"
 source="http://www.dest-unreach.org/$pkgname/download/$pkgname-$pkgver.tar.bz2
 	use-linux-headers.patch
 	netdb-internal.patch
+	0001-xiogetaddrinfo-support-SOCK_RAW.patch
 	"
 
 build() {
@@ -44,4 +45,5 @@ package() {
 
 sha512sums="6073facb3db7cd24b9380f400876d73537b52b8e53ff6aac080388c2b1fc4a2decdfac7ce23bff6ab680fb2751251cda7fc67be9b09954edc46f449e0a7d0c7e  socat-1.7.3.3.tar.bz2
 2032b6528cb27b69d8fb6a6f64af32fcc1f6e4934bb0d7c8931b38ab7ad5e27f6f4344a6cf49751fa3178cd725f954e195373362f7d5929e587d7f0309346059  use-linux-headers.patch
-22a6e0c2317a9317997c98114daac258ebbcc3d8e58e49a6ebf24781b98967afed47c63807282582fa0909076fe349281f05e4462faacb90e7aabc853903d6e6  netdb-internal.patch"
+22a6e0c2317a9317997c98114daac258ebbcc3d8e58e49a6ebf24781b98967afed47c63807282582fa0909076fe349281f05e4462faacb90e7aabc853903d6e6  netdb-internal.patch
+4679b9db042a8398c96f96cdcabbde0ead6e52c08098372cc7bb468cc21593027d6824d6ff5c92eb1e7c1e5f0138a0ec23ea51b3bc63d5f21e7266f6790a25b1  0001-xiogetaddrinfo-support-SOCK_RAW.patch"


### PR DESCRIPTION
Without this patch IP-SENDTO doesn't work on Alpine (probably due to musl) because socat uses `SOCK_DGRAM (2)` as a socktype even for raw ip sockets. This patchs makes sure that it uses `SOCK_RAW (3)` for raw ip sockets.

To verify that `IP-SENDTO` doesn't work without this patch run the following command:

```
# socat - IP6-SENDTO:localhost:6
2019/08/12 22:48:34 socat[12846] E getaddrinfo("localhost", "NULL", {1,10,2,6}, {}): Unrecognized service
```

The element `2` in the output  `{1,10,2,6}` indicates the incorrect socktype (`SOCK_DGRAM`).

---

*I also submitted this patch upstream, haven't received a response yet though.*