### PR TITLE
testing/xmrig: upgrade to 3.0.0

### DIFF
--- a/testing/xmrig/APKBUILD
+++ b/testing/xmrig/APKBUILD
@@ -2,14 +2,14 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 
 pkgname=xmrig
-pkgver=2.14.4
+pkgver=3.0.0
 pkgrel=0
 pkgdesc="XMRig is a high performance Monero (XMR) miner"
 url="https://github.com/xmrig/xmrig"
 arch="all !s390x !ppc64le"
 license="GPL-3.0-or-later"
 options="!check" # No test suite from upstream
-makedepends="cmake libmicrohttpd-dev libuv-dev openssl-dev"
+makedepends="cmake libmicrohttpd-dev libuv-dev openssl-dev hwloc-dev"
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/xmrig/xmrig/archive/v$pkgver.tar.gz"
 
@@ -32,4 +32,4 @@ package() {
 	install -Dm 644 -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
 }
 
-sha512sums="eaa43f9916e90f4d211ab037402cc898192a38c907a47920636defa387cc2b0535362423f929404555fa7f765fdf9f5ace0e506ded4d92653dcddd98055ad5c3  xmrig-2.14.4.tar.gz"
+sha512sums="1a5027452d1323c806668f2b83297caf07519ede704749cd8a476651a0dd8b842a703301642b9117d50b39225ca560f2382029788a57d129c484018cff2a66a2  xmrig-3.0.0.tar.gz"


### PR DESCRIPTION
- https://github.com/xmrig/xmrig/releases 3.0.0
- New element in makedepends: hwloc-dev