### PR TITLE
community/plymouth: add required sysmacros.h

### DIFF
--- a/community/plymouth/APKBUILD
+++ b/community/plymouth/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=plymouth
 pkgver=0.9.2
-pkgrel=2
+pkgrel=3
 pkgdesc="graphical bootsplash on linux"
 url="http://www.freedesktop.org/wiki/Software/Plymouth"
 arch="all"
@@ -15,6 +15,7 @@ subpackages="$pkgname-dev $pkgname-doc $pkgname-themes $pkgname-x11:_render $pkg
 source="https://www.freedesktop.org/software/$pkgname/releases/$pkgname-$pkgver.tar.bz2
 	plymouth-rpmatch.patch
 	plymouth-git-master-20170123.patch
+	plymouth-add-sysmacros.patch
 	"
 
 builddir="$srcdir"/plymouth-$pkgver
@@ -56,4 +57,5 @@ _render() {
 
 sha512sums="89356eb8326504fbf3155de262ce15de0847f0a0e6d157d873cf1dea9af464a6cb9e11d7143ee9a595b217a2487060b5835eba5ac142c3cd6d66689deb272e60  plymouth-0.9.2.tar.bz2
 ec1c32ddf7ee418ef1b5d173040db464193d9bca3fd85d5c3a8d2ee13ba1218947f7c9f39c403d3ccced70be28b2c7328e82dc8f967e9bdeea1651dee4be2dc7  plymouth-rpmatch.patch
-6545c29190b9cf04df0284a73c26ec7d14fddf2c4d7a8f3dff5242b49fafda24ee2aeab54b44b19deb9228707816b6b3779ea8bec7b742020cb1f7e2ca64b509  plymouth-git-master-20170123.patch"
+6545c29190b9cf04df0284a73c26ec7d14fddf2c4d7a8f3dff5242b49fafda24ee2aeab54b44b19deb9228707816b6b3779ea8bec7b742020cb1f7e2ca64b509  plymouth-git-master-20170123.patch
+b55d9bfad1de809334ee24a89496335e369e6e9a78eed2576ea93882d100dfddb09dbd05588fe478da6f9c50ae03c920defd8a352a93f2e149c39df1810a48c1  plymouth-add-sysmacros.patch"

--- a/community/plymouth/plymouth-add-sysmacros.patch
+++ b/community/plymouth/plymouth-add-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/src/libply-splash-core/ply-terminal.c
++++ b/src/libply-splash-core/ply-terminal.c
+@@ -32,6 +32,7 @@
+ #include <sys/socket.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <termios.h>
+ #include <unistd.h>
+ #include <wchar.h>


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of plymouth fails with:
```
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: libply-splash-core/.libs/libply-splash-core.so: undefined reference to `minor'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/8.3.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: libply-splash-core/.libs/libply-splash-core.so: undefined reference to `major'           
```
Explicitly including sys/sysmacros.h fixes the issue.