### PR TITLE
testing/efl: upgrade to 1.23.1

### DIFF
--- a/testing/efl/APKBUILD
+++ b/testing/efl/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Boris Faure <boris@fau.re>
 # Maintainer: Boris Faure <boris@fau.re>
 pkgname=efl
-pkgver=1.23.0
+pkgver=1.23.1
 pkgrel=0
 pkgdesc="Enlightenment Foundation Libraries"
 url="https://www.enlightenment.org"
@@ -76,4 +76,4 @@ package() {
 	DESTDIR="$pkgdir" ninja -C build install
 }
 
-sha512sums="6f96b822a8e8d44309b6174f2bde66aec8cce94386574e61fac88ab539113fec173e7f00db16a03d83b7294f5d4892800861cfda2f2b72bb78636a781bfd21b3  efl-1.23.0.tar.xz"
+sha512sums="9c81f28bb0d87e1a3e5d2204c0e2401d9b3f6dcc34f47cb2b41711ef033b3134f4cd283e87a216a0ce4ee903f721a1f8c2f003577444c5781e7f47ce827201e6  efl-1.23.1.tar.xz"


### PR DESCRIPTION
About `depends_dev="luajit-dev"`, this is a known bug in `apk`. See https://gitlab.alpinelinux.org/alpine/aports/issues/10089