### PR TITLE
testing/geary: depend on libgnome-keyring

### DIFF
--- a/testing/geary/APKBUILD
+++ b/testing/geary/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=geary
 pkgver=3.32.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Geary is an email application built around conversations"
 url="https://wiki.gnome.org/Apps/Geary"
 arch="all !armhf" #failing tests
 license="LGPL-2.1-or-later AND CC-BY-3.0 AND BSD-2-Clause"
-depends="iso-codes"
+depends="iso-codes libgnome-keyring"
 makedepends="meson glib-dev gtk+3.0-dev sqlite-dev webkit2gtk-dev enchant2-dev
 	gcr-dev folks-dev libgee-dev gnome-online-accounts-dev json-glib-dev iso-codes-dev
 	libcanberra-dev libnotify-dev libsecret-dev libxml2-dev vala gmime26-dev itstool"


### PR DESCRIPTION
crashes with SIGTRAP otherwise


@Cogitri