### PR TITLE
testing/php7-pecl-xlswriter: new aport

### DIFF
--- a/testing/php7-pecl-xlswriter/APKBUILD
+++ b/testing/php7-pecl-xlswriter/APKBUILD
@@ -1,0 +1,35 @@
+# Contributor: viest <dev@service.viest.me>
+# Maintainer: viest <dev@service.viest.me>
+pkgname="php7-pecl-xlswriter"
+_pkgreal=xlswriter
+pkgver="1.3.1"
+pkgrel=0
+pkgdesc="A PHP Extension for creating and reader XLSX files. "
+url="https://pecl.php.net/package/xlswriter"
+arch="all"
+license="BSD-2-Clause"
+depends="php7-common"
+makedepends="php7-dev zlib-dev"
+source="$pkgname-$pkgver.tar.gz::https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
+builddir="$srcdir"/$_pkgreal-$pkgver
+
+build() {
+    phpize7
+    ./configure \
+        --enable-reader \
+        --prefix=/usr \
+        --with-php-config=/usr/bin/php-config7
+    make
+}
+
+check() {
+    make NO_INTERACTION=1 REPORT_EXIT_STATUS=1 test
+}
+
+package() {
+    make INSTALL_ROOT="$pkgdir/" install
+    install -d "$pkgdir"/etc/php7/conf.d
+    echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/$_pkgreal.ini
+}
+
+sha512sums="9d14c9ae0d7a757fba9de4a4d241914778ce106d82f5349c239e2954bc95744714c5e7e87cfc87e28a733dbf917384e3b1afe1bfedf46ec94f5ce5dad963a5f7  php7-pecl-xlswriter-1.3.1.tar.gz"


### PR DESCRIPTION

https://pecl.php.net/package/xlswriter                          
xlswriter is a PHP C Extension that can be used to write text, numbers, formulas and hyperlinks to multiple worksheets in an Excel 2007+ XLSX file.