### PR TITLE
community/openjdk[9,10,11]: Enhance and unify APKBUILDs

### DIFF
--- a/community/openjdk10/APKBUILD
+++ b/community/openjdk10/APKBUILD
@@ -3,58 +3,56 @@
 pkgname=openjdk10
 pkgver=10.0.2_p13
 _pkgver=${pkgver/_p/+}
-pkgrel=0
+pkgrel=1
 pkgdesc="Oracle OpenJDK 10"
 url="https://hg.openjdk.java.net/jdk-updates/jdk10u"
-arch="all !x86 !armhf !armv7" # openjdk9 is not yet available on 32 bit arches
-license="GPL-2.0 with Classpath"
+arch="all !x86 !armhf !armv7" # oracle dopped support for 32 bit arches, so disable for now
+license="GPL-2.0-with-classpath-exception"
 makedepends="autoconf
-bash
-gawk
-grep
-make
-openjdk9-jdk
-zip
-alsa-lib-dev
-cups-dev
-elfutils-dev
-fontconfig-dev
-freetype-dev
-giflib-dev
-lcms2-dev
-libexecinfo-dev
-libffi-dev
-libjpeg-turbo-dev
-libx11-dev
-libxext-dev
-libxrender-dev
-libxt-dev
-libxtst-dev
-linux-headers
-zlib-dev"
+	bash
+	gawk
+	grep
+	make
+	openjdk9-jdk
+	zip
+	alsa-lib-dev
+	cups-dev
+	elfutils-dev
+	fontconfig-dev
+	freetype-dev
+	giflib-dev
+	lcms2-dev
+	libexecinfo-dev
+	libffi-dev
+	libjpeg-turbo-dev
+	libx11-dev
+	libxext-dev
+	libxrender-dev
+	libxt-dev
+	libxtst-dev
+	linux-headers
+	zlib-dev"
 depends="$pkgname-jmods $pkgname-demos $pkgname-doc $pkgname-jdk" # for the virtual openjdk10 package
 subpackages="$pkgname-jmods:_jmods:noarch
-$pkgname-demos:_demos:noarch
-$pkgname-doc:_doc:noarch
-$pkgname-dbg:_dbg
-$pkgname-jre:_jre
-$pkgname-src:_src:noarch
-$pkgname-jre-headless:_jre_headless
-$pkgname-jdk:_jdk"
+	$pkgname-demos:_demos:noarch
+	$pkgname-doc:_doc:noarch
+	$pkgname-dbg:_dbg
+	$pkgname-jre:_jre
+	$pkgname-src:_src:noarch
+	$pkgname-jre-headless:_jre_headless
+	$pkgname-jdk:_jdk"
 source="jdk-$_pkgver.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk10u/archive/jdk-$_pkgver.tar.bz2
 
-2019-01-05_config.sub::https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;h=3b4c7624b68d2d7f84618e1b5fa2badd43a48325;hb=286a38db91ea2dce1749ab7d1d9ea5ae344a16c1
-build.patch
-aarch64.patch
-arm.patch
-ppc64le.patch
-x86.patch
+	build.patch
+	aarch64.patch
+	arm.patch
+	ppc64le.patch
+	x86.patch
 
-HelloWorld.java
-TestECDSA.java
-TestCryptoLevel.java
-Alpine_Bug_10126.java
-"
+	HelloWorld.java
+	TestECDSA.java
+	TestCryptoLevel.java
+	Alpine_Bug_10126.java"
 builddir="$srcdir/jdk10u-jdk-$_pkgver"
 
 _java_home="/usr/lib/jvm/java-10-openjdk"
@@ -64,18 +62,19 @@ sonameprefix="$pkgname:"
 
 # enable running the JTReg tests in check?
 # see comment in that function for explanation
-_run_jtreg=0
+_run_jtreg=${_run_jtreg:-0}
 if [ $_run_jtreg -ne 0 ]; then
 	makedepends="$makedepends java-jtreg"
