### PR TITLE
main/haproxy: upgrade to 2.0.6

### DIFF
--- a/main/haproxy/APKBUILD
+++ b/main/haproxy/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jeff Bilyk <jbilyk@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=haproxy
-pkgver=2.0.5
+pkgver=2.0.6
 _pkgmajorver=${pkgver%.*}
 pkgrel=0
 pkgdesc="A TCP/HTTP reverse proxy for high availability environments"
@@ -49,6 +49,6 @@ package() {
 	        "$pkgdir"/etc/haproxy/haproxy.cfg
 }
 
-sha512sums="501de6d81e0d07dbe5f57f416d485ebe125144745441c0f5341d6000c92514f723f35a7402f2cb7b404e1d6e6b4ba4148ef7360799b2ecf3bd6b1e3d6805097b  haproxy-2.0.5.tar.gz
+sha512sums="78c8483a97845928dc3ec7da68bedfda73303c88e8146a6b38c3d2b4e2089af5668817f0675180d41274c6337d5fae7cad5534013bd15d9b06071b89a09a86b5  haproxy-2.0.6.tar.gz
 3ab277bf77fe864ec6c927118dcd70bdec0eb3c54535812d1c3c0995fa66a3ea91a73c342edeb8944caeb097d2dd1a7761099182df44af5e3ef42de6e2176d26  haproxy.initd
 26bc8f8ac504fcbaec113ecbb9bb59b9da47dc8834779ebbb2870a8cadf2ee7561b3a811f01e619358a98c6c7768e8fdd90ab447098c05b82e788c8212c4c41f  haproxy.cfg"


### PR DESCRIPTION
Ref http://git.haproxy.org/?p=haproxy-2.0.git;a=commit;h=58706ab4bdbea3468253eddf07f2d58db43bfcb4