### PR TITLE
main/openvpn-auth-ldap: Upgrade to 2.0.4

### DIFF
--- a/main/openvpn-auth-ldap/APKBUILD
+++ b/main/openvpn-auth-ldap/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=openvpn-auth-ldap
-pkgver=2.0.3
-pkgrel=6
+pkgver=2.0.4
+pkgrel=0
 pkgdesc="LDAP authentication and authorization plugin for OpenVPN 2.x"
 url="http://code.google.com/p/openvpn-auth-ldap/"
 arch="all"
@@ -10,21 +10,17 @@ depends=
 makedepends="automake autoconf re2c openldap-dev openvpn-dev gcc-objc"
 install=
 subpackages=
-source="https://github.com/threerings/openvpn-auth-ldap/archive/auth-ldap-$pkgver.tar.gz
-	"
+source="https://github.com/threerings/openvpn-auth-ldap/archive/auth-ldap-$pkgver.tar.gz"
 builddir="$srcdir"/openvpn-auth-ldap-auth-ldap-$pkgver
+options="!check"
 
 prepare() {
-	default_prepare || return 1
-	cd "$builddir"
-	sed -i -e '/^builtin(include,objc.m4)/d' aclocal.m4
-	(autoconf && autoheader) || return 1
-	update_config_sub || return 1
-	sed -i -e '/<objc\/objc-api.h>/d' configure
+	default_prepare
+	(autoconf && autoheader)
+	update_config_sub
 }
 
 build() {
-	cd "$builddir"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \
@@ -34,16 +30,14 @@ build() {
 		--infodir=/usr/share/info \
 		--with-openvpn=/usr \
 		--with-objc-runtime=GNU \
-		|| return 1
-	make || return 1
+		CFLAGS="-fPIC" \
+		OBJCFLAGS="-std=gnu11"
+	make
 }
 
 package() {
-	cd "$builddir"
 	mkdir -p "$pkgdir"/usr/lib
 	make DESTDIR="$pkgdir" install
 }
 
-md5sums="edc1e9d61d4feb9eed24656094c2f907  auth-ldap-2.0.3.tar.gz"
-sha256sums="3bafd6733513d8d824cfc84e308dfa91b2ed021b67892fc7488962cb9f94d283  auth-ldap-2.0.3.tar.gz"
-sha512sums="e09be3453fe6cf43e535c1bc85aefa4de51d83f301558176611595f63093fe70bd9bc5d21c8dea56d3ad46335019b3bb803afceeec03985514a4b27474f14512  auth-ldap-2.0.3.tar.gz"
+sha512sums="ffa1f1617acd3f4e96d3abea7e5611d8b8406c92ff1298ac0520f2d42f188116904187d3ca8c0ae88e0bcc6449ec4c8494a18770a4635c1ee7301baaaddfa12e  auth-ldap-2.0.4.tar.gz"


### PR DESCRIPTION
Updated package to 2.0.4: This fixes some issues I've had with this package (I'm running it successfully with this new build script for over a week)
Adapted build script for new version: Some new build flags were needed
Updated build script to comply with modern APKBUILD standards:
- removed explicit `return 1`
- removed `cd $builddir`
- added `options=!check`

*IMPORTANT*: I also removed two `sed` commands that didn't seem to do anything (no files were changed when executing and the resulting binaries are exactly the same with and without them) but I have no idea how `sed` actually works and therefore cannot say for sure that was the right decision.