### PR TITLE
main/nginx: security upgrade to 1.16.1

### DIFF
--- a/main/nginx/APKBUILD
+++ b/main/nginx/APKBUILD
@@ -4,6 +4,10 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 #
 # secfixes:
+#   1.16.1-r0:
+#     - CVE-2019-9511
+#     - CVE-2019-9513
+#     - CVE-2019-9516
 #   1.14.1-r0:
 #     - CVE-2018-16843
 #     - CVE-2018-16844
@@ -14,11 +18,11 @@
 pkgname=nginx
 # NOTE: Upgrade only to even-numbered versions (e.g. 1.14.z, 1.16.z)!
 # Odd-numbered versions are mainline (development) versions.
-pkgver=1.16.0
-pkgrel=4
+pkgver=1.16.1
+pkgrel=0
 # Revision of nginx-tests to use for check().
-_tests_hgrev=34e86a28cabd
-_njs_ver=0.3.3
+_tests_hgrev=40e5f2a0a238
+_njs_ver=0.3.4
 pkgdesc="HTTP and reverse proxy server (stable version)"
 url="https://www.nginx.org/"
 arch="all"
@@ -314,9 +318,9 @@ _module() {
 	done
 }
 
-sha512sums="e99cfaa4538f209c096ea2f93c04b5019756617f3bcd3305c273e98ddc89fed5bf90d65fb9b493149bc47d55ff79e73850bfcac20505fab74930d0102075df3d  nginx-1.16.0.tar.gz
-8739ee77b02c10454ef24429074eec2066e01ae012ba2c48a9cd1ff40fe1f735219ff03c68ecf33e3c8577969a0fcfafec5fa6cd9ff48007d9ea004c5460af36  nginx-tests-34e86a28cabd.tar.gz
-99d8a05865b14bd320180812ea77c7c6d5d86368ed3842f8f819d7f3713eefd27eae41f7f23c4d3a2eede1d82e792750b1d1597647992e71925f51a8670b908f  nginx-njs-0.3.3.tar.gz
+sha512sums="17e95b43fa47d4fef5e652dea587518e16ab5ec562c9c94355c356440166d4b6a6a41ee520d406e5a34791a327d2e3c46b3f9b105ac9ce07afdd495c49eca437  nginx-1.16.1.tar.gz
+69ebc81dba60c062e3a0e1ba0a7e1f2c2bf74f38f2bbd4dd0c5608e6c6965b819dc3c57fe21b596c1faceef61bc4a1c804eb9634f8824d62bc9293d17cd2bab2  nginx-tests-40e5f2a0a238.tar.gz
+41e398662b30d0ec8dd802a139af939470896f73397c2890d08300811fb50def64c847fa0541f076aee50985376e4131f943c09116a05589774b25d17b6b982c  nginx-njs-0.3.4.tar.gz
 ac7e3153ab698b4cde077f0d5d7ac0a58897927eb36cf3b58cb01268ca0296f1d589c0a5b4f889b96b5b4a57bef05b17c59be59a9d7c4d7a3d3be58f101f7f41  nginx.conf
 0907f69dc2d3dc1bad3a04fb6673f741f1a8be964e22b306ef9ae2f8e736e1f5733a8884bfe54f3553fff5132a0e5336716250f54272c3fec2177d6ba16986f3  default.conf
 09b110693e3f4377349ccea3c43cb8199c8579ee351eae34283299be99fdf764b0c1bddd552e13e4d671b194501618b29c822e1ad53b34101a73a63954363dbb  nginx.logrotate


### PR DESCRIPTION
https://mailman.nginx.org/pipermail/nginx-announce/2019/000249.html