### PR TITLE
testing/singularity: upgrade to 3.4.1

### DIFF
--- a/testing/singularity/APKBUILD
+++ b/testing/singularity/APKBUILD
@@ -1,11 +1,11 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=singularity
-pkgver=3.3.0
-pkgrel=3
+pkgver=3.4.1
+pkgrel=0
 pkgdesc="Application containers focused on reproducibility for scientific computing and HPC world."
 url="https://www.sylabs.io/singularity/"
-arch=
+arch="all"
 license="BSD-3-Clause BSD-3-Clause-LBNL"
 options="suid !check" # no test suite from upstream
 depends="squashfs-tools"
@@ -17,6 +17,7 @@ makedepends="
 	libuuid
 	util-linux-dev
 	libseccomp-dev
+	cryptsetup
 	"
 subpackages="$pkgname-doc $pkgname-bash-completion:bashcomp:noarch"
 source="$pkgname-$pkgver.tar.gz::https://github.com/sylabs/singularity/archive/v$pkgver.tar.gz"
@@ -66,4 +67,5 @@ bashcomp() {
 	mv "$pkgdir"/etc/bash_completion.d/singularity \
 		"$subpkgdir"/usr/share/bash-completion/completions/singularity
 }
-sha512sums="41c9b7ef2986b275a761295b2b8ce0bf7c323d1f67098486f591da08ff834f953ee336fd00f0a75abef188ed9182bdca9971254f7e406032f42323250b05da82  singularity-3.3.0.tar.gz"
+
+sha512sums="7a49fefd69b9d33de8ae248992a007118a2573bbb4de451d1de2aedf6611a5b1e3686259f41dcf2c247911c9f06719980e1f674e6788f5b45e9776e4d3af82ab  singularity-3.4.1.tar.gz"


### PR DESCRIPTION
- https://github.com/sylabs/singularity/releases/tag/v3.4.1 3.4.1
- Enable all architectures for builders
- Add cryptsetup to makedepends