### PR TITLE
main/cppunit: with gcc 9.2 fix deprecated copy Werror

### DIFF
--- a/main/cppunit/APKBUILD
+++ b/main/cppunit/APKBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cppunit
 pkgver=1.14.0
-pkgrel=0
+pkgrel=1
 pkgdesc="C++ unit testing framework"
 url="http://www.freedesktop.org/wiki/Software/cppunit/"
 arch="all"
 license="LGPL-2.0-or-later"
 subpackages="$pkgname-dev $pkgname-doc"
-source="https://dev-www.libreoffice.org/src/$pkgname-$pkgver.tar.gz"
+source="https://dev-www.libreoffice.org/src/$pkgname-$pkgver.tar.gz
+	fix-Werror-deprecated-copy.patch"
 
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -34,4 +35,5 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="4ea1da423c6f7ab37e4144689f593396829ce74d43872d6b10709c1ad5fbda4ee945842f7e9803592520ef81ac713e95a3fe130295bf048cd32a605d1959882e  cppunit-1.14.0.tar.gz"
+sha512sums="4ea1da423c6f7ab37e4144689f593396829ce74d43872d6b10709c1ad5fbda4ee945842f7e9803592520ef81ac713e95a3fe130295bf048cd32a605d1959882e  cppunit-1.14.0.tar.gz
+000404d7b3318743f416d4d10ecd245935a5e1f4f0a43910eeeda152a0151855adffa8a70632abe0a76e24b408233e5d1f287eff2f174e60c65b2e5cfae66c34  fix-Werror-deprecated-copy.patch"

--- a/main/cppunit/fix-Werror-deprecated-copy.patch
+++ b/main/cppunit/fix-Werror-deprecated-copy.patch
@@ -1,0 +1,30 @@
+diff --git a/examples/cppunittest/OrthodoxTest.h b/examples/cppunittest/OrthodoxTest.h
+index 8fc2a08..a2bc678 100644
+--- a/examples/cppunittest/OrthodoxTest.h
++++ b/examples/cppunittest/OrthodoxTest.h
+@@ -38,6 +38,8 @@ private:
+   public:
+     Value( int value =0 ) : m_value( value ) {}
+ 
++    Value( const Value & ) = default;
++
+     Value& operator= ( const Value& v )
+     {
+       m_value = v.m_value;
+@@ -143,6 +145,8 @@ private:
+     {
+       return ValueBadCall( -1 - m_value );
+     }
++
++    ValueBadCall &operator =( const ValueBadCall & ) = default;
+   };
+ 
+ 
+@@ -161,6 +165,8 @@ private:
+       ++m_value;
+       return *this;
+     }
++
++    ValueBadAssignment( const ValueBadAssignment & ) = default;
+   };
+ 


### PR DESCRIPTION
with move to gcc 9.2 build breaks with error:
```
error: implicitly-declared 'constexpr OrthodoxTest::Value::Value(const OrthodoxTest::Value&)' is deprecated [-Werror=deprecated-copy]
```
cppunit upstream commit https://cgit.freedesktop.org/libreoffice/cppunit/commit/?id=78e64f0edb4f3271a6ddbcdf9cba05138597bfca fixes this and has been added in this PR