### PR TITLE
[main][grub] Fix file /boot/grub/locale/C.gmo not found

### DIFF
--- a/main/grub/APKBUILD
+++ b/main/grub/APKBUILD
@@ -180,6 +180,7 @@ package() {
 
 	mkdir -p "$pkgdir"/etc/default/
 	cat >"$pkgdir"/etc/default/grub <<-EOF
+	LANG=C
 	GRUB_DISTRIBUTOR="Alpine"
 	GRUB_TIMEOUT=2
 	GRUB_DISABLE_SUBMENU=y


### PR DESCRIPTION
Due to alpine using LANG=C.UTF-8 /etc/grub.d/00_header gets confused and
tries to load C.gmo during boot:

error: file /boot/grub/locale/C.gmo not found

which fails because it does not exist. This commit fixes this (harmless)
warning by correctly setting LANG variable.

Fixes https://gitlab.alpinelinux.org/alpine/aports/issues/10816