### PR TITLE
main/busybox-initscripts: update rpi bluetooth command

### DIFF
--- a/main/busybox-initscripts/mdev.conf
+++ b/main/busybox-initscripts/mdev.conf
@@ -1,4 +1,4 @@
-# 
+#
 # This is a sample mdev.conf.
 #
 
@@ -49,7 +49,7 @@ vcs[0-9]*	root:tty 0660
 vcsa[0-9]*	root:tty 0660
 
 # rpi bluetooth
-#ttyAMA0         root:tty 660 @hciattach /dev/$MDEV bcm43xx 115200 noflow -
+#ttyAMA0         root:tty 660 @btattach -B /dev/$MDEV -P bcm -S 115200 -N &
 
 ttyUSB[0-9]	root:dialout 0660 @ln -sf $MDEV modem
 ttyLTM[0-9]	root:dialout 0660 @ln -sf $MDEV modem
@@ -116,7 +116,7 @@ ida/(.*)	root:disk 0660 =ida/%1
 rd!(.*)		root:disk 0660 =rd/%1
 rd/(.*)		root:disk 0660 =rd/%1
 
-sr0		root:cdrom 0660 @ln -sf $MDEV cdrom 
+sr0		root:cdrom 0660 @ln -sf $MDEV cdrom
 
 # xen stuff
 xvd[a-z]	root:root 0660 */lib/mdev/xvd_links


### PR DESCRIPTION
The command hciattach is deprecated in bluez.
Replace the command with btattach.