### PR TITLE
testing/jfrog-cli: Update to 1.29.1

### DIFF
--- a/testing/jfrog-cli/APKBUILD
+++ b/testing/jfrog-cli/APKBUILD
@@ -1,7 +1,6 @@
 # Maintainer: Gennady Feldman <gena01@gmail.com>
-pkgname=jfrog-cli-go
-_pkgname=jfrog-cli
-pkgver=1.29.0
+pkgname=jfrog-cli
+pkgver=1.29.1
 pkgrel=0
 pkgdesc="JFrog cli"
 url="https://jfrog.com/getcli/"
@@ -9,8 +8,9 @@ arch="all"
 license="Apache-2.0"
 makedepends="go"
 options="!check"
+replaces="jfrog-cli-go"
+provides="jfrog-cli-go=$pkgver-r$pkgrel"
 source="$pkgname-$pkgver.tar.gz::https://github.com/jfrog/$pkgname/archive/$pkgver.tar.gz"
-builddir="$srcdir/$_pkgname-$pkgver"
 
 build() {
 	go run ./python/addresources.go
@@ -21,4 +21,4 @@ package() {
 	install -m755 -D bin/jfrog "$pkgdir/usr/bin/jfrog"
 }
 
-sha512sums="922438bc4ca524fdfb6312995853570c21a326a229163a791c0099c572863e18e5c63d969bbc17e156593350ba1a5e7ca004287daf97804ef5cfc493a83c8788  jfrog-cli-go-1.29.0.tar.gz"
+sha512sums="e52e619cf93616b667cec62870c20a0cf75054c19297caea4a388311849ac6e43348215f253b6541262514dbddc73572487ee8b3ef10192d882afb36687ca6cb  jfrog-cli-1.29.1.tar.gz"


### PR DESCRIPTION
* Also renamed the package since the github repo was renamed as well.
* Added replaces line to make an easier upgrade.