### PR TITLE
main/ghostscript: remove jasper-dev from makedepends

### DIFF
--- a/main/ghostscript/APKBUILD
+++ b/main/ghostscript/APKBUILD
@@ -8,7 +8,7 @@ url="https://ghostscript.com/"
 arch="all"
 license="AGPL-3.0-or-later"
 options="!check"
-makedepends="autoconf automake libjpeg-turbo-dev libpng-dev jasper-dev expat-dev
+makedepends="autoconf automake libjpeg-turbo-dev libpng-dev expat-dev
 	zlib-dev tiff-dev freetype-dev lcms2-dev gtk+3.0-dev
 	cups-dev libtool jbig2dec-dev openjpeg-dev"
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev $pkgname-gtk"


### PR DESCRIPTION
Upstream already removed support for it in favour of openjpeg

@ncopa @Ikke