### PR TITLE
main/gcc: add patch fixing libgomp

### DIFF
--- a/main/gcc/0016-invalid_tls_model.patch
+++ b/main/gcc/0016-invalid_tls_model.patch
@@ -1,0 +1,29 @@
+Fixes errors such as:
+
+GEGL-Message: 16:04:13.794: Module '/usr/lib/gegl-0.4/raw-load.so' load error: Error relocating /usr/lib/libgomp.so.1: __cxa_finalize: initial-exec TLS resolves to dynamic definition in /usr/lib/libgomp.so.1
+
+--- a/libgomp/configure.tgt	2018-11-08 18:13:04.000000000 +0100
++++ b/libgomp/configure.tgt	2019-06-29 20:06:31.972950350 +0200
+@@ -10,23 +10,6 @@
+ #  XCFLAGS		Add extra compile flags to use.
+ #  XLDFLAGS		Add extra link flags to use.
+ 
+-# Optimize TLS usage by avoiding the overhead of dynamic allocation.
+-if test $gcc_cv_have_tls = yes ; then
+-  case "${target}" in
+-
+-    *-*-k*bsd*-gnu*)
+-	;;
+-
+-    *-*-linux* | *-*-gnu*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=initial-exec -DUSING_INITIAL_EXEC_TLS"
+-	;;
+-
+-    *-*-rtems*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=local-exec"
+-	;;
+-  esac
+-fi
+-
+ # Since we require POSIX threads, assume a POSIX system by default.
+ config_path="posix"

--- a/main/gcc/APKBUILD
+++ b/main/gcc/APKBUILD
@@ -6,7 +6,7 @@ pkgver=9.2.0
 [ "$CHOST" != "$CTARGET" ] && _target="-$CTARGET_ARCH" || _target=""
 
 pkgname="$pkgname$_target"
-pkgrel=1
+pkgrel=2
 pkgdesc="The GNU Compiler Collection"
 url="http://gcc.gnu.org"
 arch="all"
@@ -171,6 +171,7 @@ source="https://gcc.gnu.org/pub/gcc/releases/gcc-${_pkgbase:-$pkgver}/gcc-${_pkg
 	320-libffi-gnulinux.patch
 
 	gcc-pure64-mips.patch
+	0016-invalid_tls_model.patch
 	"
 
 #	gcc-4.8-build-args.patch
@@ -581,4 +582,5 @@ fa62556719449caec6b2b434355bfbcaa5ae55ffe017b3e1f827f66a2aae21b79c571ee7a4ce723e
 cceeac95f47ea8664e1c16c5ebecb472b5aaa56040e943c1b97c7873b50e3a2bf972d9f743d342a2444a3bb711a0720d2446fded43892c5e05bdeefd478b0cd1  ada-musl.patch
 a1f7750bc7b8b7d916a5dee34fcc736bd4fb249c96538b547d495794e6cfd49356aa3974506a15074b4cb58edd5d7e2868607c902dd003e8c464d5066fd4a575  libgnarl-musl.patch
 f4ef08454e28c8732db69115e4998ec153399e8d229dd27f923dbdcf57b68128a65640d026cc7f45b58ba8764ab1eb575d4eb6d6dfc550a87a183f8b94e76181  320-libffi-gnulinux.patch
-86be3338cc9c33089608bc4c5e3b7918c4e500a345c338f361b18c342119a6ed69af5495d72950de7106d760f003528b46ad14795e805f8a3331e206dcb234e3  gcc-pure64-mips.patch"
+86be3338cc9c33089608bc4c5e3b7918c4e500a345c338f361b18c342119a6ed69af5495d72950de7106d760f003528b46ad14795e805f8a3331e206dcb234e3  gcc-pure64-mips.patch
+17e0faeef742d32d57a070d983480367dd28cd28d47a8966ce327afdff3a38ea76803a833c90aff7d3a93aa66dae76c9be47b2408500913b40571af25b85aca7  0016-invalid_tls_model.patch"


### PR DESCRIPTION
The defect can be obversible e.g. with GNOME Photos

@ncopa could you give this a try?