### PR TITLE
main/raspberrypi-bootloader: Add support for Raspberry Pi 4

### DIFF
--- a/main/raspberrypi-bootloader/APKBUILD
+++ b/main/raspberrypi-bootloader/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=raspberrypi-bootloader
-pkgver=1.20190718
+pkgver=1.20190819
 pkgrel=0
 pkgdesc="Bootloader files for the Raspberry Pi"
 url=https://github.com/raspberrypi/firmware
@@ -17,7 +17,7 @@ subpackages="$pkgname-experimental $pkgname-debug $pkgname-cutdown $pkgname-doc"
 builddir="${srcdir}/firmware-${pkgver}"
 
 package() {
-	local fw; for fw in bootcode.bin fixup.dat start.elf; do
+	local fw; for fw in bootcode.bin fixup.dat fixup4.dat start.elf start4.elf; do
 		install -D "$builddir"/boot/$fw \
 			"$pkgdir"/boot/$fw
 	done
@@ -27,7 +27,7 @@ package() {
 
 experimental() {
 	pkgdesc="Experimental firmware with additional codecs"
-	local fw; for fw in start_x.elf fixup_x.dat; do
+	local fw; for fw in start_x.elf start4x.elf fixup_x.dat fixup4x.dat; do
 		install -D "$builddir"/boot/$fw \
 				"$subpkgdir"/boot/$fw
 	done
@@ -35,7 +35,7 @@ experimental() {
 
 debug() {
 	pkgdesc="Debug firmware"
-    local fw; for fw in start_db.elf fixup_db.dat; do
+    local fw; for fw in start_db.elf start4db.elf fixup_db.dat fixup4db.dat; do
 		install -D "$builddir"/boot/$fw \
 			"$subpkgdir"/boot/$fw
 	done
@@ -43,10 +43,10 @@ debug() {
 
 cutdown() {
 	pkgdesc="Cut-down firmware for lower memory settings"
-	local fw; for fw in start_cd.elf fixup_cd.dat; do
+	local fw; for fw in start_cd.elf start4cd.elf fixup_cd.dat fixup4cd.dat; do
 		install -D "$builddir"/boot/$fw \
 			"$subpkgdir"/boot/$fw
 	done
 }
 
-sha512sums="5dbf5da3346f8cce0092c95f0272a8146e3e52a5b1e049a2dad6b1110a01d54b57f80866272190d0f516020352ece1c99a5228a67835e55b58020dabf7f60604  raspberrypi-bootloader-1.20190718.tar.gz"
+sha512sums="a626c6dcfe1ef0caa0d1c87664cd3b2ab28d95157dcde4525f7e745280a53e3a837f0557685fa42a173e95ad97864c8c7be0baf5a959a11f41f37301d9214c6a  raspberrypi-bootloader-1.20190819.tar.gz"


### PR DESCRIPTION
Updates the firmware to a more recent version and adds RPi 4 specific files.