### PR TITLE
testing/mariadb-connector-odbc: new aport

### DIFF
--- a/testing/mariadb-connector-odbc/APKBUILD
+++ b/testing/mariadb-connector-odbc/APKBUILD
@@ -1,0 +1,37 @@
+# Contributor: Joe Searle <joe@jsearle.net>
+# Maintainer: Joe Searle <joe@jsearle.net>
+pkgname=mariadb-connector-odbc
+pkgver=3.1.4
+pkgrel=0
+pkgdesc="MariaDB Connector/ODBC is a standardized, LGPL licensed database driver using the industry standard ODBC API."
+url="https://github.com/MariaDB/mariadb-connector-odbc"
+arch="all"
+license="LGPL-2.1-only"
+depends="unixodbc"
+makedepends="cmake unixodbc-dev mariadb-connector-c mariadb-connector-c-dev mariadb-static"
+source="$pkgname-$pkgver.tar.gz::https://github.com/MariaDB/mariadb-connector-odbc/archive/$pkgver.tar.gz"
+subpackages="$pkgname-doc"
+options="!check" # 'test' directory not included in releases
+
+build() {
+	if [ "$CBUILD" != "$CHOST" ]; then
+		CMAKE_CROSSOPTS="-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_HOST_SYSTEM_NAME=Linux"
+	fi
+	cmake \
+		-DCMAKE_INSTALL_PREFIX=/usr \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DBUILD_SHARED_LIBS=True \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+		-DCMAKE_C_FLAGS="$CFLAGS" \
+		-DCMAKE_C_FLAGS_RELEASE="-I/usr/include/mysql" \
+		${CMAKE_CROSSOPTS} .
+	# Link to /usr/include/mysql necessary when using system installed mariadb-connector-c
+	make
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="1f662b57d78cb6b58de84b75025bbc16cdfebeea39991d0a8f28ff2be76682ea80f2a8828c006c966607eebb0fb6522bc59a98564c6a7408b878d8ba06d9ed9b  mariadb-connector-odbc-3.1.4.tar.gz"


### PR DESCRIPTION
https://downloads.mariadb.org/connector-odbc/
MariaDB Connector/ODBC is a standardized, LGPL licensed database driver using the industry standard ODBC API.