### PR TITLE
main/mariadb-connector-c: Fix include and libs path in mariadb_config

### DIFF
--- a/main/mariadb-connector-c/APKBUILD
+++ b/main/mariadb-connector-c/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mariadb-connector-c
 pkgver=3.1.3
-pkgrel=0
+pkgrel=1
 pkgdesc="The MariaDB Native Client library (C driver)"
 url="https://mariadb.org/"
 arch="all"
@@ -11,6 +11,7 @@ makedepends="$depends_dev cmake"
 replaces="mariadb-client-libs"
 subpackages="$pkgname-dev"
 source="https://downloads.mariadb.org/interstitial/connector-c-$pkgver/mariadb-connector-c-$pkgver-src.tar.gz
+	cmake.patch
 	fix-ucontext-header.patch
 	"
 builddir="$srcdir/mariadb-connector-c-$pkgver-src"
@@ -57,4 +58,5 @@ dev() {
 }
 
 sha512sums="ca3809a5f1a33317962908ee40d5c339ba6b02c5c8818bf12af9b78eb2289efad711ab74ac7706d711951b22957ba897b5e80b60e8df44924ca70569a4e1c5e7  mariadb-connector-c-3.1.3-src.tar.gz
+a3a1ec5fa984cd4a3545436c8a6f3cd5495bc2c0644ed11dd8957df399f72c9b4545f65b255909d31732b73513fe40bac98f2bffd3180ecfff22efd5ce1d38f0  cmake.patch
 757a2d3531ee271cf5473671bf4d0ac07dc8eb94ab4b6ede848ba7a55415a77f90e7275103be91c73e343e94cdbf2cd652eb6cef6ed48917991733d60d3b8777  fix-ucontext-header.patch"

--- a/main/mariadb-connector-c/cmake.patch
+++ b/main/mariadb-connector-c/cmake.patch
@@ -1,0 +1,16 @@
+Summary: Fix include and libs path in mariadb_config
+----
+
+--- a/mariadb_config/mariadb_config.c.in
++++ b/mariadb_config/mariadb_config.c.in
+@@ -5,8 +5,8 @@
+
+ static char *mariadb_progname;
+
+-#define INCLUDE "-I@CMAKE_INSTALL_PREFIX@/@INSTALL_INCLUDEDIR@ -I@CMAKE_INSTALL_PREFIX@/@INSTALL_INCLUDEDIR@/mysql"
+-#define LIBS    "-L@CMAKE_INSTALL_PREFIX@/@INSTALL_LIBDIR@/ -lmariadb"
++#define INCLUDE "-I@INSTALL_INCLUDEDIR@ -I@INSTALL_INCLUDEDIR@/mysql"
++#define LIBS    "-L@INSTALL_LIBDIR@/ -lmariadb"
+ #define LIBS_SYS "@extra_dynamic_LDFLAGS@"
+ #define CFLAGS  INCLUDE
+ #define VERSION "@MARIADB_CLIENT_VERSION@"


### PR DESCRIPTION
The cmake.patch was removed in aa9c56516cc30d4c3ed568d35b62ab53d78a8b7f, but I think it is still needed. Without the patch, mariadb_config returns

```
$ mariadb_config 
Copyright 2011-2019 MariaDB Corporation AB
Get compiler flags for using the MariaDB Connector/C.
Usage: mariadb_config [OPTIONS]
  --cflags        [-I/usr//usr/include/mysql -I/usr//usr/include/mysql/mysql]
  --include       [-I/usr//usr/include/mysql -I/usr//usr/include/mysql/mysql]
  --libs          [-L/usr//usr/lib/ -lmariadb]
  --libs_r        [-L/usr//usr/lib/ -lmariadb]
  --libs_sys      [-lz -lssl -lcrypto]
  --version       [10.4.3]
  --cc_version    [3.1.3]
  --socket        [/run/mysqld/mysqld.sock]
  --port          [3306]
  --plugindir     [/usr/lib/mariadb/plugin]
  --tlsinfo       [OpenSSL 1.1.1d]

```
with incorrectly prefixed paths. With this patch, paths are correct.