### PR TITLE
[3.10] main/tzdata: upgrade to 2019c

### DIFF
--- a/main/tzdata/APKBUILD
+++ b/main/tzdata/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=tzdata
-pkgver=2019b
-_tzcodever=2019b
+pkgver=2019c
+_tzcodever=2019c
 _ptzver=0.5
 pkgrel=0
 pkgdesc="Timezone data"
@@ -57,8 +57,8 @@ package() {
 		"$pkgdir"/usr/bin/posixtz
 }
 
-sha512sums="bcfb417fe3b7c39e702da0090291db0489744f733010ae183007fce5e441bfce885fb25ed11730cf7f363572e107d7ff0c4b38691bb99def2d8cf7017c05720f  tzcode2019b.tar.gz
-c0104078d994e501d80a41bea31364b1390a75c2fbf42968a8343a090e2ac2eddbc58770ca470b192ea19dec89fcc634141a1de703ea2ffa0325176a64afe1fc  tzdata2019b.tar.gz
+sha512sums="61ef36385f501c338c263081486de0d1fccd454b86f8777b0dbad4ea3f21bbde059d0a91c23e207b167ed013127d3db8b7528f0188814a8b44d1f946b19d9b8b  tzcode2019c.tar.gz
+2921cbb2fd44a6b8f7f2ed42c13fbae28195aa5c2eeefa70396bc97cdbaad679c6cc3c143da82cca5b0279065c02389e9af536904288c12886bf345baa8c6565  tzdata2019c.tar.gz
 68dbaab9f4aef166ac2f2d40b49366527b840bebe17a47599fe38345835e4adb8a767910745ece9c384b57af815a871243c3e261a29f41d71f8054df3061b3fd  posixtz-0.5.tar.xz
 0f2a10ee2bb4007f57b59123d1a0b8ef6accf99e568f21537f0bb19f290fff46e24050f55f12569d7787be600e1b62aa790ea85a333153f3ea081a812c81b1b5  0001-posixtz-ensure-the-file-offset-we-pass-to-lseek-is-o.patch
 fb322ab7867517ba39265d56d3576cbcea107c205d524e87015c1819bbb7361f7322232ee3b86ea9b8df2886e7e06a6424e3ac83b2006be290a33856c7d40ac4  0002-fix-implicit-declaration-warnings-by-including-strin.patch"


### PR DESCRIPTION
Other backports

- #11526 
- #11527 
- #11528