### PR TITLE
main/libheif: upgrade to 1.5.1

### DIFF
--- a/main/libheif/APKBUILD
+++ b/main/libheif/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=libheif
-pkgver=1.5.0
+pkgver=1.5.1
 pkgrel=0
 pkgdesc="ISO/IEC 23008-12:2017 HEIF file format decoder and encoder"
 url="https://www.libde265.org"
@@ -44,4 +44,4 @@ tools() {
 	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
 }
 
-sha512sums="a5f7073e17ce856d8a00d1e123e234317824e95a10fda8a29b93c2cac3798beba52093f4552c9701a0d4fe9f00ab057f36c1d304aa288317c54b25cd32f59735  libheif-1.5.0.tar.gz"
+sha512sums="05e32ebff08d5f0e82e9b1107253c27882ae1694150033fe7b3ca07db8c64567f09002081276e92a3b490a63022a1522d577b094a7f489742139758d17f484b8  libheif-1.5.1.tar.gz"


### PR DESCRIPTION
[bug-fix release](https://github.com/strukturag/libheif/releases/tag/v1.5.1).