### PR TITLE
community/containerd: update to 1.3.0

### DIFF
--- a/community/containerd/APKBUILD
+++ b/community/containerd/APKBUILD
@@ -4,8 +4,8 @@
 pkgname=containerd
 
 # NOTE: containerd's Makefile tries to get REVISION from git, but we're building from a tarball.
-_commit=d50db0a42053864a270f648048f9a8b4f24eced3
-pkgver=1.2.9
+_commit=36cf5b690dcc00ff0f34ff7799209050c3d0c59a
+pkgver=1.3.0
 pkgrel=0
 pkgdesc="An open and reliable container runtime"
 url="https://containerd.io"
@@ -18,6 +18,8 @@ source="containerd-$pkgver.tar.gz::https://github.com/containerd/containerd/arch
 builddir="$srcdir/src/github.com/containerd/containerd"
 
 # secfixes:
+#   1.3.0:
+#     - CVE-2019-16884
 #   1.2.9:
 #     - CVE-2019-9512
 #     - CVE-2019-9514
@@ -32,7 +34,10 @@ build() {
 	ln -s "$PWD/$pkgname-$pkgver" "$builddir"
 	cd "$builddir"
 	make VERSION="v$pkgver" REVISION="$_commit"
-	make man
+	# new generated manpages
+	make genman
+	# older non-generated manpages
+	make MANPAGES="containerd-config.1 containerd-config.toml.5" man
 }
 
 check() {
@@ -48,4 +53,4 @@ package() {
 	install -Dm644 "$builddir"/man/*.5 "$pkgdir"/usr/share/man/man5/
 }
 
-sha512sums="60c7d08db3796caa8148f242f8386ff530943cef19fe73c72787fd7bbf2420feac06cadd558afc93d2baf168817d679245bf2ac9feb169547286cb312818be85  containerd-1.2.9.tar.gz"
+sha512sums="cff9f0189b9fdc2b5492c92129af284aa8cd099e48de94cafd90aed191e2d20060c96008111b05fe081de0d4fc41d35f8cba5a3dc2d8cc0a5c37f695fd3cedc1  containerd-1.3.0.tar.gz"


### PR DESCRIPTION
New major release of containerd.  For more information, see https://github.com/containerd/containerd/releases/tag/v1.3.0