### PR TITLE
community/gitlab-runner: set rev&branch during build

### DIFF
--- a/community/gitlab-runner/APKBUILD
+++ b/community/gitlab-runner/APKBUILD
@@ -3,7 +3,12 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=gitlab-runner
 pkgver=12.2.0
-pkgrel=0
+pkgrel=1
+# first 8 chars of the git hash of the release, see
+# https://gitlab.com/gitlab-org/gitlab-runner/-/tags
+# PLEASE update this, since they're used to determine what version of
+# https://hub.docker.com/r/gitlab/gitlab-runner-helper/tags to use
+_rev=a987417a
 pkgdesc="GitLab runner for CI/CD jobs"
 url="https://docs.gitlab.com/runner/"
 arch="all"
@@ -33,9 +38,9 @@ build() {
 	local ldflags="
 		-X gitlab.com/gitlab-org/$pkgname/common.NAME=$pkgname
 		-X gitlab.com/gitlab-org/$pkgname/common.VERSION=$pkgver
-		-X gitlab.com/gitlab-org/$pkgname/common.REVISION=unknown
+		-X gitlab.com/gitlab-org/$pkgname/common.REVISION=$_rev
 		-X gitlab.com/gitlab-org/$pkgname/common.BUILT=$(date -u +%Y-%m-%dT%H:%M:%S%z)
-		-X gitlab.com/gitlab-org/$pkgname/common.BRANCH=unknown
+		-X gitlab.com/gitlab-org/$pkgname/common.BRANCH=master
 		-s -w
 		"
 	go build -ldflags "$ldflags" -o bin/gitlab-runner


### PR DESCRIPTION
The git rev is used to determine which docker tag of gitlab-runner-helper to use

Please test @Ikke , this fixes gitlab-runner for me, but I don't want to break
Alpine's CI setup :)