### PR TITLE
community/firefox-esr: security upgrade to 68.0.2

### DIFF
--- a/community/firefox-esr/APKBUILD
+++ b/community/firefox-esr/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox-esr
-pkgver=68.0
+pkgver=68.0.2
 pkgrel=0
 pkgdesc="Firefox web browser - Extended Support Release"
 url="https://www.mozilla.org/en-US/firefox/organizations/"
@@ -74,6 +74,8 @@ _mozappdir=/usr/lib/firefox
 ldpath="$_mozappdir"
 
 # secfixes:
+#   68.0.2-r0:
+#     - CVE-2019-11733
 #   68.0-r0:
 #     - CVE-2019-11709
 #     - CVE-2019-11711
@@ -255,7 +257,7 @@ __EOF__
 	rm -f "$pkgdir"/${_mozappdirdev}/sdk/lib/libxul.so
 }
 
-sha512sums="6f4d4063822080e4e7e1c7ed3eace9ef7c302170ae30437d96ffca969440eaa633b62dc17e6379cd0be9a26c7c6824c090860bf002f0bb57ccf7c59fbc771c93  firefox-68.0esr.source.tar.xz
+sha512sums="a12fd1fec5ed5b288c83c30372b589f56f64d26fc44205d14912e56b96f3c8115cf87e592484f16eb74376cec9a65d687b54038ce3d6af1bbd66305bd92be91b  firefox-68.0.2esr.source.tar.xz
 0b3f1e4b9fdc868e4738b5c81fd6c6128ce8885b260affcb9a65ff9d164d7232626ce1291aaea70132b3e3124f5e13fef4d39326b8e7173e362a823722a85127  stab.h
 2f4f15974d52de4bb273b62a332d13620945d284bbc6fe6bd0a1f58ff7388443bc1d3bf9c82cc31a8527aad92b0cd3a1bc41d0af5e1800e0dcbd7033e58ffd71  fix-fortify-system-wrappers.patch
 84b84d2d7dbc16002510bf856796ad345ac38ef6d3254670230189bba7c2d4781714d231236d5a3d70129a4597b430c3171644b01ad0f5a5bb13b55d407337a4  fix-seccomp-bpf.patch


### PR DESCRIPTION
https://www.mozilla.org/en-US/security/advisories/mfsa2019-24/