### PR TITLE
[3.10] main/openldap: security upgrade to 2.4.48

### DIFF
--- a/main/openldap/APKBUILD
+++ b/main/openldap/APKBUILD
@@ -2,6 +2,9 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 #
 # secfixes:
+#   2.4.48-r0:
+#   - CVE-2019-13565
+#   - CVE-2019-13057
 #   2.4.46-r0:
 #   - CVE-2017-14159
 #   - CVE-2017-17740
@@ -9,8 +12,8 @@
 #   - CVE-2017-9287
 #
 pkgname=openldap
-pkgver=2.4.47
-pkgrel=2
+pkgver=2.4.48
+pkgrel=0
 pkgdesc="LDAP Server"
 url="http://www.openldap.org/"
 arch="all"
@@ -213,7 +216,7 @@ _submv() {
 	done
 }
 
-sha512sums="d424079e34207e3d24383a2bea70a07ded40714982a6767174d2b2cb208cd94feab5ef12157accae915b8e404e5773a7547aaef65f06b44dc3cc09c6a64d5a11  openldap-2.4.47.tgz
+sha512sums="cf694a415be0bd55cc7f606099da2ed461748efd276561944cd29d7f5a8252a9be799d8778fac2d4fa9f382731eb4ca48c6b85630cb58a3b8249843561ae8feb  openldap-2.4.48.tgz
 5d34d49eabe7cb66cf8284cc3bd9730fa23df4932df68549e242d250ee50d40c434ae074ebc720d5fbcd9d16587c9333c5598d30a5f1177caa61461ab7771f38  openldap-2.4-ppolicy.patch
 44d97efb25d4f39ab10cd5571db43f3bfa7c617a5bb087085ae16c0298aca899b55c8742a502121ba743a73e6d77cd2056bc96cee63d6d0862dabc8fb5574357  openldap-2.4.11-libldap_r.patch
 9c7f41279e91ed995c91e9a8c543c797d9294a93cf260afdc03ab5777e45ed045a4d6a4d4d0180b5dc387dc04babca01d818fbfa8168309df44f4500d2a430a4  openldap-mqtt-overlay.patch


### PR DESCRIPTION
fixes:

CVE-2019-13565
CVE-2019-13057