### PR TITLE
community/lockdev: add required sysmacros.h

### DIFF
--- a/community/lockdev/APKBUILD
+++ b/community/lockdev/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=lockdev
 pkgver=0_git20130107
-pkgrel=2
+pkgrel=3
 pkgdesc="Run-time shared library for locking devices, using _both_ FSSTND and SVr4 methods."
 options="!check"
 url="https://packages.qa.debian.org/l/lockdev.html"
@@ -10,7 +10,8 @@ arch="all"
 license="LGPL-2.1-or-later"
 makedepends="automake autoconf libtool"
 subpackages="$pkgname-dev $pkgname-doc"
-source="https://dev.alpinelinux.org/archive/$pkgname/$pkgname-$pkgver.tar.gz"
+source="https://dev.alpinelinux.org/archive/$pkgname/$pkgname-$pkgver.tar.gz
+	lockdev_include_sysmacros.patch"
 giturl="git://anonscm.debian.org/lockdev/lockdev.git"
 disturl="dev.alpinelinux.org:/archive/$pkgname/"
 
@@ -37,4 +38,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="65c9a6f184742ee3bfea3c7309c1116498d5a462a973574a6b8098b2b4eaf96c822b5b84b3e5cc509a4282912cb81e25e71ef245d94137edf7a4e6acf82a8c53  lockdev-0_git20130107.tar.gz"
+sha512sums="65c9a6f184742ee3bfea3c7309c1116498d5a462a973574a6b8098b2b4eaf96c822b5b84b3e5cc509a4282912cb81e25e71ef245d94137edf7a4e6acf82a8c53  lockdev-0_git20130107.tar.gz
+a1583789b6d26e81e88203eb0b1856027541d62af3d4d3b051d917d613fb26060dfebd87421e828923ab5ee0c884463e69f951d749227caa9a2032fb220dce6f  lockdev_include_sysmacros.patch"

--- a/community/lockdev/lockdev_include_sysmacros.patch
+++ b/community/lockdev/lockdev_include_sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/src/lockdev.c
++++ b/src/lockdev.c
+@@ -117,6 +117,7 @@
+ #include <sys/stat.h>
+ #include <sys/file.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/wait.h>
+ #include "lockdev.h"
+ #include "ttylock.h"


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of lockdev fails with:
```
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: ./.libs/liblockdev.so: undefined reference to `minor'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: ./.libs/liblockdev.so: undefined reference to `major'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: ./.libs/liblockdev.so: undefined reference to `minor'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: ./.libs/liblockdev.so: undefined reference to `major'
```
Explicitly including sys/sysmacros.h fixes the issue.