### PR TITLE
[3.10] main/irssi: security upgrade to 1.2.2

### DIFF
--- a/main/irssi/APKBUILD
+++ b/main/irssi/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=irssi
-pkgver=1.2.1
+pkgver=1.2.2
 pkgrel=0
 pkgdesc="Modular textUI IRC client with IPv6 support"
 url="https://irssi.org/"
@@ -8,11 +8,12 @@ arch="all"
 license="GPL-2.0-or-later"
 makedepends="glib-dev openssl-dev ncurses-dev perl-dev automake autoconf libtool libotr-dev"
 subpackages="$pkgname-doc $pkgname-dev $pkgname-proxy $pkgname-perl $pkgname-otr"
-source="https://github.com/$pkgname/$pkgname/releases/download/$pkgver/$pkgname-$pkgver.tar.xz
+source="https://github.com/irssi/irssi/releases/download/$pkgver/irssi-$pkgver.tar.xz
 	"
-builddir="$srcdir"/$pkgname-$pkgver
 
 # secfixes:
+#   1.2.2-r0:
+#     - CVE-2019-15717
 #   1.2.1-r0:
 #     - CVE-2019-13045
 #   1.1.2-r0:
@@ -101,4 +102,4 @@ otr() {
 	mv "$pkgdir"/usr/share/irssi/help/otr "$subpkgdir"/usr/share/irssi/help/
 }
 
-sha512sums="67c4501b5a0055c1b24fa6753305658de809cd66e952e6f9233701a112989fd8721a065b1c681725b82346b40b53a29bd2b6b8b8315ac0ad196235a9e5156d5a  irssi-1.2.1.tar.xz"
+sha512sums="5444ac102ff9ad3a6399a47c967d138e181330dd226eac68886d35fee4ad455932b9306a367bee3478095158e41ba67fb46deb8f0a33512046b9b83bae37c610  irssi-1.2.2.tar.xz"


### PR DESCRIPTION
fixes CVE-2019-15717