### PR TITLE
community/john enabled jumbo version of jtr

### DIFF
--- a/community/john/APKBUILD
+++ b/community/john/APKBUILD
@@ -4,31 +4,23 @@
 pkgname=john
 pkgver=1.9.0
 _pkgrel=jumbo-1
-pkgrel=1
+pkgrel=2
 pkgdesc="John the Ripper password cracker"
 url="https://www.openwall.com/john"
 arch="all !s390x !x86 !ppc64le"
 license="GPL-2.0-or-later"
 depends="nss"
-options="!strip"
+options="!strip !check"  # needs config files in /usr which are not there during build/check
 makedepends="libpcap-dev openssl-dev gmp-dev yasm-dev zlib-dev"
 subpackages="$pkgname-doc"
 
-source="$pkgname-$pkgver.tar.gz::https://github.com/magnumripper/JohnTheRipper/archive/$pkgver.tar.gz"
-builddir="$srcdir"/JohnTheRipper-$pkgver
+source="https://www.openwall.com/john/k/$pkgname-$pkgver-$_pkgrel.tar.xz"
+builddir="$srcdir"/$pkgname-$pkgver-$_pkgrel
 
 build() {
 	cd "$builddir"/src
-	local _arch=
-	case "$CARCH" in
-		aarch64) _arch=arm64le;;
-		arm*) _arch=arm32le;;
-		ppc64le) _arch=ppc64;;
-		x86) _arch=x86-any;;
-		x86_64) _arch=x86-64;
-	esac
-
-	make linux-$_arch
+   ./configure --prefix=/usr
+	make
 }
 
 check() {
@@ -37,11 +29,18 @@ check() {
 }
 
 package() {
+	cd "$builddir/src"
+   make DESTDIR="$pkgdir" install 
+	cd "$builddir"
 	mkdir -p "$pkgdir"/usr/bin
 	mkdir -p "$pkgdir"/usr/share/doc/$pkgname
+	mkdir -p "$pkgdir"/usr/share/$pkgname/rules
 
-	install -Dm644 run/john.conf "$pkgdir"/etc/john/john.conf
+   mv doc/extras "$pkgdir"/usr/share/doc/$pkgname
 	install -Dm644 doc/* "$pkgdir"/usr/share/doc/$pkgname
+   install -Dm644 run/rules/* "$pkgdir"/usr/share/$pkgname/rules
+   install -Dm644 run/*.conf "$pkgdir"/usr/share/$pkgname/
+   install -Dm644 run/*.chr "$pkgdir"/usr/share/$pkgname/
 	install -Dm644 doc/LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 	rm "$pkgdir"/usr/share/doc/$pkgname/LICENSE*
 
@@ -55,4 +54,4 @@ package() {
 	install -Dm644 run/password.lst "$pkgdir"/usr/share/john/password.lst
 }
 
-sha512sums="408e67b0aff67b37fe20f7a07ccdd1e3d4788c68866974c970d091ab41977bfe1c9cc72417f3320ff0b910516093c9fe0023cd8a214d086b5754a224eff01709  john-1.9.0.tar.gz"
+sha512sums="c5cb5dc739ee4c666f8479cdf10511fddc391b590c59f90c060d3ccd8449b794ac7b831a6d1f7553883892499e709a66578cfa4d62caef9b7e0a831eb827e808  john-1.9.0-jumbo-1.tar.xz"


### PR DESCRIPTION
the packaged version of john is only the core version although it downloads the jumbo version. this change enables building the full jumbo patch.