### PR TITLE
esting/hiawatha: fix / improve initd

### DIFF
--- a/testing/hiawatha/APKBUILD
+++ b/testing/hiawatha/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: Stuart Cardall <developer at it-offshore dot co.uk>
 pkgname=hiawatha
 pkgver=10.9
-pkgrel=2
+pkgrel=3
 pkgdesc='Secure and advanced webserver'
 url='https://www.hiawatha-webserver.org/'
 arch="all"
@@ -63,6 +63,6 @@ letsencrypt() {
 }
 
 sha512sums="ccd59d6c302d797a88d88206c770e794b9a2a374040bd08da67530c13a36d0232bf759df1f8d54790dcf1ae3dc25cadbd7d3af542f559b845a5cf346020eb74a  hiawatha-10.9.tar.gz
-cec0adfb48e1751cf13031f2c28f4590340b2c747aa8e81d18c16bc8789bce69b2d9d99290a93b74b501db3b63190a071033a78abeeb8f60becba2dcaf3b5c40  hiawatha.initd
+115956a6a977ac34d090450af6ff27736c451d5b03507c21f3021b5759247f892eeb3739539acd85eddb352f1baab0a58e119d8fda9dff6f22aab6ef7c65669b  hiawatha.initd
 b2aad6d02e03a3e25dc6dc30deab4637a7de5448255b6b707363e8c71ae1029e669bacdb6b88889ec1aa804fe717560e872dc44d049127af9aa155a8895c8a60  hiawatha.conf.sample
 bc31823ba0894bf4dc2f1d9aac3c03382d60a1302f4d35027ca4d3e38d8a14cfdbc94af3235800b9e8cc68c4efceb1ba04c654d16ee0d297591f25a470cc567c  letsencrypt.helper"

--- a/testing/hiawatha/hiawatha.initd
+++ b/testing/hiawatha/hiawatha.initd
@@ -2,12 +2,21 @@
 
 supervisor=supervise-daemon
 
-name="Webserver"
-description="Secure and Advanced Hiawatha Webserver"
+name="Hiawatha webserver"
+description="Secure and advanced webserver"
 
 command=/usr/sbin/hiawatha
-command_args_foreground="-d"
+command_args_foreground="-d 1>/dev/null"
+pidfile=/var/run/hiawatha.pid
+healthcheck_timer=60
 
 depend() {
 	after firewall
+}
+
+stop() {
+	local supervise_pid=$(pgrep -f "$supervisor $RC_SVCNAME")
+
+	einfo "Stopping $name"
+	kill -TERM $supervise_pid
 }


### PR DESCRIPTION
* adds `$pidfile` required by supervise-daemon
* adds `healthcheck_timer` so the service is monitored
* fixes stopping the daemon

	internally `hiawatha` spawns mutiple processes. To stop `hiawatha`
	it is necessary to terminate it's `supervise-daemon` process.