### PR TITLE
main/py-pillow: running tests requires pytest version < 5

### DIFF
--- a/main/py-pillow/APKBUILD
+++ b/main/py-pillow/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=py-pillow
 _pkgname=Pillow
 pkgver=6.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Python Imaging Library"
 url="https://python-pillow.org"
 arch="all"
@@ -12,7 +12,8 @@ depends="py-olefile"
 makedepends="python2-dev python3-dev py-setuptools freetype-dev jpeg-dev libwebp-dev
 	tiff-dev libpng-dev lcms2-dev libjpeg-turbo-dev zlib-dev"
 subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
-source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz
+	py-pillow-fix-pytest-ver.patch"
 builddir="$srcdir/$_pkgname-$pkgver"
 [ "$CARCH" = "s390x" ] && options="!check"
 
@@ -54,4 +55,5 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="0cd4617519506c9bcbd6eae0d2578a2e21e1c37a1e6175a31842d2671a2f159888f38f5345e50945b243a6fbd6e2feffd5cd7dd1601f48c6bc4858a4b3664c76  Pillow-6.0.0.tar.gz"
+sha512sums="0cd4617519506c9bcbd6eae0d2578a2e21e1c37a1e6175a31842d2671a2f159888f38f5345e50945b243a6fbd6e2feffd5cd7dd1601f48c6bc4858a4b3664c76  Pillow-6.0.0.tar.gz
+111562854bd87f9978c7cf05f9876e5a22bf49b7aad367ee54967b79f89e3cc39f8c5647fa297162b8869075f9d17e870a6ea6d5e0cdb150fdf6dcdbac5bf7b0  py-pillow-fix-pytest-ver.patch"

--- a/main/py-pillow/py-pillow-fix-pytest-ver.patch
+++ b/main/py-pillow/py-pillow-fix-pytest-ver.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -785,7 +785,7 @@
+           ext_modules=[Extension("PIL._imaging", ["_imaging.c"])],
+           include_package_data=True,
+           setup_requires=pytest_runner,
+-          tests_require=['pytest'],
++          tests_require=['pytest < 5'],
+           packages=["PIL"],
+           package_dir={'': 'src'},
+           keywords=["Imaging", ],


### PR DESCRIPTION
Build fails with error:
```
Traceback (most recent call last):
  File "setup.py", line 792, in <module>
    zip_safe=not (debug_build() or PLATFORM_MINGW), )
  File "/usr/lib/python2.7/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/mksully/trees/aports/main/py-pillow/src/Pillow-6.0.0/.eggs/pytest_runner-5.1-py2.7.egg/ptr.py", line 209, in run
    return self.run_tests()
  File "/home/mksully/trees/aports/main/py-pillow/src/Pillow-6.0.0/.eggs/pytest_runner-5.1-py2.7.egg/ptr.py", line 220, in run_tests
    result_code = __import__('pytest').main()
  File "/home/mksully/trees/aports/main/py-pillow/src/Pillow-6.0.0/.eggs/pytest-5.1.2-py2.7.egg/pytest.py", line 6, in <module>
    from _pytest.assertion import register_assert_rewrite
  File "/home/mksully/trees/aports/main/py-pillow/src/Pillow-6.0.0/.eggs/pytest-5.1.2-py2.7.egg/_pytest/assertion/__init__.py", line 6, in <module>
    from _pytest.assertion import rewrite
  File "/home/mksully/trees/aports/main/py-pillow/src/Pillow-6.0.0/.eggs/pytest-5.1.2-py2.7.egg/_pytest/assertion/rewrite.py", line 453
    def _get_assertion_exprs(src: bytes) -> Dict[int, str]:
                                ^
SyntaxError: invalid syntax
```

As described in https://github.com/pytest-dev/pytest/issues/5519, to fix pytest should be limited to less than version 5. 