### PR TITLE
[WIP] main/libevent: upgrade to 2.1.11

### DIFF
--- a/community/chromium/APKBUILD
+++ b/community/chromium/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=chromium
 pkgver=76.0.3809.132
-pkgrel=0
+pkgrel=1
 pkgdesc="chromium web browser"
 url="http://www.chromium.org/"
 arch="x86_64 aarch64" # disable armhf and armv7 til we sorted out clang++

--- a/community/coturn/APKBUILD
+++ b/community/coturn/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Carlo Landmeter <clandmeter@alpinelinux.org>
 pkgname=coturn
 pkgver=4.5.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Free open source implementation of TURN and STUN Server"
 url="https://github.com/coturn/coturn"
 arch="all"

--- a/community/evince/APKBUILD
+++ b/community/evince/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer:
 pkgname=evince
 pkgver=3.32.0
-pkgrel=0
+pkgrel=1
 pkgdesc="simple document viewer for GTK+"
 url="http://projects.gnome.org/evince/"
 arch="all"

--- a/community/firefox-esr/APKBUILD
+++ b/community/firefox-esr/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox-esr
 pkgver=68.1.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Firefox web browser - Extended Support Release"
 url="https://www.mozilla.org/en-US/firefox/organizations/"
 # limited by rust and cargo

--- a/community/libcouchbase/APKBUILD
+++ b/community/libcouchbase/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Nathan Johnson <nathan@nathanjohnson.info>
 pkgname=libcouchbase
 pkgver=2.10.4
-pkgrel=0
+pkgrel=1
 pkgdesc="C client library for Couchbase"
 url="https://developer.couchbase.com/community"
 arch="all"

--- a/community/libevhtp/APKBUILD
+++ b/community/libevhtp/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libevhtp
 pkgver=1.2.18
-pkgrel=0
+pkgrel=1
 pkgdesc="Flexible replacement for libevent's httpd API"
 options="!check" # No testsuite
 url="https://github.com/criticalstack/libevhtp/"

--- a/community/libreswan/APKBUILD
+++ b/community/libreswan/APKBUILD
@@ -2,7 +2,7 @@
 
 pkgname=libreswan
 pkgver=3.29
-pkgrel=0
+pkgrel=1
 pkgdesc="IPsec implementation for Linux"
 url="https://libreswan.org"
 arch="all"

--- a/community/netatalk/APKBUILD
+++ b/community/netatalk/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Alexander Rigbo <alex@dnb.nu>
 pkgname=netatalk
 pkgver=3.1.12
-pkgrel=0
+pkgrel=1
 pkgdesc="Netatalk is a freely-available Open Source AFP fileserver"
 url="http://netatalk.sourceforge.net/"
 arch="all"

--- a/community/pgbouncer/APKBUILD
+++ b/community/pgbouncer/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=pgbouncer
 pkgver=1.11.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A lightweight connection pooler for PostgreSQL"
 url="https://wiki.postgresql.org/wiki/PgBouncer"
 arch="all"

--- a/community/php7-pecl-event/APKBUILD
+++ b/community/php7-pecl-event/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=php7-pecl-event
 _pkgname=event
 pkgver=2.5.3
-pkgrel=0
+pkgrel=1
 pkgdesc="PHP extension that provides interface to libevent library - PECL"
 url="https://pecl.php.net/package/event"
 arch="all"

--- a/community/redsocks/APKBUILD
+++ b/community/redsocks/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=redsocks
 pkgver=0.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Transparent redirector of any TCP connection to proxy using your firewall"
 url="http://darkk.net.ru/redsocks"
 arch="all"

--- a/community/rspamd/APKBUILD
+++ b/community/rspamd/APKBUILD
@@ -5,7 +5,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=rspamd
 pkgver=1.9.4
-pkgrel=0
+pkgrel=1
 pkgdesc="Fast, free and open-source spam filtering system"
 url="https://rspamd.com/"
 arch="all !s390x"

--- a/community/scanssh/APKBUILD
+++ b/community/scanssh/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Fabian Affolter <fabian@affolter-engineering.ch>
 pkgname=scanssh
 pkgver=2.1.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Fast SSH server and open proxy scanner"
 url="https://github.com/ofalk/scanssh"
 arch="all"

--- a/community/shards/APKBUILD
+++ b/community/shards/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=shards
 pkgver=0.9.0
-pkgrel=0
+pkgrel=1
 _minitestver=0.4.2
 pkgdesc="Dependency manager for the Crystal language"
 url="https://github.com/crystal-lang/shards"

--- a/community/tg/APKBUILD
+++ b/community/tg/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=tg
 pkgver=1.3.1
-pkgrel=12
+pkgrel=13
 _tglver=2.0.1
 _tlparserver=0_git20151118
 pkgdesc="Command line Telegram client"

--- a/community/tor/APKBUILD
+++ b/community/tor/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Christine Dodrill <me@christine.website>
 pkgname=tor
 pkgver=0.4.1.6
-pkgrel=0
+pkgrel=1
 pkgdesc="Anonymous network connectivity"
 url="https://www.torproject.org/"
 arch="all"

--- a/community/zabbix/APKBUILD
+++ b/community/zabbix/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=zabbix
 pkgver=4.2.6
-pkgrel=0
+pkgrel=1
 pkgdesc="Enterprise-class open source distributed monitoring"
 url="http://www.zabbix.com"
 arch="all"

--- a/main/fstrm/APKBUILD
+++ b/main/fstrm/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: tcely <fstrm+aports@tcely.33mail.com>
 pkgname="fstrm"
 pkgver="0.5.0"
-pkgrel=0
+pkgrel=1
 pkgdesc="Frame Streams implementation in C"
 url="https://github.com/farsightsec/fstrm"
 arch="all"

