### PR TITLE
main/libheif: upgrade to 1.5.0

### DIFF
--- a/main/libheif/APKBUILD
+++ b/main/libheif/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=libheif
-pkgver=1.4.0
+pkgver=1.5.0
 pkgrel=0
 pkgdesc="ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
 url="https://www.libde265.org"
@@ -11,8 +11,11 @@ depends_dev="x265-dev libde265-dev"
 makedepends="$depends_dev libjpeg-turbo-dev libpng-dev"
 options="!check"  # no tests provided
 subpackages="$pkgname-dev $pkgname-tools"
-source="https://github.com/strukturag/libheif/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz"
-builddir="$srcdir/$pkgname-$pkgver"
+source="https://github.com/strukturag/libheif/releases/download/v$pkgver/libheif-$pkgver.tar.gz"
+
+# secfixes:
+#   1.5.0-r0:
+#     - CVE-2019-11471
 
 build() {
 	# This is en/decoder, so performance matters more than size.
@@ -41,4 +44,4 @@ tools() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="fc48caaadb71ffa87227de75c9e13d5006c66f1c966ce454552defb8947999f5242a9bbd1413f58be1ccbf61df7f118defe96d67376e3b4e7b12fe5dfa0fe0c7  libheif-1.4.0.tar.gz"
+sha512sums="a5f7073e17ce856d8a00d1e123e234317824e95a10fda8a29b93c2cac3798beba52093f4552c9701a0d4fe9f00ab057f36c1d304aa288317c54b25cd32f59735  libheif-1.5.0.tar.gz"


### PR DESCRIPTION
Fixes CVE-2019-11471