### PR TITLE
[3.10] main/openssl: Fix openssl secfix version number

### DIFF
--- a/main/openssl/APKBUILD
+++ b/main/openssl/APKBUILD
@@ -20,7 +20,7 @@ esac
 builddir="$srcdir/openssl-$pkgver"
 
 # secfixes:
-#   1.1.1d-r1:
+#   1.1.1d-r0:
 #     - CVE-2019-1547
 #     - CVE-2019-1549
 #     - CVE-2019-1563


### PR DESCRIPTION
In 3.10, `pkgrel` is `0` not `1` as it is in the master branch.  Secfix block should reflect this.