### PR TITLE
main/mesa: enable v3d gallium driver, packaged as mesa-dri-v3d

### DIFF
--- a/main/mesa/APKBUILD
+++ b/main/mesa/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mesa
 pkgver=19.1.7
-pkgrel=0
+pkgrel=1
 pkgdesc="Mesa DRI OpenGL library"
 url="https://www.mesa3d.org"
 arch="all"
@@ -84,9 +84,10 @@ x86*)
 	esac
 	;;
 armhf|armv7|aarch64)
-	_gallium_drivers="${_gallium_drivers},vc4,kmsro,lima,panfrost,etnaviv,tegra"
+	_gallium_drivers="${_gallium_drivers},vc4,v3d,kmsro,lima,panfrost,etnaviv,tegra"
 	subpackages="$subpackages
 		$pkgname-dri-vc4:_dri
+		$pkgname-dri-v3d:_dri
 		$pkgname-dri-kmsro:_dri
 		$pkgname-dri-lima:_dri
 		$pkgname-dri-panfrost:_dri
@@ -275,6 +276,9 @@ _dri() {
 		;;
 	vc4)
 		_mv_dri vc4_dri
+		;;
+	v3d)
+		_mv_dri v3d_dri
 		;;
 	vmwgfx)
 		_mv_dri vmwgfx_dri && _mv_gpipe vmwgfx


### PR DESCRIPTION
Provide support for 3D acceleration on Raspberry Pi 4, like vc4 for
earlier boards.