### PR TITLE
community/borgbackup: fix depends to use renamed py3-pyzmq

### DIFF
--- a/community/borgbackup/APKBUILD
+++ b/community/borgbackup/APKBUILD
@@ -2,12 +2,12 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=borgbackup
 pkgver=1.1.10
-pkgrel=0
+pkgrel=1
 pkgdesc="Deduplicating backup program"
 url="https://borgbackup.readthedocs.io/"
 arch="all !s390x" # limited by py3-zmq
 license="BSD-3-Clause"
-depends="python3 py3-zmq"
+depends="python3 py3-pyzmq"
 makedepends="python3-dev lz4-dev acl-dev attr-dev openssl-dev linux-headers
 	py3-setuptools"
 source="https://github.com/$pkgname/borg/releases/download/$pkgver/$pkgname-$pkgver.tar.gz"


### PR DESCRIPTION
With commit https://github.com/alpinelinux/aports/commit/b55f6b44acb3a11d419bc0836c138e6ca2462a7c#diff-07f1e9d972db2e3b56c0f8c68025d000 depends package name has been renamed from py-zmq to py3-pyzmq.

This PR modified borgbackup depends statement to reflect new py3-pyzmq package name.