### PR TITLE
community/cassandra-cpp-driver: avoid Werror=deprecated-copy with gcc 9.2

### DIFF
--- a/community/cassandra-cpp-driver/APKBUILD
+++ b/community/cassandra-cpp-driver/APKBUILD
@@ -19,6 +19,7 @@ builddir="$srcdir/$_pkgname-$pkgver"
 build() {
 	mkdir -p "$builddir"/build
 	cd "$builddir"/build
+	export CXXFLAGS="$CXXFLAGS -Wno-error=deprecated-copy"
 	cmake \
 		-DCMAKE_BUILD_TYPE=RELEASE \
 		-DCASS_BUILD_STATIC=ON \


### PR DESCRIPTION
with move to gcc 9.2 build breaks with errors of type:
```
src/execution_profile.hpp:27:7: error: implicitly-declared 'cass::Vector<std::__cxx11::basic_string<char, std::char_traits<char>, cass::Allocator<char> > >& cass::Vector<std::__cxx11::basic_string<char, std::char_traits<char>, cass::Allocator<char> > >::operator=(const cass::Vector<std::__cxx11::basic_string<char, std::char_traits<char>, cass::Allocator<char> > >&)' is deprecated [-Werror=deprecated-copy]
   27 | class ExecutionProfile {
      |       ^~~~~~~~~~~~~~~~
```
no fix yet in upstream cassandra-cpp-driver source so workaround with adding -Wno-error=deprecated-copy to CXXFLAGS         