### PR TITLE
main/py-certifi: upgrade to 2019.9.11

### DIFF
--- a/main/py-certifi/APKBUILD
+++ b/main/py-certifi/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Dmitry Romanenko <dmitry@romanenko.in>
 pkgname=py-certifi
 _pkgname=certifi
-pkgver=2019.6.16
+pkgver=2019.9.11
 pkgrel=0
 pkgdesc="Python package for providing Mozilla's CA Bundle"
 url="https://pypi.python.org/pypi/certifi"
@@ -48,4 +48,4 @@ _py() {
 	$python setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="4641626bc5073cd0b3a520855ddef1007dcb42933baa7a3469856f936e725581042bcbd5b67e984ba9748e7faa62b9125cba7dc160dcc5db2eafe46461a29f5e  certifi-2019.6.16.tar.gz"
+sha512sums="aab5734bf65cbad12772bb120153b0325a5c3226339e0a03fdf4c3413303feb930b6d53d1d9dab93bd4f3cf00d2bfbe86419c4c462570340f1a4aa143a31373c  certifi-2019.9.11.tar.gz"


### PR DESCRIPTION
For now still cross-python package, but it will be switched to `py3-` version as nested dependencies get converted from cross-python version into `py3-` only versions (py-tornado and py-requests)