### PR TITLE
testing/consul: upgrade to 1.6.1 and improve init script

### DIFF
--- a/testing/consul/APKBUILD
+++ b/testing/consul/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Olivier Mauras <olivier@mauras.ch>
 # Maintainer: Francesco Colista <fcolista@alpinelinux.org>
 pkgname=consul
-pkgver=1.6.0
+pkgver=1.6.1
 pkgrel=0
 pkgdesc="Tool for service discovery, monitoring and configuration"
 url="https://www.consul.io"
@@ -61,8 +61,9 @@ package() {
 		install -m640 -o root -g consul "$srcdir"/$cf "$pkgdir"/etc/$pkgname
 	done
 }
-sha512sums="a122892693e3bee0fc0e0b5c0945e4a8dddb890228c091112e0db11a8afd33430611c20ff9bc13d2b3a2ac0d3b560be2d9c4e03a9cc425983fbd8f7edb699658  consul-1.6.0.tar.gz
-818cd9696a6306a85cbb007f9437dbe3d17e70d8dcbc16fa2e7c399571cc71d9da197160abbad86ab37d6a4f4aff873ff8b6f5f3418869a82274a5a265c5281a  consul.initd
+
+sha512sums="67e2032bd128288b0177f23fbacaa8c289682a88ad75a744e583619e9cf9426747f3e129be89080eb2f7c8d186a9c25899d3a4ac3c0cce73b9433bb29ba18ab2  consul-1.6.1.tar.gz
+74c2581bcafa119b4fc8ce72cf0c73584316a4bf3007130ae8864e97a91dcc4aab15f39faa423d90bfa667e26db11f7f581982f9fe7e1870df72e2dc0240676a  consul.initd
 f2c5af74dfcbca2fea8ebea31139d93f44455b93ef17ec611b880d7071af4125615dbbd23969d0d04ca636c26d7b4e7eb97f1266baa89252097f4cbc5173d817  consul.confd
 d4310dde63d3b8fc4791124bd255bf2a1402b86d00f6b1732e18b0caedb75eae6c77382e1a48f12469828ef4bb363db4580fb1aafa63fcdc97b1431f6ea96d58  acl.json.sample
 ec30ad73c13f9dd5ba15389567436dbf74c24e822cb959c6ccc40a35e36e212313c70f3cf1ccee3f63a7bb98760173d6c2478161a25b85e14dd889a47572aff1  encrypt.json.sample

--- a/testing/consul/consul.initd
+++ b/testing/consul/consul.initd
@@ -1,44 +1,48 @@
 #!/sbin/openrc-run
-CONSUL_LOG_FILE="/var/log/${SVCNAME}.log"
-
-name=consul
 description="A tool for service discovery, monitoring and configuration"
-description_checkconfig="Verify configuration file"
-daemon=/usr/sbin/$name
-daemon_user=$name
-daemon_group=$name
-extra_commands="checkconfig"
+description_checkconfig="Verify configuration files"
+description_healthcheck="Check health status"
+description_reload="Reload configuration"
 
-start_pre() {
-        checkpath -f -m 0644 -o ${SVCNAME}:${SVCNAME} "$CONSUL_LOG_FILE"
-}
+extra_commands="checkconfig"
+extra_started_commands="healthcheck reload"
+
+command="/usr/sbin/$RC_SVCNAME"
+command_args="$consul_opts"
+command_user="$RC_SVCNAME:$RC_SVCNAME"
+
+supervisor=supervise-daemon
+pidfile="/run/$RC_SVCNAME.pid"
+output_log="/var/log/$RC_SVCNAME.log"
+error_log="/var/log/$RC_SVCNAME.log"
+umask=027
+respawn_max=0
+respawn_delay=10
+healthcheck_timer=60
 
 depend() {
-        need net
-        after firewall
+	need net
+	after firewall
 }
 
 checkconfig() {
-        consul validate /etc/consul
+	ebegin "Checking /etc/consul"
+	consul validate /etc/consul
+	eend $?
 }
 
-start() {
-        checkconfig || return 1
-
-        ebegin "Starting ${name}"
-                start-stop-daemon --start --quiet \
-                        -m --pidfile /var/run/${name}.pid \
-                        --user ${daemon_user} --group ${daemon_group} \
-                        -b --stdout $CONSUL_LOG_FILE --stderr $CONSUL_LOG_FILE \
-			-k 027 --exec ${daemon} -- ${consul_opts}
-        eend $?
+start_pre() {
+	checkconfig
+	checkpath -f -m 0640 -o "$command_user" "$output_log" "$error_log"
 }
 
-stop() {
-        ebegin "Stopping ${name}"
-                start-stop-daemon --stop --quiet \
-                        --pidfile /var/run/${name}.pid \
-                        --exec ${daemon}
-        eend $?
+healthcheck() {
+	$command info > /dev/null 2>&1
 }
 
+reload() {
+	start_pre \
+		&& ebegin "Reloading $RC_SVCNAME configuration" \
+		&& supervise-daemon "$RC_SVCNAME" --signal HUP --pidfile "$pidfile"
+	eend $?
+}


### PR DESCRIPTION
Upgrade Consul to latest 1.6.1 and migrate init scrip to `supervise-daemon` as well as add `healthcheck` and config `reload` functions.