### PR TITLE
libnfs: update to 4.0.0

### DIFF
--- a/main/libnfs/APKBUILD
+++ b/main/libnfs/APKBUILD
@@ -1,7 +1,8 @@
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
+# Contributor: Nick Black <dankamongmen@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=libnfs
-pkgver=3.0.0
+pkgver=4.0.0
 pkgrel=0
 pkgdesc="Client library for accessing NFS shares"
 url="https://github.com/sahlberg/libnfs"
@@ -35,5 +36,5 @@ package() {
         make DESTDIR="$pkgdir" install
 }
 
-sha512sums="9af31f8824431e9d28267c468dafc7cfc4062b1a280ca141036bc28a2ba544c4470a67955b5e5fbcc6c175435812381013b4c5d3d3d1a175d5efc7b802ae9b3b  libnfs-3.0.0.tar.gz
+sha512sums="3d93d83d1909f24de304c0d47fa6240da7ecf43ce2488a242a58ddabe51d774caf813f5a90ae720a8edd251a765b30e88c0e5b6a13ecb254dfecdc98e30737fa  libnfs-4.0.0.tar.gz
 14219122c6decf7e0e292a2962a7dbf9b2e408b87d8e22cf1761b742834e817652f3e4919dded00f645ccf79e035e03712e7072ec1cb23bfd24ad012e9183824  fix-includes.patch"


### PR DESCRIPTION
Libnfs 4.0.0 was released in February 2019. This builds fine, and continues to benefit from the fix-includes.patch.