### PR TITLE
community/bsm-simple-themes: fix broken source link

### DIFF
--- a/community/bsm-simple-themes/APKBUILD
+++ b/community/bsm-simple-themes/APKBUILD
@@ -10,7 +10,7 @@ arch="noarch"
 license="GPL"
 depends="gtk-engines-clearlooks faenza-icon-theme"
 subpackages="$pkgname-xfwm4 $pkgname-metacity"
-source="https://distfiles.alpinelinux.org/distfiles/121685-BSM%2520Simple%2520$_ver.tar.gz
+source="https://distfiles.alpinelinux.org/distfiles/121685-BSM%252520Simple%252520$_ver.tar.gz
 	bsm-simple-panel.patch
 	bsm-simple-xfwm.patch"
 
@@ -48,6 +48,6 @@ metacity() {
 	done
 }
 
-sha512sums="4254ccdb2869a1caefbac9f9b1bffa6f5bc0a3ba64989d198cd2154d23e5e725dd8f408b17bb37d56eaef6ce74660d29b1167d99b91df7480ddf649957449adb  121685-BSM%2520Simple%252013.tar.gz
+sha512sums="4254ccdb2869a1caefbac9f9b1bffa6f5bc0a3ba64989d198cd2154d23e5e725dd8f408b17bb37d56eaef6ce74660d29b1167d99b91df7480ddf649957449adb  121685-BSM%252520Simple%25252013.tar.gz
 84ad713a7a5850b970a96e97d6c71b81e127a02caead429b71cd50868bfdfce6d327ed113aca40f7a4d4ccfd18f48a84ec27dcbc2af6fe0cbbb47e207ad41e47  bsm-simple-panel.patch
 8f015a39d06d6713d75d872fba1139cf734a7ea6af272e198cbc0192148c5eabed3828902a608aa83b2661fc92159057508a9e792f7032680c6f728325b6792f  bsm-simple-xfwm.patch"


### PR DESCRIPTION
Source link is broken returning error:
```
curl: (22) The requested URL returned error: 404
```
This PR modifies download link to properly retrieve source pkg. 