### PR TITLE
testing/py3-sshuttle: new aport

### DIFF
--- a/testing/py3-sshuttle/APKBUILD
+++ b/testing/py3-sshuttle/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Michael Pirogov <vbnet.ru@gmail.com>
+# Maintainer: Michael Pirogov <vbnet.ru@gmail.com>
+pkgname="py3-sshuttle"
+_pyname=sshuttle
+pkgver="0.78.5"
+pkgrel=0
+pkgdesc="Transparent proxy server that works as a poor man's VPN using ssh"
+url="https://github.com/sshuttle/sshuttle"
+arch="noarch"
+license="LGPL-2.1-or-later"
+depends="py3-setuptools"
+makedepends="py3-setuptools_scm"
+checkdepends="py3-pytest py3-pytest-mock py3-pytest-cov py3-pytest-runner py3-pytest-flake8"
+_pypiprefix="${_pyname%${_pyname#?}}"
+source="https://files.pythonhosted.org/packages/source/$_pypiprefix/$_pyname/$_pyname-$pkgver.tar.gz"
+
+builddir=$srcdir/$_pyname-$pkgver
+
+build() {
+	python3 setup.py build
+}
+
+check() {
+	python3 setup.py test
+}
+
+package() {
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+	chmod -R a+r "$pkgdir" # allow regular user
+}
+
+sha512sums="562acbf0e825ad41458c5b6065592a45b8bac92cd64b20619027fe4d0bec60a22c5191c7a7ed6b216d8cf5c9e027f58a6cdca69dd3a11ec6f6d348ef2f13bb38  sshuttle-0.78.5.tar.gz"


### PR DESCRIPTION
https://github.com/sshuttle/sshuttle
Transparent proxy server that works as a poor man's VPN. Forwards over ssh. Doesn't require admin. Works with Linux and MacOS. Supports DNS tunneling.