### PR TITLE
community/docker: upgrade to 19.03.3

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -2,9 +2,9 @@
 # Contributor: Jake Buchholz <tomalok@gmail.com>
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 pkgname=docker
-pkgver=19.03.2
-_gitcommit=6a30dfca03664a0b6bf0646a7d389ee7d0318e6e	# https://github.com/docker/docker-ce/commits/v$pkgver
-pkgrel=1
+pkgver=19.03.3
+_gitcommit=a872fc2f86c042e6992e17db6cdd9826c9c4232b	# https://github.com/docker/docker-ce/commits/v$pkgver
+pkgrel=0
 pkgdesc="Pack, ship and run any application as a lightweight container"
 url="https://www.docker.io/"
 arch="all"
@@ -194,7 +194,7 @@ cli_vim() {
 	done
 }
 
-sha512sums="6b594fdbb53dcc0228781375a3884eb370446738c44f7c1e42945c4ccc263e75f53d984bc8ea6a6a498446859e667305bd967299c12956f1cb925d868a4bf2b8  docker-19.03.2.tar.gz
+sha512sums="251756ca8b5d8eb962fde447fdab8307ce8013e14dc3b955387af5d8bdfdee16ea170ecb37a59e5900fa5c2e366f0d4080e79c28e5b8ef945cc67cb959d88eef  docker-19.03.3.tar.gz
 dea31fd82ab2d445fbd39fe15550a91f7e489a06f6dedd32ea1925f7e9a7971952d26b874f9687249609a0d204ea35da357e0a957b819df2026a0cf8109cb354  libnetwork-fc5a7d91d54cc98f64fc28f9e288b46a0bee756c.tar.gz
 c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 6d3f1e71910a717d52820fbfe81663baadf3f5aa5ab39071d15c02ef49b51fe1978033e1cafc8482a468983bf872ab39d37759b82221778cbb2392a9eac41d65  docker-openrc-fixes.patch"


### PR DESCRIPTION
Ref https://github.com/docker/docker-ce/releases/tag/v19.03.3