### PR TITLE
community/mawk: version in source download updated to version 20190203

### DIFF
--- a/community/mawk/APKBUILD
+++ b/community/mawk/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Miguel Terron <miguel.a.terron@gmail.com>
 pkgname=mawk
 pkgver=1.3.4
-pkgdate=20171017
+pkgdate=20190203
 pkgrel=0
 pkgdesc="mawk is an interpreter for the AWK Programming Language"
 url="https://invisible-island.net/mawk/"
@@ -34,4 +34,4 @@ package() {
         make DESTDIR="$pkgdir" install
 }
 
-sha512sums="4ed6ca0ecca12e7409d3d364b72dc6a2b411c61bf53fe8aa0b0cac65a3bdb941921c0b81d94f34c8ac9f4922c8c7566d347b5e6b5c74518ae3a88904f9e20f27  mawk.tar.gz"
+sha512sums="64d5b1838d34d30e32966f46cb7457c865caccfe9fe1049d2645ba301b1ddb4efc18588115dbcf96234a2a0b791211a7f82264a3c81899459dc3029e65837646  mawk.tar.gz"


### PR DESCRIPTION
Source contained in downloaded mawk archive, https://invisible-island.net/datafiles/release/mawk.tar.gz,
has been updated moving from version 20171017 to version 20190203. The pkgdate value must be updated to avoid build error:
```
/usr/bin/abuild: cd: line 16: can't cd to /home/mksully/trees/aports/community/mawk/src/mawk-1.3.4-20171017: No such file or directory
```