### PR TITLE
community/php7: security upgrade to 7.3.9 (CVE-2019-13224)

### DIFF
--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -26,8 +26,8 @@
 
 pkgname=php7
 _pkgreal=php
-pkgver=7.3.8
-pkgrel=1
+pkgver=7.3.9
+pkgrel=0
 _apiver=20180731
 _suffix=${pkgname#php}
 # Is this package the default (latest) PHP version?
@@ -183,6 +183,8 @@ case "$CARCH" in
 esac
 
 # secfixes:
+#   7.3.9-r0:
+#     - CVE-2019-13224
 #   7.3.8-r0:
 #     - CVE-2019-11041
 #     - CVE-2019-11042
@@ -673,7 +675,7 @@ _mv() {
 	mv $@
 }
 
-sha512sums="c8aea78a21e95a1ad91bdd157684f80b316c51f9fdd6718554d59e0256f39213dec8b176e621ede44e1ef037f77ba2865169274b2bd9f13f319bf01c7e9ed058  php-7.3.8.tar.bz2
+sha512sums="a46beb28a91f7ee99f37215ddf5f65ab1743373ba98a703ed45615625ee6b4cbda1be8495901da54089f7cb285a6ac21773a29d32871e0a9540c43b57ea41b97  php-7.3.9.tar.bz2
 1c708de82d1086f272f484faf6cf6d087af7c31750cc2550b0b94ed723961b363f28a947b015b2dfc0765caea185a75f5d2c2f2b099c948b65c290924f606e4f  php7-fpm.initd
 cacce7bf789467ff40647b7319e3760c6c587218720538516e8d400baa75651f72165c4e28056cd0c1dc89efecb4d00d0d7823bed80b29136262c825ce816691  php7-fpm.logrotate
 274bd7b0b2b7002fa84c779640af37b59258bb37b05cb7dd5c89452977d71807f628d91b523b5039608376d1f760f3425d165242ca75ee5129b2730e71c4e198  php7-module.conf


### PR DESCRIPTION
Ref https://www.php.net/archive/2019.php#2019-08-29-1