### PR TITLE
testing/traefik: upgrade to 2.0.4

### DIFF
--- a/testing/traefik/APKBUILD
+++ b/testing/traefik/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Joe Holden <jwh@zorins.us>
 # Maintainer: Joe Holden <jwh@zorins.us>
 pkgname=traefik
-pkgver=1.7.16
+pkgver=2.0.4
 pkgrel=0
 pkgdesc="The Cloud Native Edge Router"
 url="https://traefik.io"
@@ -12,6 +12,7 @@ install="$pkgname.pre-install"
 pkgusers="$pkgname"
 pkggroups="$pkgname"
 subpackages="$pkgname-openrc"
+options="chmod-clean"
 source="$pkgname-$pkgver.tar.gz::https://github.com/containous/traefik/archive/v$pkgver.tar.gz
 	traefik.initd
 	traefik.confd
@@ -24,6 +25,8 @@ builddir="$srcdir/src/github.com/containous/$pkgname"
 #   - CVE-2019-9512
 #   - CVE-2019-9514
 
+export GOPATH="$srcdir"
+
 prepare() {
 	default_prepare
 	mkdir -p "$srcdir/src/github.com/containous"
@@ -31,17 +34,17 @@ prepare() {
 }
 
 build() {
-	GOPATH="$srcdir" go generate
-	GOPATH="$srcdir" go build -v -o bin/$pkgname ./cmd/$pkgname
+	go generate
+	go build -v -o bin/$pkgname ./cmd/$pkgname
 }
 
 check() {
 	# Unit tests
-	GOPATH="$srcdir" go test ./...
+	go test ./...
 
 	# Integration tests
 	cd "$builddir"/integration
-	GOPATH="$srcdir" go test -integration ./...
+	go test -integration ./...
 }
 
 package() {
@@ -62,7 +65,7 @@ package() {
 		"$pkgdir"/etc/$pkgname/$pkgname.toml
 
 }
-sha512sums="67cfa255dedb30408fb9b9380c7702417e4a9363edc7502afd9bb62303eec887803837d4062f9ab2a13a7fa1ed34dd13ab1aa144b48910dcc2034766aaa8c88b  traefik-1.7.16.tar.gz
+sha512sums="56075bc283e24616f33caf7e6e103623d44311bd07807902cc24a02aecdb87a8145f55436837cf34215c770d6757bfb2858facd33ee1c6a6bc3704fd4e7dfe6d  traefik-2.0.4.tar.gz
 2fe42052cdb035b202c7c0a1acd5cfe9ed1800ca067f2f5588d54e6ffbdd672d7c46cfd57fcfc219cadaa24d64a0e038a20d092eb1e4c04b67b8eb83c0af74fd  traefik.initd
 1519c2f446c4bc3af8407eb367a05e5ec0491f28d56d5385b12a550c84606d84e2424aadd5d72e56e628fd1da3f0f194ab3c077e6da85ead75a256f8e8069751  traefik.confd
-140904e2358bc6dadbfb0f2c3cd83cd7aabeae1a54cd7424bbb50f941bde3273046c402352a2b888425ba74dda27d0a6e2197c2855b4fd6ad522eb9c4eaebd61  traefik.toml"
+7dff62db55362433fe33a69bfb556e6f285a033aaaab46ea970ae4ee1b19a4b0d6b25bf5523d4dc6b40d26922945fd1263ae8e53d295d6bf7f18ea1477a9e4d5  traefik.toml"

--- a/testing/traefik/traefik.toml
+++ b/testing/traefik/traefik.toml
@@ -1,38 +1,27 @@
-debug = false
+[global]
+  checkNewVersion = true
+  sendAnonymousUsage = true
 
-defaultEntryPoints = ["http", "https"]
+[log]
+  level = "INFO"
 
 [entryPoints]
   [entryPoints.http]
   address = ":80"
-    [entryPoints.http.redirect]
-    entryPoint = "https"
   [entryPoints.https]
   address = ":443"
-    [entryPoints.https.tls]
+  [entryPoints.traefik]
+  address = "localhost:8080"
 
 [api]
+  insecure = true
+  dashboard = true
 
 [ping]
 
-#[consul]
-#  endpoint = ""
-#  watch = true
-
-#[consulCatalog]
-#  endpoint = ""
-#  domain = ""
-
-#[acme]
+#[certificatesResolvers.sample.acme]
 #  email = ""
 #  storage = "traefik/acme/account"
-#  entryPoint = "https"
-#  onDemand = true
-#  onHostRule = true
-#  acmeLogging = true
-#  [acme.dnsChallenge]
+#  [certificatesResolvers.sample.acme.dnsChallenge]
 #    provider = "cloudflare"
 #    delayBeforeCheck = 10
-
-[rest]
-  entryPoint = "traefik"


### PR DESCRIPTION
Ref https://blog.containo.us/traefik-2-0-6531ec5196c2

- https://docs.traefik.io/migration/v1-to-v2/
- https://docs.traefik.io/contributing/building-testing/

https://github.com/alpinelinux/aports/pull/11752