### PR TITLE
testing/py3-cobs: new aport

### DIFF
--- a/testing/py3-cobs/APKBUILD
+++ b/testing/py3-cobs/APKBUILD
@@ -1,0 +1,27 @@
+# Maintainer: Martijn Braam <martijn@brixit.nl>
+pkgname=py3-cobs
+_pyname=cobs
+pkgver=1.1.3
+pkgrel=0
+pkgdesc="Consistent Overhead Byte Stuffing"
+url="https://pypi.org/project/cobs/"
+arch="noarch"
+license="MIT"
+depends="python3"
+makedepends="py3-setuptools"
+_pypiprefix="${_pyname%${_pyname#?}}"
+source="https://files.pythonhosted.org/packages/source/$_pypiprefix/$_pyname/$_pyname-$pkgver.tar.gz"
+builddir=$srcdir/$_pyname-$pkgver
+
+build() {
+	python3 setup.py build
+}
+
+check() {
+	python3 setup.py test
+}
+
+package() {
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+}
+sha512sums="e3169d0c4e62cd9427c9ccefad780aebf197365e3cc78b011fc065846978caa445eb183ec8df0f3b8129329168c298a1fa10c7435f75b606f747c33237c1e255  cobs-1.1.3.tar.gz"


### PR DESCRIPTION
New aport for an useful python library for software that communicates with hardware.