### PR TITLE
testing/next: new aport

### DIFF
--- a/testing/next/APKBUILD
+++ b/testing/next/APKBUILD
@@ -1,0 +1,26 @@
+# Maintainer: Will Sinatra <wpsinatra@gmail.com>
+# Contributor: Will Sinatra <wpsinatra@gmail.com>
+# Contributor: Benjamin Buccianti <bebuccianti@gmail.com>
+pkgname=next
+pkgver=1.3.2
+pkgrel=0
+pkgdesc="Atlas Engineer Next Browser"
+url="https://next.atlas.engineer"
+arch="x86_64" #SBCL currently only built for x86_64, to be expanded once compatibility is met.
+license="BSD-3-Clause"
+source=next.zip::"https://github.com/atlas-engineer/next/archive/$pkgver.zip"
+makedepends="git sbcl webkit2gtk-dev"
+depends="webkit2gtk glib-networking gsettings-desktop-schemas libfixposix libfixposix-dev gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly libffi libffi-dev"
+options="!check !strip" #No testsuite exists; Stripping the package causes the
+# package to build, but the next browser is unfunctional, dropping to an SBCL repl
+# instead of properly running.
+
+
+build() {
+	make all
+}      
+
+package() {
+	make PREFIX=/usr DESTDIR="$pkgdir" install
+}
+sha512sums="07bc3b47a4ebb3857d7ada4c8dc56d35f7c84460d108467a580b6d42a9da273ffafd73b2beb8274f94788554444132beb605b383fd9e3d6d4ff6cacc1e870da9  next.zip"


### PR DESCRIPTION
New aport for Atlas Engineering's NEXT browser