### PR TITLE
community/abook: modify to support current gettext 0.20 version

### DIFF
--- a/community/abook/APKBUILD
+++ b/community/abook/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=abook
 pkgver=0.6.1
 _ver=${pkgver/_pre/pre}
-pkgrel=4
+pkgrel=5
 pkgdesc="Text-based addressbook designed for use with Mutt"
 url="http://abook.sourceforge.net"
 license="GPL-2.0"
@@ -19,7 +19,7 @@ prepare() {
 	cd "$builddir"
 
 	aclocal && automake --add-missing && autoconf -v
-	sed 's/0.18/0.19/g' -i po/Makefile.in.in
+	sed 's/0.18/0.20/g' -i po/Makefile.in.in
 }
 
 build() {


### PR DESCRIPTION
abook source currently expects gettext version 0.19. Building fails with error:
```
*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.19 but the autoconf macros are from gettext version 0.20
```
This change makes modification to build correctly with Alpine's current gettext 0.20 package.