### PR TITLE
testing/gnome-authenticator: depend on libhandy

### DIFF
--- a/testing/gnome-authenticator/APKBUILD
+++ b/testing/gnome-authenticator/APKBUILD
@@ -2,13 +2,13 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=gnome-authenticator
 pkgver=3.32.2
-pkgrel=0
+pkgrel=1
 pkgdesc="A Two-Factor Authentication application"
 url="https://gitlab.gnome.org/World/Authenticator"
 arch="noarch"
 license="GPL-3.0-only"
 depends="python3 py3-otp py3-beautifulsoup4 py3-pillow py3-favicon py3-pyzbar
-	py3-yoyo-migrations"
+	py3-yoyo-migrations libhandy"
 makedepends="meson gtk+3.0-dev libsecret-dev zbar-dev gobject-introspection-dev"
 checkdepends="appstream-glib desktop-file-utils"
 subpackages="$pkgname-lang"


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/authenticator", line 31, in <module>
    require_version("Handy", "0.0")
  File "/usr/lib/python3.7/site-packages/gi/__init__.py", line 129, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Handy not available

@Cogitri