### PR TITLE
testing/netcdf-fortran: fix nf-config

### DIFF
--- a/testing/netcdf-fortran/APKBUILD
+++ b/testing/netcdf-fortran/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Holger Jaekel <holger.jaekel@gmx.de>
 pkgname=netcdf-fortran
 pkgver=4.5.1
-pkgrel=0
+pkgrel=1
 pkgdesc="NetCDF fortran bindings"
 url="https://www.unidata.ucar.edu/software/netcdf/"
 arch="all !armhf !armv7"  # disabling on armhf and armv7 as netcdf is not available
@@ -25,11 +25,9 @@ subpackages="
 source="$pkgname-$pkgver.tar.gz::https://github.com/Unidata/netcdf-fortran/archive/v$pkgver.tar.gz"
 
 build() {
-	cmake . \
-		-DCMAKE_INSTALL_PREFIX=/usr \
-		-DCMAKE_INSTALL_LIBDIR=lib \
-		-DCMAKE_BUILD_TYPE=Release \
-		-DENABLE_DOXYGEN=ON
+	./configure \
+		--prefix=/usr \
+		--disable-static
 	make
 }
 
@@ -39,6 +37,6 @@ package() {
 }
 
 check() {
-	ctest
+	make check
 }
 sha512sums="9fab5b3e4013146e6ba9428af5495bad249734a15d839e37d8bdf2c62dc18d8d076eec6b976bd42c5f737eb28d06801e5998465d316f9214e1ba0e6a44180c69  netcdf-fortran-4.5.1.tar.gz"


### PR DESCRIPTION
workaround for bug https://github.com/Unidata/netcdf-fortran/issues/60 which leads to an unusable `nf-config`: switch from CMake to configure. As now also a static library is build, I added a -static subpackage.