### PR TITLE
community/engrampa: fix g_ptr_array_copy conflicting types err by pkg upgrade

### DIFF
--- a/community/engrampa/APKBUILD
+++ b/community/engrampa/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Alan Lacerda <alacerda@alpinelinux.org>
 pkgname=engrampa
 pkgver=1.22.1
-pkgrel=0
+pkgrel=1
 pkgdesc="An archive manager for the MATE"
 url="https://github.com/mate-desktop/engrampa"
 arch="all"
@@ -10,7 +10,8 @@ license="GPL-2.0"
 depends="libxml2-utils"
 makedepends="glib-dev gtk+3.0-dev caja-dev itstool libsm-dev intltool"
 subpackages="$pkgname-doc $pkgname-lang"
-source="https://pub.mate-desktop.org/releases/${pkgver%.*}/$pkgname-$pkgver.tar.xz"
+source="https://pub.mate-desktop.org/releases/${pkgver%.*}/$pkgname-$pkgver.tar.xz
+	engrampa-remove-unused-variable.patch"
 builddir="$srcdir/$pkgname-$pkgver"
 
 build() {
@@ -30,4 +31,5 @@ package() {
 	make DESTDIR="${pkgdir}" install
 }
 
-sha512sums="111eeb470555ae8edb7754159bb2e70b03cbbc7b1c9d61c253d9d67e50d84ff0e0654e16547883c39aeeb223e8ba58201d45b50819784fc6cf7a21f0cf176c70  engrampa-1.22.1.tar.xz"
+sha512sums="111eeb470555ae8edb7754159bb2e70b03cbbc7b1c9d61c253d9d67e50d84ff0e0654e16547883c39aeeb223e8ba58201d45b50819784fc6cf7a21f0cf176c70  engrampa-1.22.1.tar.xz
+edc82ad22cc0765e3f0199ab982e2e616d6dac4692859c5c6296d988f0542f442015409c908c2c7b5c47d83a482dde37f844d19bd775320723afdf8ec6536f22  engrampa-remove-unused-variable.patch"

--- a/community/engrampa/engrampa-remove-unused-variable.patch
+++ b/community/engrampa/engrampa-remove-unused-variable.patch
@@ -1,0 +1,35 @@
+--- a/src/glib-utils.c
++++ b/src/glib-utils.c
+@@ -568,22 +568,6 @@
+ }
+ 
+ 
+-GPtrArray *
+-g_ptr_array_copy (GPtrArray *array)
+-{
+-	GPtrArray *new_array;
+-	
+-	if (array == NULL)
+-		return NULL;
+-		
+-	new_array = g_ptr_array_sized_new (array->len);
+-	memcpy (new_array->pdata, array->pdata, array->len * sizeof (gpointer)); 
+-	new_array->len = array->len;
+-	
+-	return new_array;
+-}
+-
+-
+ void
+ g_ptr_array_free_full (GPtrArray *array,
+                        GFunc      free_func,
+--- a/src/glib-utils.h
++++ b/src/glib-utils.h
+@@ -66,7 +66,6 @@
+ 						  int          last_field);
+ int                 n_fields                     (char       **str_array);
+ char *              get_time_string              (time_t       time);
+-GPtrArray *         g_ptr_array_copy             (GPtrArray   *array);
+ void                g_ptr_array_free_full        (GPtrArray   *array,
+                        				  GFunc        func,
+                        				  gpointer     user_data);


### PR DESCRIPTION
Build of pkg version 1.22.1 fails with error:
```
glib-utils.h:69:21: error: conflicting types for 'g_ptr_array_copy'
```
Upstream commit https://github.com/mate-desktop/engrampa/commit/66076cf781963cd1b781ba8e42d32efcf8fa9180 fixes the issue but since this commit is integrated into now available 1.23.1 version of source this PR updates to new version.