### PR TITLE
community/gegl: enable support for more image formats

### DIFF
--- a/community/gegl/APKBUILD
+++ b/community/gegl/APKBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gegl
 pkgver=0.4.16
-pkgrel=2
+pkgrel=3
 pkgdesc="Graph based image processing framework"
 url="https://www.gegl.org/"
 arch="all"
 license="GPL-3.0 LGPL-3.0"
 makedepends="babl-dev libpng-dev libjpeg-turbo-dev gtk+-dev librsvg-dev
-	lua5.1-dev exiv2-dev json-glib-dev"
+	lua5.1-dev gexiv2-dev json-glib-dev libraw-dev libwebp-dev pango-dev
+	gdk-pixbuf-dev ffmpeg-dev vala"
 checkdepends="diffutils"
 subpackages="$pkgname-dev $pkgname-lang"
 source="https://download.gimp.org/pub/gegl/${pkgver%.*}/gegl-$pkgver.tar.bz2"
@@ -17,9 +18,18 @@ build() {
 		--build=$CBUILD \
 		--prefix=/usr \
 		--disable-docs \
-		--with-exiv2 \
+		--with-gexiv2 \
 		--without-jasper \
-		--with-lua
+		--with-lua \
+		--with-vala \
+		--with-pango \
+		--with-cairo \
+		--with-pangocairo \
+		--with-gdk-pixbuf \
+		--with-zlib \
+		--with-librsvg \
+		--with-libraw \
+		--with-webp
 	make
 }
 


### PR DESCRIPTION
* fix gexiv2 support (it needs gexiv2, not exiv2)
* add support for webp, raw, pango&gdk-pixbuf and much more with ffmpeg
* enable vala bindings