### PR TITLE
testing/restart-services: new aport

### DIFF
--- a/testing/restart-services/APKBUILD
+++ b/testing/restart-services/APKBUILD
@@ -1,0 +1,39 @@
+# Contributor: Michael Pirogov <vbnet.ru@gmail.com>
+# Maintainer: Michael Pirogov <vbnet.ru@gmail.com>
+pkgname="restart-services"
+pkgver="0.14.4"
+pkgrel=0
+pkgdesc="Tool to manage OpenRC services that need to be restarted"
+url="https://dev.gentoo.org/~mschiff/restart-services/"
+arch="noarch"
+license="GPL-3.0"
+depends="py3-lib_users openrc"
+options="!check" # single bash script w/o tests
+subpackages="$pkgname-doc"
+source="https://dev.gentoo.org/~mschiff/src/restart-services/restart-services-$pkgver.tgz
+	alpine.patch"
+
+package() {
+	install -D -m 0755 $pkgname "$pkgdir"/usr/sbin/$pkgname
+	install -D -p -m 644 $pkgname.1 \
+		"$pkgdir"/usr/share/man/man1/$pkgname.1
+	install -D -m644 CHANGES \
+		"$pkgdir"/usr/share/doc/$pkgname/CHANGES
+	install -D -m644 README \
+		"$pkgdir"/usr/share/doc/$pkgname/README
+	sed -i "s/^#include/include/" $pkgname.conf
+	install -D -m600 $pkgname.conf "$pkgdir"/etc/$pkgname.conf
+	mkdir -p "$pkgdir"/etc/$pkgname.d
+	cat>"$pkgdir"/etc/$pkgname.d/00-local.conf<<-EOF
+	# You may put your local changes here or in any other *.conf file
+	# in this directory so you can leave /etc/restart-services.conf as is.
+	# Example:
+	# *extend* SV_ALWAYS to match 'myservice'
+	# SV_ALWAYS+=( myservice )
+	EOF
+
+
+}
+
+sha512sums="89bd5edf5175694b3438788759f9b747251431ba700ad199f43b8fa551faa23411f33688e1aa6b04ae6524e737c4073926b989fa1422ddfca94514f9afd8de66  restart-services-0.14.4.tgz
+bb2ab053de7de951a8038b21c67b7349ccce227cc1ffdd11a4056b32e379f1550c595a10729dc8b34adbddf697dcf281e37d399e22144d239e6463a96e1c45fd  alpine.patch"

--- a/testing/restart-services/alpine.patch
+++ b/testing/restart-services/alpine.patch
@@ -1,0 +1,43 @@
+--- a/restart-services.orig
++++ b/restart-services
+@@ -380,7 +380,7 @@
+ 	done
+ # lib_users <= 0.12 reports postgres' "/anon_hugepage" as deleted lib, so tell it to ignore this manually (see bug #648356)
+ # bug #678500: ignore tmp-files
+-done < <(lib_users -m -I /anon_hugepage -i '/tmp/*')
++done < <(lib_users.py -m -I /anon_hugepage -i '/tmp/*')
+ 
+ debug "analyzing remaining processes (not direct hits) ..."
+ debug "TODO_PROCESSES_EXE: ${TODO_PROCESSES_EXE[*]}"
+@@ -422,7 +422,7 @@
+ 				EXEC_PATH_RE="/(usr/)?((s)?bin|lib(32|64|exec))?/"
+ 				if [[ $s =~ $EXEC_PATH_RE ]]; then
+ 					debug "'$s' may be script, looking for package"
+-					if PKG=$(qfile --nocolor -- "$s"|awk '{print $1}'); then
++					if PKG=$(apk info --who-owns --no-progress -- "$s"|awk '{print $1}'); then
+ 						debug "bingo. '$s' belongs to a package"
+ 						break
+ 					fi
+@@ -431,19 +431,13 @@
+ 		fi
+ 	else
+ 		debug "process does not look like a script"
+-		PKG=$(qfile --nocolor -- "$lu_exe"|awk '{print $1}')
++		PKG=$(apk info --who-owns --no-progress -- "$lu_exe"|awk '{print $1}')
+ 	fi
+ 
+ 	if [[ $PKG ]]; then
+ 		debug "found package: $PKG"
+ 
+-		# some processes have their init scripts in a seperate package :-/
+-		# so as a last resort we add hardcoded well known cases
+-		case $PKG in
+-			dev-lang/php) PKG="app-admin/eselect-php" ;;
+-		esac
+-
+-		_init_scripts=( $(qlist -e $PKG|grep /etc/init.d/|paste -s -d" ") )
++		_init_scripts=( $(apk info -L "${PKG}-openrc"|grep /etc/init.d/|paste -s -d" ") )
+ 		if [[ ${#_init_scripts} -gt 0 ]]; then
+ 			debug "found init scripts: ${_init_scripts[*]}"
+ 			for i in "${_init_scripts[@]}"; do
+


### PR DESCRIPTION
Tool to manage OpenRC services that need to be restarted. Ported from gentoo.
https://dev.gentoo.org/~mschiff/restart-services/