### PR TITLE
community/bcc: fix subpackage reference

### DIFF
--- a/community/bcc/APKBUILD
+++ b/community/bcc/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Adam Jensen <acjensen@gmail.com>
 pkgname=bcc
 pkgver=0.10.0
-pkgrel=5
+pkgrel=6
 pkgdesc="A toolkit for creating efficient kernel tracing and manipulation programs"
 url="https://github.com/iovisor/bcc/"
 arch="aarch64 x86 x86_64"
@@ -48,7 +48,7 @@ _doc() {
 }
 
 _tools() {
-	depends="$pkgname py-$pkgname"
+	depends="$pkgname py3-$pkgname"
 	pkgdesc="$pkgdesc (tools)"
 
 	mkdir -p "$subpkgdir"/usr/share/bcc


### PR DESCRIPTION
This was broken in https://github.com/alpinelinux/aports/commit/95ea046667fba789c30d2d50710fadc0361abf59. Currently, bcc-tools can't be installed due to the dangling subpackage reference.