### PR TITLE
community/bitcoin: upgrade to 0.18.1

### DIFF
--- a/community/bitcoin/APKBUILD
+++ b/community/bitcoin/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=bitcoin
-pkgver=0.17.1
+pkgver=0.18.1
 _ver=${pkgver/_/}
-pkgrel=2
+pkgrel=0
 pkgdesc="Decentralized P2P electronic cash system"
 url="https://www.bitcoin.org"
 arch="all !armhf"
@@ -15,6 +15,7 @@ subpackages="$pkgname-dev $pkgname-qt $pkgname-cli $pkgname-tx $pkgname-tests $p
 	$pkgname-doc $pkgname-openrc"
 source="$pkgname-$_ver.tar.gz::https://github.com/bitcoin/bitcoin/archive/v${_ver}.tar.gz
 	ssize_t.patch
+	skip-fs-test-utf8.patch
 	$pkgname.initd
 	$pkgname.conf
 	"
@@ -88,7 +89,8 @@ check() {
 	make check
 }
 
-sha512sums="a72008004e244ae6d8d7f52eefa7dc7d3de5fb23efad8080bcc52d79d1fb8a43bf7de9c012b37f2586e3e4e2f44014a678d63c429132200eca0ca120c820053c  bitcoin-0.17.1.tar.gz
+sha512sums="5fe10f51d1e3119a6e4f522c945ca6d280298c326d4bf4ab996bf6db79ddd1e751fa91efc7c6517083a861b1639ff529effd7cd7d0401c85a3b93d46a6bb38ee  bitcoin-0.18.1.tar.gz
 98aa5ad81bdb4ae961b791bc978c39117cdf2d83c2181f92bebbb0db107d9b6e86eda265fb3f93ff8a5ca8a7754d7148818b98095d57201dff9363d60b97e7dd  ssize_t.patch
+6856e38efbe289e64329c80de9e8489ffbdd8c6eda0f3424fe3922fc765afd90b2915cd4f23abd5bdb72e1882871b1c2fde846ced06e60963dcbdc7aad2844c0  skip-fs-test-utf8.patch
 71e5f3b5079a22b6ddecfad89363fc642d5ea7da18f1203057f626d214734467f4b933b839c269401be7af2c3dcc01afcb3b98198b7d580c56d8740b34451558  bitcoin.initd
 a31210d8db76c5a9b614a6de756c1678c0344898565ac3e5d6a34ac1bed66aec4964f1dc874294bc978f53b0e961df921655f7309df19b66c90aa6bd40379a09  bitcoin.conf"

--- a/community/bitcoin/skip-fs-test-utf8.patch
+++ b/community/bitcoin/skip-fs-test-utf8.patch
@@ -1,0 +1,13 @@
+diff --git a/src/test/fs_tests.cpp b/src/test/fs_tests.cpp
+index 6d5a6641f..b504a3cbb 100644
+--- a/src/test/fs_tests.cpp
++++ b/src/test/fs_tests.cpp
+@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(fsbridge_fstream)
+     fs::path tmpfolder = GetDataDir();
+     // tmpfile1 should be the same as tmpfile2
+     fs::path tmpfile1 = tmpfolder / "fs_tests_₿_🏃";
+-    fs::path tmpfile2 = tmpfolder / L"fs_tests_₿_🏃";
++    fs::path tmpfile2 = tmpfolder / "fs_tests_₿_🏃";
+     {
+         fsbridge::ofstream file(tmpfile1);
+         file << "bitcoin";


### PR DESCRIPTION
Ref https://github.com/bitcoin/bitcoin/releases/tag/v0.18.1

There's another [patch that upgraded to 0.18.0](https://patchwork.alpinelinux.org/patch/4896/) but unfortunately, similarly to PR #7986, simply updating the version causes a test to fail and therefore the build. My approach is identical to the one applied for namecoin.