### PR TITLE
community/docker: upgrade to 19.03.4

### DIFF
--- a/community/docker/APKBUILD
+++ b/community/docker/APKBUILD
@@ -2,8 +2,8 @@
 # Contributor: Jake Buchholz <tomalok@gmail.com>
 # Maintainer: Jake Buchholz <tomalok@gmail.com>
 pkgname=docker
-pkgver=19.03.3
-_gitcommit=a872fc2f86c042e6992e17db6cdd9826c9c4232b	# https://github.com/docker/docker-ce/commits/v$pkgver
+pkgver=19.03.4
+_gitcommit=9013bf583a215dc1488d941f9b6f7f11e1ea899f	# https://github.com/docker/docker-ce/commits/v$pkgver
 pkgrel=0
 pkgdesc="Pack, ship and run any application as a lightweight container"
 url="https://www.docker.io/"
@@ -17,7 +17,7 @@ install="$pkgname.pre-install"
 # from components/engine/vendor.conf:
 #    grep libnetwork components/engine/vendor.conf
 #    grep cobra components/engine/vendor.conf
-_libnetwork_ver=fc5a7d91d54cc98f64fc28f9e288b46a0bee756c
+_libnetwork_ver=3eb39382bfa6a3c42f83674ab080ae13b0e34e5d
 _cobra_ver="0.0.3"
 
 # secfixes:
@@ -194,7 +194,7 @@ cli_vim() {
 	done
 }
 
-sha512sums="251756ca8b5d8eb962fde447fdab8307ce8013e14dc3b955387af5d8bdfdee16ea170ecb37a59e5900fa5c2e366f0d4080e79c28e5b8ef945cc67cb959d88eef  docker-19.03.3.tar.gz
-dea31fd82ab2d445fbd39fe15550a91f7e489a06f6dedd32ea1925f7e9a7971952d26b874f9687249609a0d204ea35da357e0a957b819df2026a0cf8109cb354  libnetwork-fc5a7d91d54cc98f64fc28f9e288b46a0bee756c.tar.gz
+sha512sums="bcf79f82eb8433b8c04ceb2fd90a80101b148dd819f5bbda83d535ff2fad65d08aee2f72ac41c38ce879f3970a087555bb7ab63c5bb071a3c1cd6aa177621cac  docker-19.03.4.tar.gz
+a21b9b5883056cf75dda9f229ff199e6daad63d94dcf75ebe3e21204bdeef89c41ddd5730bb6bb4387af9a84a8a81e7adfaf726b2fdd299d8aa9d6d35a096ce2  libnetwork-3eb39382bfa6a3c42f83674ab080ae13b0e34e5d.tar.gz
 c38db9432a168f913b41a1e1b11d84bedfade82ff70791be9d343a6cc86b8a05b18bae344d67ebd8bae4c98662db7ac664a9dc86fa9b9ad4aa5c96cbf0178efb  cobra-0.0.3.tar.gz
 6d3f1e71910a717d52820fbfe81663baadf3f5aa5ab39071d15c02ef49b51fe1978033e1cafc8482a468983bf872ab39d37759b82221778cbb2392a9eac41d65  docker-openrc-fixes.patch"


### PR DESCRIPTION
Rolls back libnetwork changes so DOCKER-USER iptables chain is back.

For more details, see https://github.com/docker/docker-ce/releases/tag/v19.03.4