### PR TITLE
main/openssh: fix login on old kernels with openssl 1.1.1d

### DIFF
--- a/main/openssh/0001-Deny-non-fatal-shmget-shmat-shmdt-in-preauth-privsep.patch
+++ b/main/openssh/0001-Deny-non-fatal-shmget-shmat-shmdt-in-preauth-privsep.patch
@@ -1,0 +1,34 @@
+From 3ef92a657444f172b61f92d5da66d94fa8265602 Mon Sep 17 00:00:00 2001
+From: Lonnie Abelbeck <lonnie@abelbeck.com>
+Date: Tue, 1 Oct 2019 09:05:09 -0500
+Subject: [PATCH] Deny (non-fatal) shmget/shmat/shmdt in preauth privsep child.
+
+New wait_random_seeded() function on OpenSSL 1.1.1d uses shmget, shmat, and shmdt
+in the preauth codepath, deny (non-fatal) in seccomp_filter sandbox.
+---
+ sandbox-seccomp-filter.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/sandbox-seccomp-filter.c b/sandbox-seccomp-filter.c
+index 840c5232..39dc289e 100644
+--- a/sandbox-seccomp-filter.c
++++ b/sandbox-seccomp-filter.c
+@@ -168,6 +168,15 @@ static const struct sock_filter preauth_insns[] = {
+ #ifdef __NR_stat64
+ 	SC_DENY(__NR_stat64, EACCES),
+ #endif
++#ifdef __NR_shmget
++	SC_DENY(__NR_shmget, EACCES),
++#endif
++#ifdef __NR_shmat
++	SC_DENY(__NR_shmat, EACCES),
++#endif
++#ifdef __NR_shmdt
++	SC_DENY(__NR_shmdt, EACCES),
++#endif
+ 
+ 	/* Syscalls to permit */
+ #ifdef __NR_brk
+-- 
+2.23.0
+

--- a/main/openssh/APKBUILD
+++ b/main/openssh/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=openssh
 pkgver=8.0_p1
 _myver=${pkgver%_*}${pkgver#*_}
-pkgrel=1
+pkgrel=2
 pkgdesc="Port of OpenBSD's free SSH release"
 url="https://www.openssh.com/portable.html"
 arch="all"
@@ -36,6 +36,7 @@ source="https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/$pkgname-$_myver.ta
 	sftp-interactive.patch
 	disable-forwarding-by-default.patch
 	fix-verify-dns-segfault.patch
+	0001-Deny-non-fatal-shmget-shmat-shmdt-in-preauth-privsep.patch
 
 	sshd.initd
 	sshd.confd
@@ -214,5 +215,6 @@ f2b8daa537ea3f32754a4485492cc6eb3f40133ed46c0a5a29a89e4bcf8583d82d891d94bf2e5eb1
 c1d09c65dbc347f0904edc30f91aa9a24b0baee50309536182455b544f1e3f85a8cecfa959e32be8b101d8282ef06dde3febbbc3f315489339dcf04155c859a9  sftp-interactive.patch
 8df35d72224cd255eb0685d2c707b24e5eb24f0fdd67ca6cc0f615bdbd3eeeea2d18674a6af0c6dab74c2d8247e2370d0b755a84c99f766a431bc50c40b557de  disable-forwarding-by-default.patch
 b0d1fc89bd46ebfc8c7c00fd897732e67a6cda996811c14d99392685bb0b508b52c9dc3188b1a84c0ffa3f72f57189cc615a76b81796dd1b5f552542bd53f84d  fix-verify-dns-segfault.patch
+347662bf5742432588987aadb5d900044cd0e62881f20925da48cef56cc77ce6267f6e1d88bee7cdda1e2f44cd908dd1a6b9c7669b59223e64af688e00187ac4  0001-Deny-non-fatal-shmget-shmat-shmdt-in-preauth-privsep.patch
 8122ac1838586a1487dad1f70ed2ec8161ae57b4a7ee8bfef9757b590aa76a887a6c5e5f2575728da4c6c2f00d2a924360e23d84a4df204d7021b44b690cb2f8  sshd.initd
 ec506156c286e5b28a530e9964dd68b7f6c9e881fbc47247a988e52a1f9cd50cbfaf4955c96774f9e2508d8b734c4abf98785fbaa75ae6249e3464b5495f1afc  sshd.confd"


### PR DESCRIPTION
See
- https://github.com/openssl/openssl/issues/9984
- https://github.com/openssh/openssh-portable/pull/149
- https://gitlab.com/postmarketOS/pmaports/issues/367