### PR TITLE
testing/py-pillow-simd: new aport

### DIFF
--- a/testing/py-pillow-simd/APKBUILD
+++ b/testing/py-pillow-simd/APKBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Marcel Esser <marcel.esser@gmail.com>
+pkgname=py-pillow-simd
+_pkgname=Pillow-SIMD
+pkgver=6.0.0
+pkgrel=0
+pkgdesc="Python Imaging Library SIMD"
+url="https://github.com/uploadcare/pillow-simd"
+arch="x86_64"
+license="PSF"
+provides="py-pillow py2-pillow py3-pillow"
+depends="py-olefile freetype jpeg libwebp tiff libpng lcms2 libjpeg-turbo zlib"
+makedepends="python2-dev python3-dev py-setuptools freetype-dev jpeg-dev libwebp-dev
+	tiff-dev libpng-dev lcms2-dev libjpeg-turbo-dev zlib-dev"
+subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+source="https://files.pythonhosted.org/packages/b1/19/b7043190f481abb94dcdd1e69c4432432aaa73455cf1128eae39b8eb2518/Pillow-SIMD-$pkgver.post0.tar.gz"
+builddir="$srcdir/Pillow-SIMD-$pkgver.post0"
+options="!check" # Unknown if test host has necessary SSE4 extensions.
+
+build() {
+	cd "$builddir"
+	# zlib resides in lib
+	export CFLAGS="$CFLAGS -L/lib"
+	python2 setup.py build
+	python3 setup.py build
+}
+
+package() {
+	mkdir -p "$pkgdir"
+}
+
+_py2() {
+	replaces="$pkgname py-imaging"
+	depends="${depends//py-/py2-}"
+	_py python2
+}
+
+_py3() {
+	depends="${depends//py-/py3-}"
+	_py python3
+}
+
+_py() {
+	local python="$1"
+	pkgdesc="$pkgdesc (for $python)"
+	install_if="$pkgname=$pkgver-r$pkgrel $python"
+
+	cd "$builddir"
+	$python setup.py install --prefix=/usr --root="$subpkgdir"
+}
+
+sha512sums="792b0bbc6a2e72cd7277f76703f87c94aec27cd9ad7f4891dc32cbfa684cd3031b64618550995177daa0c4729beeb6e0802d06e41a1f22c2f783f736e02a3d44  Pillow-SIMD-6.0.0.post0.tar.gz"

--- a/testing/py3-pillow-simd/APKBUILD
+++ b/testing/py3-pillow-simd/APKBUILD
@@ -1,5 +1,5 @@
 # Maintainer: Marcel Esser <marcel.esser@gmail.com>
-pkgname=py-pillow-simd
+pkgname=py3-pillow-simd
 _pkgname=Pillow-SIMD
 pkgver=6.0.0
 pkgrel=0
@@ -7,11 +7,11 @@ pkgdesc="Python Imaging Library SIMD"
 url="https://github.com/uploadcare/pillow-simd"
 arch="x86_64"
 license="PSF"
-provides="py-pillow py2-pillow py3-pillow"
-depends="py-olefile freetype jpeg libwebp tiff libpng lcms2 libjpeg-turbo zlib"
-makedepends="python2-dev python3-dev py-setuptools freetype-dev jpeg-dev libwebp-dev
+provides="py-pillow py3-pillow"
+depends="py3-olefile freetype jpeg libwebp tiff libpng lcms2 libjpeg-turbo zlib"
+makedepends="python3-dev py3-setuptools freetype-dev jpeg-dev libwebp-dev
 	tiff-dev libpng-dev lcms2-dev libjpeg-turbo-dev zlib-dev"
-subpackages="py2-${pkgname#py-}:_py2 py3-${pkgname#py-}:_py3"
+subpackages="py3-${pkgname#py-}:_py3"
 source="https://files.pythonhosted.org/packages/b1/19/b7043190f481abb94dcdd1e69c4432432aaa73455cf1128eae39b8eb2518/Pillow-SIMD-$pkgver.post0.tar.gz"
 builddir="$srcdir/Pillow-SIMD-$pkgver.post0"
 options="!check" # Unknown if test host has necessary SSE4 extensions.
@@ -20,7 +20,6 @@ build() {
 	cd "$builddir"
 	# zlib resides in lib
 	export CFLAGS="$CFLAGS -L/lib"
-	python2 setup.py build
 	python3 setup.py build
 }
 
@@ -28,24 +27,12 @@ package() {
 	mkdir -p "$pkgdir"
 }
 
-_py2() {
-	replaces="$pkgname py-imaging"
-	depends="${depends//py-/py2-}"
-	_py python2
-}
-
 _py3() {
-	depends="${depends//py-/py3-}"
-	_py python3
-}
-
-_py() {
-	local python="$1"
-	pkgdesc="$pkgdesc (for $python)"
-	install_if="$pkgname=$pkgver-r$pkgrel $python"
+	pkgdesc="$pkgdesc (for python3)"
+	install_if="$pkgname=$pkgver-r$pkgrel python3"
 
 	cd "$builddir"
-	$python setup.py install --prefix=/usr --root="$subpkgdir"
+	python3 setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
 sha512sums="792b0bbc6a2e72cd7277f76703f87c94aec27cd9ad7f4891dc32cbfa684cd3031b64618550995177daa0c4729beeb6e0802d06e41a1f22c2f783f736e02a3d44  Pillow-SIMD-6.0.0.post0.tar.gz"

--- a/testing/py3-pillow-simd/APKBUILD
+++ b/testing/py3-pillow-simd/APKBUILD
@@ -3,17 +3,17 @@ pkgname=py3-pillow-simd
 _pkgname=Pillow-SIMD
 pkgver=6.0.0
 pkgrel=0
+_pypi_rel=0 # rare pypi "post-release" version used by this project
 pkgdesc="Python Imaging Library SIMD"
 url="https://github.com/uploadcare/pillow-simd"
 arch="x86_64"
 license="PSF"
-provides="py-pillow py3-pillow"
 depends="py3-olefile freetype jpeg libwebp tiff libpng lcms2 libjpeg-turbo zlib"
 makedepends="python3-dev py3-setuptools freetype-dev jpeg-dev libwebp-dev
 	tiff-dev libpng-dev lcms2-dev libjpeg-turbo-dev zlib-dev"
-subpackages="py3-${pkgname#py-}:_py3"
-source="https://files.pythonhosted.org/packages/b1/19/b7043190f481abb94dcdd1e69c4432432aaa73455cf1128eae39b8eb2518/Pillow-SIMD-$pkgver.post0.tar.gz"
-builddir="$srcdir/Pillow-SIMD-$pkgver.post0"
+subpackages="py3-${_pkgname#py-}:_py3"
+source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.post$_pypi_rel.tar.gz"
+builddir="$srcdir/$_pkgname-$pkgver.post0"
 options="!check" # Unknown if test host has necessary SSE4 extensions.
 
 build() {


### PR DESCRIPTION
Provides the SSE4 vectorized version of Pillow-SIMD from UploadCare, as an
alternative to py-pillow.