### PR TITLE
community/sigar: add required sysmacros.h

### DIFF
--- a/community/sigar/0007-sigar-add-sysmacros.patch
+++ b/community/sigar/0007-sigar-add-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/include/sigar.h
++++ b/include/sigar.h
+@@ -110,6 +110,7 @@
+ typedef unsigned long sigar_gid_t;
+ #else
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ typedef pid_t sigar_pid_t;
+ typedef uid_t sigar_uid_t;
+ typedef gid_t sigar_gid_t;

--- a/community/sigar/APKBUILD
+++ b/community/sigar/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=sigar
 pkgver=1.6.4
-pkgrel=1
+pkgrel=2
 pkgdesc="System Information Gatherer And Reporter"
 url="http://sigar.hyperic.com/"
 arch="all"
@@ -14,6 +14,7 @@ source="https://github.com/hyperic/sigar/archive/sigar-$pkgver.tar.gz
 	0004-make-the-package-compile-on-MIPS.patch
 	0005-no-m64-mips-arm.patch
 	0006-fix-undefined-symbols.patch
+	0007-sigar-add-sysmacros.patch
 	"
 
 builddir="$srcdir"/sigar-sigar-$pkgver
@@ -35,4 +36,5 @@ sha512sums="0515f3501a51357d6ac01dc5e3ecffae10995f347b98c66928adff247b86e52112d2
 1896f8deb1945dd18283cb391528791b7554b2a4d56c0bc02a58d36a6af2a333782486a508e4d756b558d522d9a759bb3eefe12f0fd1720a9b83426d2b9bf469  0003-build-with-libtirpc-and-gcc5.patch
 2999ac33ee0346ebb2d390bb4e315e340eb0c5c3e78c078f7687ddfa83b9817d13d46d4e1f7d208c75a49a279d035efb1a50af56c021d068ea313813e013c851  0004-make-the-package-compile-on-MIPS.patch
 c77796ce9d34a42ea8663bf47b119ec1e3b8a4daf938dad7a15a4c11239cd58ee9797725da4c7defa846479db4d8eb190220beafc969c9dac5fa6d5adebf55b6  0005-no-m64-mips-arm.patch
-b85593c1b07c2c7ac3cd66df70e2ab75e615547c14c797c4e6ce0508fc3a02988e5c9055f0dada14bdf0cb060c35129872239f01e9cf0e0481d0038578f93908  0006-fix-undefined-symbols.patch"
+b85593c1b07c2c7ac3cd66df70e2ab75e615547c14c797c4e6ce0508fc3a02988e5c9055f0dada14bdf0cb060c35129872239f01e9cf0e0481d0038578f93908  0006-fix-undefined-symbols.patch
+678fe505286ec31297d1459788f44144ecd7f35a35523f53be8cf8d699e45491a4573968ac8e8f88620acdae49e5aa2b130dc18c1c7c311b026b3ed1e65166fe  0007-sigar-add-sysmacros.patch"


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of sigar fails with:
```
[cc] /home/mksully/trees/aports/community/sigar/src/sigar-sigar-1.6.4/src/os/linux/linux_sigar.c: In function 'get_iostat_procp':
[cc] /home/mksully/trees/aports/community/sigar/src/sigar-sigar-1.6.4/src/os/linux/linux_sigar.c:1152:22: error: called object 'major' is not a function or function pointer       
```
Explicitly including sys/sysmacros.h fixes the issue.