### PR TITLE
added rdnssd.initd for ndisc6 package

### DIFF
--- a/testing/ndisc6/APKBUILD
+++ b/testing/ndisc6/APKBUILD
@@ -2,17 +2,20 @@
 # Maintainer: Kevin Daudt <kdaudt@alpinelinux.org>
 pkgname=ndisc6
 pkgver=1.0.4
-pkgrel=0
+pkgrel=1
 pkgdesc="ndisc6 gathers a few diagnostic tools for IPv6 networks including"
 url="https://www.remlab.net/ndisc6"
 arch="all"
 license="GPL-2.0-or-later"
 depends="perl"
 makedepends="linux-headers"
-subpackages="$pkgname-doc"
+subpackages="$pkgname-doc
+			 $pkgname-openrc"
 source="https://www.remlab.net/files/ndisc6/ndisc6-$pkgver.tar.bz2
-	remove-undef-gnu-source.patch
-	"
+		remove-undef-gnu-source.patch
+	
+		rdnssd.initd
+		"
 options="suid"
 
 build() {
@@ -31,7 +34,11 @@ check() {
 
 package() {
 	make DESTDIR="$pkgdir" install
+	install -D -m755 "$srcdir"/rdnssd.initd \
+		"$pkgdir"/etc/init.d/rdnssd
 }
 
 sha512sums="6f6cd939fb7079518db5c1bcd11353c722237d7735d229f9fd20d03e9f16b1ddf07c7c78c91364886148f2a82d6805eafe7e27da6b4e7c99b111603ec5fab842  ndisc6-1.0.4.tar.bz2
-d70c74f965308afbfc266071ec0d073d59cfd42f250e27c8f4f3e1c7b849a6bb9226407e74af30366d348e4213c7497791e8f2edc7b903703e611c036c250644  remove-undef-gnu-source.patch"
+d70c74f965308afbfc266071ec0d073d59cfd42f250e27c8f4f3e1c7b849a6bb9226407e74af30366d348e4213c7497791e8f2edc7b903703e611c036c250644  remove-undef-gnu-source.patch
+8342a2d64b35e8f1a2354f5c7b59a7c4a8b84333b47a52f1dc7e2c8c375c35ab3a0734e6b30d1c764d57c0dadb42916a1112451a14957ebe5605e98480dc619b  rdnssd.initd
+"

--- a/testing/ndisc6/rdnssd.initd
+++ b/testing/ndisc6/rdnssd.initd
@@ -1,0 +1,20 @@
+#!/sbin/openrc-run
+# Copyright 1999-2008 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+depend() {
+	need localmount
+	before net
+	use logger
+}
+
+start() {
+	ebegin "Starting rdnssd"
+	start-stop-daemon --start --quiet --exec /usr/sbin/rdnssd -- -u root -r /etc/resolv.conf
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping rdnssd"
+	start-stop-daemon --stop --quiet --pidfile /run/rdnssd.pid
+} 


### PR DESCRIPTION
This is service (openrc init.d) file for rdnssd binary inside ndisc6 package. It is basically taken from Gentoo's ndisc6 package and modified a little.