### PR TITLE
testing/wcm: new aport

### DIFF
--- a/testing/wcm/APKBUILD
+++ b/testing/wcm/APKBUILD
@@ -1,0 +1,22 @@
+# Contributor: Danct12 <danct12@disroot.org>
+# Maintainer: Danct12 <danct12@disroot.org>
+pkgname=wcm
+pkgver=0.3
+pkgrel=0
+pkgdesc="Wayfire Config Manager"
+url="https://wayfire.org"
+arch="all"
+license="MIT"
+makedepends="wf-config-dev meson ninja cmake libxml++-dev gtk+3.0-dev"
+options="!check" # no testsuite
+source="$pkgname-$pkgver.tar.gz::https://github.com/WayfireWM/$pkgname/archive/v$pkgver.tar.gz"
+
+build() {
+	meson build --prefix=/usr --buildtype=release
+}
+
+package() {
+	DESTDIR="$pkgdir" ninja -C build install
+}
+
+sha512sums="e997d1b0f707cca2d170bc82667fdacd8489eff629931e3af1c03ac2be5461f07c81b54930561b0baaf10f5e632f0939247344ffeedf3c3eef8f03cb74b2fd0d  wcm-0.3.tar.gz"


### PR DESCRIPTION
Wayfire Config Manager is a graphical settings manager for Wayfire.

Signed-off-by: Danct12 <danct12@disroot.org>