### PR TITLE
testing/createrepo_c: upgrade to 0.14.3

### DIFF
--- a/testing/createrepo_c/APKBUILD
+++ b/testing/createrepo_c/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor:
 # Maintainer: Paul Morgan <jumanjiman@gmail.com>
 pkgname=createrepo_c
-pkgver=0.13.1
-pkgrel=1
+pkgver=0.14.3
+pkgrel=0
 pkgdesc="C implementation of createrepo"
 url="https://github.com/rpm-software-management/createrepo_c/"
 arch="all"
@@ -90,4 +90,4 @@ bashcomp() {
 	mv "${pkgdir}"/usr/share/bash-completion "${subpkgdir}"/usr/share/
 }
 
-sha512sums="30885bde608712bb781348a45e09099b2993b2d949926f63237d5299b1b4f16fa47a2e9942ac6dbc374e7079afebf7168ec50d9d3ba7d4a4ae61cfebaa6c9265  createrepo_c-0.13.1.tar.gz"
+sha512sums="949d3831ec0a54800948e2338eaf65e3d5d4ef06fcb4cef10541eac8dd44be80aecfc06c5de1de9cb318df01fdd9369912101fcb7b7265f32daa377765e98a55  createrepo_c-0.14.3.tar.gz"


### PR DESCRIPTION
From the repo for createrepo_c:

    git log --reverse --no-merges --pretty='- %s' 0.13.1..0.14.3

- Make ownership of createrepo, mergerepo, modifyrepo symlinks conditional
- Release 0.13.2
- Fix crash when dumping updateinfo and module is ommited (RhBug:1707981)
- Use g_clear_pointer() in koji_stuff_destroy()
- Add --pkgorigins mode
- Update manpage docs
- Release 0.14.0
- Correct pkg count in headers if there were invalid pkgs (RhBug:1596211)
- Add basic unit tests for rewriting pkg count in headers
- Fix documentation inconsistency introduced in PR #92
- Update depracated glib threads calls
- Failure_exit_cleanup uses global var instead of parameter it never got
- Prevent exiting with 0 if errors occur while finalizing repodata.
- Release 0.14.1
- [spec] Obsolete createrepo on all Fedoras again (RhBug:1702771)
- Depend on the appropriate minimum version of libmodulemd
- Add explicit initialization of GMutexes and GConds (RhBug:1714666)
- Add check for fobidden control chars in package before xml_dump
- Add tests for checking if package contains forbidden control chars
- Fix various warnings when -DCMAKE_BUILD_TYPE:STRING=DEBUG
- Release 0.14.2
- detect plain tar file as non compressed
- Add missing python metadata to python2/3-createrepo_c (RhBug:1695677)
- Release 0.14.3