### PR TITLE
community/h2o: security upgrade to 2.2.6

### DIFF
--- a/community/h2o/APKBUILD
+++ b/community/h2o/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Bennett Goble <nivardus@gmail.com>
 # Maintainer: Bennett Goble <nivardus@gmail.com>
 pkgname=h2o
-pkgver=2.2.5
-pkgrel=4
+pkgver=2.2.6
+pkgrel=0
 pkgdesc="An optimized HTTP/1, HTTP/2 server written in C"
 url="https://h2o.examp1e.net"
 arch="all"
@@ -18,6 +18,13 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$
 	h2o.logrotate"
 
 builddir="$srcdir/$pkgname-$pkgver"
+
+# secfixes:
+#   2.2.6-r0:
+#   - CVE-2019-9512
+#   - CVE-2019-9514
+#   - CVE-2019-9515
+
 build() {
 	cd "$builddir"
 	cmake \
@@ -49,7 +56,7 @@ package() {
 	install -m700 -d "$pkgdir"/var/log/$pkgname
 }
 
-sha512sums="24b07140d24fbb7796038aab44f44be5ffabc6f2841954273e2ad9f1a864e5482051dd7abfa6446297a46b6868763114695fa4f123ee3175bdac53b4c1868bc2  h2o-2.2.5.tar.gz
+sha512sums="f2f28905c01782a0432c9dfdb2f21054e0a4741ac4c5f26802d4b439d0172840aa215aba5dc7c9af62275dcc24de105674a3819384dc38246e43ce3e8263eb20  h2o-2.2.6.tar.gz
 ac0b587cc55124a350b42470d1f514f6cb4624914f92bcc3ed125909e98ef62101d452c098bb381f71b1becd7d21bc6a0d33c3890db72e92976d373406623e6f  h2o-libressl-2.7.0.patch
 444f55c3eaae1f349223036086e45c983ea8be89e793068537ec25488c4065174bc509d0987ddc65a0357cb8acfec272e90d13ea7cdadf9cf112953d857aa574  h2o.conf
 e93e66a6b00b1bff94e37489c5fdf99d9d657adc63975ec54be30f8da23dafe7d7389f02a6452ed819efc9d8398aa716782a7fd6d8509621a975ed954b73bef9  h2o.initd


### PR DESCRIPTION
- CVE-2019-9512
- CVE-2019-9514
- CVE-2019-9515

Ref https://github.com/h2o/h2o/releases/tag/v2.2.6