### PR TITLE
testing/sbcl: upgrade to 1.5.6

### DIFF
--- a/testing/sbcl/APKBUILD
+++ b/testing/sbcl/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Will Sinatra <wpsinatra@gmail.com>
 # Maintainer: Will Sinatra <wpsinatra@gmail.com>
 pkgname=sbcl
-pkgver=1.5.5
+pkgver=1.5.6
 pkgrel=0
 pkgdesc="Steel Bank Common Lisp"
 url="http://www.sbcl.org/"
@@ -19,13 +19,6 @@ source="$pkgname-$pkgver.tar.bz2::https://prdownloads.sourceforge.net/$pkgname/$
 	"
 	
 builddir="$srcdir/$pkgname-$pkgver"
-
-prepare() {
-	default_prepare
-
-	# FIXME: This test fails (returns incorrect result), don't know why.
-	rm tests/traceroot.test.sh
-}
 
 build() {
 	cd "$builddir"
@@ -61,7 +54,7 @@ package() {
 		"$pkgdir"/usr/share/info 2>/dev/null || true
 }
 
-sha512sums="9de71dfc767e7d96e278b6ffe69465be5a829d9228be4e44c7ec511cbb6cec98cce2ae99e3a40d8917832e61d587f1302861f9e1808fe0b7e1fe0e2105d4c4b8  sbcl-1.5.5.tar.bz2
+sha512sums="5adeb4c694d41c08c780d5f0ed2e0f4c830ea74fdb7b345813b1cd616a0b310c2394f4727b6f5a75b04bd0dda92ee774298bef7225253e7d325e8f83bc645320  sbcl-1.5.6.tar.bz2
 cda5c7268b314145a1bdb8293c7970e077aebf3cce5dace12542bf18beb7b124bf97f4754906f2f681428869ca3060300b88cab80055a3d5881dfcdcfbe51d6d  pax-genesis-stage-two.patch
 507ecaf8fc296586c637d6ad8c91770efe18158a3aa551d0d2993ce9592454f33442d425d076bcb7121525d7942a03d9a0038252251f1540c575e95fb334ef7e  musl-fixes.patch
 86b8a51d518d71a3c4d3069f80bc00cccd4b97edc6c96ff12875a0727cc2b96208f35c3a11044d98881b5e6c2e607fc65506020b7ff990b257edae55eb6a1c59  musl-fix-threads.patch


### PR DESCRIPTION
Upgrade SBCL to 1.5.6, remove prepare() as it is no longer necessary