### PR TITLE
community/salt: fix py3-pyzmq and py3-apache-libcloud depends

### DIFF
--- a/community/salt/APKBUILD
+++ b/community/salt/APKBUILD
@@ -3,14 +3,14 @@
 # Maintainer: Kevin Daudt <kdaudt@alpinelinux.org>
 pkgname=salt
 pkgver=2019.2.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A parallel remote execution system"
 url="https://github.com/saltstack/salt"
 arch="noarch !s390x"
 license="Apache-2.0"
-depends="py3-tornado py3-yaml py3-jinja2 py3-markupsafe py3-msgpack py3-crypto py3-zmq
+depends="py3-tornado py3-yaml py3-jinja2 py3-markupsafe py3-msgpack py3-crypto py3-pyzmq
 	py3-six py3-requests py3-pygit2 py3-dateutil procps"
-makedepends="python3-dev py3-libcloud"
+makedepends="python3-dev py3-apache-libcloud"
 subpackages="$pkgname-doc
 	$pkgname-master $pkgname-master-openrc:master_openrc
 	$pkgname-minion $pkgname-minion-openrc:minion_openrc


### PR DESCRIPTION
Some salt dependency names are out of date:
With commit https://github.com/alpinelinux/aports/commit/63cb7d35302e22b37a23c858025855676cae0985#diff-1a9b1fce38d3de90632bd33cce337a88 py3-libcloud has been renamed to py3-apache-libcloud
With commit https://github.com/alpinelinux/aports/commit/b55f6b44acb3a11d419bc0836c138e6ca2462a7c#diff-07f1e9d972db2e3b56c0f8c68025d000 py-zmq has been renamed to py3-pyzmq. 

This PR modifies salt dependencies to reflect the new package names.