### PR TITLE
main/ruby: upgrade to 2.6.5

### DIFF
--- a/main/ruby/APKBUILD
+++ b/main/ruby/APKBUILD
@@ -3,6 +3,11 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 #
 # secfixes:
+#   2.6.5-r0:
+#     - CVE-2019-16255
+#     - CVE-2019-16254
+#     - CVE-2019-15845
+#     - CVE-2019-16201
 #   2.5.2-r0:
 #     - CVE-2018-16395
 #     - CVE-2018-16396
@@ -26,7 +31,7 @@
 #     - CVE-2017-17405
 #
 pkgname=ruby
-pkgver=2.6.4
+pkgver=2.6.5
 _abiver="${pkgver%.*}.0"
 pkgrel=0
 pkgdesc="An object-oriented language for quick and easy programming"
@@ -353,7 +358,7 @@ _mvgem() {
 	done
 }
 
-sha512sums="3dad0d98695e10ece015933e96114ffd9a10d3c59d1ead8a9ab041df113aabee3f4100aa7ffe7ef5c43b62ac3c7506c3f3ceeb8828b2a800b6d0f4119d5bf926  ruby-2.6.4.tar.gz
+sha512sums="7ab7a0cdaf4863152efc86dbcfada7f10ab3fe33590eee3b6ab7b26fc27835a8a0ded4ec02b58e9969175582a2be5410da3dc9f8694a3cd2db97708bd72773e1  ruby-2.6.5.tar.gz
 cfdc5ea3b2e2ea69c51f38e8e2180cb1dc27008ca55cc6301f142ebafdbab31c3379b3b6bba9ff543153876dd98ed2ad194df3255b7ea77a62e931c935f80538  rubygems-avoid-platform-specific-gems.patch
 814fe6359505b70d8ff680adf22f20a74b4dbd3fecc9a63a6c2456ee9824257815929917b6df5394ed069a6869511b8c6dce5b95b4acbbb7867c1f3a975a0150  test_insns-lower-recursion-depth.patch
 8d730f02f76e53799f1c220eb23e3d2305940bb31216a7ab1e42d3256149c0721c7d173cdbfe505023b1af2f5cb3faa233dcc1b5d560fa8f980c17c2d29a9d81  fix-get_main_stack.patch


### PR DESCRIPTION
Security fixes:
- CVE-2019-16255
- CVE-2019-16254
- CVE-2019-15845
- CVE-2019-16201