### PR TITLE
testing/traefik: bump to 1.7.14

### DIFF
--- a/testing/traefik/APKBUILD
+++ b/testing/traefik/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Joe Holden <jwh@zorins.us>
 # Maintainer: Joe Holden <jwh@zorins.us>
 pkgname=traefik
-pkgver=1.7.12
+pkgver=1.7.14
 pkgrel=0
 pkgdesc="The Cloud Native Edge Router"
 url="https://traefik.io"
@@ -46,19 +46,18 @@ package() {
 	install -m644 -D "$srcdir"/$pkgname.confd \
 		"$pkgdir"/etc/conf.d/$pkgname
 
-	install -m750 -o $pkgname -g $pkgname \
-		-D bin/$pkgname \
+	install -m755 -D bin/$pkgname \
 		"$pkgdir"/usr/sbin/$pkgname
 
 	setcap cap_net_bind_service=+ep \
 		"$pkgdir"/usr/sbin/$pkgname
 
 	install -m750 -o $pkgname -g $pkgname -d "$pkgdir"/etc/$pkgname
-	install -m644 -o $pkgname -g $pkgname "$srcdir"/traefik.toml \
+	install -m755 -o $pkgname -g $pkgname "$srcdir"/traefik.toml \
 		"$pkgdir"/etc/$pkgname/$pkgname.toml
 
 }
-sha512sums="99523fb3f83d30c482a64ac4d88e1e278eb79f08e396be6835e08ad97d63ac6deda58e4d5f752182e8afb9abd49f22bf2ac5606d18b4d3cbd0944f49f59bdc55  traefik-1.7.12.tar.gz
+sha512sums="ef632130ed7befb9d3e1a693f3bd708da123eb3d631a2e3662512bc91e15ca8225fc9a14930cb67657ae4786d6abdb7a9f61890e2f5be9d3f721b77e67cb7b06  traefik-1.7.14.tar.gz
 2fe42052cdb035b202c7c0a1acd5cfe9ed1800ca067f2f5588d54e6ffbdd672d7c46cfd57fcfc219cadaa24d64a0e038a20d092eb1e4c04b67b8eb83c0af74fd  traefik.initd
 1519c2f446c4bc3af8407eb367a05e5ec0491f28d56d5385b12a550c84606d84e2424aadd5d72e56e628fd1da3f0f194ab3c077e6da85ead75a256f8e8069751  traefik.confd
 140904e2358bc6dadbfb0f2c3cd83cd7aabeae1a54cd7424bbb50f941bde3273046c402352a2b888425ba74dda27d0a6e2197c2855b4fd6ad522eb9c4eaebd61  traefik.toml"


### PR DESCRIPTION
https://github.com/containous/traefik/releases/tag/v1.7.14