### PR TITLE
community/libnsl: modify to work with gettext version 0.20

### DIFF
--- a/community/libnsl/APKBUILD
+++ b/community/libnsl/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=libnsl
 pkgver=1.2.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Public client interface for NIS(YP) and NIS+ in a IPv6 ready version"
 url="https://github.com/thkukuk/libnsl"
 arch="all"
@@ -24,6 +24,7 @@ prepare() {
 	default_prepare
 	cd "$builddir"
 	./autogen.sh
+	sed 's/0.19/0.20/g' -i po/Makefile.in.in
 }
 
 build() {


### PR DESCRIPTION
libnsl source currently expects gettext version 0.19 and building fails with:
```
*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.19 but the autoconf macros are from gettext version 0.20
```
This PR allows libnsl to build correctly with current Alpine version of libnsl 0.20.