### PR TITLE
[3.9] main/openssl: Fix openssl secfix version number

### DIFF
--- a/main/openssl/APKBUILD
+++ b/main/openssl/APKBUILD
@@ -20,7 +20,7 @@ esac
 builddir="$srcdir/openssl-$pkgver"
 
 # secfixes:
-#   1.1.1d-r1:
+#   1.1.1d-r0:
 #     - CVE-2019-1547
 #     - CVE-2019-1549
 #     - CVE-2019-1563


### PR DESCRIPTION
Same issue/fix as for 3.10 branch (secfix block does not match pkgver+pkgrel): https://github.com/alpinelinux/aports/pull/11387