### PR TITLE
community/containerd: upgrade to 1.2.9

### DIFF
--- a/community/containerd/APKBUILD
+++ b/community/containerd/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=containerd
 
 # NOTE: containerd's Makefile tries to get REVISION from git, but we're building from a tarball.
-_commit=a4bc1d432a2c33aa2eed37f338dceabb93641310
-pkgver=1.2.8
+_commit=d50db0a42053864a270f648048f9a8b4f24eced3
+pkgver=1.2.9
 pkgrel=0
 pkgdesc="An open and reliable container runtime"
 url="https://containerd.io"
@@ -18,6 +18,10 @@ source="containerd-$pkgver.tar.gz::https://github.com/containerd/containerd/arch
 builddir="$srcdir/src/github.com/containerd/containerd"
 
 # secfixes:
+#   1.2.9:
+#     - CVE-2019-9512
+#     - CVE-2019-9514
+#     - CVE-2019-9515 
 #   1.2.6:
 #     - CVE-2019-9946
 
@@ -44,4 +48,4 @@ package() {
 	install -Dm644 "$builddir"/man/*.5 "$pkgdir"/usr/share/man/man5/
 }
 
-sha512sums="384cc0cf837986a77dee9ece36d79c9bc37078bef4217824231e7b89db62b04cacb26963dc8693ae47a1cd40f1094e5da4f86a9f8ae5b2a851f4a506b020a3fe  containerd-1.2.8.tar.gz"
+sha512sums="60c7d08db3796caa8148f242f8386ff530943cef19fe73c72787fd7bbf2420feac06cadd558afc93d2baf168817d679245bf2ac9feb169547286cb312818be85  containerd-1.2.9.tar.gz"


### PR DESCRIPTION
Fixes CVE-2019-9512, CVE-2019-2514, and CVE-2019-2515.
More release notes at:  https://github.com/containerd/containerd/releases/tag/v1.2.9