### PR TITLE
community/nodejs-current: upgrade to 12.9.1

### DIFF
--- a/community/nodejs-current/APKBUILD
+++ b/community/nodejs-current/APKBUILD
@@ -20,7 +20,7 @@
 #
 pkgname=nodejs-current
 # The current stable version, i.e. non-LTS.
-pkgver=12.9.0
+pkgver=12.9.1
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - current stable version"
 url="https://nodejs.org/"
@@ -93,6 +93,6 @@ package() {
 	rm "$pkgdir"/usr/bin/npm "$pkgdir"/usr/bin/npx
 }
 
-sha512sums="a6c298c98800fcd0d971a041d40f23390f175d3dc46d7215afdb6342b3d50a80e051f35715f38a4f6ce8ec83163a94195863f2c99c24b9dcf57a705037b26411  node-v12.9.0.tar.gz
+sha512sums="146d8e8d839a1907aa8391feee8d7eb0db7ee8a7974ba9ee03eb195c4500bf93acd83586a7628fbd21c63c7fb98d9125e068ce09337237af506bea2c1d963522  node-v12.9.1.tar.gz
 3c536776e2ecb5dc677bf711a09418085b3c5e931a6eaf647f47c28e194d5c6dec354d4e7a039a5805b30fc7e83140594851e18d9120f523eec2f93539eac4db  dont-run-gyp-files-for-bundled-deps.patch
 9f60928b53447f9590c7065bcdbdd4065d10a06e8451531615791a3bd7d14f9114807e5446e0ec00e2cb7a11a277050345e34636b199db2979d7f022b31ffde4  link-with-libatomic-on-mips32.patch"


### PR DESCRIPTION
Changelog: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.9.1