### PR TITLE
community/docker: upgrade to 19.03.2

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -2,10 +2,10 @@
 # Contributor: Jake Buchholz <tomalok@gmail.com>
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 pkgname=docker
-pkgver=19.03.1
-_gitcommit=74b1e89e8ac68948be88fe0aa1e2767ae28659fe	# https://github.com/docker/docker-ce/commits/v$pkgver
+pkgver=19.03.2
+_gitcommit=6a30dfca03664a0b6bf0646a7d389ee7d0318e6e	# https://github.com/docker/docker-ce/commits/v$pkgver
 _ver=${pkgver/_/-}-ce
-pkgrel=3
+pkgrel=0
 pkgdesc="Pack, ship and run any application as a lightweight container"
 url="https://www.docker.io/"
 arch="all"
@@ -213,7 +213,7 @@ cli_vim() {
 	done
 }
 
-sha512sums="92b4e5fe2bbf96a261d290ca807550af45146be9d21680940bd6aa45d9127ae8ddbc706df4056f1720ed6975a2a92004f1789fae4109c50206904ad827d4bf2e  docker-19.03.1.tar.gz
+sha512sums="6b594fdbb53dcc0228781375a3884eb370446738c44f7c1e42945c4ccc263e75f53d984bc8ea6a6a498446859e667305bd967299c12956f1cb925d868a4bf2b8  docker-19.03.2.tar.gz
 dea31fd82ab2d445fbd39fe15550a91f7e489a06f6dedd32ea1925f7e9a7971952d26b874f9687249609a0d204ea35da357e0a957b819df2026a0cf8109cb354  libnetwork-fc5a7d91d54cc98f64fc28f9e288b46a0bee756c.tar.gz
 c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 d796e6dcab6443a84064f3439dde46bc7e1989e1b52910b3e80a0af0ae1ddd288f0306a24c8d31032e24f5fd4218d2f25614752021355441f118ba2b524cfbd1  docker-openrc-fixes.patch"


### PR DESCRIPTION
Latest release of `docker`.

See https://github.com/docker/docker-ce/releases/tag/v19.03.2 for more details.