### PR TITLE
community/capstone fixes py bindings which fail due to not finding lib

### DIFF
--- a/community/capstone/APKBUILD
+++ b/community/capstone/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Valery Kartel <valery.kartel@gmail.com>
 pkgname=capstone
 pkgver=4.0.1
-pkgrel=0
+pkgrel=1
 pkgdesc="The Ultimate Disassembler"
 options="!check" # Testsuite fails
 url="https://www.capstone-engine.org"
@@ -10,8 +10,9 @@ arch="all"
 license="BSD-3-Clause-Clear"
 depends_dev="$pkgname"
 makedepends="bash py3-setuptools cython3 python3-dev"
-subpackages="$pkgname-dev py3-${pkgname}:_py3 cstool"
-source="$pkgname-$pkgver.tar.gz::https://github.com/aquynh/capstone/archive/$pkgver.tar.gz"
+subpackages="$pkgname-static $pkgname-dev py3-${pkgname}:_py3 cstool"
+source="$pkgname-$pkgver.tar.gz::https://github.com/aquynh/capstone/archive/$pkgver.tar.gz
+	py-path-fix.patch"
 
 build() {
 	CFLAGS="$CFLAGS -O2" make
@@ -43,4 +44,5 @@ cstool() {
 	mv "$pkgdir"/usr/bin/cstool "$subpkgdir"/usr/bin
 }
 
-sha512sums="43c52024065b41b45eff9423341db3f3d5163fa7aa01b360faa30437786740c8f2c34c36faa04dced5308e09d8bd78df3bad0ab9c06f98612169edb176f83c36  capstone-4.0.1.tar.gz"
+sha512sums="43c52024065b41b45eff9423341db3f3d5163fa7aa01b360faa30437786740c8f2c34c36faa04dced5308e09d8bd78df3bad0ab9c06f98612169edb176f83c36  capstone-4.0.1.tar.gz
+e9a2d7cb391285890872123fb3e5ae8f8cde6e4f858c31f5c815c110f6c6d5ec86cef4920b277d5630745a34a268e52b402855429b072f0b5a722d6a610366a8  py-path-fix.patch"

--- a/community/capstone/py-path-fix.patch
+++ b/community/capstone/py-path-fix.patch
@@ -1,0 +1,11 @@
+diff -urw src/capstone-4.0.1/bindings/python/capstone/__init__.py capstone-4.0.1/bindings/python/capstone/__init__.py
+--- src/capstone-4.0.1/bindings/python/capstone/__init__.py	2019-01-10 13:45:56.000000000 +0000
++++ capstone-4.0.1/bindings/python/capstone/__init__.py	2019-10-18 20:56:27.509240524 +0000
+@@ -301,6 +301,7 @@
+ # - last-gasp attempt at some hardcoded paths on darwin and linux
+ 
+ _path_list = [os.getenv('LIBCAPSTONE_PATH', None),
++              '/usr/lib/',
+               pkg_resources.resource_filename(__name__, 'lib'),
+               join(split(__file__)[0], 'lib'),
+               '',


### PR DESCRIPTION
without this fix the following happens:
```
% python3 -m capstone
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 183, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.7/runpy.py", line 142, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/usr/lib/python3.7/runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "/usr/lib/python3.7/site-packages/capstone/__init__.py", line 315, in <module>
    raise ImportError("ERROR: fail to load the dynamic library.")
ImportError: ERROR: fail to load the dynamic library.
```