### PR TITLE
community/ntpsec: upgrade to 1.1.7

### DIFF
--- a/community/ntpsec/APKBUILD
+++ b/community/ntpsec/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: tcely <ntpsec+aports@tcely.33mail.com>
 _pkgname="ntpsec"
 pkgname="${_pkgname}"
-pkgver="1.1.6"
+pkgver="1.1.7"
 pkgrel=0
 pkgdesc="NTP reference implementation, refactored for security"
 url="https://www.ntpsec.org/"
@@ -44,5 +44,5 @@ package() {
 gpg_signature_extensions="asc"
 gpgfingerprints="good:B482 3776 1A26 9022 2C99  5F44 5A22 E330 161C 3978"
 
-sha512sums="f57fde6f329a858313968798d64df5e93d7eba43edf4752cd0eb45ff1a2237ce2731b4603ec997c493dea85edb42976f96eb1508beae087a8c2ae8a76c0a6941  ntpsec-1.1.6.tar.gz
-a813811109f0df7b6c408b1c7566f986c149f201eca9ed909e1a08e0e8240bde2986ca7e7c719edf9bd9aa9f2f683b0f67467fc4b3b118b56f9c89a113c70b36  python-to-python3.patch"
+sha512sums="734b12820539e655e504dd5071a58b9d1f80c0b0c3c7458c797ba7ada23d8e446751fbcbddd9832d9151a3ba9464749878db9e77e23cdd5f6215ab9e1d908ae9  ntpsec-1.1.7.tar.gz
+86287e90f0eac4b9d0aaa912f8ca70a7b8a10f135143d388a013af41d61af820bb27355c0117911b611f2d9d778be4ffdf67d34f8e4f007e43d63d866c92bef4  python-to-python3.patch"

--- a/community/ntpsec/python-to-python3.patch
+++ b/community/ntpsec/python-to-python3.patch
@@ -389,8 +389,8 @@ index 044af45..24eb3dd 100755
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env python
 +#!/usr/bin/env python3
- # encoding: ISO8859-1
- # Thomas Nagy, 2005-2017
+ # encoding: latin-1
+ # Thomas Nagy, 2005-2018
  #
 diff --git a/wafhelpers/pythonize-header b/wafhelpers/pythonize-header
 index c58542a..f5ce2ad 100755


### PR DESCRIPTION
ref: https://blog.ntpsec.org/2019/09/02/version-1.1.7.html