### PR TITLE
community/runc: upgrade to 1.0.0_rc8 + CVE-2019-16884

### DIFF
--- a/community/runc/APKBUILD
+++ b/community/runc/APKBUILD
@@ -5,13 +5,13 @@ pkgname=runc
 pkgdesc="CLI tool for spawning and running containers according to the OCI specification"
 url="https://www.opencontainers.org"
 
-_commit=425e105d5a03fabd737a126ad93d62a9eeede87f
+_commit=3e425f80a8c931f88e6d94a8c831b9d5aa481657
 pkgver=1.0.0_rc8
-pkgrel=1
+pkgrel=2
 
-_ver=v${pkgver/_rc/-rc}
+#_ver=v${pkgver/_rc/-rc}
 # if we're building against an explicit commit beyond pkgver, use this instead:
-#_ver=${_commit}
+_ver=${_commit}
 
 arch="all"
 license="Apache-2.0"
@@ -19,8 +19,11 @@ makedepends="go go-md2man libseccomp-dev libtool"
 subpackages="$pkgname-doc"
 source="runc-$_ver.tar.gz::https://github.com/opencontainers/runc/archive/$_ver.tar.gz"
 builddir="$srcdir/src/github.com/opencontainers/runc"
+options="!check"
 
 # secfixes:
+#   1.0.0_rc8-r2:
+#     - CVE-2019-16884
 #   1.0.0_rc7:
 #     - CVE-2019-5736
 
@@ -41,4 +44,4 @@ package() {
 	install -Dm644 "$builddir"/man/man8/* "$pkgdir"/usr/share/man/man8/
 }
 
-sha512sums="4bf464acc87b6d687010f0c070d96e171d91e46c45b84b5570c6f607e7d06777d2d83b2ead87ac4aa761e34afc68a3d9be9ab25107d499e8f41cb68647e23541  runc-v1.0.0-rc8.tar.gz"
+sha512sums="7287738ba1cf50569c5ac3637e45b4c6af6fa4c0b6f9e65d9f9889ef7a5736d49c68cd243f08b94131814c579064e13f04258b90d688285be2b7b1c9eb634801  runc-3e425f80a8c931f88e6d94a8c831b9d5aa481657.tar.gz"


### PR DESCRIPTION
Upgrade runc to post-1.0.0_rc8 patch that includes fix for CVE-2019-16684, as containerd-1.3.0 explicitly mentiones that commit.

See https://github.com/opencontainers/runc/commits/master between 425e105d5a03fabd737a126ad93d62a9eeede87f and 3e425f80a8c931f88e6d94a8c831b9d5aa481657 for full list of changes.