### PR TITLE
community/vault: upgrade to 1.2.3 and improve init script

### DIFF
--- a/community/vault/APKBUILD
+++ b/community/vault/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Christian Kampka <christian@kampka.net>
 # Maintainer: Gennady Feldman <gena01@gmail.com>
 pkgname=vault
-pkgver=1.2.2
-pkgrel=2
+pkgver=1.2.3
+pkgrel=0
 pkgdesc="Vault is a tool for securely accessing secrets"
 url="https://www.vaultproject.io/"
 arch="all !s390x"
@@ -18,17 +18,10 @@ source="$pkgname-$pkgver.tar.gz::https://github.com/hashicorp/$pkgname/archive/v
 	vault.confd
 	vault.hcl
 	vault.initd"
-builddir="$srcdir/src/github.com/hashicorp/$pkgname"
-
-prepare() {
-	mkdir -p "$srcdir/src/github.com/hashicorp"
-	mv "$srcdir"/$pkgname-$pkgver "$builddir"/
-	default_prepare
-}
 
 build() {
-	GOPATH="$srcdir" CGO_ENABLED=0 make static-dist prep
-	GOPATH="$srcdir" CGO_ENABLED=0 go build -v -o bin/$pkgname \
+	CGO_ENABLED=0 make static-dist prep
+	CGO_ENABLED=0 go build -v -o bin/$pkgname \
 		-ldflags "-X github.com/hashicorp/vault/version.GitDescribe='$pkgver'" \
 		--tags ui
 }
@@ -53,8 +46,8 @@ package() {
 	install -m750 -o vault -g vault -d "$pkgdir/var/lib/$pkgname"
 }
 
-sha512sums="ce9211b3deb1839759646f8488fe2b89fec379bafed472921a62cd507f842ed05647fe4da7cb9482d195b028a29eb576f947da24aecd8b19181c7282fd3a155d  vault-1.2.2.tar.gz
+sha512sums="9543e394f187cd9b06e88b64319504e07519041741650db3b7b905f1b34348ed7d9e22955ce2a456ffd2e06210e9e01b1a0ded459cde4840fbf5903ff6e21e75  vault-1.2.3.tar.gz
 e551aa366287ca86436b14c72c254d739c2492dec7a877da135ba81bf2170bbe694f2ac98798d5855004a0aca406a27c1bdf0c791844f1bd330ea3a1160c6327  static-assets.patch
 6f3f30e5c9d9dd5117f18fce0e669f0cd752a6be4910405d6b394f15273372731ee887a5ba4c700293e5b8bc2bf40fd69d4337156f77b03549d2dc2c0a666bec  vault.confd
 8c064aa5dcca84822c1fa85e9d0ff520df46f794b2e9c689a9b4f81f74279387b3aebc08b3ca26cf786c2fcf1a330e765bf5a511074c24f87e5346672346ba1c  vault.hcl
-dfaa3b246c51e527cda99ca12b18f52416286d2d0cbbe418ba01075dd43d54b7e8350a10985e96690a2768314326586e05a1ec931fcff7d8c78729f1869d3293  vault.initd"
+9a1846a10eff015cf7d4c8c2c20540c125213302925e54bdfae1c1ec9c43bf0e97b3433c041615c9fdc7d5e9468a0f606321991c597af3be92025bd5042c08df  vault.initd"

--- a/community/vault/vault.initd
+++ b/community/vault/vault.initd
@@ -1,21 +1,32 @@
 #!/sbin/openrc-run
-
-supervisor=supervise-daemon
-
 name="Vault server"
 description="Vault is a tool for securely accessing secrets"
+description_reload="Reload configuration"
 
-VAULT_LOG_FILE="/var/log/${RC_SVCNAME}.log"
+extra_started_commands="reload"
 
-command=/usr/sbin/${RC_SVCNAME}
+command="/usr/sbin/${RC_SVCNAME}"
 command_args="${vault_opts}"
 command_user="${RC_SVCNAME}:${RC_SVCNAME}"
 
-start_pre() {
-	checkpath -f -m 0644 -o "$command_user" "$VAULT_LOG_FILE"
-}
+supervisor=supervise-daemon
+output_log="/var/log/${RC_SVCNAME}.log"
+error_log="/var/log/${RC_SVCNAME}.log"
+respawn_max=0
+respawn_delay=10
 
 depend() {
 	need net
 	after firewall
+}
+
+start_pre() {
+	checkpath -f -m 0644 -o "$command_user" "$output_log" "$error_log"
+}
+
+reload() {
+	start_pre \
+		&& ebegin "Reloading $RC_SVCNAME configuration" \
+		&& $supervisor "$RC_SVCNAME" --signal HUP
+	eend $?
 }


### PR DESCRIPTION
Upgrade Vault to latest 1.2.3 and improve init scrip with supervise-daemon configurations and config `reload` functions.