### PR TITLE
testing/traefik: upgrade to 1.7.16

### DIFF
--- a/testing/traefik/APKBUILD
+++ b/testing/traefik/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Joe Holden <jwh@zorins.us>
 # Maintainer: Joe Holden <jwh@zorins.us>
 pkgname=traefik
-pkgver=1.7.14
-pkgrel=1
+pkgver=1.7.16
+pkgrel=0
 pkgdesc="The Cloud Native Edge Router"
 url="https://traefik.io"
 arch="all !x86 !s390x !armhf !armv7" # tests fails on x86 and armhf
@@ -62,7 +62,7 @@ package() {
 		"$pkgdir"/etc/$pkgname/$pkgname.toml
 
 }
-sha512sums="ef632130ed7befb9d3e1a693f3bd708da123eb3d631a2e3662512bc91e15ca8225fc9a14930cb67657ae4786d6abdb7a9f61890e2f5be9d3f721b77e67cb7b06  traefik-1.7.14.tar.gz
+sha512sums="67cfa255dedb30408fb9b9380c7702417e4a9363edc7502afd9bb62303eec887803837d4062f9ab2a13a7fa1ed34dd13ab1aa144b48910dcc2034766aaa8c88b  traefik-1.7.16.tar.gz
 2fe42052cdb035b202c7c0a1acd5cfe9ed1800ca067f2f5588d54e6ffbdd672d7c46cfd57fcfc219cadaa24d64a0e038a20d092eb1e4c04b67b8eb83c0af74fd  traefik.initd
 1519c2f446c4bc3af8407eb367a05e5ec0491f28d56d5385b12a550c84606d84e2424aadd5d72e56e628fd1da3f0f194ab3c077e6da85ead75a256f8e8069751  traefik.confd
 140904e2358bc6dadbfb0f2c3cd83cd7aabeae1a54cd7424bbb50f941bde3273046c402352a2b888425ba74dda27d0a6e2197c2855b4fd6ad522eb9c4eaebd61  traefik.toml"


### PR DESCRIPTION
Ref https://github.com/containous/traefik/releases/tag/v1.7.16