### PR TITLE
main/acpi: adopt

### DIFF
--- a/main/acpi/APKBUILD
+++ b/main/acpi/APKBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Cág <ca6c@bitmessage.ch>
+# Maintainer: Will Sinatra <wpsinatra@gmail.com>
 pkgname=acpi
 pkgver=1.7
 pkgrel=3


### PR DESCRIPTION
Adopt maintenance of ACPI as Cag has decided to no longer maintain this package.