### PR TITLE
testing/minio: upgrade to 20191002

### DIFF
--- a/testing/minio/APKBUILD
+++ b/testing/minio/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Carlo Landmeter <clandmeter@alpinelinux.org>
 # Maintainer: Chloe Kudryavtsev <toast@toastin.space>
 pkgname=minio
-_pkgver='RELEASE.2019-09-18T21-55-05Z'
+_pkgver='RELEASE.2019-10-02T21-19-38Z'
 pkgver=${_pkgver#*.}
 pkgver=${pkgver%T*}
 pkgver=0.${pkgver//-}
@@ -58,4 +58,4 @@ cleanup_srcdir() {
 
 sha512sums="6427a225d4e6c51cc5de077ccd29ddf52556722cf958e83e480df1c5882aa4fa7daebfeb970e80f8f9c3176594d8e427e8c8dbf268ce945647a11bdf1e69affd  minio.initd
 ed9790fbadfb38e4d660eb1befd87e803d70dec04d936e8cd26def4a9c21240bb7cae8750ae3395aa4761e6738b9e346c86ba57761cfde30efe46d2cb459a7e4  minio.confd
-d4470c223f12796699807c1d41f716e308a68861c5f06a124017a35fd551c1b6f3dc502a774e41b196605690289e775a479f63c155c4c9b4b171af5f74b78cf0  minio-0.20190918.tar.gz"
+4cc63b0f04e821487673f9d0a81ac0db33fe8cf25bf6090c3d67f44319de7a3ba3ddf9c8ad2901d4a6ce29d725e90fd576b378fe36adc79b2aa665872a8a0f20  minio-0.20191002.tar.gz"


### PR DESCRIPTION
Ref https://github.com/minio/minio/releases/tag/RELEASE.2019-10-02T21-19-38Z