### PR TITLE
testing/firefox: security upgrade to 68.0.2

### DIFF
--- a/testing/firefox/APKBUILD
+++ b/testing/firefox/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox
 pkgver=68.0.2
-pkgrel=1
+pkgrel=0
 pkgdesc="Firefox web browser"
 url="https://www.firefox.com/"
 # limited by rust and cargo

--- a/testing/firefox/APKBUILD
+++ b/testing/firefox/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=firefox
-pkgver=68.0.1
+pkgver=68.0.2
 pkgrel=1
 pkgdesc="Firefox web browser"
 url="https://www.firefox.com/"
@@ -72,6 +72,10 @@ _mozappdir=/usr/lib/firefox
 
 # help our shared-object scanner to find the libs
 ldpath="$_mozappdir"
+
+# secfixes:
+#   68.0.2-r0:
+#     - CVE-2019-11733
 
 prepare() {
 	default_prepare
@@ -185,7 +189,7 @@ __EOF__
 	rm -f "$pkgdir"/${_mozappdirdev}/sdk/lib/libxul.so
 }
 
-sha512sums="96b45135cf0b2368013afccb8c375de54d591a4e11016e8b65fc83904cedc362096dd15814cd02be23f6e52e392c605817b86a59ee2300d3e7a754d345399c81  firefox-68.0.1.source.tar.xz
+sha512sums="5c289825fd0de062b9943eabcc16e09c1821c04717e689aa8df03162e722b72ea698195f3ea93e1e746c481dacd77d125301dba951468d134b986e35eb4ef5bb  firefox-68.0.2.source.tar.xz
 0b3f1e4b9fdc868e4738b5c81fd6c6128ce8885b260affcb9a65ff9d164d7232626ce1291aaea70132b3e3124f5e13fef4d39326b8e7173e362a823722a85127  stab.h
 2f4f15974d52de4bb273b62a332d13620945d284bbc6fe6bd0a1f58ff7388443bc1d3bf9c82cc31a8527aad92b0cd3a1bc41d0af5e1800e0dcbd7033e58ffd71  fix-fortify-system-wrappers.patch
 84b84d2d7dbc16002510bf856796ad345ac38ef6d3254670230189bba7c2d4781714d231236d5a3d70129a4597b430c3171644b01ad0f5a5bb13b55d407337a4  fix-seccomp-bpf.patch


### PR DESCRIPTION
See https://www.mozilla.org/en-US/security/advisories/mfsa2019-24/ and #10123 