### PR TITLE
testing/k3s: upgrade to 0.9.0

### DIFF
--- a/testing/k3s/APKBUILD
+++ b/testing/k3s/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=k3s
-pkgver=0.8.1
+pkgver=0.9.0
 pkgrel=0
 pkgdesc="Lightweigt Kubernetes. 5 less than k8s."
 url="https://k3s.io"
@@ -63,6 +63,6 @@ package() {
 	install -m644 -D "$srcdir"/k3s.confd "$pkgdir"/etc/conf.d/k3s
 }
 
-sha512sums="797350f131bb9868574338b2ce7e09c26271ad28e9c2e5902c2cb0232173863cd593088bee14d65ff9545e3625a30e2275485008782bef6be164022061b48b65  k3s-0.8.1.tar.gz
+sha512sums="23548f3bca5f48b680f9db2d21ec7ab23e9e9d8eed4eb6da39178e4090f26249a490851e8d55314686045b40384e8356ede7a383622b00c3955bf2d64887002d  k3s-0.9.0.tar.gz
 9501422f1bf5375555116cbeedb32de32109153396699bde1300ce01156c3e57fe3fb14a57f7de1dce47c955e5e6d61de7fea181a07b407f5b452006bc58991c  k3s.initd
 dda2fc70e884ef439fece8f850d798f98d07cd431f0b8b79183f192b35f68fc7c633d3c790aae7b86ca57331212a7bb2f783131b752a4e1e71ef918469e6b944  k3s.confd"


### PR DESCRIPTION
- https://github.com/rancher/k3s/releases/tag/v0.9.0 0.9.0