### PR TITLE
community/udisks: add required sysmacros.h

### DIFF
--- a/community/udisks/APKBUILD
+++ b/community/udisks/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=udisks
 pkgver=1.0.5
-pkgrel=3
+pkgrel=4
 pkgdesc="Disk Management Service"
 url="http://www.freedesktop.org/wiki/Software/udisks"
 arch="all"
@@ -15,6 +15,7 @@ makedepends="glib-dev polkit-dev parted-dev libgudev-dev sg3_utils-dev
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
 source="https://hal.freedesktop.org/releases/$pkgname-$pkgver.tar.gz
 	udisks-uhelper.patch
+	udisks-include-sysmacros.patch
 	"
 
 builddir="$srcdir"/$pkgname-$pkgver
@@ -40,4 +41,5 @@ package() {
 }
 
 sha512sums="bdf4970113975221ff0e17866db18fd969ff9c8e1e851c8ad7572630814ab0c46b59df59433edcb2e7cc41cc8152afd35807f45e07f6d0fa87b21b5a77d0965a  udisks-1.0.5.tar.gz
-f96d9626d1361af5ff80bd9a57a5adac2d7a0a12b1f47c446a623fe64c4e58f0e6d591bbc2ad7ca619fee09706fe13e8692f86219f2cc3ef825f055f765af2ce  udisks-uhelper.patch"
+f96d9626d1361af5ff80bd9a57a5adac2d7a0a12b1f47c446a623fe64c4e58f0e6d591bbc2ad7ca619fee09706fe13e8692f86219f2cc3ef825f055f765af2ce  udisks-uhelper.patch
+90682b197fd851fbdf5d1cc577f9a4b2dac766240ff925ecfe14e85bca4ae385007b846f2ac32e4794fcacf0f1a2799f969f65fc42aa1909c6bc77420624881e  udisks-include-sysmacros.patch"

--- a/community/udisks/udisks-include-sysmacros.patch
+++ b/community/udisks/udisks-include-sysmacros.patch
@@ -1,0 +1,50 @@
+--- a/src/device.c
++++ b/src/device.c
+@@ -29,6 +29,7 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/wait.h>
+ #include <sys/stat.h>
+ #include <sys/time.h>
+--- a/src/mount-monitor.c
++++ b/src/mount-monitor.c
+@@ -28,6 +28,7 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <mntent.h>
+ 
+--- a/src/daemon.c
++++ b/src/daemon.c
+@@ -39,6 +39,7 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <sys/time.h>
+ #include <sys/resource.h>
+--- a/tools/udisks.c
++++ b/tools/udisks.c
+@@ -29,6 +29,7 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <sys/wait.h>
+ #include <fcntl.h>
+--- a/tools/umount-udisks.c
++++ b/tools/umount-udisks.c
+@@ -29,6 +29,7 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <pwd.h>


### PR DESCRIPTION
In the musl package, http://git.musl-libc.org/cgit/musl/commit/?id=a31a30a0076c284133c0f4dfa32b8b37883ac930
removed the implicit include of sys/sysmacros.h from sys/types.h

Because of this change to musl-dev provided header files, the compilation of udisks fails with:
```
/usr/lib/gcc/powerpc64le-alpine-linux-musl/9.2.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: udisks_daemon-daemon.o: in function `daemon_find_device_by_major_minor':
daemon.c:(.text+0x2820): undefined reference to `makedev'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/9.2.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: udisks_daemon-device.o: in function `get_property':
device.c:(.text+0x8d34): undefined reference to `major'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/9.2.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: device.c:(.text+0x8d58): undefined reference to `minor'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/9.2.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: udisks_daemon-device.o: in function `update_info':
device.c:(.text+0xa458): undefined reference to `makedev'
/usr/lib/gcc/powerpc64le-alpine-linux-musl/9.2.0/../../../../powerpc64le-alpine-linux-musl/bin/ld: udisks_daemon-mount-monitor.o: in function `mount_monitor_ensure':
mount-monitor.c:(.text+0x440): undefined reference to `makedev'            
```
Explicitly including sys/sysmacros.h fixes the issue.