### PR TITLE
community/imagemagick: security upgrade to 7.0.8.68

### DIFF
--- a/community/imagemagick/APKBUILD
+++ b/community/imagemagick/APKBUILD
@@ -3,8 +3,8 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
 _pkgname=ImageMagick
-pkgver=7.0.8.64
-pkgrel=1
+pkgver=7.0.8.68
+pkgrel=0
 _pkgver=${pkgver%.*}-${pkgver##*.}
 _abiver=7
 pkgdesc="Collection of tools and libraries for many image formats"
@@ -29,9 +29,14 @@ source="$_pkgname-$_pkgver.tar.gz::https://github.com/ImageMagick/ImageMagick/ar
 builddir="$srcdir/$_pkgname-$_pkgver"
 
 # secfixes:
-#   6.9.10.56-r0:
+#   7.0.8.62-r0:
+#     - CVE-2019-17547
+#   7.0.8.56-r0:
+#     - CVE-2019-17541
+#     - CVE-2019-17540
+#     - CVE-2019-14981
 #     - CVE-2019-13454
-#   6.9.10.53-r0:
+#   7.0.8.53-r0:
 #     - CVE-2019-13391
 #     - CVE-2019-13311
 #     - CVE-2019-13310
@@ -56,13 +61,23 @@ builddir="$srcdir/$_pkgname-$_pkgver"
 #     - CVE-2019-13134
 #     - CVE-2019-13133
 #   7.0.8.44-r0:
+#     - CVE-2019-16713
+#     - CVE-2019-16712
+#     - CVE-2019-16711
+#     - CVE-2019-15141
+#     - CVE-2019-15140
+#     - CVE-2019-15139
+#     - CVE-2019-14980
 #     - CVE-2019-11598
 #     - CVE-2019-11597
 #     - CVE-2019-11472
 #   7.0.8.38-r0:
 #     - CVE-2019-9956
-#     - CVE-2019-10649
+#     - CVE-2019-16710
+#     - CVE-2019-16709
+#     - CVE-2019-16708
 #     - CVE-2019-10650
+#     - CVE-2019-10649
 
 build() {
 	case "$CARCH" in
@@ -142,5 +157,5 @@ _perlmagick_doc() {
 	make -j1 DESTDIR="$subpkgdir" doc_vendor_install
 }
 
-sha512sums="6fa1a3ee272eee05fc6d80941adee6396c637705dde928e895826eac9cb6e5978e981d71a3102c0961fe3a118c0bd1b3bab6a80f6da264113012aa036ec5633e  ImageMagick-7.0.8-64.tar.gz
+sha512sums="ee337901890724fcf06b804ae6377926e75e00b1319adf4d2cc7e4a5f2381263740e0269e119bca91413413742d904e7e3cf2bd3ca5d6974f9b61abf66b96802  ImageMagick-7.0.8-68.tar.gz
 58afb2da075a6208b6a990ff297b3a827d260687c3355198a8b4d987e1596c0b0cd78aff6f0be0e1896e537fbe44a3d467473183f5f149664ea6e6fb3d3291a9  disable-avaraging-tests.patch"


### PR DESCRIPTION
Various security fixes without CVE: https://github.com/ImageMagick/ImageMagick/milestone/25?closed=1