### PR TITLE
main/py-dbus: drop testing on python2

### DIFF
--- a/main/py-dbus/APKBUILD
+++ b/main/py-dbus/APKBUILD
@@ -3,14 +3,14 @@
 pkgname=py-dbus
 _pkgname=dbus-python
 pkgver=1.2.12
-pkgrel=0
+pkgrel=1
 pkgdesc="Python bindings for DBUS"
 url="http://www.freedesktop.org/wiki/Software/DBusBindings"
 arch="all"
 license="MIT"
 depends_dev="py-dbus"
 makedepends="dbus-glib-dev python2-dev python3-dev py2-sphinx"
-checkdepends="bash dbus py-gobject3 py-tappy"
+checkdepends="bash dbus py3-gobject3 py3-tappy"
 subpackages="$pkgname-dev $pkgname-doc py2-dbus:_py2 py3-dbus:_py3"
 source="https://dbus.freedesktop.org/releases/dbus-python/$_pkgname-$pkgver.tar.gz"
 
@@ -43,8 +43,6 @@ build() {
 
 check() {
 	cd "$builddir"
-	cd "../build-python2"
-	make check
 	cd "../build-python3"
 	make check
 }


### PR DESCRIPTION
- Requires py-gobject3 which is now py3-gobject3

@Cogitri