### PR TITLE
testing/k3s: upgrade to 0.9.1

### DIFF
--- a/testing/k3s/APKBUILD
+++ b/testing/k3s/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=k3s
-pkgver=0.9.0
+pkgver=0.9.1
 pkgrel=0
 pkgdesc="Lightweigt Kubernetes. 5 less than k8s."
 url="https://k3s.io"
@@ -68,6 +68,6 @@ cleanup_srcdir() {
 	default_cleanup_srcdir
 }
 
-sha512sums="23548f3bca5f48b680f9db2d21ec7ab23e9e9d8eed4eb6da39178e4090f26249a490851e8d55314686045b40384e8356ede7a383622b00c3955bf2d64887002d  k3s-0.9.0.tar.gz
+sha512sums="df47969e4cba64724a4a99cfba10ca00ac2728657b3e0011bbf96b1d813727b76c840880116fa580ff01b11fe26ba01dae0c6af79bef545da69764f703effc5a  k3s-0.9.1.tar.gz
 9501422f1bf5375555116cbeedb32de32109153396699bde1300ce01156c3e57fe3fb14a57f7de1dce47c955e5e6d61de7fea181a07b407f5b452006bc58991c  k3s.initd
 dda2fc70e884ef439fece8f850d798f98d07cd431f0b8b79183f192b35f68fc7c633d3c790aae7b86ca57331212a7bb2f783131b752a4e1e71ef918469e6b944  k3s.confd"


### PR DESCRIPTION
- https://github.com/rancher/k3s/releases/tag/v0.9.1 0.9.1