### PR TITLE
community/gnome-music: add gstreamer dependency

### DIFF
--- a/community/gnome-music/APKBUILD
+++ b/community/gnome-music/APKBUILD
@@ -2,13 +2,13 @@
 # Maintainer: Rasmus Thomsen <oss@cogitri.dev>
 pkgname=gnome-music
 pkgver=3.34.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Music is the new GNOME music playing application"
 url="https://wiki.gnome.org/Apps/Music"
 arch="all"
 license="GPL-2.0-or-later"
 depends="grilo grilo-plugins gnome-online-accounts libdazzle libsoup py3-gobject3
-	tracker libmediaart py3-cairo"
+	tracker libmediaart py3-cairo gst-plugins-good"
 makedepends="meson gnome-online-accounts-dev libdazzle-dev gtk+3.0-dev libsoup-dev
 	gobject-introspection-dev grilo-dev grilo-plugins-dev tracker-dev py-gobject3-dev
 	libmediaart-dev py-cairo-dev itstool"


### PR DESCRIPTION
Without the volume and the limiter plugin from gstreamer gnome-music
will crash on launch.