### PR TITLE
main/raspberrypi: leave *.a files

### DIFF
--- a/main/raspberrypi/APKBUILD
+++ b/main/raspberrypi/APKBUILD
@@ -2,17 +2,17 @@
 pkgname=raspberrypi
 pkgver=0.20190416
 _commitid=ff2bd4552145e8dc190276d8fbdbadc7e8e0da78
-pkgrel=0
+pkgrel=1
 pkgdesc="Raspberry Pi support tools"
 url="https://github.com/raspberrypi/userland"
 arch="armhf armv7 aarch64"
 license="BSD"
 depends=""
-depends_dev="linux-headers raspberrypi-libs"
+depends_dev="linux-headers raspberrypi-static raspberrypi-libs"
 makedepends="cmake $depends_dev"
 install=""
 options="!fhs !check"
-subpackages="$pkgname-dev $pkgname-libs $pkgname-openrc"
+subpackages="$pkgname-dev $pkgname-static $pkgname-libs $pkgname-openrc"
 source="raspberrypi-$pkgver.tar.gz::https://github.com/raspberrypi/userland/archive/$_commitid.tar.gz
 	"
 
@@ -44,8 +44,14 @@ package() {
 
 	# nuke the unwanted stuff
 	rm -rf "$pkgdir"/opt/vc/src
-	rm -rf "$pkgdir"/opt/vc/lib/*.a
 	mv "$pkgdir"/opt/vc/etc "$pkgdir"
+}
+
+static() {
+	pkgdesc="Static files for $pkgname"
+
+	mkdir -p "$subpkgdir"/opt/vc/lib
+	mv "$pkgdir"/opt/vc/lib/*.a "$subpkgdir"/opt/vc/lib
 }
 
 libs() {


### PR DESCRIPTION
*.a files were deleted from the package but some *.pc files reference them, hence they have to be included

Original issue: https://gitlab.alpinelinux.org/alpine/aports/issues/9400