### PR TITLE
main/dovecot: security upgrade to 2.3.7.2

### DIFF
--- a/main/dovecot/APKBUILD
+++ b/main/dovecot/APKBUILD
@@ -4,10 +4,10 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=dovecot
-pkgver=2.3.7.1
+pkgver=2.3.7.2
 _pkgvermajor=2.3
 pkgrel=0
-_pigeonholever=0.5.7
+_pigeonholever=0.5.7.2
 _pigeonholevermajor=${_pigeonholever%.*}
 pkgdesc="IMAP and POP3 server"
 url="https://www.dovecot.org/"
@@ -66,6 +66,8 @@ builddir="$srcdir/$pkgname-$pkgver"
 _builddir_pigeonhole="$srcdir/$pkgname-$_pkgvermajor-pigeonhole-$_pigeonholever"
 
 # secfixes:
+#   2.3.7.2-r0:
+#     - CVE-2019-11500
 #   2.3.6-r0:
 #     - CVE-2019-11499
 #     - CVE-2019-11494
@@ -299,8 +301,8 @@ _submv() {
 	done
 }
 
-sha512sums="9addfe2be9ae745ac9164e1658e6638df96bd611d45f172e2cd1cb2c6596e4ce534674e9eea3c1d17f497555061031916e0fb9a9fbc6de0eb6034e2fd0bed3b9  dovecot-2.3.7.1.tar.gz
-f58098ae13b41a6378080340240928083514a541f2fe3c8f516853455ab27635e0c47587a101aca5eb4e97ec8afe6a5dd5360c46e956b009ae971316e491f1b8  dovecot-2.3-pigeonhole-0.5.7.tar.gz
+sha512sums="172f7f0edb884259e4c050607510aee67a35c3a20b7dd147e7c8a25a04921c18f7d6b5c85af2c69ae8c4d53791550970e471b033dbfae94253e331053b6a317d  dovecot-2.3.7.2.tar.gz
+7fc8d89ee31c8e8c16a9aeaeffb591f4188de36fc80e3a30a9ae10bc5acd7ea5d5d91e077fda566e61d588d9221ec53044ce17a9cc0c9c219dbe6824558a1d60  dovecot-2.3-pigeonhole-0.5.7.2.tar.gz
 fe4fbeaedb377d809f105d9dbaf7c1b961aa99f246b77189a73b491dc1ae0aa9c68678dde90420ec53ec877c08f735b42d23edb13117d7268420e001aa30967a  skip-iconv-check.patch
 794875dbf0ded1e82c5c3823660cf6996a7920079149cd8eed54231a53580d931b966dfb17185ab65e565e108545ecf6591bae82f935ab1b6ff65bb8ee93d7d5  split-protocols.patch
 0d8f89c7ba6f884719b5f9fc89e8b2efbdc3e181de308abf9b1c1b0e42282f4df72c7bf62f574686967c10a8677356560c965713b9d146e2770aab17e95bcc07  default-config.patch


### PR DESCRIPTION
https://dovecot.org/pipermail/dovecot-news/2019-August/000418.html