### PR TITLE
community/flatbuffers: on gcc9 fix nontrivial memset issues

### DIFF
--- a/community/flatbuffers/APKBUILD
+++ b/community/flatbuffers/APKBUILD
@@ -11,7 +11,8 @@ depends_dev=""
 makedepends="$depends_dev cmake"
 install=""
 subpackages="$pkgname-dev"
-source="flatbuffers-$pkgver.tar.gz::https://github.com/google/flatbuffers/archive/v$pkgver.tar.gz"
+source="flatbuffers-$pkgver.tar.gz::https://github.com/google/flatbuffers/archive/v$pkgver.tar.gz
+	flatbuffers-fix-nontrivial-memset.patch"
 builddir="$srcdir/flatbuffers-$pkgver"
 
 build() {
@@ -36,4 +37,5 @@ package() {
 		"$pkgdir"/usr/bin/flatc
 }
 
-sha512sums="b8382c8e9a45d6aca83270e93704b9ef2938e4ef9bb5165edbd8f286329e86353037ad6e54a99fd3d70b0c893d06cfd8766e00f05497e69be4b9e6c0506133d2  flatbuffers-1.10.0.tar.gz"
+sha512sums="b8382c8e9a45d6aca83270e93704b9ef2938e4ef9bb5165edbd8f286329e86353037ad6e54a99fd3d70b0c893d06cfd8766e00f05497e69be4b9e6c0506133d2  flatbuffers-1.10.0.tar.gz
+c3882cb7934cf133aca66607c43778dd29564764a6400e4aa4ae4b76745587de03417576bb812ecbb70297d2895d1e0b537eda60e3bf981ba2d10f912d6952c1  flatbuffers-fix-nontrivial-memset.patch"

--- a/community/flatbuffers/flatbuffers-fix-nontrivial-memset.patch
+++ b/community/flatbuffers/flatbuffers-fix-nontrivial-memset.patch
@@ -1,0 +1,106 @@
+From 2e865f4d4e67a9b628c137aab7da8140dd9339a4 Mon Sep 17 00:00:00 2001
+From: Laurent Stacul <laurent.stacul@gmail.com>
+Date: Mon, 4 Mar 2019 20:10:18 +0100
+Subject: [PATCH] [Fix #5112] flatc generates constructors with memset for
+ non-trivial types (#5222)
+
+---
+ samples/monster_generated.h                      | 2 +-
+ src/idl_gen_cpp.cpp                              | 2 +-
+ tests/monster_test_generated.h                   | 6 +++---
+ tests/namespace_test/namespace_test1_generated.h | 2 +-
+ tests/union_vector/union_vector_generated.h      | 4 ++--
+ 5 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/samples/monster_generated.h b/samples/monster_generated.h
+index db79c2e5d..5286ffd80 100644
+--- a/samples/monster_generated.h
++++ b/samples/monster_generated.h
+@@ -166,7 +166,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Vec3 FLATBUFFERS_FINAL_CLASS {
+ 
+  public:
+   Vec3() {
+-    memset(this, 0, sizeof(Vec3));
++    memset(static_cast<void *>(this), 0, sizeof(Vec3));
+   }
+   Vec3(float _x, float _y, float _z)
+       : x_(flatbuffers::EndianScalar(_x)),
+diff --git a/src/idl_gen_cpp.cpp b/src/idl_gen_cpp.cpp
+index a25dd6f94..efbfe07c6 100644
+--- a/src/idl_gen_cpp.cpp
++++ b/src/idl_gen_cpp.cpp
+@@ -2617,7 +2617,7 @@ class CppGenerator : public BaseGenerator {
+ 
+     // Generate a default constructor.
+     code_ += "  {{STRUCT_NAME}}() {";
+-    code_ += "    memset(this, 0, sizeof({{STRUCT_NAME}}));";
++    code_ += "    memset(static_cast<void *>(this), 0, sizeof({{STRUCT_NAME}}));";
+     code_ += "  }";
+ 
+     // Generate a constructor that takes all fields as arguments.
+diff --git a/tests/monster_test_generated.h b/tests/monster_test_generated.h
+index 9154439eb..f8c82f528 100644
+--- a/tests/monster_test_generated.h
++++ b/tests/monster_test_generated.h
+@@ -516,7 +516,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(2) Test FLATBUFFERS_FINAL_CLASS {
+ 
+  public:
+   Test() {
+-    memset(this, 0, sizeof(Test));
++    memset(static_cast<void *>(this), 0, sizeof(Test));
+   }
+   Test(int16_t _a, int8_t _b)
+       : a_(flatbuffers::EndianScalar(_a)),
+@@ -559,7 +559,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Vec3 FLATBUFFERS_FINAL_CLASS {
+ 
+  public:
+   Vec3() {
+-    memset(this, 0, sizeof(Vec3));
++    memset(static_cast<void *>(this), 0, sizeof(Vec3));
+   }
+   Vec3(float _x, float _y, float _z, double _test1, Color _test2, const Test &_test3)
+       : x_(flatbuffers::EndianScalar(_x)),
+@@ -631,7 +631,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Ability FLATBUFFERS_FINAL_CLASS {
+ 
+  public:
+   Ability() {
+-    memset(this, 0, sizeof(Ability));
++    memset(static_cast<void *>(this), 0, sizeof(Ability));
+   }
+   Ability(uint32_t _id, uint32_t _distance)
+       : id_(flatbuffers::EndianScalar(_id)),
+diff --git a/tests/namespace_test/namespace_test1_generated.h b/tests/namespace_test/namespace_test1_generated.h
+index 3f964b090..d26bf43e8 100644
+--- a/tests/namespace_test/namespace_test1_generated.h
++++ b/tests/namespace_test/namespace_test1_generated.h
+@@ -57,7 +57,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) StructInNestedNS FLATBUFFERS_FINAL_CLASS
+ 
+  public:
+   StructInNestedNS() {
+-    memset(this, 0, sizeof(StructInNestedNS));
++    memset(static_cast<void *>(this), 0, sizeof(StructInNestedNS));
+   }
+   StructInNestedNS(int32_t _a, int32_t _b)
+       : a_(flatbuffers::EndianScalar(_a)),
+diff --git a/tests/union_vector/union_vector_generated.h b/tests/union_vector/union_vector_generated.h
+index f085bbcb6..8629d4edf 100644
+--- a/tests/union_vector/union_vector_generated.h
++++ b/tests/union_vector/union_vector_generated.h
+@@ -189,7 +189,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) Rapunzel FLATBUFFERS_FINAL_CLASS {
+ 
+  public:
+   Rapunzel() {
+-    memset(this, 0, sizeof(Rapunzel));
++    memset(static_cast<void *>(this), 0, sizeof(Rapunzel));
+   }
+   Rapunzel(int32_t _hair_length)
+       : hair_length_(flatbuffers::EndianScalar(_hair_length)) {
+@@ -214,7 +214,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(4) BookReader FLATBUFFERS_FINAL_CLASS {
+ 
+  public:
+   BookReader() {
+-    memset(this, 0, sizeof(BookReader));
++    memset(static_cast<void *>(this), 0, sizeof(BookReader));
+   }
+   BookReader(int32_t _books_read)
+       : books_read_(flatbuffers::EndianScalar(_books_read)) {


### PR DESCRIPTION
With move to gcc 9.2 build fails with errors:
```
monster_test_generated.h:315:33: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct MyGame::
```
Upstream source has commit to fix the issue, https://github.com/google/flatbuffers/commit/2e865f4d4e67a9b628c137aab7da8140dd9339a4

This PR adds the patch. 