### PR TITLE
main/librsync: upgrade to 2.1.0

### DIFF
--- a/main/librsync/APKBUILD
+++ b/main/librsync/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Jeremy Thomerson <jeremy@thomersonfamily.com>
 # Maintainer: Jeremy Thomerson <jeremy@thomersonfamily.com>
 pkgname=librsync
-pkgver=2.0.2
-pkgrel=1
+pkgver=2.1.0
+pkgrel=0
 pkgdesc="librsync implements the rolling-checksum algorithm of rsync"
 url="https://github.com/librsync/librsync"
 arch="all"
@@ -30,4 +30,4 @@ package() {
 	install -D -m644 doc/librsync.3 "$pkgdir/usr/share/man/man3/librsync.3"
 }
 
-sha512sums="5d2bc1d62b37e9ed7416203615d0a0e3c05c4c884b5da63eda10dd5c985845b500331bce226e4d45676729382c85b41528282e25d491afda31ba434ac0fefad7  librsync-2.0.2.tar.gz"
+sha512sums="9b91f4b696c1d1cdacb5c0679c7df7a92641e0a6a599c2e5de2bc0af3052b2045bb16c40b072c40859074d792c78c57afb0817917fa9843b179befa4506ebf04  librsync-2.1.0.tar.gz"

--- a/main/librsync/APKBUILD
+++ b/main/librsync/APKBUILD
@@ -6,11 +6,17 @@ pkgrel=0
 pkgdesc="librsync implements the rolling-checksum algorithm of rsync"
 url="https://github.com/librsync/librsync"
 arch="all"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 makedepends="cmake popt-dev bzip2-dev zlib-dev perl"
 subpackages="$pkgname-dev $pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/$pkgname/$pkgname/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver"
+
+prepare() {
+	default_prepare
+	# don't invoke bash in test scripts
+	sed -i 's,#! /bin/bash,#!/bin/sh,' tests/rdiff_bad_option.sh
+}
 
 build() {
 	cd "$builddir"
@@ -21,6 +27,10 @@ build() {
 		.
 	make
 
+}
+
+check() {
+	make check
 }
 
 package() {


### PR DESCRIPTION
[Release notes](https://github.com/librsync/librsync/releases/tag/v2.1.0).