--- a/main/libevent/APKBUILD
+++ b/main/libevent/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sergei Lukin <sergej.lukin@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libevent
-pkgver=2.1.10
+pkgver=2.1.11
 _pkgver=$pkgver-stable
 pkgrel=0
 pkgdesc="An event notification library"
@@ -12,7 +12,7 @@ options="!check" # regression tests failed
 depends_dev="python2"
 makedepends="$depends_dev openssl-dev"
 subpackages="$pkgname-static $pkgname-dev"
-source="https://github.com/$pkgname/$pkgname/releases/download/release-$_pkgver/$pkgname-$_pkgver.tar.gz"
+source="https://github.com/libevent/libevent/releases/download/release-$_pkgver/libevent-$_pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$_pkgver"
 
 # secfixes:
@@ -62,4 +62,4 @@ static() {
 	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib
 }
 
-sha512sums="2a449b60c5bba0908f693d3169a2941f0952b462ea18cf3c7a7288cd902592f35a42c76096af502f04259ffce2567233fda3586578c2ac53fbfce6e00d35c086  libevent-2.1.10-stable.tar.gz"
+sha512sums="9d0517b117f128f4f196b19a810524814bab75fa967d533063aaa619d3cf2dca97b443edd5805b764da2993d8e37caa536dce39f68ffcc2a88d32a89204c2de3  libevent-2.1.11-stable.tar.gz"

--- a/main/libverto/APKBUILD
+++ b/main/libverto/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=libverto
 pkgver=0.3.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Main loop abstraction library"
 url="https://github.com/npmccallum/libverto"
 arch="all"

--- a/main/memcached/APKBUILD
+++ b/main/memcached/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=memcached
 pkgver=1.5.17
-pkgrel=0
+pkgrel=1
 pkgdesc="Distributed memory object caching system"
 url="http://memcached.org/"
 arch="all"

--- a/main/nfs-utils/APKBUILD
+++ b/main/nfs-utils/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nfs-utils
 pkgver=2.4.1
-pkgrel=0
+pkgrel=1
 pkgdesc="kernel-mode NFS"
 url="http://linux-nfs.org"
 arch="all"

--- a/main/nsd/APKBUILD
+++ b/main/nsd/APKBUILD
@@ -5,7 +5,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=nsd
 pkgver=4.2.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Authoritative only, high performance and simple DNS server"
 url="https://www.nlnetlabs.nl/projects/nsd"
 arch="all"

--- a/main/opensmtpd/APKBUILD
+++ b/main/opensmtpd/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Jonathan Curran <jonathan@curran.in>
 pkgname=opensmtpd
 pkgver=6.4.2p1
-pkgrel=0
+pkgrel=1
 pkgdesc="Secure, reliable, lean, and easy-to configure SMTP server"
 url="http://www.opensmtpd.org"
 arch="all"

--- a/main/samba/APKBUILD
+++ b/main/samba/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=samba
 pkgver=4.10.8
-pkgrel=0
+pkgrel=1
 pkgdesc="Tools to access a server's filespace and printers via SMB"
 url="https://www.samba.org/"
 arch="all"

--- a/main/tmux/APKBUILD
+++ b/main/tmux/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=tmux
 pkgver=2.9a
-pkgrel=0
+pkgrel=1
 pkgdesc="Tool to control multiple terminals from a single terminal"
 url="https://tmux.github.io"
 arch="all"

--- a/main/transmission/APKBUILD
+++ b/main/transmission/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=transmission
 pkgver=2.94
-pkgrel=2
+pkgrel=3
 pkgdesc="Lightweight GTK BitTorrent client"
 url="http://www.transmissionbt.com"
 install="transmission-daemon.pre-install transmission-daemon.post-upgrade"

--- a/testing/ameba/APKBUILD
+++ b/testing/ameba/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=ameba
 pkgver=0.8.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A static code analysis tool for Crystal"
 url="https://veelenga.github.io/ameba/"
 arch="x86_64"  # limited by crystal. build fails on aarch64

--- a/testing/firefox/APKBUILD
+++ b/testing/firefox/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox
 pkgver=68.0.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Firefox web browser"
 url="https://www.firefox.com/"
 # limited by rust and cargo

--- a/testing/seamonkey/APKBUILD
+++ b/testing/seamonkey/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Marc Vertes <mvertes@free.fr>
 pkgname=seamonkey
 pkgver=2.49.4
-pkgrel=8
+pkgrel=9
 pkgdesc="all-in-one internet application suite"
 url="https://www.seamonkey-project.org"
 arch="x86_64 x86"

--- a/testing/tmate/APKBUILD
+++ b/testing/tmate/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Daniel Isaksen <d@duniel.no>
 pkgname=tmate
 pkgver=2.2.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Instant Terminal Sharing"
 url="https://tmate.io/"
 arch="all"


### PR DESCRIPTION
Tracking local builds

- [ ] ameba
- [x] bitcoin
- [x] chromium
- [x] coturn
- [ ] crystal
- [x] evince
- [x] firefox
- [x] firefox-esr
- [x] fstrm
- [x] gearmand
- [x] kamailio
- [x] libcouchbase
- [x] libevhtp
- [x] libreswan
- [x] libverto
- [x] lldpd
- [x] memcached
- [x] namecoin
- [x] netatalk
- [x] nfs-utils
- [x] nsd
- [x] opensmtpd
- [x] pgbouncer
- [x] php7-pecl-event
- [x] qt5-qtwebengine
- [x] redsocks
- [x] rspamd
- [x] samba
- [x] scanssh
- [ ] seamonkey
- [x] sems
- [ ] shards
- [x] tg
- [x] tmate
- [x] tmux
- [x] tor
- [x] transmission
- [x] unbound
- [x] zabbix