### PR TITLE
testing/tpm2-tss-engine: new aport

### DIFF
--- a/testing/tpm2-tss-engine/APKBUILD
+++ b/testing/tpm2-tss-engine/APKBUILD
@@ -1,0 +1,27 @@
+# Contributor:
+# Maintainer: Alexander Sack <asac@pantacor.com>
+pkgname="tpm2-tss-engine"
+pkgver="1.0.1"
+pkgrel=0
+pkgdesc="tpm2tss engine for openssl"
+url="https://github.com/tpm2-software/tpm2-tss-engine/"
+arch="all"
+license="BSD-2-Clause"
+makedepends="tpm2-tss-dev automake autoconf autoconf-archive libtool openssl-dev doxygen linux-headers curl-dev"
+source="https://github.com/tpm2-software/tpm2-tss-engine/releases/download/v1.0.1/tpm2-tss-engine-1.0.1.tar.gz"
+subpackages="$pkgname-doc"
+
+
+build() {
+	./configure \
+		--build=$CBUILD \
+		--host=$CHOST \
+		--prefix=/usr
+	make	
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="106fc6aadf0b4b27c3b38be596356aa59b4b76ec1602e8c5564aec6b4be7e2b5d6077006ee13d41e58402255b879aadaa966c758b5b326ae32742007ce2ef238  tpm2-tss-engine-1.0.1.tar.gz"


### PR DESCRIPTION
tpm2tss engine for openssl
https://github.com/tpm2-software/tpm2-tss-engine/