### PR TITLE
testing/ldc: new aport

### DIFF
--- a/testing/ldc/APKBUILD
+++ b/testing/ldc/APKBUILD
@@ -1,0 +1,112 @@
+# -*- shell-script -*-
+# Contributor: Mathias LANG <pro.mathias.lang@gmail.com>
+# Maintainer: Mathias LANG <pro.mathias.lang@gmail.com>
+#
+# This package is divided between the actual package,
+# and the two subpackages, 'static' and 'runtime'.
+# The main package depends on them.
+# A user might want to install 'runtime' when they have
+# a dynamically-linked D program.
+pkgname=ldc
+pkgver=1.8.0
+pkgrel=0
+pkgdesc="The LLVM-based D Compiler"
+url="https://github.com/ldc-developers/ldc"
+# Bootstrapping was done with an upstream-provided package,
+# with only x86_64 available
+# Once we can use GDC for bootstrapping, this can be "all"
+arch="x86_64"
+license="BSD-3-Clause AND BSL-1.0 AND (Artistic-1.0 OR GPL-2.0-or-later) AND NCSA AND NCSA AND MIT"
+depends="libexecinfo"
+makedepends="chrpath cmake llvm5-libs libexecinfo-static"
+subpackages="$pkgname-runtime $pkgname-doc $pkgname-static"
+provides="dlang-compiler"
+source="https://github.com/ldc-developers/ldc/releases/download/v$pkgver/ldc2-$pkgver-alpine-linux-x86_64.tar.xz
+		ldc2.package.conf"
+builddir="$srcdir/"
+
+build() {
+	rootdir="$srcdir/ldc2-$pkgver-alpine-linux-x86_64/"
+
+	# Unfortunately the upstream-provided version has the builder's /home/ in its rpath - strip it
+	chrpath -d "$rootdir/bin/ldc2"
+	chrpath -d "$rootdir/bin/ldmd2"
+	# This exe is not installed, just used in build, but do it for completeness
+	chrpath -d "$rootdir/bin/ldc-build-runtime"
+
+	# Now build the runtime - the compiler itself is already built by upstream
+	"$rootdir"/bin/ldc-build-runtime --buildDir="$builddir/ldc-runtime-build/"
+
+	# CMake added the rpaths to the shared libs - strip them
+	chrpath -d "$builddir"/ldc-runtime-build/lib/*.so
+	:
+}
+
+check() {
+	rootdir="$srcdir/ldc2-$pkgver-alpine-linux-x86_64/"
+	libroot="$builddir/ldc-runtime-build/lib/"
+
+	echo 'import std.stdio; void main () { try throw new Exception(null); catch (Exception) writeln("Hello World!"); }' > hello_world.d
+	if [ "$($rootdir/bin/ldmd2 -conf='' -I$rootdir/import/ldc -I$rootdir/import/ -L-L$libroot -defaultlib=phobos2-ldc,druntime-ldc -L-lexecinfo -L-rpath=$libroot -run hello_world.d)" != "Hello World!" ]; then
+		return 1
+	fi
+	:
+}
+
+package() {
+	depends="$pkgname-runtime $pkgname-static"
+	rootdir="$srcdir/ldc2-$pkgver-alpine-linux-x86_64/"
+
+	install -s -D "$rootdir/bin/ldc2"  "$pkgdir/usr/bin/ldc2"
+	install -s -D "$rootdir/bin/ldmd2" "$pkgdir/usr/bin/ldmd2"
+
+	install -D "$srcdir/ldc2.package.conf" "$pkgdir/etc/ldc2.conf"
+
+	install -D "$rootdir/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+	# Install the import files
+	for impfile in $(find "$rootdir/import" -name "*.d*");
+	do
+		target="${impfile##*import/}"
+		install -D "$impfile" "$pkgdir/usr/include/dlang/$pkgname-$pkgver/$target"
+	done
+
+	# Install the static runtime libraries
+	for libn in "libdruntime-ldc" "libdruntime-ldc-debug" "libphobos2-ldc" "libphobos2-ldc-debug";
+	do
+		install -D "$builddir/ldc-runtime-build/lib/$libn.a" "$pkgdir/usr/lib/$libn.a"
+	done
+
+	# Install the shared runtime libraries
+	for libn in "libdruntime" "libphobos2";
+	do
+		install -D "$builddir/ldc-runtime-build/lib/$libn-ldc-shared.so.2.0.78" "$pkgdir/usr/lib/$libn-ldc-shared.so.2.0.78"
+	done
+}
+
+runtime() {
+	depends="libexecinfo-dev"
+	pkgdesc="Dynamic runtime library for D code compiled with $pkgname-$pkgver"
+
+	mkdir -p "$subpkgdir/usr/lib/"
+	for libn in "libdruntime" "libphobos2";
+	do
+		mv "$pkgdir/usr/lib/$libn-ldc-shared.so.2.0.78" "$subpkgdir/usr/lib/$libn-ldc-shared.so.2.0.78"
+		ln -s "$libn-ldc-shared.so.2.0.78" "$pkgdir/usr/lib/$libn-ldc-shared.so.78"
+		ln -s "$libn-ldc-shared.so.2.0.78" "$pkgdir/usr/lib/$libn-ldc-shared.so"
+	done
+
+	mv "$pkgdir"/usr/lib/*.so* "$subpkgdir/usr/lib/"
+	:
+}
+
+static() {
+	depends="libexecinfo-static"
+	pkgdesc="$pkgdesc (static library)"
+
+	mkdir -p "$subpkgdir/usr/lib/"
+	mv "$pkgdir"/usr/lib/*.a "$subpkgdir/usr/lib/"
+}
+
+sha512sums="3a870c9e7e9500d4e2a47e53d10cb10641319223200e3730abf9b6debf1c261cef11bac0b797ee2aa66c63c950461326273e0c14685b6d641155de307997e1af  ldc2-1.8.0-alpine-linux-x86_64.tar.xz
+0fd1613ffdd52db1f486ad15bc5f2df2f2f1b94bddf12d67a38897f73cd83d5d222bb184dd88df1058be9f9d31fdb6c8d6850d6ce672d25e4a0cbbf579d248a1  ldc2.package.conf"

--- a/testing/ldc/ldc2.package.conf
+++ b/testing/ldc/ldc2.package.conf
@@ -1,0 +1,24 @@
+// See comments in driver/config.d in ldc source tree for grammar description of
+// this config file.
+
+// The default group is required
+default:
+{
+	// default switches injected before all explicit command-line switches
+	switches = [
+		// ldc2 is installed in $pkgdir/usr/bin/ldc2
+		// Imports are in $pkgdir/usr/include/dlang/ldc-1.8.0/
+		"-I%%ldcbinarypath%%/../include/dlang/ldc-1.8.0/ldc/",
+		"-I%%ldcbinarypath%%/../include/dlang/ldc-1.8.0/",
+		"-defaultlib=phobos2-ldc,druntime-ldc"
+	];
+	// default switches appended after all explicit command-line switches
+	post-switches = [
+		// libs are installed to $pkgdir/usr/lib/
+		// `libexecinfo` includes `backtrace`, which is used by druntime,
+		// and is part of glibc
+		"-L-L%%ldcbinarypath%%/../lib",
+		"-L--no-warn-search-mismatch",
+		"-L-lexecinfo"
+	];
+};


### PR DESCRIPTION
```
This add a package to support the D Programming Language.
Currently, one has to jump through hoops in order to use D on Alpine.
This packages installs the official (and only) LDC build that came
with an Alpine build, LDC-1.8.0.
While it is an old version of the compiler, 2.078.3,
it can be used to bootstrap other compiler versions.
```

Note: D compilers have their frontend written in D since a few years.
This cause obvious problems of self-hosting.
We have 3 compilers:
- DMD, the reference compiler;
- GDC, based on GCC and included with it since GCC9
- LDC, based on LLVM

My plan was to originally use GCC9, but some backports are necessary to support musl, and response time has been slow.
The LDC guys however provided a build for musl last year, but it was never made a package.
Once this is in, I'd like to use it as a base to compile the new compilers (new DMD and new LDC, a new GCC will come as self hosted) and other tools (e.g. our package manager).
[This is the same approach that was used for Rust](https://github.com/alpinelinux/aports/commit/2a8472b921baf8c2ac35688df5188f034b526441#diff-0d0f9a278fdcdf00a9167fd4861cdfe7R16-R25), except it uses an upstream-provided binary instead of one compiled by a contributor.

Things I wasn't sure about:
- The "LICENSE" file was a bit complicated: I included "Some part" but didn't see an example for multi-licensed code.