### PR TITLE
testing/cfitsio: new aport

### DIFF
--- a/testing/cfitsio/APKBUILD
+++ b/testing/cfitsio/APKBUILD
@@ -1,0 +1,51 @@
+# Contributor: Holger Jaekel <holger.jaekel@gmx.de>
+# Maintainer: Holger Jaekel <holger.jaekel@gmx.de>
+pkgname=cfitsio
+pkgver=3.47
+pkgrel=0
+pkgdesc="A library reading and writing data files in Flexible Image Transport System data format"
+url="https://heasarc.gsfc.nasa.gov/fitsio/"
+arch="all"
+license="custom"
+makedepends="
+	bzip2-dev
+	curl-dev
+	gfortran
+	"
+subpackages="
+	$pkgname-static
+	$pkgname-dev
+	"
+source="https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/$pkgname-$pkgver.tar.gz"
+
+build() {
+	./configure \
+		--prefix=/usr \
+		--with-bzip2 \
+		--enable-reentrant \
+		--enable-sse2 \
+		--enable-ssse3 \
+		--enable-hera
+	make shared
+	make utils
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+	mkdir -p "$pkgdir"/usr/share/licenses/cfitsio/
+	cp License.txt "$pkgdir"/usr/share/licenses/cfitsio/
+
+	# delete test/demo programs
+	rm "$pkgdir"/usr/bin/testprog
+	rm "$pkgdir"/usr/bin/cookbook
+
+	# avoid conflicts with smem
+	rm "$pkgdir"/usr/bin/smem
+}
+
+check() {
+	LD_LIBRARY_PATH=. ./testprog > testprog.lis
+	[[ -z $(diff testprog.lis testprog.out) ]]
+	[[ -z $(cmp testprog.fit testprog.std) ]]
+}
+sha512sums="c0502699e266928dd25abe57730dc4b357ccc9023789fe745324ae01aa688516aceaf37321ee578f0430111d9718f0fec0dc5b54c07f935529560f00b32ce1e3  cfitsio-3.47.tar.gz"


### PR DESCRIPTION
I'm not sure about the correct license, there is no matching SPDX license identifier. So I set `license="custom"` and copied the license file to `/usr/share/licenses/cfitsio/`.

Here is the license text:

```
Copyright (Unpublished--all rights reserved under the copyright laws of
the United States), U.S. Government as represented by the Administrator
of the National Aeronautics and Space Administration.  No copyright is
claimed in the United States under Title 17, U.S. Code.

Permission to freely use, copy, modify, and distribute this software
and its documentation without fee is hereby granted, provided that this
copyright notice and disclaimer of warranty appears in all copies.

DISCLAIMER:

THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND,
EITHER EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO,
ANY WARRANTY THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY
IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
PURPOSE, AND FREEDOM FROM INFRINGEMENT, AND ANY WARRANTY THAT THE
DOCUMENTATION WILL CONFORM TO THE SOFTWARE, OR ANY WARRANTY THAT THE
SOFTWARE WILL BE ERROR FREE.  IN NO EVENT SHALL NASA BE LIABLE FOR ANY
DAMAGES, INCLUDING, BUT NOT LIMITED TO, DIRECT, INDIRECT, SPECIAL OR
CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM, OR IN ANY WAY
CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT BASED UPON WARRANTY,
CONTRACT, TORT , OR OTHERWISE, WHETHER OR NOT INJURY WAS SUSTAINED BY
PERSONS OR PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS SUSTAINED
FROM, OR AROSE OUT OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR
SERVICES PROVIDED HEREUNDER.
```