### PR TITLE
community/libfreehand: with gcc 9.2 prevent Werror=deprecated-copy

### DIFF
--- a/community/libfreehand/APKBUILD
+++ b/community/libfreehand/APKBUILD
@@ -24,6 +24,7 @@ prepare() {
 
 build() {
 	cd "$builddir"
+	export CXXFLAGS="$CXXFLAGS -Wno-error=deprecated-copy"
 	./configure \
 		--build=$CBUILD \
 		--host=$CHOST \


### PR DESCRIPTION
with move to gcc 9.2 build breaks with errors of type:
```
FHCollector.cpp:285:68: error: implicitly-declared 'constexpr libfreehand::FHTransform& libfreehand::FHTransform::operator=(const libfreehand::FHTransform&)' is deprecated [-Werror=deprecated-copy]
```
No updates to fix yet available to the libfreehand source. Adding Wno-error=deprecated-copy to CXXFLAGS will work around problem until upstream fix is available.