### PR TITLE
[3.10] community/znc: security upgrade to 1.7.4

### DIFF
--- a/community/znc/APKBUILD
+++ b/community/znc/APKBUILD
@@ -1,10 +1,10 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=znc
-pkgver=1.7.3
-pkgrel=2
+pkgver=1.7.4
+pkgrel=0
 pkgdesc="Advanced IRC bouncer"
-url="http://znc.in"
+url="https://wiki.znc.in/ZNC"
 arch="all"
 license="Apache-2.0"
 makedepends="perl-dev openssl-dev cyrus-sasl-dev python2-dev c-ares-dev swig
@@ -20,6 +20,8 @@ source="http://znc.in/releases/znc-$pkgver.tar.gz
 builddir="$srcdir/znc-$pkgver"
 
 # secfixes:
+#   1.7.4-r0:
+#   - CVE-2019-12816
 #   1.7.3-r0:
 #   - CVE-2019-9917
 #   1.7.1-r0:
@@ -111,6 +113,6 @@ _mv_to_sub() {
 	done
 }
 
-sha512sums="4cd63be2cb3bc1e3950f38984b128c6511bd1b9fc01a00d51cfcdc46826c2dedad120d6ed8e30d9c400909e33d39b2b14579fb40ee1e3508b7f3a07eff3a15d8  znc-1.7.3.tar.gz
+sha512sums="ea559ee9e06bfbc51c03ef08e145bc39ee7402638cc153fab7dc1dcedae01548fa0743d726304f9e4631a66241eb96c03940b76093954093a35f69641133b2ae  znc-1.7.4.tar.gz
 47f9bd00f07861e195333d2cda5b1c7386e2324a1842b890837a7936a94b65b7a269f7fee656a522ec86b58a94bd451a2a3629bd6465578681b8d0733c2c77dc  znc.initd
 00360f9b487ed5a9d50c85ce597e65c89cf869cabb893c294d0bc7fcd88f9610ecb63ba6df7af1ba1dd977b6d5b05da625a3ee799a46d381f17ac04b976a1f29  znc.confd"


### PR DESCRIPTION
This fixes CVE-2019-12816. Also fix the website while we're at it.

ref #10732