-	checkdepends="$checkdepends ttf-freefont xvfb"
+	checkdepends="$checkdepends ttf-freefont xvfb-run"
 fi
 
 
 prepare() {
 	default_prepare
 
-	# update the config.sub file to detect alpine
-	cp $srcdir/2019-01-05_config.sub make/autoconf/build-aux/autoconf-config.sub
+	# update autoconf files to detect alpine
+	update_config_sub
+	update_config_guess
 
 	# remove not compilable module (hotspot jdk.hotspot.agent)
 	# this needs libthread_db which is only provided by glibc
@@ -100,7 +99,9 @@ build() {
 	# shellcheck disable=2097 disable=2098
 	CFLAGS='' CXXFLAGS='' LDFLAGS='' \
 		bash ./configure \
-		--openjdk-target=$CHOST \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--target=$CTARGET \
 		--prefix="$_java_home" \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
@@ -134,8 +135,6 @@ build() {
 }
 
 check() {
-	cd "$builddir"
-
 	local _java_bin="./build/*-normal-server-release/images/jdk/bin"
 
 	# 1) compile and run a simple hello world
@@ -155,6 +154,7 @@ check() {
 	$_java_bin/java Alpine_Bug_10126
 
 	# run the gtest unittest suites
+	# they don't take long, DO NOT DISABLE THEM!
 	MAKEFLAGS='' make test-hotspot-gtest
 
 	# The jtreg tests take very, very long to finish and show some failures (9 - 12 on my machine, varying between runs)
@@ -163,29 +163,19 @@ check() {
 	# When updating this aport please let them run at least once on your machine to see if the failure count changes.
 	if [ $_run_jtreg -ne 0 ]; then
 		_logfile=$( mktemp -p "$builddir" )
-		if [ -z "$DISPLAY" ]; then
-			Xvfb :99 &
-			_xvfb_pid=$!
-			DISPLAY=:99
-		fi
-		MAKEFLAGS='' DISPLAY=$DISPLAY make \
+		MAKEFLAGS='' xvfb-run make \
 			run-test-tier1 \
 			run-test-tier2 \
 			run-test-tier3 \
 			| tee "$_logfile"
 		msg "---------------------------------------"
 		msg "The build log can be found at $_logfile"
-		if [ -n "$_xvfb_pid" ]; then
-			kill $_xvfb_pid
-		fi
 		# abort the build so you may take a look at the logfile
 		false
 	fi
 }
 
 package() {
-	cd "$builddir"
-
 	mkdir -p "$pkgdir/$_java_home"
 	cp -r build/*-normal-server-release/images/jdk/* "$pkgdir/$_java_home"
 }
@@ -315,12 +305,11 @@ _jdk() {
 }
 
 sha512sums="7491da11d5e0013db75d33e09be7a91ac0dbcde6282541a39fe471fd5368d49b15403bc7508b330ca60210b3ca02730743ba280657283a231853f6882a3ca74d  jdk-10.0.2+13.tar.bz2
-74e3d868d766e605921542969dd2f646a8adec1b82181aaeb02b623a524cb9011e44c261d4e13ab24268c79c6bc1d260e62d41a928b1b402b186dc5676272e36  2019-01-05_config.sub
-e0e7957ca035346071e04aa1b09226189c69878461c0c94c8057983f9ceab493bd192799ac33be0155831a75fac8a61f40aafea1ad4bacfdb50dfe310406c777  build.patch
+5af890bee5db3641ba94d15f6ca9ffe16ca3290e9ef08829131544338b78d51bf37cfb3ceabcb445f06fe5a6a1f24b33446074d68a5aab498dec2d7821de8511  build.patch
 479d0183aece1ca3f41d4eb9e9bf69d3d0fc2668e32d8b826ae3bd117da5d83241868e8b0cab6773cb87bd7403f17d519cc190c530a783b51f28a6aee0272bea  aarch64.patch
 776edc09c2860820e7f8500153b9b64e03e93df8c060cb02546da72102f8574d31b1c8354d02b2714b3aa480d4ec6f487942dd09bec2a921d4e18a39539a4d95  arm.patch
 06f134112d8f6c3909f332713e8fef755e65815697f08ef8ea35f89ad658c76d9063d39754eec50de93ef709a4d37dcb0815d7a74663d8668af0e23793972395  ppc64le.patch
-d882d3be6d19a23b495f0f4211b7d01bcf900afadcd1c783b0943db32c41935f336615ea4c68fe7c597ec19b793c05c9674f630c0c9580e9241d11f4a86d3781  x86.patch
+e14b0b99cb7527dee0e5e77dc912df7b8c7ad7c9211fca433173311cf863bd213b96299c6966cdc6b6ce4defcc184eb5e86424e8281c86b38fcb6b2564306e9f  x86.patch
 d1767dddd8e0956e25c0f77ed45c6fc86a1191bae1704a6dc33be490fd20eaa50461fe5c2a3349512059d555651e2eb41437dd3c1096c351e8ee68b4534a2579  HelloWorld.java
 27e91edef89d26c0c5b9a813e2045f8d2b348745a506ae37b34b660fa7093da9a4e0e676ea41dc4a5c901bce02e5304d95e90f68d6c99cbf461b2da40a7a9853  TestECDSA.java
 b02dff8d549f88317bb4c741a9e269e8d59eef990197d085388fc49c7423a4eb9367dbe1e02bffb10e7862f5980301eb58d4494e177d0e8f60af6b05c7fbbe60  TestCryptoLevel.java

--- a/community/openjdk10/build.patch
+++ b/community/openjdk10/build.patch
@@ -8,26 +8,6 @@
  endef
  
  # Param 1 - The file containing the MODULES list
---- old/make/autoconf/build-aux/config.guess
-+++ new/make/autoconf/build-aux/config.guess
-@@ -30,6 +30,17 @@
- DIR=`dirname $0`
- OUT=`. $DIR/autoconf-config.guess`
- 
-+# config.guess doesn't identify systems running the musl C library, and will
-+# instead return a string with a -gnu suffix. This block detects musl and
-+# modifies the string to have a -musl suffix instead. 
-+echo $OUT | grep -- -linux- > /dev/null 2> /dev/null
-+if test $? = 0; then
-+  ldd_version=`ldd --version 2>&1 | head -1 | cut -f1 -d' '`
-+  if [ x"${ldd_version}" = x"musl" ]; then
-+    OUT=`echo $OUT | sed 's/-gnu/-musl/'`
-+  fi
-+fi
-+
- # Test and fix solaris on x86_64
- echo $OUT | grep i386-pc-solaris > /dev/null 2> /dev/null
- if test $? = 0; then
 --- old/make/hotspot/lib/CompileJvm.gmk
 +++ new/make/hotspot/lib/CompileJvm.gmk
 @@ -140,6 +140,7 @@

--- a/community/openjdk10/x86.patch
+++ b/community/openjdk10/x86.patch
@@ -127,3 +127,14 @@
  address os::current_stack_pointer() {
  #ifdef SPARC_WORKS
    register void *esp;
+--- old/make/hotspot/lib/JvmOverrideFiles.gmk
++++ new/make/hotspot/lib/JvmOverrideFiles.gmk
+@@ -65,7 +65,7 @@
+     # Declare variables for each source file that needs the pic flag like this:
+     # BUILD_JVM_<srcfile>_CXXFLAGS := -fno-PIC
+     # This will get implicitly picked up by SetupNativeCompilation below.
+-    $(foreach s, $(NONPIC_SRC), $(eval BUILD_LIBJVM_$(notdir $s)_CXXFLAGS := -fno-PIC))
++    #$(foreach s, $(NONPIC_SRC), $(eval BUILD_LIBJVM_$(notdir $s)_CXXFLAGS := -fno-PIC))
+   endif
+ 
+ else ifeq ($(OPENJDK_TARGET_OS), solaris)

--- a/community/openjdk11/APKBUILD
+++ b/community/openjdk11/APKBUILD
@@ -3,57 +3,57 @@
 pkgname=openjdk11
 pkgver=11.0.5_p10
 _pkgver=${pkgver/_p/+}
-pkgrel=0
+pkgrel=1
 pkgdesc="Oracle OpenJDK 11"
 url="https://hg.openjdk.java.net/jdk-updates/jdk11u"
-arch="all !x86 !armhf !armv7" # openjdk10 is not yet available on 32 bit arches
-license="GPL-2.0 with Classpath"
+arch="all !x86 !armhf !armv7" # oracle dopped support for 32 bit arches, so disable for now
+license="GPL-2.0-with-classpath-exception"
 makedepends="autoconf
-bash
-gawk
-grep
-make
-openjdk10-jdk
-zip
-alsa-lib-dev
-cups-dev
-elfutils-dev
-fontconfig-dev
-freetype-dev
-giflib-dev
-lcms2-dev
-libexecinfo-dev
-libffi-dev
-libjpeg-turbo-dev
-libx11-dev
-libxext-dev
-libxrandr-dev
-libxrender-dev
-libxt-dev
-libxtst-dev
-linux-headers
-zlib-dev"
+	bash
+	gawk
+	grep
+	make
+	openjdk10-jdk
+	zip
+	alsa-lib-dev
+	cups-dev
+	elfutils-dev
+	fontconfig-dev
+	freetype-dev
+	giflib-dev
+	lcms2-dev
+	libexecinfo-dev
+	libffi-dev
+	libjpeg-turbo-dev
+	libx11-dev
+	libxext-dev
+	libxrandr-dev
+	libxrender-dev
+	libxt-dev
+	libxtst-dev
+	linux-headers
+	zlib-dev"
 depends="$pkgname-jmods $pkgname-demos $pkgname-doc $pkgname-jdk" # for the virtual openjdk11 package
 subpackages="$pkgname-jmods:_jmods:noarch
-$pkgname-demos:_demos:noarch
-$pkgname-doc:_doc:noarch
-$pkgname-dbg:_dbg
-$pkgname-jre:_jre
-$pkgname-src:_src:noarch
-$pkgname-jre-headless:_jre_headless
-$pkgname-jdk:_jdk"
+	$pkgname-demos:_demos:noarch
+	$pkgname-doc:_doc:noarch
+	$pkgname-dbg:_dbg
+	$pkgname-jre:_jre
+	$pkgname-src:_src:noarch
+	$pkgname-jre-headless:_jre_headless
+	$pkgname-jdk:_jdk"
 source="jdk-$_pkgver.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk11u/archive/jdk-$_pkgver.tar.bz2
 
-build.patch
-aarch64.patch
-arm.patch
-ppc64le.patch
-x86.patch
+	build.patch
+	aarch64.patch
+	arm.patch
+	ppc64le.patch
+	x86.patch
 
-HelloWorld.java
-TestECDSA.java
-TestCryptoLevel.java
-Alpine_Bug_10126.java
+	HelloWorld.java
+	TestECDSA.java
+	TestCryptoLevel.java
+	Alpine_Bug_10126.java
 "
 builddir="$srcdir/jdk11u-jdk-$_pkgver"
 
@@ -64,10 +64,10 @@ sonameprefix="$pkgname:"
 
 # enable running the JTReg tests in check?
 # see comment in that function for explanation
-_run_jtreg=0
+_run_jtreg=${_run_jtreg:-0}
 if [ $_run_jtreg -ne 0 ]; then
 	makedepends="$makedepends java-jtreg"
-	checkdepends="$checkdepends ttf-freefont xvfb"
+	checkdepends="$checkdepends ttf-freefont xvfb-run"
 fi
 
 
@@ -86,8 +86,6 @@ prepare() {
 }
 
 build() {
-	cd "$builddir"
-
 	if [ $_run_jtreg -ne 0 ]; then
 		_with_jtreg="--with-jtreg=/usr/share/java/jtreg"
 	else
@@ -100,9 +98,12 @@ build() {
 	#  --with-extra-cxxflags="${CXXFLAGS}"
 	#  --with-extra-ldflags="${LDFLAGS}"
 	# See also paragraph "Configure Control Variables" from "common/doc/building.md"
-	CFLAGS= CXXFLAGS= LDFLAGS= \
+	# shellcheck disable=2097 disable=2098
+	CFLAGS='' CXXFLAGS='' LDFLAGS='' \
 		bash ./configure \
-		--openjdk-target=$CHOST \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--target=$CTARGET \
 		--prefix="$_java_home" \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
@@ -132,12 +133,10 @@ build() {
 		--with-vendor-url="https://alpinelinux.org/" \
 		--with-vendor-bug-url="https://bugs.alpinelinux.org/projects/alpine/issues" \
 		--with-vendor-vm-bug-url="https://bugs.alpinelinux.org/projects/alpine/issues"
-	MAKEFLAGS= make images
+	MAKEFLAGS='' make jdk-image
 }
 
 check() {
-	cd "$builddir"
-
 	local _java_bin="./build/*-normal-server-release/images/jdk/bin"
 
 	# 1) compile and run a simple hello world
@@ -157,7 +156,8 @@ check() {
 	$_java_bin/java Alpine_Bug_10126
 
 	# run the gtest unittest suites
-	MAKEFLAGS= make test-hotspot-gtest
+	# they don't take long, DO NOT DISABLE THEM!
+	MAKEFLAGS='' make test-hotspot-gtest
 
 	# The jtreg tests take very, very long to finish and show some failures (9 - 12 on my machine, varying between runs)
 	# I think these are not critical and can be safely ignored.
@@ -165,29 +165,19 @@ check() {
 	# When updating this aport please let them run at least once on your machine to see if the failure count changes.
 	if [ $_run_jtreg -ne 0 ]; then
 		_logfile=$( mktemp -p "$builddir" )
-		if [ -z "$DISPLAY" ]; then
-			Xvfb :99 &
-			_xvfb_pid=$!
-			DISPLAY=:99
-		fi
-		MAKEFLAGS= DISPLAY=$DISPLAY make \
+		MAKEFLAGS='' xvfb-run make \
 			run-test-tier1 \
 			run-test-tier2 \
 			run-test-tier3 \
 			| tee "$_logfile"
 		msg "---------------------------------------"
 		msg "The build log can be found at $_logfile"
-		if [ -n "$_xvfb_pid" ]; then
-			kill $_xvfb_pid
-		fi
 		# abort the build so you may take a look at the logfile
 		false
 	fi
 }
 
 package() {
-	cd "$builddir"
-
 	mkdir -p "$pkgdir/$_java_home"
 	cp -r build/*-normal-server-release/images/jdk/* "$pkgdir/$_java_home"
 }
@@ -230,6 +220,7 @@ _dbg() {
 
 	mkdir -p "$_toroot/lib/server"
 	mkdir -p "$_toroot/lib/jli"
+
 	mv "$_fromroot"/lib/server/*.debuginfo "$_toroot"/lib/server
 	mv "$_fromroot"/lib/jli/*.debuginfo "$_toroot"/lib/jli
 	mv "$_fromroot"/lib/*.debuginfo "$_toroot"/lib
@@ -308,11 +299,11 @@ _jdk() {
 }
 
 sha512sums="0d52c78e217b79756be0fc6b3f9204bae254ec7b9ae10b6c3114463a9c028143807f4422711f0c02b81a034ae6e88fa2efc6bed85022720807344230a8aa12a6  jdk-11.0.5+10.tar.bz2
-66a9f2736da87de09d7bcc136771ab760bdba7847f3a23b2aa4efbc2e55ac8b49510c6d7afdf3f8d046c6e3fe9dca0d4cb0b5a38d7a3aebaf86fa0e3cc635eac  build.patch
+1460cbacb57427b23244fd85d47af9666760d9877f4c0424c92b9708343e147d0647477311d14abedb7de707cde85f21340686eeb07c2e02a23cc808d8b268e5  build.patch
 8c0f1f8d2a78ebb30a8460bc0ea9cd2349cea98819df1577bf7de19a1dd82d06a593f36b4e17c282ed53d23f00163e387e3dd1f3c9e5a092726e78c3aa710370  aarch64.patch
-d2903a5b3b9f82c4888416580f0b93888bf21ae0dac0ce6e926607a82a9e53b7e10e13f07a984f65dc116e81f58cd3844d6156088534c0059be8f6ee68e19a43  arm.patch
+36a87d59001e13351b5f3fd6f8a9351eb3ecfe2b16af3af22986847ff009b7ff8baec67b9b938fe650aaebd4751af4576a6d1133e5e5f8eef91616db5e5ece02  arm.patch
 4eb577645e7b6d4563290480e162702030033515ff4845edbd1dbf2604b6f1e7d2a3cdd85058d6b41938b54c097635125c4429b9df3fcda589b980aa1740fd2e  ppc64le.patch
-89e681da2de0bcb5131e2512d1280ce8da684ede5b38379c6325cd9f57e78a4bdde3abfa0a0a496889411dd57264312094973ce2da301293d0826114a3ef09d3  x86.patch
+4dbae3089f7a2d1d69174add13802d2ed0d1fea6649bff9384d92f2259e8bb6bf5f70b61ca21f2f67624b261995468ace562b19f1573dea07df9733edb8eddf8  x86.patch
 d1767dddd8e0956e25c0f77ed45c6fc86a1191bae1704a6dc33be490fd20eaa50461fe5c2a3349512059d555651e2eb41437dd3c1096c351e8ee68b4534a2579  HelloWorld.java
 27e91edef89d26c0c5b9a813e2045f8d2b348745a506ae37b34b660fa7093da9a4e0e676ea41dc4a5c901bce02e5304d95e90f68d6c99cbf461b2da40a7a9853  TestECDSA.java
 b02dff8d549f88317bb4c741a9e269e8d59eef990197d085388fc49c7423a4eb9367dbe1e02bffb10e7862f5980301eb58d4494e177d0e8f60af6b05c7fbbe60  TestCryptoLevel.java

--- a/community/openjdk11/arm.patch
+++ b/community/openjdk11/arm.patch
@@ -8,7 +8,7 @@
  # include <asm/ptrace.h>
  
  #define SPELL_REG_SP  "sp"
-@@ -104,6 +103,18 @@
+@@ -100,6 +99,18 @@
  #define ARM_REGS_IN_CONTEXT  31
  
  #else

--- a/community/openjdk11/build.patch
+++ b/community/openjdk11/build.patch
@@ -8,26 +8,6 @@
  endef
  
  # Param 1 - The file containing the MODULES list
---- old/make/autoconf/build-aux/config.guess
-+++ new/make/autoconf/build-aux/config.guess
-@@ -30,6 +30,17 @@
- DIR=`dirname $0`
- OUT=`. $DIR/autoconf-config.guess`
- 
-+# config.guess doesn't identify systems running the musl C library, and will
-+# instead return a string with a -gnu suffix. This block detects musl and
-+# modifies the string to have a -musl suffix instead. 
-+echo $OUT | grep -- -linux- > /dev/null 2> /dev/null
-+if test $? = 0; then
-+  ldd_version=`ldd --version 2>&1 | head -1 | cut -f1 -d' '`
-+  if [ x"${ldd_version}" = x"musl" ]; then
-+    OUT=`echo $OUT | sed 's/-gnu/-musl/'`
-+  fi
-+fi
-+
- # Test and fix solaris on x86_64
- echo $OUT | grep i386-pc-solaris > /dev/null 2> /dev/null
- if test $? = 0; then
 --- old/make/hotspot/lib/CompileJvm.gmk
 +++ new/make/hotspot/lib/CompileJvm.gmk
 @@ -77,6 +77,7 @@
@@ -58,7 +38,7 @@
  # include <sys/ipc.h>
  # include <sys/shm.h>
  # include <link.h>
-@@ -511,6 +510,11 @@
+@@ -592,6 +591,11 @@
  // detecting pthread library
  
  void os::Linux::libpthread_init() {
@@ -70,7 +50,7 @@
    // Save glibc and pthread version strings.
  #if !defined(_CS_GNU_LIBC_VERSION) || \
      !defined(_CS_GNU_LIBPTHREAD_VERSION)
-@@ -528,6 +532,7 @@
+@@ -609,6 +613,7 @@
    str = (char *)malloc(n, mtInternal);
    confstr(_CS_GNU_LIBPTHREAD_VERSION, str, n);
    os::Linux::set_libpthread_version(str);
@@ -78,7 +58,7 @@
  }
  
  /////////////////////////////////////////////////////////////////////////////
-@@ -2916,20 +2921,36 @@
+@@ -3080,20 +3085,36 @@
  extern "C" JNIEXPORT void numa_warn(int number, char *where, ...) { }
  extern "C" JNIEXPORT void numa_error(char *where) { }
  
@@ -278,7 +258,7 @@
  
  #include <jvm.h>
  #include <jni.h>
-@@ -786,26 +783,6 @@
+@@ -790,26 +787,6 @@
      }
      return ret;
  }
@@ -391,7 +371,7 @@
      printf("Testing stack guard page behaviour for initial thread\n");
 --- old/test/jdk/java/lang/ProcessBuilder/Basic.java
 +++ new/test/jdk/java/lang/ProcessBuilder/Basic.java
-@@ -389,8 +389,8 @@
+@@ -396,8 +396,8 @@
                  if (failed != 0) throw new Error("null PATH");
              } else if (action.equals("PATH search algorithm")) {
                  equal(System.getenv("PATH"), "dir1:dir2:");
@@ -402,7 +382,7 @@
                  String[] cmd = {"prog"};
                  ProcessBuilder pb1 = new ProcessBuilder(cmd);
                  ProcessBuilder pb2 = new ProcessBuilder(cmd);
-@@ -431,13 +431,13 @@
+@@ -438,13 +438,13 @@
                          checkPermissionDenied(pb);
  
                          // continue searching if EACCES
@@ -418,7 +398,7 @@
                          equal(run(pb).exitValue(), True.exitValue());
  
                          // Check empty PATH component means current directory.
-@@ -453,10 +453,10 @@
+@@ -460,10 +460,10 @@
                              pb.command(command);
                              File prog = new File("./prog");
                              // "Normal" binaries
@@ -431,7 +411,7 @@
                              equal(run(pb).exitValue(),
                                    False.exitValue());
                              prog.delete();
-@@ -511,12 +511,12 @@
+@@ -518,12 +518,12 @@
                          new File("dir2/prog").delete();
                          new File("prog").delete();
                          new File("dir3").mkdirs();
@@ -448,7 +428,7 @@
                          equal(run(pb).exitValue(), False.exitValue());
  
                      } finally {
-@@ -613,6 +613,13 @@
+@@ -620,6 +620,13 @@
               new File("/bin/false").exists());
      }
  
@@ -462,7 +442,7 @@
      static class UnicodeOS {
          public static boolean is() { return is; }
          private static final String osName = System.getProperty("os.name");
-@@ -651,6 +658,45 @@
+@@ -658,6 +665,45 @@
          }
      }
  
@@ -508,7 +488,7 @@
      static class EnglishUnix {
          private static final Boolean is =
              (! Windows.is() && isEnglish("LANG") && isEnglish("LC_ALL"));
-@@ -1954,7 +2000,7 @@
+@@ -1961,7 +2007,7 @@
              //----------------------------------------------------------------
              try {
                  new File("suBdiR").mkdirs();

--- a/community/openjdk11/x86.patch
+++ b/community/openjdk11/x86.patch
@@ -127,3 +127,14 @@
  address os::current_stack_pointer() {
  #ifdef SPARC_WORKS
    register void *esp;
+--- old/make/hotspot/lib/JvmOverrideFiles.gmk
++++ new/make/hotspot/lib/JvmOverrideFiles.gmk
+@@ -75,7 +75,7 @@
+     # Declare variables for each source file that needs the pic flag like this:
+     # BUILD_JVM_<srcfile>_CXXFLAGS := -fno-PIC
+     # This will get implicitly picked up by SetupNativeCompilation below.
+-    $(foreach s, $(NONPIC_SRC), $(eval BUILD_LIBJVM_$(notdir $s)_CXXFLAGS := -fno-PIC))
++    #$(foreach s, $(NONPIC_SRC), $(eval BUILD_LIBJVM_$(notdir $s)_CXXFLAGS := -fno-PIC))
+   endif
+ 
+ else ifeq ($(OPENJDK_TARGET_OS), solaris)

--- a/community/openjdk9/APKBUILD
+++ b/community/openjdk9/APKBUILD
@@ -3,63 +3,62 @@
 pkgname=openjdk9
 pkgver=9.0.4_p12
 _pkgver=${pkgver/_p/+}
-pkgrel=1
+pkgrel=2
 pkgdesc="Oracle OpenJDK 9"
 url="https://hg.openjdk.java.net/jdk-updates/jdk9u"
-arch="all !x86 !armhf !armv7" # build fails on 32bit arches
-license="GPL-2.0 with Classpath"
+arch="all !x86 !armhf !armv7" # oracle dopped support for 32 bit arches, so disable for now
+license="GPL-2.0-with-classpath-exception"
 makedepends="autoconf
-bash
-gawk
-grep
-make
-openjdk8
-zip
-alsa-lib-dev
-cups-dev
-freetype-dev
-giflib-dev
-lcms2-dev
-elfutils-dev
-libexecinfo-dev
-libffi-dev
-libjpeg-turbo-dev
-libx11-dev
-libxext-dev
-libxrender-dev
-libxt-dev
-libxtst-dev
-linux-headers
-zlib-dev
-"
+	bash
+	gawk
+	grep
+	make
+	openjdk8
+	zip
+	alsa-lib-dev
+	cups-dev
+	freetype-dev
+	giflib-dev
+	lcms2-dev
+	elfutils-dev
+	libexecinfo-dev
+	libffi-dev
+	libjpeg-turbo-dev
+	libx11-dev
+	libxext-dev
+	libxrender-dev
+	libxt-dev
+	libxtst-dev
+	linux-headers
+	zlib-dev"
 depends="$pkgname-jmods $pkgname-demos $pkgname-doc $pkgname-dbg $pkgname-jdk" # for the virtual openjdk9 package
 subpackages="$pkgname-jmods:_jmods:noarch
-$pkgname-demos:_demos:noarch
-$pkgname-doc:_doc:noarch
-$pkgname-dbg:_dbg
-$pkgname-jre:_jre
-$pkgname-src:_src
-$pkgname-jre-headless:_jre_headless
-$pkgname-jdk:_jdk
-"
+	$pkgname-demos:_demos:noarch
+	$pkgname-doc:_doc:noarch
+	$pkgname-dbg:_dbg
+	$pkgname-jre:_jre
+	$pkgname-src:_src:noarch
+	$pkgname-jre-headless:_jre_headless
+	$pkgname-jdk:_jdk"
 source="jdk-$_pkgver-root.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/archive/jdk-$_pkgver.tar.bz2
-jdk-$_pkgver-corba.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/corba/archive/jdk-$_pkgver.tar.bz2
-jdk-$_pkgver-hotspot.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/hotspot/archive/jdk-$_pkgver.tar.bz2
-jdk-$_pkgver-jaxp.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/jaxp/archive/jdk-$_pkgver.tar.bz2
-jdk-$_pkgver-jaxws.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/jaxws/archive/jdk-$_pkgver.tar.bz2
-jdk-$_pkgver-jdk.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/jdk/archive/jdk-$_pkgver.tar.bz2
-jdk-$_pkgver-langtools.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/langtools/archive/jdk-$_pkgver.tar.bz2
-jdk-$_pkgver-nashorn.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/nashorn/archive/jdk-$_pkgver.tar.bz2
+	jdk-$_pkgver-corba.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/corba/archive/jdk-$_pkgver.tar.bz2
+	jdk-$_pkgver-hotspot.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/hotspot/archive/jdk-$_pkgver.tar.bz2
+	jdk-$_pkgver-jaxp.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/jaxp/archive/jdk-$_pkgver.tar.bz2
+	jdk-$_pkgver-jaxws.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/jaxws/archive/jdk-$_pkgver.tar.bz2
+	jdk-$_pkgver-jdk.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/jdk/archive/jdk-$_pkgver.tar.bz2
+	jdk-$_pkgver-langtools.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/langtools/archive/jdk-$_pkgver.tar.bz2
+	jdk-$_pkgver-nashorn.tar.bz2::http://hg.openjdk.java.net/jdk-updates/jdk9u/nashorn/archive/jdk-$_pkgver.tar.bz2
 
-2019-01-05_config.sub::https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;h=3b4c7624b68d2d7f84618e1b5fa2badd43a48325;hb=286a38db91ea2dce1749ab7d1d9ea5ae344a16c1
-build.patch
-aarch64.patch
-arm.patch
-ppc64le.patch
-x86.patch
+	build.patch
+	aarch64.patch
+	arm.patch
+	ppc64le.patch
+	x86.patch
 
-HelloWorld.java
-"
+	HelloWorld.java
+	TestECDSA.java
+	TestCryptoLevel.java
+	Alpine_Bug_10126.java"
 builddir="$srcdir/jdk9u-jdk-$_pkgver"
 
 _java_home="/usr/lib/jvm/java-9-openjdk"
@@ -68,10 +67,10 @@ sonameprefix="$pkgname:"
 
 # enable running the JTReg tests in check?
 # see comment in that function for explanation
-_run_jtreg=0
+_run_jtreg=${_run_jtreg:-0}
 if [ $_run_jtreg -ne 0 ]; then
 	makedepends="$makedepends java-jtreg"
-	checkdepends="$checkdepends ttf-freefont xvfb"
+	checkdepends="$checkdepends ttf-freefont xvfb-run"
 fi
 
 
@@ -94,8 +93,9 @@ unpack() {
 prepare() {
 	default_prepare
 
-	# update the config.sub file to detect alpine
-	cp $srcdir/2019-01-05_config.sub common/autoconf/build-aux/autoconf-config.sub
+	# update autoconf files to detect alpine
+	update_config_sub
+	update_config_guess
 
 	# remove not compilable module (hotspot jdk.hotspot.agent)
 	# this needs libthread_db which is only provided by glibc
@@ -105,8 +105,6 @@ prepare() {
 }
 
 build() {
-	cd "$builddir"
-
 	if [ $_run_jtreg -ne 0 ]; then
 		_with_jtreg="--with-jtreg=/usr/share/java/jtreg"
 	else
@@ -118,10 +116,13 @@ build() {
 	#  --with-extra-cflags="${CFLAGS}"
 	#  --with-extra-cxxflags="${CXXFLAGS}"
 	#  --with-extra-ldflags="${LDFLAGS}"
-	# See also paragraph "Configure Control Variables from "jdk9-${_hg_tag}/common/doc/building.md
-	CFLAGS= CXXFLAGS= LDFLAGS= \
+	# See also paragraph "Configure Control Variables" from "common/doc/building.md"
+	# shellcheck disable=2097 disable=2098
+	CFLAGS='' CXXFLAGS='' LDFLAGS='' \
 		bash ./configure \
-		--openjdk-target=$CHOST \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--target=$CTARGET \
 		--prefix="$_java_home" \
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
@@ -148,20 +149,31 @@ build() {
 		--with-version-opt=alpine-r${pkgrel} \
 		--with-version-build=${_pkgver#*+}
 
-	MAKEFLAGS= make jdk-image
+	MAKEFLAGS='' make jdk-image
 }
 
 check() {
-	cd "$builddir"
+	local _java_bin="./build/*-normal-server-release/images/jdk/bin"
 
-	# compile and run a simple hello world
-	cp "$srcdir/HelloWorld.java" .
-	./build/*-normal-server-release/images/jdk/bin/javac HelloWorld.java
-	./build/*-normal-server-release/images/jdk/bin/java HelloWorld
+	# 1) compile and run a simple hello world
+	$_java_bin/javac -d . "$srcdir"/HelloWorld.java
+	$_java_bin/java HelloWorld
+
+	# 2) compile and run a testcase for unlimited policy
+	$_java_bin/javac -d . "$srcdir"/TestCryptoLevel.java
+	$_java_bin/java -cp . --add-opens java.base/javax.crypto=ALL-UNNAMED TestCryptoLevel
+
+	# 3) compile and run a testcase for ECDSA signatures
+	$_java_bin/javac -d . "$srcdir"/TestECDSA.java
+	$_java_bin/java TestECDSA
+
+	# 4) compile and run testcase for bug 10126
+	$_java_bin/javac -d . "$srcdir"/Alpine_Bug_10126.java
+	$_java_bin/java Alpine_Bug_10126
 
 	# run the gtest unittest suites
 	# they don't take long, DO NOT DISABLE THEM!
-	MAKEFLAGS= make test-hotspot-gtest
+	MAKEFLAGS='' make test-hotspot-gtest
 
 	# The jtreg tests take very, very long to finish and show some failures (9 - 12 on my machine, varying between runs)
 	# I think these are not critical and can be safely ignored.
@@ -169,28 +181,19 @@ check() {
 	# When updating this aport please let them run at least once on your machine to see if the failure count changes.
 	if [ $_run_jtreg -ne 0 ]; then
 		_logfile=$( mktemp -p "$builddir" )
-		if [ -z "$DISPLAY" ]; then
-			Xvfb :99 &
-			_xvfb_pid=$!
-			DISPLAY=:99
-		fi
-		MAKEFLAGS= DISPLAY=$DISPLAY make \
+		MAKEFLAGS='' xvfb-run make \
 			run-test-tier1 \
 			run-test-tier2 \
 			run-test-tier3 \
 			| tee "$_logfile"
 		msg "---------------------------------------"
 		msg "The build log can be found at $_logfile"
-		if [ -n "$_xvfb_pid" ]; then
-			kill $_xvfb_pid
-		fi
+		# abort the build so you may take a look at the logfile
 		false
 	fi
 }
 
 package() {
-	cd "$builddir"
-
 	mkdir -p "$pkgdir/$_java_home"
 	cp -r build/*-normal-server-release/images/jdk/* "$pkgdir/$_java_home"
 }
@@ -254,7 +257,6 @@ _jre() {
 		"$_fromroot/lib/libsplashscreen.so" \
 		"$_toroot/lib"
 }
-
 
 _src() {
 	pkgdesc="OpenJDK $_majorver Source Bundle"
@@ -325,10 +327,12 @@ sha512sums="cef3655ae7db657e6c81aa86587e451e58896bb6ee786495f6d757096334435b6a4d
 259228d3f439dde239e38cdebb8c3bbb83804ab141d87a9c236310707de9c58cd78cd80ceb4c17755cc1048071f24462839988112c2698f7ec1453a8810610f2  jdk-9.0.4+12-jdk.tar.bz2
 ef3c70be906a4b0dd9c9195c88da045909ee3ef144941fb7b4495ed66b4162f481095cad87626d2bd38e5a62134b440223cd008dd6123b6b43c00e338610a692  jdk-9.0.4+12-langtools.tar.bz2
 848c6ece418e250561572ad704baeb565580098cfc5f849d4e1a3b41b916aae3487eb4d8d0b319f3a503d122ec064ed4de0678d06821c9a2bdb09c990e589c97  jdk-9.0.4+12-nashorn.tar.bz2
-74e3d868d766e605921542969dd2f646a8adec1b82181aaeb02b623a524cb9011e44c261d4e13ab24268c79c6bc1d260e62d41a928b1b402b186dc5676272e36  2019-01-05_config.sub
-386490c3be4c9aa9dc4b73911bc0b97298ff8b1a50e53bd601f4d2a7b3e469f5b8e70e446b2bbe6876854302a373522b4819fde24c85eafc00f9524268096615  build.patch
+ea02bc4653fc50fafa90b0208336bfb93b9b4b003be10aaf2ca617c2712dcd27e3bc138a25fbd6e0198d3a15ec460a0051d9a30993e9184d94559cfcf7e1cbdd  build.patch
 3cc00d9b81377fdffb7f5b3f732a35cebd2575825d85df88330740903dd98de30fe75e69229811d52f2ef192c1df0715c2696edf31f64c8d7de4b502a16792e4  aarch64.patch
 fa9fcc0c2f0972435b078669175c44f7d5d3cc29fbecb3e053d196c041ef0ff3feee8ec189a86fce0b35c5fd647ff71963a15e1e6fa50775cc2b6fa35d2ccf0a  arm.patch
 7244d0dfdb78d2f03ea992ef770ed888e2bd48f49e58438e7f0a763633c9aa8fc27b953d82c023f8f99ff23009a15031c99b2ef5550d277c63db684cd984ce8e  ppc64le.patch
-427c525e184e2a74f511aad8192dd411fe7fcc4e7a4dc03a3496fb030cec0177b3b520cbdd1c7700f6761a15ff2e5cce59c93d7079b744954122f684d34ce723  x86.patch
-d1767dddd8e0956e25c0f77ed45c6fc86a1191bae1704a6dc33be490fd20eaa50461fe5c2a3349512059d555651e2eb41437dd3c1096c351e8ee68b4534a2579  HelloWorld.java"
+607a77eb37e318e508dde518df9048dbe0e597faf6e2b2194f755d67c9adffb99368120dc02f226d63f812a5612b418b800f7d1eae4ede2c1ab147799fe93316  x86.patch
+d1767dddd8e0956e25c0f77ed45c6fc86a1191bae1704a6dc33be490fd20eaa50461fe5c2a3349512059d555651e2eb41437dd3c1096c351e8ee68b4534a2579  HelloWorld.java
+27e91edef89d26c0c5b9a813e2045f8d2b348745a506ae37b34b660fa7093da9a4e0e676ea41dc4a5c901bce02e5304d95e90f68d6c99cbf461b2da40a7a9853  TestECDSA.java
+b02dff8d549f88317bb4c741a9e269e8d59eef990197d085388fc49c7423a4eb9367dbe1e02bffb10e7862f5980301eb58d4494e177d0e8f60af6b05c7fbbe60  TestCryptoLevel.java
+18f72fcc3b09e772da10d6875a7081fe21d3b387e1d4d9a45bb9cc3e306393960b19c27dac61d33a20d7484c22109c2d091c062523d5575b8d30b20949b74f70  Alpine_Bug_10126.java"

--- a/community/openjdk9/Alpine_Bug_10126.java
+++ b/community/openjdk9/Alpine_Bug_10126.java
@@ -1,0 +1,13 @@
+public class Alpine_Bug_10126 {
+    public static void main(String[] args) throws Exception {
+        try (java.net.Socket sock = javax.net.ssl.SSLSocketFactory.getDefault().createSocket("bugs.alpinelinux.org", 443);
+             java.io.InputStream in = sock.getInputStream();
+             java.io.OutputStream out = sock.getOutputStream()) {
+            out.write("GET / HTTP/1.0\n\nHost: bugs.alpinelinux.org\n\nConnection: close\n\n\n\n".getBytes());
+            out.flush();
+            while (in.read(new byte[1024]) != -1) ;
+        }
+        System.out.println("Secured connection performed successfully");
+    }
+}
+

--- a/community/openjdk9/TestCryptoLevel.java
+++ b/community/openjdk9/TestCryptoLevel.java
@@ -1,0 +1,72 @@
+/* TestCryptoLevel -- Ensure unlimited crypto policy is in use.
+   Copyright (C) 2012 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
+
+import java.security.Permission;
+import java.security.PermissionCollection;
+
+public class TestCryptoLevel
+{
+    public static void main(String[] args)
+            throws NoSuchFieldException, ClassNotFoundException,
+            IllegalAccessException, InvocationTargetException
+    {
+        Class<?> cls = null;
+        Method def = null, exempt = null;
+
+        try
+        {
+            cls = Class.forName("javax.crypto.JceSecurity");
+        }
+        catch (ClassNotFoundException ex)
+        {
+            System.err.println("Running a non-Sun JDK.");
+            System.exit(0);
+        }
+        try
+        {
+            def = cls.getDeclaredMethod("getDefaultPolicy");
+            exempt = cls.getDeclaredMethod("getExemptPolicy");
+        }
+        catch (NoSuchMethodException ex)
+        {
+            System.err.println("Running IcedTea with the original crypto patch.");
+            System.exit(0);
+        }
+        def.setAccessible(true);
+        exempt.setAccessible(true);
+        PermissionCollection defPerms = (PermissionCollection) def.invoke(null);
+        PermissionCollection exemptPerms = (PermissionCollection) exempt.invoke(null);
+        Class<?> apCls = Class.forName("javax.crypto.CryptoAllPermission");
+        Field apField = apCls.getDeclaredField("INSTANCE");
+        apField.setAccessible(true);
+        Permission allPerms = (Permission) apField.get(null);
+        if (defPerms.implies(allPerms) && (exemptPerms == null || exemptPerms.implies(allPerms)))
+        {
+            System.err.println("Running with the unlimited policy.");
+            System.exit(0);
+        }
+        else
+        {
+            System.err.println("WARNING: Running with a restricted crypto policy.");
+            System.exit(-1);
+        }
+    }
+}

--- a/community/openjdk9/TestECDSA.java
+++ b/community/openjdk9/TestECDSA.java
@@ -1,0 +1,49 @@
+/* TestECDSA -- Ensure ECDSA signatures are working.
+   Copyright (C) 2016 Red Hat, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+
+/**
+ * @test
+ */
+public class TestECDSA {
+
+    public static void main(String[] args) throws Exception {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+        KeyPair key = keyGen.generateKeyPair();
+
+        byte[] data = "This is a string to sign".getBytes("UTF-8");
+
+        Signature dsa = Signature.getInstance("NONEwithECDSA");
+        dsa.initSign(key.getPrivate());
+        dsa.update(data);
+        byte[] sig = dsa.sign();
+        System.out.println("Signature: " + new BigInteger(1, sig).toString(16));
+
+        Signature dsaCheck = Signature.getInstance("NONEwithECDSA");
+        dsaCheck.initVerify(key.getPublic());
+        dsaCheck.update(data);
+        boolean success = dsaCheck.verify(sig);
+        if (!success) {
+            throw new RuntimeException("Test failed. Signature verification error");
+        }
+        System.out.println("Test passed.");
+    }
+}

--- a/community/openjdk9/build.patch
+++ b/community/openjdk9/build.patch
@@ -1,23 +1,3 @@
---- old/common/autoconf/build-aux/config.guess
-+++ new/common/autoconf/build-aux/config.guess
-@@ -30,6 +30,17 @@
- DIR=`dirname $0`
- OUT=`. $DIR/autoconf-config.guess`
- 
-+# config.guess doesn't identify systems running the musl C library, and will
-+# instead return a string with a -gnu suffix. This block detects musl and
-+# modifies the string to have a -musl suffix instead. 
-+echo $OUT | grep -- -linux- > /dev/null 2> /dev/null
-+if test $? = 0; then
-+  ldd_version=`ldd --version 2>&1 | head -1 | cut -f1 -d' '`
-+  if [ x"${ldd_version}" = x"musl" ]; then
-+    OUT=`echo $OUT | sed 's/-gnu/-musl/'`
-+  fi
-+fi
-+
- # Test and fix solaris on x86_64
- echo $OUT | grep i386-pc-solaris > /dev/null 2> /dev/null
- if test $? = 0; then
 --- old/hotspot/make/lib/CompileJvm.gmk
 +++ new/hotspot/make/lib/CompileJvm.gmk
 @@ -135,6 +135,7 @@

--- a/community/openjdk9/x86.patch
+++ b/community/openjdk9/x86.patch
@@ -1,4 +1,3 @@
-Only in old: build.patch
 --- old/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
 +++ new/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
 @@ -88,6 +88,126 @@
@@ -128,3 +127,14 @@ Only in old: build.patch
  address os::current_stack_pointer() {
  #ifdef SPARC_WORKS
    register void *esp;
+--- old/hotspot/make/lib/JvmOverrideFiles.gmk
++++ new/hotspot/make/lib/JvmOverrideFiles.gmk
+@@ -65,7 +65,7 @@
+     # Declare variables for each source file that needs the pic flag like this:
+     # BUILD_JVM_<srcfile>_CXXFLAGS := -fno-PIC
+     # This will get implicitly picked up by SetupNativeCompilation below.
+-    $(foreach s, $(NONPIC_SRC), $(eval BUILD_LIBJVM_$(notdir $s)_CXXFLAGS := -fno-PIC))
++    #$(foreach s, $(NONPIC_SRC), $(eval BUILD_LIBJVM_$(notdir $s)_CXXFLAGS := -fno-PIC))
+   endif
+ 
+ else ifeq ($(OPENJDK_TARGET_OS), solaris)


### PR DESCRIPTION
Enhance and unify APKBUILDs for java builds. Add patches to enable 32 bit builds sometime later.
Travis / drone will fail on this, as the builds take too long.