### PR TITLE
community/skopeo: upgrade to 0.1.39

### DIFF
--- a/community/skopeo/APKBUILD
+++ b/community/skopeo/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
 # Maintainer: Carlo Landmeter <clandmeter@alpinelinux.org>
 pkgname=skopeo
-pkgver=0.1.32
+pkgver=0.1.39
 pkgrel=1
 pkgdesc="Work with remote images registries - retrieving information, images, signing content"
 url="https://github.com/containers/skopeo"
@@ -48,4 +48,4 @@ package() {
 		"$pkgdir"/etc/containers/registries.d/default.yaml
 }
 
-sha512sums="c52eeee85aa01448c9742d4e415e3ce6f2e0ef4e26a55758202baecb573ad8e3efb94c762d4c303fb21b896998b32e19f919a7382dfd6b17df2a96d66d07267b  skopeo-0.1.32.tar.gz"
+sha512sums="c4aadc40f9d637c628cd96c204b3e9bc3a928c145521bed2e5046508fc936ff99442dda8b4a4cdd85c4d04e64a9ccee5ea8d563c6ebf4e6020d50d96b921716c  skopeo-0.1.39.tar.gz"


### PR DESCRIPTION
Upgrade skopeo to 0.1.39 from https://github.com/containers/skopeo/releases