### PR TITLE
testing/wf-config: new aport

### DIFF
--- a/testing/wf-config/APKBUILD
+++ b/testing/wf-config/APKBUILD
@@ -1,0 +1,28 @@
+# Contributor: Danct12 <danct12@disroot.org>
+# Maintainer: Danct12 <danct12@disroot.org>
+pkgname=wf-config
+pkgver=0.3
+pkgrel=0
+pkgdesc="Library for managing configuration files written for Wayfire"
+url="https://wayfire.org"
+arch="all"
+license="MIT"
+makedepends="libevdev-dev wlroots-dev meson ninja"
+options="!check" # no testsuite
+subpackages="$pkgname-dev"
+
+# Source
+source="https://github.com/WayfireWM/$pkgname/releases/download/${pkgver}/$pkgname-$pkgver.tar.xz"
+builddir="$srcdir/$pkgname-$pkgver"
+
+build() {
+	cd "$builddir"
+	meson build --prefix=/usr --buildtype=release
+}
+
+package() {
+	cd "$builddir"
+	DESTDIR="$pkgdir" ninja -C build install
+}
+
+sha512sums="b0df9735583c0665fb2fdd2353dbce07e11239eb26fd080159c7f386dba9b370d7908b09504bafde1e11f45be95adc128466017c45e9fcd75a0dea00af70d741  wf-config-0.3.tar.xz"


### PR DESCRIPTION
This is a library for managing configuration files, it's for Wayfire, which is a Compiz-like Wayland compositor.

I'll upstream Wayfire after this PR is accepted.

**This will built after #11872 is merged.**

Signed-off-by: Danct12 <danct12@disroot.org>