### PR TITLE
main/vte3: upgrade to 0.58.0

### DIFF
--- a/main/vte3/APKBUILD
+++ b/main/vte3/APKBUILD
@@ -1,43 +1,45 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=vte3
-pkgver=0.56.3
+pkgver=0.58.0
 pkgrel=0
 pkgdesc="Virtual Terminal Emulator library"
 url="https://developer.gnome.org/vte/"
 arch="all"
 license="LGPL-2.0-or-later"
 subpackages="$pkgname-dev $pkgname-doc $pkgname-lang"
-makedepends="pango-dev gtk+3.0-dev intltool python2-dev
+makedepends="pango-dev gtk+3.0-dev intltool
 	ncurses-dev gobject-introspection-dev vala gnutls-dev
 	linux-headers libxml2-utils pcre2-dev gperf
-	autoconf automake libtool"
+	meson gtk-doc"
 source="https://download.gnome.org/sources/vte/${pkgver%.*}/vte-$pkgver.tar.xz
 	fix-W_EXITCODE.patch"
 builddir="$srcdir/vte-$pkgver"
 
+prepare() {
+	default_prepare
+	mkdir "$builddir"/build
+}
+
 build() {
-	cd "$builddir"
-	export CFLAGS="$CFLAGS -D_GNU_SOURCE"
-	./configure \
-		--build=$CBUILD \
-		--host=$CHOST \
+	cd "$builddir/build"
+	meson \
+		--buildtype=release \
+		-Ddocs=true \
 		--prefix=/usr \
 		--sysconfdir=/etc \
 		--libexecdir=/usr/lib/$pkgname \
-		--localstatedir=/var \
-		--disable-static \
-		--enable-introspection
-	make V=1
+		..
+	ninja
 }
 
 check() {
 	cd "$builddir"
-	make check
+	meson test -C build --print-errorlogs
 }
 
 package() {
-	cd "$builddir"
-	make DESTDIR="$pkgdir" install
+	cd "$builddir"/build
+	DESTDIR="$pkgdir" ninja install
 }
-sha512sums="f78b3d532ca47e53c1bb51db6780697ce4692d493c0030d2dc4beb63a2595e44a43eb409ee31b94e4551eae259ac1baa8f06825a02fd66df8352e192f4ea1988  vte-0.56.3.tar.xz
+sha512sums="4d0fc725e0c71921b3d235d434600ad3c0807d5c0e7bd62fb782d857254db334bb851b75382c9613a5af753b5d6a1c05b174731427a8560b9b14101b3cc38c06  vte-0.58.0.tar.xz
 94de7160b71f1c41aa19e8f9dc4538cd493da1a33dda6482c332f8e8932213631ccc2355506a616772dae451d653f035c66c721bd839570d6cb55e4d2b12e8a3  fix-W_EXITCODE.patch"


### PR DESCRIPTION
Upgrades to the latest vte3 version, which switches the build system to meson.

The python dependency also doesn't seem to be needed anymore.

This is a requirement for gnome-terminal 3.34