### PR TITLE
community/spacefm: add required sysmacros.h

### DIFF
--- a/community/spacefm/APKBUILD
+++ b/community/spacefm/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Bartłomiej Piotrowski <bpiotrowski@alpinelinux.org>
 pkgname=spacefm
 pkgver=1.0.6
-pkgrel=0
+pkgrel=1
 pkgdesc="Multi-panel tabbed file manager (GTK2 version)"
 arch=all
 url="http://ignorantguru.github.com/spacefm"
@@ -10,7 +10,8 @@ license="GPL-3.0-or-later"
 depends="bash"
 makedepends="intltool gettext-dev gtk+2.0-dev gtk+3.0-dev eudev-dev ffmpegthumbnailer-dev linux-headers"
 subpackages="$pkgname-lang $pkgname-doc $pkgname-gtk3 $pkgname-gtk3-lang:lang3:noarch $pkgname-gtk3-doc:doc3:noarch"
-source="$pkgname-$pkgver.tar.gz::https://github.com/IgnorantGuru/spacefm/archive/$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::https://github.com/IgnorantGuru/spacefm/archive/$pkgver.tar.gz
+	spacefm-include-sysmacros.patch"
 
 builddir="$srcdir"/$pkgname-$pkgver
 
@@ -58,4 +59,5 @@ package() {
 	make -j1 DESTDIR="$pkgdir" install
 }
 
-sha512sums="37fc0dd31f02158502f592415b4c375ee49560af6f03d75b035d7c6c45bdc47064bba1ae8987b4cc8be2e02b3dfcdc17ec760411975e7b5f74343a2293fb2c8c  spacefm-1.0.6.tar.gz"
+sha512sums="37fc0dd31f02158502f592415b4c375ee49560af6f03d75b035d7c6c45bdc47064bba1ae8987b4cc8be2e02b3dfcdc17ec760411975e7b5f74343a2293fb2c8c  spacefm-1.0.6.tar.gz
+d7b33441700141dc956df54f03393c02783fc5188b82883401d4781c52fb383089af5ed3b3645b686078a6ac06d3b3e269f7ee5ab3f4d1416ebb0141fbaa7b7e  spacefm-include-sysmacros.patch"

--- a/community/spacefm/spacefm-include-sysmacros.patch
+++ b/community/spacefm/spacefm-include-sysmacros.patch
@@ -1,0 +1,10 @@
+--- a/src/main.c
++++ b/src/main.c
+@@ -21,6 +21,7 @@
+ 
+ /* socket is used to keep single instance */
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/socket.h>
+ #include <sys/un.h>
+ 


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of spacefm fails with:
```
main.c:189:42: error: implicit declaration of function 'major' [-Werror=implicit-function-declaration]
                                          major( stat_buf.st_dev ),
                                          ^~~~~
main.c:190:42: error: implicit declaration of function 'minor'; did you mean 'mknod'? [-Werror=implicit-function-declaration]
                                          minor( stat_buf.st_dev ),
                                          ^~~~~
                                          mknod

```
Explicitly including sys/sysmacros.h fixes the issue.