### PR TITLE
main/nginx: upgrade njs to 0.3.5

### DIFF
--- a/main/nginx/APKBUILD
+++ b/main/nginx/APKBUILD
@@ -19,10 +19,10 @@ pkgname=nginx
 # NOTE: Upgrade only to even-numbered versions (e.g. 1.14.z, 1.16.z)!
 # Odd-numbered versions are mainline (development) versions.
 pkgver=1.16.1
-pkgrel=0
+pkgrel=1
 # Revision of nginx-tests to use for check().
 _tests_hgrev=40e5f2a0a238
-_njs_ver=0.3.4
+_njs_ver=0.3.5
 pkgdesc="HTTP and reverse proxy server (stable version)"
 url="https://www.nginx.org/"
 arch="all"
@@ -320,7 +320,7 @@ _module() {
 
 sha512sums="17e95b43fa47d4fef5e652dea587518e16ab5ec562c9c94355c356440166d4b6a6a41ee520d406e5a34791a327d2e3c46b3f9b105ac9ce07afdd495c49eca437  nginx-1.16.1.tar.gz
 69ebc81dba60c062e3a0e1ba0a7e1f2c2bf74f38f2bbd4dd0c5608e6c6965b819dc3c57fe21b596c1faceef61bc4a1c804eb9634f8824d62bc9293d17cd2bab2  nginx-tests-40e5f2a0a238.tar.gz
-41e398662b30d0ec8dd802a139af939470896f73397c2890d08300811fb50def64c847fa0541f076aee50985376e4131f943c09116a05589774b25d17b6b982c  nginx-njs-0.3.4.tar.gz
+e7e11b5ed8703adac1d4fb3b8e82731f868eb6c1cad405e9664f3761733ebfaa9a122517ac78cf4ef93d8d78cdb58d36bdbd96dff164079a3a18e9eba60f4aae  nginx-njs-0.3.5.tar.gz
 ac7e3153ab698b4cde077f0d5d7ac0a58897927eb36cf3b58cb01268ca0296f1d589c0a5b4f889b96b5b4a57bef05b17c59be59a9d7c4d7a3d3be58f101f7f41  nginx.conf
 0907f69dc2d3dc1bad3a04fb6673f741f1a8be964e22b306ef9ae2f8e736e1f5733a8884bfe54f3553fff5132a0e5336716250f54272c3fec2177d6ba16986f3  default.conf
 09b110693e3f4377349ccea3c43cb8199c8579ee351eae34283299be99fdf764b0c1bddd552e13e4d671b194501618b29c822e1ad53b34101a73a63954363dbb  nginx.logrotate


### PR DESCRIPTION
https://nginx.org/en/docs/njs/changes.html#njs0.3.5