### PR TITLE
testing/libexosip2: new aport

### DIFF
--- a/testing/libexosip2/APKBUILD
+++ b/testing/libexosip2/APKBUILD
@@ -19,9 +19,7 @@ makedepends="
 "
 options="libtool"
 subpackages="$pkgname-dev"
-source="
-	http://download.savannah.nongnu.org/releases/exosip/$pkgname-$pkgver.tar.gz
-	"
+source="http://download.savannah.nongnu.org/releases/exosip/libexosip2-$pkgver.tar.gz"
 
 prepare() {
 	default_prepare

--- a/testing/libexosip2/APKBUILD
+++ b/testing/libexosip2/APKBUILD
@@ -1,0 +1,44 @@
+# Maintainer: David Sugar <tychosoft@gmail.com>
+# Contributor: David Sugar <tychosoft@gmail.com>
+pkgname=libexosip2
+pkgver=5.1.0
+pkgrel=0
+pkgdesc="Extended osip2 library"
+url="http://savannah.nongnu.org/projects/exosip"
+arch="all"
+license="GPL-2.0-or-later"
+depends="openssl libosip2 c-ares"
+makedepends="
+	autoconf
+	automake
+	libtool
+	pkgconf
+	c-ares-dev
+	libosip2-dev
+	openssl-dev
+"
+options="libtool"
+subpackages="$pkgname-dev"
+source="
+	http://download.savannah.nongnu.org/releases/exosip/$pkgname-$pkgver.tar.gz
+	"
+
+prepare() {
+	default_prepare
+	./autogen.sh
+}
+
+build() {
+	./configure \
+		--prefix=/usr \
+		--disable-tools \
+		--enable-pthread \
+		--with-gnu-ld
+	make
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="9ffddaaf9f62839b8aa1642a5b821d12e7e4d34097f92bcc9c90cabb97200e6a8faa2f0c9a62270f9b4b3ea783a90468e8491b1d5f834b335b4522b524496a19  libexosip2-5.1.0.tar.gz"

--- a/testing/libosip2/APKBUILD
+++ b/testing/libosip2/APKBUILD
@@ -7,16 +7,11 @@ pkgdesc="oSIP is an implementation of SIP"
 url="https://www.gnu.org/software/osip/"
 arch="all"
 license="LGPL-2.1-or-later"
-makedepends="
-	autoconf
-	automake
-	libtool
-"
+makedepends="autoconf automake libtool"
 options="libtool"
 subpackages="$pkgname-dev $pkgname-doc"
-source="
-	http://ftp.gnu.org/gnu/osip/$pkgname-$pkgver.tar.gz
-	"
+source="http://ftp.gnu.org/gnu/osip/libosip2-$pkgver.tar.gz"
+
 prepare() {
 	default_prepare
 	./autogen.sh

--- a/testing/libosip2/APKBUILD
+++ b/testing/libosip2/APKBUILD
@@ -1,0 +1,36 @@
+# Maintainer: David Sugar <tychosoft@gmail.com>
+# Contributor: David Sugar <tychosoft@gmail.com>
+pkgname=libosip2
+pkgver=5.1.0
+pkgrel=0
+pkgdesc="oSIP is an implementation of SIP"
+url="https://www.gnu.org/software/osip/"
+arch="all"
+license="LGPL-2.1-or-later"
+makedepends="
+	autoconf
+	automake
+	libtool
+"
+options="libtool"
+subpackages="$pkgname-dev $pkgname-doc"
+source="
+	http://ftp.gnu.org/gnu/osip/$pkgname-$pkgver.tar.gz
+	"
+prepare() {
+	default_prepare
+	./autogen.sh
+}
+
+build() {
+	./configure \
+		--prefix=/usr \
+		--with-gnu-ld
+	make
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+}
+
+sha512sums="391c9a0ea399f789d7061b0216d327eecba5bbf0429659f4f167604b9e703e1678ba6f58079aa4f84b3636a937064ecfb92e985368164fcb679e95654e43d65b  libosip2-5.1.0.tar.gz"


### PR DESCRIPTION
This includes libexosip2 and libosip2 as a dependency and also a new aport:

    testing/libexosip2: new aport
    
    http://savannah.nongnu.org/projects/exosip
    Extended osip2 library

    testing/libosip2: new aport
    
    https://www.gnu.org/software/osip
    oSIP is an implementation of SIP