### PR TITLE
main/linux-rpi: Build a subpackage for RPi 4

### DIFF
--- a/main/linux-rpi/APKBUILD
+++ b/main/linux-rpi/APKBUILD
@@ -6,7 +6,7 @@ case $pkgver in
 *.*.*)	_kernver=${pkgver%.*};;
 *.*)	_kernver=${pkgver};;
 esac
-pkgrel=0
+pkgrel=1
 pkgdesc="Linux kernel with Raspberry Pi patches"
 url=https://github.com/raspberrypi/linux
 depends="mkinitfs"
@@ -24,10 +24,12 @@ source="https://kernel.org/pub/linux/kernel/v4.x/linux-$_kernver.tar.xz
 	issue-4973.patch
 
 	config-changes-rpi.armhf
+	config-changes-rpi.armv7
 	config-changes-rpi.aarch64
 	config-changes-rpi2.armhf
-	config-changes-rpi.armv7
 	config-changes-rpi2.armv7
+	config-changes-rpi4.armv7
+	config-changes-rpi4.aarch64
 	"
 subpackages=""
 arch="armhf armv7 aarch64"
@@ -109,6 +111,7 @@ _genconfig() {
 		rpi) defconfig=bcmrpi_defconfig
 		[ "$CARCH" = "aarch64" ] && defconfig=bcmrpi3_defconfig ;;
 		rpi2) defconfig=bcm2709_defconfig ;;
+		rpi4) defconfig=bcm2711_defconfig ;;
 		*) die "Unknown flavor: $flavor" ;;
 	esac
 
@@ -231,8 +234,12 @@ package() {
 # subflavors install in $subpkgdir
 rpi2() {
 	depends="$depends linux-firmware-brcm"
-
 	_package rpi2 "$subpkgdir"
+}
+
+rpi4() {
+	depends="$depends linux-firmware-brcm"
+	_package rpi4 "$subpkgdir"
 }
 
 _dev() {
@@ -288,7 +295,9 @@ a73ea67811cdb6c7b86a249f21252e76af5926b50df7cd7a3b418b49a24afd5c66e69394cd0152dc
 eb3d355d3c8c79d77abf3aad18ad9bca53ded43c0b7127a01f6794fa8688de6439fcd23c9029cb931b7b8e4d2a912419afd372ca03d4db6df8bb0be8188f666f  rpi-4.19.67-alpine.patch
 501c91bf2538a18102da59bbccc3097f9c3c90079acc0e946ff075074160c09b8a66934e5ce5470e170f0e4f93d114709a95230367426d0bb7ea02c4bdf4cc9b  issue-4973.patch
 6c1c1c61ceb323eecb0e81e226af6b5b8fef7c8c075b1eb836639f465de5ef5d23648716c953d295250f8c6567546782956afe644573b84920a4f6902a1a0454  config-changes-rpi.armhf
+6c1c1c61ceb323eecb0e81e226af6b5b8fef7c8c075b1eb836639f465de5ef5d23648716c953d295250f8c6567546782956afe644573b84920a4f6902a1a0454  config-changes-rpi.armv7
 6c1c1c61ceb323eecb0e81e226af6b5b8fef7c8c075b1eb836639f465de5ef5d23648716c953d295250f8c6567546782956afe644573b84920a4f6902a1a0454  config-changes-rpi.aarch64
 6c1c1c61ceb323eecb0e81e226af6b5b8fef7c8c075b1eb836639f465de5ef5d23648716c953d295250f8c6567546782956afe644573b84920a4f6902a1a0454  config-changes-rpi2.armhf
-6c1c1c61ceb323eecb0e81e226af6b5b8fef7c8c075b1eb836639f465de5ef5d23648716c953d295250f8c6567546782956afe644573b84920a4f6902a1a0454  config-changes-rpi.armv7
-6c1c1c61ceb323eecb0e81e226af6b5b8fef7c8c075b1eb836639f465de5ef5d23648716c953d295250f8c6567546782956afe644573b84920a4f6902a1a0454  config-changes-rpi2.armv7"
+6c1c1c61ceb323eecb0e81e226af6b5b8fef7c8c075b1eb836639f465de5ef5d23648716c953d295250f8c6567546782956afe644573b84920a4f6902a1a0454  config-changes-rpi2.armv7
+6c1c1c61ceb323eecb0e81e226af6b5b8fef7c8c075b1eb836639f465de5ef5d23648716c953d295250f8c6567546782956afe644573b84920a4f6902a1a0454  config-changes-rpi4.armv7
+6c1c1c61ceb323eecb0e81e226af6b5b8fef7c8c075b1eb836639f465de5ef5d23648716c953d295250f8c6567546782956afe644573b84920a4f6902a1a0454  config-changes-rpi4.aarch64"

--- a/main/linux-rpi/config-changes-rpi4.aarch64
+++ b/main/linux-rpi/config-changes-rpi4.aarch64
@@ -1,0 +1,1 @@
+config-changes-rpi.armhf

--- a/main/linux-rpi/config-changes-rpi4.armv7
+++ b/main/linux-rpi/config-changes-rpi4.armv7
@@ -1,0 +1,1 @@
+config-changes-rpi.armhf


### PR DESCRIPTION
The Raspberry Pi 4 needs to be built with a different configuration: https://www.raspberrypi.org/documentation/linux/kernel/building.md