### PR TITLE
testing/sniffglue: enable on arches supported by rust >= 1.37.0-r0

### DIFF
--- a/testing/sniffglue/APKBUILD
+++ b/testing/sniffglue/APKBUILD
@@ -5,7 +5,8 @@ pkgver=0.9.0
 pkgrel=0
 pkgdesc="Secure multithreaded packet sniffer"
 url="https://github.com/kpcyrd/sniffglue"
-arch="x86_64" # limited by cargo pkg
+# !aarch64: https://cloud.drone.io/alpinelinux/aports/10687/3/1
+arch="x86_64 x86 armhf armv7 ppc64le" # limited by cargo
 license="GPL-3.0-or-later"
 makedepends="
 	cargo
@@ -20,12 +21,17 @@ source="
 	"
 
 build() {
-	cd "$builddir"
+	# libring fails to compile otherwise
+	case "$CARCH" in
+		x86)
+			export CFLAGS="$CFLAGS -fno-stack-protector"
+			;;
+	esac
+
 	cargo build --release --locked
 }
 
 check() {
-	cd "$builddir"
 	cargo test --release --locked
 }
 


### PR DESCRIPTION
* Remove unneccesary `cd "$builddir"`