### PR TITLE
community/dvd+rw-tools: add required sysmacros.h header

### DIFF
--- a/community/dvd+rw-tools/APKBUILD
+++ b/community/dvd+rw-tools/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: ScrumpyJack <scrumpyjack@st.ilet.to>
 pkgname=dvd+rw-tools
 pkgver=7.1
-pkgrel=0
+pkgrel=1
 pkgdesc="DVD and Blu-ray burning tools"
 url="http://fy.chalmers.se/~appro/linux/DVD+RW/"
 arch="all"
@@ -13,6 +13,7 @@ makedepends="$depends_dev m4 linux-headers"
 install=""
 subpackages="$pkgname-doc"
 source="http://fy.chalmers.se/~appro/linux/DVD+RW/tools/${pkgname}-${pkgver}.tar.gz
+	fix-sysmacros-header.patch
 	transport.hxx.patch"
 builddir=$srcdir/${pkgname}-${pkgver}
 
@@ -30,9 +31,6 @@ package() {
   	install -m644 growisofs.1 ${pkgdir}/usr/share/man/man1/growisofs.1
 }
 
-md5sums="8acb3c885c87f6838704a0025e435871  dvd+rw-tools-7.1.tar.gz
-fee956907bf81623a8445f1c58e633e4  transport.hxx.patch"
-sha256sums="f8d60f822e914128bcbc5f64fbe3ed131cbff9045dca7e12c5b77b26edde72ca  dvd+rw-tools-7.1.tar.gz
-e6b510fe2afe56a10be58c85d23b4d7e65989a3a6ac13be49867383c985b1772  transport.hxx.patch"
 sha512sums="938f9ec5597158af275c7bf63002696ba362f6f22a219108c6a1df28792f0485046a7af5ce57e41695aaaa0d69543bd66cbbeb4415df5c0e0a902a3f1d278a31  dvd+rw-tools-7.1.tar.gz
+c3ca41eeac3c50a3c662d358b2e7c5f406b6d946720efad18af5feb26a214c80044c2f529491c51a0b07fb421fcaff45980d038cd7b26d8b8f06a21863c04c3f  fix-sysmacros-header.patch
 9929fa03fd8a6c9b9ad724d1d0de77a602558bb75691148c7a9562f95b5379149fc39ab66a151c10fbe15e18c75b0ecd2d51f7c0499ced3c2e88a54330c44067  transport.hxx.patch"

--- a/community/dvd+rw-tools/fix-sysmacros-header.patch
+++ b/community/dvd+rw-tools/fix-sysmacros-header.patch
@@ -1,0 +1,10 @@
+--- a/growisofs.c
++++ b/growisofs.c
+@@ -440,6 +440,7 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <assert.h>
+ #include "mp.h"


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of dvd+rw-tools fails with:
```
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: growisofs.o: in function `find_raw_device':
growisofs.c:(.text+0x658): undefined reference to `major'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: growisofs.c:(.text+0x668): undefined reference to `minor'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: growisofs.o: in function `grab_sg':
growisofs.c:(.text+0x8d8): undefined reference to `minor'                                                                                 
```
Explicitly including sys/sysmacros.h fixes the issue.