### PR TITLE
community/java-sigar: add required sysmacros.h

### DIFF
--- a/community/java-sigar/APKBUILD
+++ b/community/java-sigar/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=java-sigar
 _pkgname=sigar
 pkgver=1.6.4
-pkgrel=0
+pkgrel=1
 pkgdesc="System Information Gatherer And Reporter"
 url="https://github.com/hyperic/sigar/"
 arch="all !aarch64"
@@ -15,6 +15,7 @@ source="https://github.com/hyperic/$_pkgname/archive/$_pkgname-$pkgver.tar.gz
 	musl-compat-HZ.patch
 	musl-compat-strerror_r.patch
 	tirpc.patch
+	java-sigar-include-sysmacros.patch
 	fix-inlined-functions-definition.patch
 	"
 builddir="$srcdir/$_pkgname-$_pkgname-$pkgver"
@@ -45,4 +46,5 @@ sha512sums="0515f3501a51357d6ac01dc5e3ecffae10995f347b98c66928adff247b86e52112d2
 bfb4f6f945207be652c58cfc8d3a552c84424d0ca9a3c0bf4177f4caa24c65a44ed3342b28d6d80d82a3e61d72f61d9c4194902bafa5372710db71f85e713f0f  musl-compat-HZ.patch
 ea85154edc0ca2b15d556bbfe4fa61b37d2a53befa969b4c91d976b502f14ce138b0dbbd7d46985aa809a490df97b6ef388f3f16820e1e14b52fc85851342527  musl-compat-strerror_r.patch
 c6bda65e389a62495951a908f675fbe4aa24b3b819e8e4bc9fee87e9e59ca5533b9ad738737d42f7d7665cc077a3bbc868420aa281536d0673a62e94b165488c  tirpc.patch
+678fe505286ec31297d1459788f44144ecd7f35a35523f53be8cf8d699e45491a4573968ac8e8f88620acdae49e5aa2b130dc18c1c7c311b026b3ed1e65166fe  java-sigar-include-sysmacros.patch
 ff313c86155c6c6e827cca1ea092308fce3f57eff88fb097e7f2f125ce42b44e45de57f7f45dd0b440fae854a169fad3e2ebe9d2fc9f2c7406413928ed081e15  fix-inlined-functions-definition.patch"

--- a/community/java-sigar/java-sigar-include-sysmacros.patch
+++ b/community/java-sigar/java-sigar-include-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/include/sigar.h
++++ b/include/sigar.h
+@@ -110,6 +110,7 @@
+ typedef unsigned long sigar_gid_t;
+ #else
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ typedef pid_t sigar_pid_t;
+ typedef uid_t sigar_uid_t;
+ typedef gid_t sigar_gid_t;


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of java-sigar fails with:
```
       [cc] /home/mksully/trees/aports/community/java-sigar/src/sigar-sigar-1.6.4/src/os/linux/linux_sigar.c:1225:40: note: in expansion of macro 'ST_MINOR'
       [cc]                           ST_MAJOR(sb), ST_MINOR(sb));
       [cc]                                         ^~~~~~~~
       [cc] /home/mksully/trees/aports/community/java-sigar/src/sigar-sigar-1.6.4/src/os/linux/linux_sigar.c:1149:22: error: called object 'major' is not a function or function pointer
       [cc]  #define ST_MAJOR(sb) major((sb).st_rdev)
       [cc]                       ^~~~~
```
Explicitly including sys/sysmacros.h fixes the issue.