### PR TITLE
testing/clisp: Attempt to build on all platforms

### DIFF
--- a/testing/clisp/APKBUILD
+++ b/testing/clisp/APKBUILD
@@ -3,10 +3,10 @@
 # Maintainer: Will Sinatra <wpsinatra@gmail.com>
 pkgname=clisp
 pkgver=2.49
-pkgrel=3
+pkgrel=4
 pkgdesc="ANSI Common Lisp interpreter, compiler and debugger"
 url="https://clisp.sourceforge.io/"
-arch="x86_64"
+arch="all"
 license="GPL-2.0-only"
 depends_dev="libsigsegv-dev ffcall ncurses-dev"
 makedepends="$depends_dev"


### PR DESCRIPTION
Attempt to see if current APKBUILD builds on any platform outside of x86_64.