### PR TITLE
community/eigen install eigen3.pc, use cmake

### DIFF
--- a/community/eigen/APKBUILD
+++ b/community/eigen/APKBUILD
@@ -1,36 +1,55 @@
+# Contributor: stef <l0ls0fo2i@ctrlc.hu>
 # Contributor: Bradley J Chambers <brad.chambers@gmail.com>
 # Maintainer: Bradley J Chambers <brad.chambers@gmail.com>
 pkgname=eigen
 pkgver=3.3.7
-pkgrel=0
+pkgrel=1
 pkgdesc="Eigen is a C++ template library for linear algebra"
 url="http://eigen.tuxfamily.org/index.php?title=Main_Page"
 arch="noarch"
-options="!check"  # Headers-only: no tests are possible.
 license="MPL-2.0"
 depends=""
-makedepends=""
+options="!check"  # checks take a long time, and tend to fail randomly
+makedepends="cmake openblas-dev suitesparse-dev mpfr-dev fftw-dev boost-dev gmp-dev glu-dev freeglut-dev"
 install=""
 subpackages="$pkgname-dev $pkgname-doc"
-source="$pkgname-$pkgver.tar.gz::http://bitbucket.org/eigen/$pkgname/get/$pkgver.tar.gz"
+source="$pkgname-$pkgver.tar.gz::http://bitbucket.org/eigen/$pkgname/get/$pkgver.tar.gz
+	fftw-test-fix.patch"
 builddir="$srcdir/$pkgname-$pkgname"
 
 build() {
-        return 0
+	mkdir -p build
+	cd build
+	# needs -std so c11 tests are being built
+	CXXFLAGS="-std=c++11" \
+	cmake -DCMAKE_INSTALL_PREFIX=/usr "$builddir"
+	make
 }
 
 prepare() {
-        mv "$builddir"-* "$builddir"  # directory name contains hash
-        default_prepare
+	mv "$builddir"-* "$builddir"  # directory name contains hash
+	default_prepare
+}
+
+check() {
+	cd "$builddir/build"
+	make check
+}
+
+dev() {
+	default_dev
+	mkdir -p ${subpkgdir}/usr/share/cmake/Modules
+	mv $pkgdir/usr/share/eigen3/cmake/*.cmake ${subpkgdir}/usr/share/cmake/Modules
 }
 
 package() {
-        mkdir -p "$pkgdir"/usr/include/eigen3
-        cp -r "$builddir"/Eigen "$pkgdir"/usr/include/eigen3
-        cp -r "$builddir"/unsupported "$pkgdir"/usr/include/eigen3
-        cp "$builddir"/signature_of_eigen3_matrix_library "$pkgdir"/usr/include/eigen3
-        mkdir -p "$pkgdir"/usr/share/doc/$pkgname
-        cp -r "$builddir"/doc/ "$pkgdir"/usr/share/doc/$pkgname
+	cd "$builddir/build"
+	make DESTDIR="$pkgdir" install
+	mkdir -p "$pkgdir"/usr/share/doc/$pkgname
+	cp -r "$builddir"/doc/ "$pkgdir"/usr/share/doc/$pkgname
+	mkdir -p $pkgdir/usr/lib/pkgconfig
+	mv $pkgdir/usr/share/pkgconfig/eigen3.pc $pkgdir/usr/lib/pkgconfig
 }
 
-sha512sums="34cf600914cce719d61511577ef9cd26fbdcb7a6fad1d0ab8396f98b887fac6a5577d3967e84a8f56225cc50de38f3b91f34f447d14312028383e32b34ea1972  eigen-3.3.7.tar.gz"
+sha512sums="34cf600914cce719d61511577ef9cd26fbdcb7a6fad1d0ab8396f98b887fac6a5577d3967e84a8f56225cc50de38f3b91f34f447d14312028383e32b34ea1972  eigen-3.3.7.tar.gz
+c1f9d7d8c9025b4b2b3a679f80519e494f206d7bee232cd10dd45df454b1ce6697858547bc0d956a5818481d344948704db8dbb39d04ac69ff7de99961492384  fftw-test-fix.patch"

--- a/community/eigen/fftw-test-fix.patch
+++ b/community/eigen/fftw-test-fix.patch
@@ -1,0 +1,11 @@
+diff -urw src/eigen-eigen/unsupported/test/FFTW.cpp eigen-eigen/unsupported/test/FFTW.cpp
+--- src/eigen-eigen/unsupported/test/FFTW.cpp	2018-12-11 17:57:55.000000000 +0000
++++ eigen-eigen/unsupported/test/FFTW.cpp	2019-10-06 22:32:27.239613362 +0000
+@@ -8,6 +8,7 @@
+ // with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+ #include "main.h"
++#include <stdint.h>
+ #include <unsupported/Eigen/FFT>
+ 
+ template <typename T> 


### PR DESCRIPTION
this PR replaces https://github.com/alpinelinux/aports/pull/11799 which installs eigen3.pc. however this PR uses the cmake build system, which also enables us to enable `check()`.