### PR TITLE
testing/traefik: upgrade to 1.7.18

### DIFF
--- a/testing/traefik/APKBUILD
+++ b/testing/traefik/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Joe Holden <jwh@zorins.us>
 # Maintainer: Joe Holden <jwh@zorins.us>
 pkgname=traefik
-pkgver=1.7.16
+pkgver=1.7.18
 pkgrel=0
 pkgdesc="The Cloud Native Edge Router"
 url="https://traefik.io"
@@ -24,6 +24,9 @@ builddir="$srcdir/src/github.com/containous/$pkgname"
 #   - CVE-2019-9512
 #   - CVE-2019-9514
 
+export CGO_ENABLED=0
+export GOPATH="$srcdir"
+
 prepare() {
 	default_prepare
 	mkdir -p "$srcdir/src/github.com/containous"
@@ -31,17 +34,17 @@ prepare() {
 }
 
 build() {
-	GOPATH="$srcdir" go generate
-	GOPATH="$srcdir" go build -v -o bin/$pkgname ./cmd/$pkgname
+	go generate
+	go build -v -a -installsuffix nocgo -o bin/$pkgname ./cmd/$pkgname
 }
 
 check() {
 	# Unit tests
-	GOPATH="$srcdir" go test ./...
+	go test ./...
 
 	# Integration tests
 	cd "$builddir"/integration
-	GOPATH="$srcdir" go test -integration ./...
+	go test -integration ./...
 }
 
 package() {
@@ -62,7 +65,7 @@ package() {
 		"$pkgdir"/etc/$pkgname/$pkgname.toml
 
 }
-sha512sums="67cfa255dedb30408fb9b9380c7702417e4a9363edc7502afd9bb62303eec887803837d4062f9ab2a13a7fa1ed34dd13ab1aa144b48910dcc2034766aaa8c88b  traefik-1.7.16.tar.gz
+sha512sums="c3da26cea0349bdbf01b7e4390515ccef8db0d860796988ce26c737f1ab1e4536674ac29a5b6f8a53ebdf9d3fb1351b959a5d626b3e0fb9c6581eaf45ba677cc  traefik-1.7.18.tar.gz
 2fe42052cdb035b202c7c0a1acd5cfe9ed1800ca067f2f5588d54e6ffbdd672d7c46cfd57fcfc219cadaa24d64a0e038a20d092eb1e4c04b67b8eb83c0af74fd  traefik.initd
 1519c2f446c4bc3af8407eb367a05e5ec0491f28d56d5385b12a550c84606d84e2424aadd5d72e56e628fd1da3f0f194ab3c077e6da85ead75a256f8e8069751  traefik.confd
 140904e2358bc6dadbfb0f2c3cd83cd7aabeae1a54cd7424bbb50f941bde3273046c402352a2b888425ba74dda27d0a6e2197c2855b4fd6ad522eb9c4eaebd61  traefik.toml"


### PR DESCRIPTION
Refs
- https://github.com/containous/traefik/releases/tag/v1.7.17
- https://github.com/containous/traefik/releases/tag/v1.7.18