### PR TITLE
testing/getssl: upgrade to 2.11

### DIFF
--- a/testing/getssl/APKBUILD
+++ b/testing/getssl/APKBUILD
@@ -1,16 +1,16 @@
 # Maintainer: Leo Unglaub <leo@unglaub.at>
 pkgname=getssl
-pkgver=2.10
-pkgrel=1
+pkgver=2.11
+pkgrel=0
 pkgdesc="A pure shell implementation of the LetsEncrypt ACME protocol."
 url="https://github.com/srvrco/getssl"
 arch="noarch"
 license="GPL-3.0"
 depends="curl bash"
+options="!check"
 source="$pkgname-$pkgver.tar.gz::https://github.com/srvrco/$pkgname/archive/v$pkgver.tar.gz"
 
 package () {
-	cd "$srcdir/getssl-$pkgver"
 	make DESTDIR="$pkgdir" install
 }
-sha512sums="47cabf5b1aefd8095548c692cbd9b982e53541f72d932acded2cd0ff2e7b780eb765e45ac0e86be9024e78293e76d5731e705eef7b7f18999c6477c130225e0a  getssl-2.10.tar.gz"
+sha512sums="c6a74b9bc4a8ab22975c3d75354978fb96dd31fc3fe4de2712b47150e183afc1de015e3756fa8c82bc5255a19202e4799f4454f17963de538cfd4b409095cae7  getssl-2.11.tar.gz"


### PR DESCRIPTION
* fixes: `getssl: Error registering account ... JWS has no anti-replay nonce`

	https://github.com/srvrco/getssl/issues/423