### PR TITLE
main/gdb fixes gdb failing on internal musl signals

### DIFF
--- a/main/gdb/APKBUILD
+++ b/main/gdb/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=gdb
 pkgver=8.3.1
-pkgrel=0
+pkgrel=1
 pkgdesc="The GNU Debugger"
 url="https://www.gnu.org/software/gdb/"
 arch="all"
@@ -14,6 +14,7 @@ source="https://ftp.gnu.org/gnu/gdb/gdb-$pkgver.tar.xz
 	s390x-use-elf-gdb_fpregset_t.patch
 	ppc-musl.patch
 	ppc-ptregs.patch
+	musl-signals.patch
 	"
 
 build () {
@@ -58,4 +59,5 @@ package() {
 sha512sums="9053a2dc6b9eb921907afbc4cecc75d635aa76df5e8c4f0e5824ccf57cb206b299c19b127fff000b65c334826ff8304a54ff6098428365a8e997cca886c39e9a  gdb-8.3.1.tar.xz
 70e7d04e4d72461436da503b5bfa370c5779e03245c521f30e9779d5ff37dbb2d708b05f2afb27f43ad9defc44df4bd979d72f777e744851fdbf156295e1cc9f  s390x-use-elf-gdb_fpregset_t.patch
 04911f87904b62dd7662435f9182b20485afb29ddb3d6398a9d31fef13495f7b70639c77fdae3a40e2775e270d7cd40d0cfd7ddf832372b506808d33c8301e01  ppc-musl.patch
-b75e1c1ee503a1948a7d5b8d90427b5c7d38ded69978056cee0adca222771a5c95ed1ac73127fcae7b795ea94296344eee5fca47e4cd04b418c164a756fb0933  ppc-ptregs.patch"
+b75e1c1ee503a1948a7d5b8d90427b5c7d38ded69978056cee0adca222771a5c95ed1ac73127fcae7b795ea94296344eee5fca47e4cd04b418c164a756fb0933  ppc-ptregs.patch
+660317b7f886ac8d7fcdf44d214e109fdd818ed326afea8bf8046c0a39b36afa29751aefc2acd168207e40254f7340e98c0f34c5e6ad0e2e0a6b0a26cd86641b  musl-signals.patch"

--- a/main/gdb/musl-signals.patch
+++ b/main/gdb/musl-signals.patch
@@ -1,0 +1,18 @@
+diff --git gdb-7.12/gdb/common/signals.c gdb-fixed/gdb/common/signals.c
+index f84935d..413ff1d 100644
+--- gdb-7.12/gdb/common/signals.c
++++ gdb-fixed/gdb/common/signals.c
+@@ -31,6 +31,13 @@ struct gdbarch;
+    _available_ realtime signal, not the lowest supported; glibc takes
+    several for its own use.  */
+
++#ifndef __SIGRTMIN
++# define __SIGRTMIN 32
++#endif
++#ifndef __SIGRTMAX
++# define __SIGRTMAX _NSIG
++#endif
++
+ #ifndef REALTIME_LO
+ # if defined(__SIGRTMIN)
+ #  define REALTIME_LO __SIGRTMIN


### PR DESCRIPTION
without this patch when debugging a multithreaded binary gdb throws this:
`Thread 5 "a.out" received signal ?, Unknown signal.`
with this patch gdb throws:
`Thread 5 "qtwe" received signal SIG34, Real-time event 34.`
which can be handled by `handle SIG34 nostop noprint` and further on ignored.

For further info there is also this upstream bug: https://sourceware.org/bugzilla/show_bug.cgi?id=23616

The patch itself comes from smaeul on #musl