### PR TITLE
testing/libdiscid: new aport

### DIFF
--- a/testing/libdiscid/APKBUILD
+++ b/testing/libdiscid/APKBUILD
@@ -1,0 +1,25 @@
+# Maintainer: 
+pkgname="libdiscid"
+pkgver="0.6.2"
+pkgrel=0
+pkgdesc="C library for creating MusicBrainz DiscIDs from audio CDs"
+url="https://musicbrainz.org/doc/libdiscid"
+arch="all"
+license="LGPL-2.1-or-later"
+makedepends="linux-headers"
+source="http://ftp.musicbrainz.org/pub/musicbrainz/$pkgname/$pkgname-$pkgver.tar.gz"
+
+build() {
+	./configure --prefix=/usr
+	make
+}
+
+check() {
+	make check
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="7ce9bb589f64644ef44400620bd3e65a329e52c5698b44c3dc1569fb143d9af15d540b95fbdce1b87db0263e2ff55c81133213ed1708cdb25af1b38a46c4e1ac  libdiscid-0.6.2.tar.gz"


### PR DESCRIPTION
C library for creating MusicBrainz DiscIDs from audio CDs