### PR TITLE
testing/bcc: move python dep to py subpkg

### DIFF
--- a/testing/bcc/APKBUILD
+++ b/testing/bcc/APKBUILD
@@ -1,18 +1,17 @@
 # Maintainer: Adam Jensen <acjensen@gmail.com>
 pkgname=bcc
 pkgver=0.10.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A toolkit for creating efficient kernel tracing and manipulation programs"
 url="https://github.com/iovisor/bcc/"
 arch="aarch64 x86 x86_64"
 license="Apache-2.0"
 # bcc's test suite requires privileged access to run BPF programs
 options="!check"
-depends="python"
 subpackages="$pkgname-dev $pkgname-doc:_doc $pkgname-tools:_tools $pkgname-lua:_lua py-$pkgname:_py"
 _llvmver=8
-makedepends="tar git llvm$_llvmver-dev llvm$_llvmver-static clang-dev clang-static cmake flex-dev
-	bison luajit-dev build-base iperf linux-headers elfutils-dev zlib-dev
+makedepends="tar git llvm$_llvmver-dev llvm$_llvmver-static clang-dev clang-static cmake python
+	flex-dev bison luajit-dev build-base iperf linux-headers elfutils-dev zlib-dev
 	libbpf-dev"
 source="$pkgname-$pkgver.tar.gz::https://github.com/iovisor/bcc/archive/v$pkgver.tar.gz
 	10-use-system-libbpf.patch"
@@ -45,7 +44,7 @@ _doc() {
 }
 
 _tools() {
-	depends="bcc py-bcc"
+	depends="$pkgname py-$pkgname"
 	pkgdesc="$pkgdesc (tools)"
 
 	mkdir -p "$subpkgdir"/usr/share/bcc
@@ -54,7 +53,7 @@ _tools() {
 }
 
 _py() {
-	depends="bcc"
+	depends="$pkgname python"
 	pkgdesc="$pkgdesc (python bindings)"
 
 	mkdir -p "$subpkgdir"/usr/lib
@@ -62,7 +61,7 @@ _py() {
 }
 
 _lua() {
-	depends="bcc"
+	depends="$pkgname"
 	pkgdesc="$pkgdesc (lua bindings)"
 
 	mkdir -p "$subpkgdir"/usr/bin


### PR DESCRIPTION
libbcc doesn't depend on python, only tools and py bindings do.