### PR TITLE
main/nodejs: upgrade to 12.13.0

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -44,7 +44,7 @@
 pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
-pkgver=10.16.3
+pkgver=12.13.0
 pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="https://nodejs.org/"
@@ -52,10 +52,9 @@ arch="all !mips64 !mips64el"
 license="MIT"
 depends="ca-certificates"
 depends_dev="libuv"
-# gold is needed for mksnapshot
-makedepends="$depends_dev python2 openssl-dev zlib-dev libuv-dev linux-headers
-	paxmark binutils-gold http-parser-dev ca-certificates c-ares-dev"
-subpackages="$pkgname-dev $pkgname-doc npm::noarch"
+makedepends="linux-headers python2 paxmark
+	zlib-dev libuv-dev openssl-dev c-ares-dev nghttp2-dev"
+subpackages="$pkgname-dev $pkgname-doc"
 provides="nodejs-lts=$pkgver"  # for backward compatibility
 replaces="nodejs-current nodejs-lts"  # nodejs-lts for backward compatibility
 source="https://nodejs.org/dist/v$pkgver/node-v$pkgver.tar.gz
@@ -68,7 +67,7 @@ prepare() {
 	default_prepare
 
 	# Remove bundled dependencies that we're not using.
-	rm -rf deps/http_parser deps/openssl deps/uv deps/zlib
+	rm -rf deps/cares deps/openssl deps/uv deps/zlib
 }
 
 build() {
@@ -83,11 +82,11 @@ build() {
 		--shared-zlib \
 		--shared-libuv \
 		--shared-openssl \
-		--shared-http-parser \
 		--shared-cares \
+		--shared-nghttp2 \
 		--openssl-use-def-ca-store
 
-	# We need run mksnapshot at build time so paxmark it early.
+	# we need run mksnapshot at build time so paxmark it early.
 	make -C out mksnapshot BUILDTYPE=Release
 	paxmark -m out/Release/mksnapshot
 	make
@@ -137,6 +136,6 @@ npm() {
 	mv "$pkgdir"/usr/lib/node_modules/npm "$subpkgdir"/usr/lib/node_modules/
 }
 
-sha512sums="c3a95d8810599db8e9a17932c55ff57223cf9e66028e776088420023ab7ba393e9b60518a189fcab46ca2597d213f8a6414abba282a73c9501c294dbc7b041e6  node-v10.16.3.tar.gz
-9d09a88074bf0093f35c5b610e73ebf4c5381df2a2b29feb69da1af0b18776a683b13f1276375bbcfc60936cc27769539e1f01b4ba94b22cad2d5f4daae14c46  dont-run-gyp-files-for-bundled-deps.patch
-4fd3f10bd82d1e851ed000169c2635c001a4a051283edf96f1efb2260e2d395199dd5843f79f1cff8f2c0c65462c44241c508ea67835dfbd9880d9196fae290a  link-with-libatomic-on-mips32.patch"
+sha512sums="0c1b8f9163ee5cb274666814eff1e2acc0ec286b5383a1e879fa8e587751a8fd11e891730dd099c1702b00c624bd172a683be7ceec3cc38981559dd19462d9c5  node-v12.13.0.tar.gz
+3c536776e2ecb5dc677bf711a09418085b3c5e931a6eaf647f47c28e194d5c6dec354d4e7a039a5805b30fc7e83140594851e18d9120f523eec2f93539eac4db  dont-run-gyp-files-for-bundled-deps.patch
+9f60928b53447f9590c7065bcdbdd4065d10a06e8451531615791a3bd7d14f9114807e5446e0ec00e2cb7a11a277050345e34636b199db2979d7f022b31ffde4  link-with-libatomic-on-mips32.patch"

--- a/main/nodejs/dont-run-gyp-files-for-bundled-deps.patch
+++ b/main/nodejs/dont-run-gyp-files-for-bundled-deps.patch
@@ -9,13 +9,12 @@ Node.js 7.2.0
 
 --- a/Makefile
 +++ b/Makefile
-@@ -123,8 +123,7 @@
- test-code-cache: with-code-cache
- 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --mode=$(BUILDTYPE_LOWER) code-cache
+@@ -141,7 +141,7 @@
+ 	echo "'test-code-cache' target is a noop"
  
--out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp \
--              deps/zlib/zlib.gyp deps/v8/gypfiles/toolchain.gypi \
-+out/Makefile: common.gypi deps/v8/gypfiles/toolchain.gypi \
-               deps/v8/gypfiles/features.gypi deps/v8/gypfiles/v8.gyp node.gyp \
-               config.gypi
+ out/Makefile: config.gypi common.gypi node.gyp \
+-	deps/uv/uv.gyp deps/http_parser/http_parser.gyp deps/zlib/zlib.gyp \
++	deps/http_parser/http_parser.gyp \
+ 	tools/v8_gypfiles/toolchain.gypi tools/v8_gypfiles/features.gypi \
+ 	tools/v8_gypfiles/inspector.gypi tools/v8_gypfiles/v8.gyp
  	$(PYTHON) tools/gyp_node.py -f make

--- a/main/nodejs/link-with-libatomic-on-mips32.patch
+++ b/main/nodejs/link-with-libatomic-on-mips32.patch
@@ -1,6 +1,20 @@
+--- a/tools/v8_gypfiles/v8.gyp
++++ b/tools/v8_gypfiles/v8.gyp
+@@ -2460,6 +2460,11 @@
+         }, {
+           'toolsets': ['target'],
+         }],
++        [ 'host_arch=="mips" or host_arch=="mipsel"', {
++          'link_settings': {
++            'libraries': [ '-latomic' ],
++          },
++        }],
+         ['component=="shared_library"', {
+           'direct_dependent_settings': {
+             'defines': [ 'USING_V8_PLATFORM_SHARED' ],
 --- a/node.gyp
 +++ b/node.gyp
-@@ -478,6 +478,11 @@
+@@ -315,6 +315,11 @@
        'msvs_disabled_warnings!': [4244],
  
        'conditions': [
@@ -9,6 +23,6 @@
 +            'libraries': [ '-latomic' ],
 +          },
 +        }],
-         [ 'node_code_cache_path!=""', {
-           'sources': [ '<(node_code_cache_path)' ]
-         }, {
+         [ 'node_intermediate_lib_type=="static_library" and '
+             'node_shared=="true" and OS=="aix"', {
+           # For AIX, shared lib is linked by static lib and .exp. In the


### PR DESCRIPTION
Node.js v12.13.0 ('Erbium') is the new LTS branch: https://nodejs.org/en/blog/release/v12.13.0/

This PR uses the build steps from the nodejs-current package as this already is updated to build v12 versions of Node.js