### PR TITLE
[3.9] main/ruby: upgrade to 2.5.7

### DIFF
--- a/main/ruby/APKBUILD
+++ b/main/ruby/APKBUILD
@@ -3,6 +3,11 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 #
 # secfixes:
+#   2.5.7-r0:
+#     - CVE-2019-16255
+#     - CVE-2019-16254
+#     - CVE-2019-15845
+#     - CVE-2019-16201
 #   2.5.5-r0:
 #     - CVE-2019-8320
 #     - CVE-2019-8321
@@ -33,7 +38,7 @@
 #     - CVE-2017-17405
 #
 pkgname=ruby
-pkgver=2.5.5
+pkgver=2.5.7
 _abiver="${pkgver%.*}.0"
 pkgrel=0
 pkgdesc="An object-oriented language for quick and easy programming"
@@ -346,7 +351,7 @@ _mvgem() {
 	done
 }
 
-sha512sums="82d0ae019c02822668f7e8c7ad7f62170b059ea70a95a7a7cb26f809e2f2f0f5d25b5bb0ca147413ae42cf0fc5bf60329b56609c266556b1e9f04813c33bb4c9  ruby-2.5.5.tar.gz
+sha512sums="6c4219e1ac316fb00cdd5ff2ac6292448e6ddf49f25eda91426f8e0072288e8849d5c623bf9d532b8e93997b23dddc24718921d92b74983aac8fdb50db4ee809  ruby-2.5.7.tar.gz
 cfdc5ea3b2e2ea69c51f38e8e2180cb1dc27008ca55cc6301f142ebafdbab31c3379b3b6bba9ff543153876dd98ed2ad194df3255b7ea77a62e931c935f80538  rubygems-avoid-platform-specific-gems.patch
 814fe6359505b70d8ff680adf22f20a74b4dbd3fecc9a63a6c2456ee9824257815929917b6df5394ed069a6869511b8c6dce5b95b4acbbb7867c1f3a975a0150  test_insns-lower-recursion-depth.patch
 8d730f02f76e53799f1c220eb23e3d2305940bb31216a7ab1e42d3256149c0721c7d173cdbfe505023b1af2f5cb3faa233dcc1b5d560fa8f980c17c2d29a9d81  fix-get_main_stack.patch"


### PR DESCRIPTION
Security fixes:

CVE-2019-16255
CVE-2019-16254
CVE-2019-15845
CVE-2019-16201