### PR TITLE
testing/opendetex: new aport

### DIFF
--- a/testing/opendetex/APKBUILD
+++ b/testing/opendetex/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
+# Maintainer: Sören Tempel <soeren+alpine@soeren-tempel.net>
+pkgname=opendetex
+pkgver=2.8.5
+pkgrel=0
+pkgdesc="Extract plain text from TeX and LaTeX sources"
+url="https://github.com/pkubowicz/opendetex"
+arch="all"
+license="BSD-3-Clause"
+makedepends="flex flex-dev"
+checkdepends="perl"
+subpackages="$pkgname-doc"
+source="opendetex-$pkgver.tar.gz::https://github.com/pkubowicz/opendetex/archive/v$pkgver.tar.gz
+	respect-ldflags.patch"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	make DEFS="$CFLAGS"
+}
+
+check() {
+	make test
+}
+
+package() {
+	install -Dm755 detex "$pkgdir"/usr/bin/detex
+	install -Dm644 detex.1 "$pkgdir"/usr/share/man/man1/detex.1
+
+	mkdir -p "$pkgdir"/usr/share/doc/$pkgname
+	install -m644 CONTRIBUTING ChangeLog README \
+		"$pkgdir"/usr/share/doc/$pkgname/
+}
+
+sha512sums="f8f3ca5b6d5874aa141d115a6c70873fe42f84072cb6f77fcf35adec256a3ef9ddc54663830b8888d8e4efa23d9e65875088e97eb7a3f0879b646298eda3519f  opendetex-2.8.5.tar.gz
+daf29b954b4883836377a4694762a98a5df4db0adeb6eab14ec2c0886801258453ee278cba612d30b4a8e911dd58318cdef1ea22efa2583ffbd6d52038347730  respect-ldflags.patch"

--- a/testing/opendetex/respect-ldflags.patch
+++ b/testing/opendetex/respect-ldflags.patch
@@ -1,0 +1,15 @@
+By default the Makefile ignores the LDFLAGS specified in
+/etc/abuild.conf make sure these are respected.
+
+diff -upr opendetex-2.8.5.orig/Makefile opendetex-2.8.5/Makefile
+--- opendetex-2.8.5.orig/Makefile	2019-08-18 13:47:35.008004838 +0200
++++ opendetex-2.8.5/Makefile	2019-08-18 13:48:24.344354667 +0200
+@@ -110,7 +110,7 @@ VERSION = 2.8.5
+ all:	${PROGS}
+ 
+ detex: ${D_OBJ}
+-	${CC} ${CFLAGS} -o $@ ${D_OBJ} ${LEXLIB}
++	${CC} ${CFLAGS} -o $@ ${D_OBJ} ${LEXLIB} ${LDFLAGS}
+ 
+ delatex: detex
+ 	cp detex delatex


### PR DESCRIPTION
*Just checking if it builds on all architectures.*