### PR TITLE
main/multipath-tools: bump pkgrel

### DIFF
--- a/main/multipath-tools/APKBUILD
+++ b/main/multipath-tools/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname=multipath-tools
 pkgver=0.8.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Device Mapper Multipathing Driver"
 url="http://christophe.varoqui.free.fr"
 arch="all"


### PR DESCRIPTION
Rebuild against userspace-rcu 0.11.1

Fixes
```
ERROR: unsatisfiable constraints:
  so:liburcu.so.5 (missing):
    required by: multipath-tools-0.8.2-r0[so:liburcu.so.5]
```