### PR TITLE
main/wget: add iri support

### DIFF
--- a/main/wget/APKBUILD
+++ b/main/wget/APKBUILD
@@ -1,15 +1,16 @@
+# Contributor: Sandro Jäckel <sandro.jaeckel@posteo.de>
 # Contributor: Sergei Lukin <sergej.lukin@gmail.com>
 # Contributor: Carlo Landmeter <clandmeter@gmail.com>
 # Maintainer: Carlo Landmeter <clandmeter@gmail.com>
 pkgname=wget
 pkgver=1.20.3
-pkgrel=0
+pkgrel=1
 pkgdesc="A network utility to retrieve files from the Web"
 url="https://www.gnu.org/software/wget/wget.html"
 arch="all"
 license="GPL-3.0-or-later"
 depends=""
-makedepends="openssl-dev perl"
+makedepends="libidn2-dev openssl-dev perl"
 checkdepends="perl-http-daemon"
 subpackages="$pkgname-doc"
 install=""
@@ -37,6 +38,7 @@ build() {
 		--sysconfdir=/etc \
 		--mandir=/usr/share/man \
 		--infodir=/usr/share/info \
+		--with-libidn \
 		--with-ssl=openssl \
 		--disable-nls
 	make


### PR DESCRIPTION
I need support for remote encoding in wget and I thought this is useful in upstream.

Currently this command ``wget --remote-encoding=utf-8 http://example.com`` returns:
````
This version does not have support for IRIs
````
After this patch it works as intended.
