### PR TITLE
testing/hwloc: upgrade to 1.11.13

### DIFF
--- a/testing/hwloc/APKBUILD
+++ b/testing/hwloc/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Daniel Sabogal <dsabogalcc@gmail.com>
 pkgname=hwloc
-pkgver=1.11.9
+pkgver=1.11.13
 pkgrel=0
 pkgdesc="Portable abstraction of hierarchical hardware architectures"
 url="https://www.open-mpi.org/"
@@ -40,4 +40,4 @@ _tools() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr
 }
 
-sha512sums="59198b460e2acb9ff0f8b06a86116a2ab67515e92035d3ecc1619ddbe42c7dd8991acab9cfe9c7130517238552aa570e3a51d135773ba34fbe343f2dfe48d956  hwloc-1.11.9.tar.bz2"
+sha512sums="dd38bcc9a5df2dcfd3bbd828ab13fdb1c1d21747a0b62e6c87df95d2835c0472590344ff5bda4f6c28e597eaba1ea11c0bc96907ad45f1215f51f95ac9f58138  hwloc-1.11.13.tar.bz2"


### PR DESCRIPTION
- https://www.open-mpi.org/software/hwloc/v1.11/ 1.11.13
