### PR TITLE
testing/cage: new aport

### DIFF
--- a/testing/cage/APKBUILD
+++ b/testing/cage/APKBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Will Sinatra <wpsinatra@gmail.com>
+# Contributor: Will Sinatra <wpsinatra@gmail.com>
+pkgname=cage
+pkgver=0.1.1
+pkgrel=0
+pkgdesc="A Wayland Kiosk"
+url="https://github.com/Hjdskes/cage"
+arch="all"
+license="MIT"
+depends="xorg-server-xwayland"
+makedepends="meson cmake wlroots-dev wayland-protocols"
+options="!check" #No checks
+source="$pkgname"-"$pkgver".tar.gz::https://github.com/Hjdskes/cage/archive/v"$pkgver".tar.gz
+
+prepare(){
+	meson --buildtype=release -Dxwayland=true --prefix /usr "$srcdir/build"
+}
+	
+build(){
+	ninja -C "$srcdir/build"
+}      
+
+package(){
+	DESTDIR="$pkgdir" ninja -C "$srcdir/build" install
+}
+
+sha512sums="f071f04f1ff7d2b89ae72238ef1a28fd3fbc389803e4a4fe0c3d938c7a2a1cc962b63929d081d975f98131ff6dd9637762e8036bb320277e2580f0cbeb0c6201  cage-0.1.1.tar.gz"


### PR DESCRIPTION
Create a new aport for cage, a Wayland kiosk environment.