### PR TITLE
testing/go-ipfs: upgrade to 0.4.22

### DIFF
--- a/testing/go-ipfs/APKBUILD
+++ b/testing/go-ipfs/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=go-ipfs
-pkgver=0.4.21
-pkgrel=1
+pkgver=0.4.22
+pkgrel=0
 pkgdesc="Inter Platnetary File System (IPFS), a peer-to-peer hypermedia distribution protocol"
 url="https://ipfs.io/"
 arch="x86_64 x86 aarch64 armhf armv7"
@@ -64,6 +64,6 @@ cleanup_srcdir() {
 	default_cleanup_srcdir
 }
 
-sha512sums="570ea2c126538b88264242bac961cabfed5bf964e3e4ff294978f96aaf931a3df9d5a82659255cefbeedc00b748b8933a28d9862a233760e35d4ae9993e18dad  go-ipfs-0.4.21.tar.gz
+sha512sums="4ffb76a862aba2ab457f70f706099388785818d8a975c746d84bca7103001e1c43a66892acee0bb2e27e0c7dc35c5ca9fd7edfd990d1aa9172d43e2231363ba0  go-ipfs-0.4.22.tar.gz
 3e51e9a3dca1b991e8549f8354f7c2cfd1bb9b73d7a59557878d5c9ab4189988676d789172af3ba1fd57193ec48ca9125919507b0de7d0400ce0d6166622e556  ipfs.initd
 c55afeb3efe381d18258ddf00f58325b77156375cf223fb2daa049df056efe22e9139cce0f81dc4c73759dad5097af5f3201414beb5950bd894df9ae8c7c4ed1  ipfs.confd"


### PR DESCRIPTION
- https://github.com/ipfs/go-ipfs/releases 0.4.22