### PR TITLE
main/imap: SNI patch required for TLS 1.3

### DIFF
--- a/main/imap/APKBUILD
+++ b/main/imap/APKBUILD
@@ -5,7 +5,7 @@
 # build it shared
 pkgname=imap
 pkgver=2007f
-pkgrel=9
+pkgrel=10
 pkgdesc="An IMAP/POP server"
 url="http://www.washington.edu/imap"
 arch="all"
@@ -17,6 +17,7 @@ source="http://ftp.ntua.gr/pub/net/mail/imap/imap-$pkgver.tar.gz
 	fix-linking.patch
 	c-client-2006k_KOLAB_Annotations.patch
 	1006_openssl1.1_autoverify.patch
+	sni.patch
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver
@@ -65,4 +66,5 @@ cclient() {
 sha512sums="7c3e1d9927872001e768ff2ddbcf3af74078243efe58dd70e01d966856b7611134e4b579818691a954bade9acaeeda6f2f30f40d812b8aa20990de5cb90d5d35  imap-2007f.tar.gz
 f8a4b5b8759b690273ec8c86db55c3c3ebf7b358321aa829341bc65e98db0f10696b1eeae922eecada668f011b0b3231ed73c3a959b47b4cba00568bf7d231c1  fix-linking.patch
 871093236b3ae300968e1e200a2389566af72ed1f62ad57c1dc617dd59e8378f29175fe07e5cfc575e022f3c27769b06850cbf21567f7cc359ca204c4d87a3af  c-client-2006k_KOLAB_Annotations.patch
-7ecbe52adc6e3d1deee05790745642f794150ffaebf51c0cf689dc036eea9c7d80e643648aac37bf0aa83ac138b8bb63abfad3b540bc9440de3456162dfabae5  1006_openssl1.1_autoverify.patch"
+7ecbe52adc6e3d1deee05790745642f794150ffaebf51c0cf689dc036eea9c7d80e643648aac37bf0aa83ac138b8bb63abfad3b540bc9440de3456162dfabae5  1006_openssl1.1_autoverify.patch
+2b1ec17da5c57832f3adb30f09f4fd31f6cdfc63a696f36141b84bdc0a375f0b40a2c84cba3d11658a2895125687f49ead04ef381eed4b61564ede65f6149622  sni.patch"

--- a/main/imap/sni.patch
+++ b/main/imap/sni.patch
@@ -1,0 +1,24 @@
+Description: Google IMAP servers require SNI if client supports TLS 1.3.
+Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/php-imap/+bug/1834340
+
+--- a/src/osdep/unix/ssl_unix.c
++++ b/src/osdep/unix/ssl_unix.c
+@@ -273,6 +273,18 @@ static char *ssl_start_work (SSLSTREAM *stream,char *host,unsigned long flags)
+ 				/* create connection */
+   if (!(stream->con = (SSL *) SSL_new (stream->context)))
+     return "SSL connection failed";
++#if OPENSSL_VERSION_NUMBER >= 0x10200000L
++  ASN1_OCTET_STRING *ip;
++  /* support SNI if host is not an IP address */
++  /* per RFC 6066: */
++  /* Literal IPv4 and IPv6 addresses are not permitted in "HostName". */
++  /* a2i_IPADDRESS is available since OpenSSL 1.0.2 */
++  ip = a2i_IPADDRESS(host);
++  if (ip == NULL) {
++    ERR_clear_error();
++    SSL_set_tlsext_host_name(stream->con,host);
++  }
++#endif
+   bio = BIO_new_socket (stream->tcpstream->tcpsi,BIO_NOCLOSE);
+   SSL_set_bio (stream->con,bio,bio);
+   SSL_set_connect_state (stream->con);


### PR DESCRIPTION
Hopefully solves https://gitlab.alpinelinux.org/alpine/aports/issues/10773
Ubuntu bug https://bugs.launchpad.net/ubuntu/+source/php-imap/+bug/1834340

Google IMAP servers require SNI if client supports TLS 1.3, since Alpine now has OpenSSL 1.1.1, this is enabled and `php-imap` started failing.

This simplest check possible appears to be:
```sh
php -r 'imap_open("{imap.gmail.com:993/imap/ssl}INBOX", "username", "password");'
```
Where the failure looks like:
```
PHP Warning: imap_open(): Couldn't open stream {imap.gmail.com:993/imap/ssl}INBOX in Command line code on line 1
PHP Notice: Unknown: Certificate failure for imap.gmail.com: self signed certificate: /OU=No SNI provided; please fix your client./CN=invalid2.invalid (errflg=2) in Unknown on line 0
```

I was **not able** to confirm if this will work after the patch is applied, even though I tried to build this package and then php7 packages with patched c-client, the above warning/notice still appeared. But I think it's just lack of knowledge on my side. Because frankly I have no idea how the packages / libraries / etc. work. :) If someone could please confirm the fix is working, or just let me know how to properly test this, I would greatly appreciate it.

---

Patch taken from Ubuntu bug tracker, originally by David Zuelke (dzuelke), see https://bugs.launchpad.net/ubuntu/+source/php-imap/+bug/1834340/comments/7