### PR TITLE
community/shadow: remove usr/share/man/man1/passwd.1.gz provided by openssl-doc

### DIFF
--- a/community/shadow/APKBUILD
+++ b/community/shadow/APKBUILD
@@ -1,14 +1,12 @@
-# Contributor:
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=shadow
 pkgver=4.6
-pkgrel=2
+pkgrel=3
 pkgdesc="PAM-using login and passwd utilities (usermod, useradd, ...)"
 url="http://pkg-shadow.alioth.debian.org/"
 arch="all"
-license="GPL"
-depends=""
+license="BSD-3-Clause"
 makedepends="linux-pam-dev"
 subpackages="$pkgname-doc $pkgname-dbg $pkgname-uidmap"
 source="https://github.com/shadow-maint/shadow/releases/download/$pkgver/shadow-$pkgver.tar.xz
@@ -27,11 +25,8 @@ source="https://github.com/shadow-maint/shadow/releases/download/$pkgver/shadow-
 #   - CVE-2016-6252
 
 options="suid"
-builddir="$srcdir/shadow-$pkgver"
 
 build() {
-	cd "$builddir"
-
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -54,13 +49,10 @@ build() {
 }
 
 check() {
-	cd "$builddir"
 	make check
 }
 
 package() {
-	cd "$builddir"
-
 	make DESTDIR="$pkgdir" install
 
 	# Do not install these pam.d files they are broken and outdated.
@@ -92,7 +84,8 @@ package() {
 
 	# Avoid conflict with man-pages.
 	rm "$pkgdir"/usr/share/man/man3/getspnam.3* \
-		"$pkgdir"/usr/share/man/man5/passwd.5*
+		"$pkgdir"/usr/share/man/man5/passwd.5* \
+		"$pkgdir"/usr/share/man/man1/passwd.1*
 }
 
 uidmap() {


### PR DESCRIPTION
* Fix license
* Modernize

fixes #10724