### PR TITLE
[3.10] community/containerd: upgrade to 1.2.9

### DIFF
--- a/community/containerd/APKBUILD
+++ b/community/containerd/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=containerd
 
 # NOTE: containerd's Makefile tries to get REVISION from git, but we're building from a tarball.
-_commit=85f6aa58b8a3170aec9824568f7a31832878b603
-pkgver=1.2.7
+_commit=d50db0a42053864a270f648048f9a8b4f24eced3
+pkgver=1.2.9
 pkgrel=0
 pkgdesc="An open and reliable container runtime"
 url="https://containerd.io"
@@ -18,6 +18,10 @@ source="containerd-$pkgver.tar.gz::https://github.com/containerd/containerd/arch
 builddir="$srcdir/src/github.com/containerd/containerd"
 
 # secfixes:
+#   1.2.9:
+#     - CVE-2019-9512
+#     - CVE-2019-9514
+#     - CVE-2019-9515 
 #   1.2.6:
 #     - CVE-2019-9946
 
@@ -32,12 +36,10 @@ build() {
 }
 
 check() {
-	cd "$builddir"
 	./bin/containerd --version
 }
 
 package() {
-	cd "$builddir"
 	install -d "$pkgdir"/usr/bin/
 	install -Dsm755 "$builddir"/bin/* "$pkgdir"/usr/bin/
 	install -d "$pkgdir"/usr/share/man/man1/
@@ -46,4 +48,4 @@ package() {
 	install -Dm644 "$builddir"/man/*.5 "$pkgdir"/usr/share/man/man5/
 }
 
-sha512sums="b96ca236d28933c1bf309fc7204af7d2c356e19af394d5c2274a178c8f15298faf6ca9bb8e7d04acb7c3c9c41035446643a8df0103017f7ed0320bfc37cb8ca9  containerd-1.2.7.tar.gz"
+sha512sums="60c7d08db3796caa8148f242f8386ff530943cef19fe73c72787fd7bbf2420feac06cadd558afc93d2baf168817d679245bf2ac9feb169547286cb312818be85  containerd-1.2.9.tar.gz"


### PR DESCRIPTION
Fixes CVE-2019-9512, CVE-2019-2514, and CVE-2019-2515.
More release notes at:  https://github.com/containerd/containerd/releases/tag/v1.2.9