### PR TITLE
community/opensc: fix werror format-overflow with gcc9

### DIFF
--- a/community/opensc/APKBUILD
+++ b/community/opensc/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=opensc
 _realname=OpenSC
 pkgver=0.19.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Open source smart card tools and middleware"
 url="https://github.com/OpenSC/OpenSC"
 arch="all"
@@ -15,6 +15,7 @@ install=""
 subpackages="$pkgname-dev $pkgname-doc"
 source="$_realname-${pkgver}.tar.gz::https://github.com/OpenSC/OpenSC/archive/${pkgver}.tar.gz
 	fix-overlapping-memcpy.patch
+	opensc-fix-format-overflow-werror.patch
 	"
 
 builddir="$srcdir/$_realname-$pkgver"
@@ -62,4 +63,5 @@ package() {
 }
 
 sha512sums="a54161b72e6ecea9d61d8bdf0fe0dbd0f97dd8fff0ce6ce344442d9dd9218779851054f8a9049c95c4276e69d3ab96afd0906ebb3278739c8f8e32ad3dbf2d4b  OpenSC-0.19.0.tar.gz
-db96b06131c9a49245d9b1f23acb37ca29e2826eeec44462435a90daf8a247d498f517a08350fb786d8b43ac6ba139f11e3a6fdb3424f529210ec7f087116135  fix-overlapping-memcpy.patch"
+db96b06131c9a49245d9b1f23acb37ca29e2826eeec44462435a90daf8a247d498f517a08350fb786d8b43ac6ba139f11e3a6fdb3424f529210ec7f087116135  fix-overlapping-memcpy.patch
+cba98571f3f3cc132d28f0c4957bc4bc05689eb24af9a09630e750c8bb1b36c1abd080c8b543bf21c511860214f9763219c0da9e7635c0cecc173a8fe64c745c  opensc-fix-format-overflow-werror.patch"

--- a/community/opensc/opensc-fix-format-overflow-werror.patch
+++ b/community/opensc/opensc-fix-format-overflow-werror.patch
@@ -1,0 +1,10 @@
+--- a/src/pkcs15init/pkcs15-oberthur.c
++++ b/src/pkcs15init/pkcs15-oberthur.c
+@@ -70,7 +70,6 @@
+ 	ctx = p15card->card->ctx;
+ 
+ 	SC_FUNC_CALLED(ctx, SC_LOG_DEBUG_VERBOSE);
+-	sc_debug(ctx, SC_LOG_DEBUG_NORMAL, "cosm_write_tokeninfo() label '%s'; flags 0x%X", label, flags);
+ 	if (sc_profile_get_file(profile, COSM_TITLE"-token-info", &file)) {
+ 		rv = SC_ERROR_INCONSISTENT_PROFILE;
+ 		SC_TEST_GOTO_ERR(ctx, SC_LOG_DEBUG_NORMAL, rv, "Cannot find "COSM_TITLE"-token-info");


### PR DESCRIPTION
With gcc 9.2 build fails with error:
```
../../src/libopensc/log.h:48:47: error: '%s' directive argument is null [-Werror=format-overflow=]
				   48 | #define sc_debug(ctx, level, format, args...) sc_do_log(ctx, level, __FILE__, __LINE__, __FUNCTION__, format , ## args)
      |                         						                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Upstream added commit https://github.com/OpenSC/OpenSC/commit/35cb70b5d664c4be417dee2cbe6b652185e6da2d to fix the issue. 

This PR adds this commit as a patch.