### PR TITLE
testing/etcd: upgrade to 3.4.0

### DIFF
--- a/testing/etcd/APKBUILD
+++ b/testing/etcd/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Francesco Colista <fcolista@alpinelinux.org>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=etcd
-pkgver=3.3.15
+pkgver=3.4.0
 pkgrel=0
 pkgdesc="A highly-available key value store for shared configuration and service discovery"
 url="https://github.com/coreos/etcd"
@@ -52,7 +52,7 @@ ctl() {
 	install -Dm755 "$builddir"/bin/etcdctl "$subpkgdir"/usr/bin/etcdctl
 }
 
-sha512sums="9fbc02c4aacb000335d558e9c5d4df672194d1b1b8511918efa35a6123bcd7f1a06ecc527f7ff01af7c7f0e818b4809918e640fd596ec51898bf511849f0a2c5  etcd-3.3.15.tar.gz
+sha512sums="8e130cc76a2284c98bb72e3832e10e25e45c6fbaa5da7c6a7a2dd14a069d4fea7659b13c1450b87b869e5936bdad47606d0c65292febb7257369531ff2658674  etcd-3.4.0.tar.gz
 1fd53fccc524ab07f2780039d8155ef66af7fb23e13783ac24ab47e7841f417ac98973e7e6eaa6424c4122a9a6826cb0e20f453e02492c789514f096f0243d87  etcd.yaml
 e2c178b376dc05de7daee6ca3b38cc289e7c73106055dcccde08fe36a392224edf9f98203d50f14c7abeea74552675ff73a061ba20c56628eb657fa15dcd8942  etcd.confd
 c251f63cbaee2d5edaed3f82b4d0b8918ecee977ee459b59f0b9fef02cfe69f0de997e9a59ad29732c58782c224591b0d27378b24435f1bac0e77a35d8886bba  etcd.initd"


### PR DESCRIPTION
@fcolista

Upgrading guide: https://github.com/etcd-io/etcd/blob/master/Documentation/upgrades/upgrade_3_4.md

- ETCDCTL_API=3 is now default
- --enable-v2=false is now default (no longer serve v2 requests on etcd server)

changelog: https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.4.md