### PR TITLE
testing/libyang: update to 1.0-r4

### DIFF
--- a/testing/libyang/APKBUILD
+++ b/testing/libyang/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Sören Tempel <soeren+alpine@soeren-tempel.net>
 # Maintainer: Christian Franke <nobody@nowhere.ws>
 pkgname=libyang
-pkgver=1.0_p3
+pkgver=1.0_p4
 _realver=${pkgver/_p/-r}
 pkgrel=1
 pkgdesc="YANG data modelling language parser and toolkit"
@@ -45,4 +45,4 @@ package() {
 	make DESTDIR="$pkgdir" install
 }
 
-sha512sums="02573db0085c9d15b49f38d1f4eea311ea91c20b4c45c33194bbcd0e2e7f00a286dd7053919138a543744913387c8c47f5024740d70477f40d700ca9d3f5bbd6  libyang-1.0_p3.tar.gz"
+sha512sums="f4864e50d1a63ca5597411845d0e22f7b4b480eb3e018e5c50d9151a6833a0b8f604129a49f25354a52b83da049d3923cba37fb8d3ce3ef120bc23ba82856e30  libyang-1.0_p4.tar.gz"


### PR DESCRIPTION
This is an update to the latest released version of libyang.

See: <https://github.com/CESNET/libyang/releases/tag/v1.0-r4>