### PR TITLE
main/qemu: add zlib-static makedepends due to zlib packaging change

### DIFF
--- a/main/qemu/APKBUILD
+++ b/main/qemu/APKBUILD
@@ -4,7 +4,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=qemu
 pkgver=4.0.0
-pkgrel=2
+pkgrel=3
 pkgdesc="QEMU is a generic machine emulator and virtualizer"
 url="http://qemu.org/"
 arch="all"
@@ -46,6 +46,7 @@ makedepends="
 	vte3-dev
 	xfsprogs-dev
 	zlib-dev
+	zlib-static
 	"
 pkggroups="qemu"
 install="$pkgname.pre-install $pkgname.post-install"


### PR DESCRIPTION
With change to zlib packaging 
 due to commit https://github.com/alpinelinux/aports/commit/388a4fb3640f8ccbd18e105df3ad741dca4247e1
zlib.a is now part of the zlib-static.apk. Since qemu requires this static library to build, zlib-static needs to be added to qemu's makedepends list.