### PR TITLE
[3.10] community/ceph: security upgrade to 14.2.3

### DIFF
--- a/community/ceph/APKBUILD
+++ b/community/ceph/APKBUILD
@@ -1,12 +1,12 @@
 # Contributor: John Coyle <dx9err@gmail.com>
 # Maintainer: John Coyle <dx9err@gmail.com>
 pkgname=ceph
-pkgver=14.2.1
+pkgver=14.2.3
 pkgrel=0
 pkgdesc="Ceph is a distributed object store and file system"
 pkgusers="ceph"
 pkggroups="ceph"
-url="http://ceph.com"
+url="https://ceph.com/"
 arch="x86_64"
 # https://github.com/ceph/ceph/blob/master/COPYING
 license="LGPL-2.1-only AND LGPL-2.0-or-later AND GPL-2.0-only AND GPL-3.0-only AND CC-BY-SA-1.0 AND BSL-1.0 AND GPL-2.0 WITH Autoconf-exception-2.0 AND BSD-3-Clause AND MIT AND custom"
@@ -81,7 +81,7 @@ makedepends="
 	$_ceph_test_deps
 "
 
-source="http://download.ceph.com/tarballs/ceph_$pkgver.orig.tar.gz
+source="https://download.ceph.com/tarballs/ceph_$pkgver.orig.tar.gz
 	allperms.patch
 	musl-fixes.patch
 	"
@@ -108,6 +108,10 @@ subpackages="
 	py2-rbd:_py2_rbd
 	py2-cephfs:_py2_cephfs
 "
+
+# secfixes:
+#   14.2.3-r0:
+#     - CVE-2019-10222
 
 _ceph_uid=167
 _ceph_gid=167
@@ -444,6 +448,6 @@ _pkg() {
 	done
 }
 
-sha512sums="fccde341344c721fbfc7f7cb73db4f65933d7fcacc9495398b55b37d1e208f0bad0cd78a4da08a3b5e26cca3175e7707f7dfb76fae5aa094f58afaed8603c866  ceph_14.2.1.orig.tar.gz
+sha512sums="3d02e766a1d53d39355ee88738dd0233dc02f8a3cb44935194cb538b888507de8f8acdd99bf7890895f68795a310f53e2a8652305d5f2be5212efbd9046bd3a9  ceph_14.2.3.orig.tar.gz
 e1becd813ed3f28e2e4a6bef78b3b5117c1c0bb9cabe0ba9c912e0a20b551b6b2667495cddb94acd64192e287144911ff1c11e0d636fe04cc458146cfb0daca8  allperms.patch
 35722b11ad52a3145153635b6a96abda2a23ae9c7e63e2eac006c1e5b8014452c4a1a11bbe0292fd731e4c43aa38e27dd75d2ff9d25bcf52290278f71e868570  musl-fixes.patch"


### PR DESCRIPTION
https://ceph.io/releases/v14-2-3-nautilus-released/#notable-changes