### PR TITLE
main/libaio: update to 0.3.112

### DIFF
--- a/main/libaio/APKBUILD
+++ b/main/libaio/APKBUILD
@@ -1,27 +1,21 @@
+# Contributor: Michael Pirogov <vbnet.ru@gmail.com>
 # Contributor: Leonardo Arena <rnalrd@alpinelinux.org>
 # Maintainer: Leonardo Arena <rnalrd@alpinelinux.org>
 pkgname="libaio"
-pkgver=0.3.111
+pkgver=0.3.112
 pkgrel=0
 pkgdesc="Asynchronous input/output library"
-url="http://lse.sourceforge.net/io/aio.html"
+url="https://pagure.io/libaio"
 arch="all"
 license="LGPL-2.1-or-later"
-options="!check"  # No test suite.
-depends=
-makedepends_build=""
-makedepends_host="linux-headers"
-makedepends="$makedepends_build $makedepends_host"
-install=
+options="!check" # No test suite.
+makedepends="linux-headers"
 subpackages="$pkgname-dev"
-source="http://ftp.debian.org/debian/pool/main/liba/$pkgname/${pkgname}_${pkgver}.orig.tar.gz"
-
-build() {
-	cd $builddir
-}
+source="https://releases.pagure.org/libaio/libaio-$pkgver.tar.gz
+	libaio-optional-werror.patch
+	libaio-cppflags.patch"
 
 package() {
-	cd $builddir
 	make prefix="$pkgdir/usr" \
 		sysconfdir="$pkgdir/etc" \
 		mandir="$pkgdir/usr/share/man" \
@@ -29,4 +23,6 @@ package() {
 		install
 }
 
-sha512sums="440f2b62f99ca2e72ffc8c2c04b4779a1a7cf24a8ba2a30b34d18b4ee77630a2078610fe8c435559f81a5c3bfa93049bd53d77464a0da8267833fbde3f40ceeb  libaio_0.3.111.orig.tar.gz"
+sha512sums="5f984529c9f747a6c82f1e4457fc0832bb1fc299ae6e700f2ac5a8ea7b9bfc6ea1e75809728cc115a020cff6685ed1f4e38c6aeacc1ea98dfccce04dd19dafaa  libaio-0.3.112.tar.gz
+9b04df1f92b245c3012d161a96bc54d3bcc07d8a1049d7e5acfae50fba9bba94cbdbc220d75d186d6bf2333d58b093b9cf17bd7cd594cfdbfb6682a63daf19fd  libaio-optional-werror.patch
+c9ad6ff35ba12f33e308059d89592281768cef7091213b4702b64af2d194462864ec660dea327f8b718e5c723ec9ba6170b591461e2b140ba94f6838cddb8d7c  libaio-cppflags.patch"

--- a/main/libaio/libaio-cppflags.patch
+++ b/main/libaio/libaio-cppflags.patch
@@ -1,0 +1,17 @@
+respect env CPPFLAGS
+
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -2,8 +2,9 @@ prefix=/usr
+ includedir=$(prefix)/include
+ libdir=$(prefix)/lib
+ 
+-CFLAGS ?= -g -fomit-frame-pointer -O2
+-CFLAGS += -Wall -I. -fPIC
++CFLAGS ?= -fomit-frame-pointer -O2
++CFLAGS += -I. -fPIC
++CFLAGS += $(CPPFLAGS)
+ SO_CFLAGS=-shared $(CFLAGS)
+ L_CFLAGS=$(CFLAGS)
+ LINK_FLAGS=
+

--- a/main/libaio/libaio-optional-werror.patch
+++ b/main/libaio/libaio-optional-werror.patch
@@ -1,0 +1,31 @@
+From ebe62b178f3e5fcde8a311e64aaffe62099204a5 Mon Sep 17 00:00:00 2001
+From: Mike Frysinger <vapier@gentoo.org>
+Date: Sun, 21 Apr 2019 12:44:26 +0200
+Subject: [PATCH] make -Werror into an optional flag
+
+This lets distros disable the flag as random errors might come up with
+different compiler flags and older/newer toolchain versions.
+
+Signed-off-by: Mike Frysinger <vapier@gentoo.org>
+---
+ harness/Makefile | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/harness/Makefile b/harness/Makefile
+index f477737..a155c4b 100644
+--- a/harness/Makefile
++++ b/harness/Makefile
+@@ -6,7 +6,8 @@ PROGS:=$(PARTPROGS) $(EXTRAPROGS)
+ HARNESS_SRCS:=main.c
+ # io_queue.c
+ 
+-CFLAGS+=-Wall -Werror -I../src -g -O2 -DPAGE_SIZE=$(shell getconf PAGESIZE)
++CFLAGS_WERROR?=-Werror
++CFLAGS+=-Wall $(CFLAGS_WERROR) -I../src -g -O2 -DPAGE_SIZE=$(shell getconf PAGESIZE)
+ #-lpthread -lrt
+ 
+ all: $(PROGS)
+-- 
+2.21.0
+
+


### PR DESCRIPTION
Fixes gone debian source link (scripts/bootstrap.sh fails because of this).
Changes homepage link.
Applies patches from gentoo.
Cleanups.