### PR TITLE
community/phpmyadmin: security upgrade to 4.9.1 - CVE-2019-12922

### DIFF
--- a/community/phpmyadmin/APKBUILD
+++ b/community/phpmyadmin/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Matt Smith <mcs@darkregion.net>
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
 pkgname=phpmyadmin
-pkgver=4.9.0.1
+pkgver=4.9.1
 pkgrel=0
 pkgdesc="A Web-based PHP tool for administering MySQL"
 url="https://www.phpmyadmin.net/"
@@ -20,6 +20,8 @@ source="https://files.phpmyadmin.net/phpMyAdmin/$pkgver/$_fullpkgname.tar.xz
 options="!check"  # tests require running MySQL
 
 # secfixes:
+#   4.9.1-r0:
+#     - CVE-2019-12922
 #   4.9.0.1-r0:
 #     - CVE-2019-11768
 #     - CVE-2019-12616
@@ -99,5 +101,5 @@ doc() {
 	done
 }
 
-sha512sums="92fc032ba44e84f6c6a62bb658c2c7ea984bfd8c963b18bf19c26c3991cfe635771376ad8aebf90140bb1bd723b62a5adaca35d88f7bb68169fd0d07c3995356  phpMyAdmin-4.9.0.1-all-languages.tar.xz
+sha512sums="c2804bdb9d8501309e46d66fe4c27c3618de9cbd440928bf6335b3623a7e71608bb02fda17c5f1715b0cb32ecd68e2bbca86565f240b138c3630084225c56f83  phpMyAdmin-4.9.1-all-languages.tar.xz
 ba5776800f5c7b6cbb4ae594ec77c4d3e0d0bd319d109c676bd6c969054967baef99cab1a30c2efa26487b2ec03ef9b81d035a4323003565cffb19b08fdce9f5  phpmyadmin.apache2.conf"


### PR DESCRIPTION
Ref https://www.phpmyadmin.net/news/2019/9/21/phpmyadmin-491-released/