### PR TITLE
testing/mdbook: enable on arches supported by rust >= 1.37.0-r0

### DIFF
--- a/testing/mdbook/APKBUILD
+++ b/testing/mdbook/APKBUILD
@@ -4,15 +4,20 @@ pkgver=0.3.1
 pkgrel=0
 pkgdesc="mdBook is a utility to create modern online books from Markdown files"
 url="https://rust-lang-nursery.github.io/mdBook"
-arch="x86_64"
+arch="x86_64 x86 armhf armv7 aarch64 ppc64le" # limited by cargo
 license="MPL-2.0"
 makedepends="rust cargo"
 source="$pkgname-$pkgver.tar.gz::https://github.com/rust-lang-nursery/mdBook/archive/v$pkgver.tar.gz"
 builddir="$srcdir/mdBook-$pkgver"
 export CARGO_HOME="$srcdir"/cargo
-export RUSTFLAGS="-C target-feature=-crt-static"
 
 build() {
+	case "$CARCH" in
+		x86)
+			export CFLAGS="$CFLAGS -fno-stack-protector"
+			;;
+	esac
+
 	cargo build --release --verbose
 }
 


### PR DESCRIPTION
* remove unneccesary RUSTFLAGS statements, we default to -crt-static