### PR TITLE
main/bind security upgrade to 9.14.7 (CVE-2019-6475, CVE-2019-6476)

### DIFF
--- a/main/bind/APKBUILD
+++ b/main/bind/APKBUILD
@@ -4,7 +4,7 @@
 # Contributor: Natanael Copa <ncopa@alpinelinux.org>
 # Maintainer: tcely <bind+aports@tcely.33mail.com>
 pkgname=bind
-pkgver=9.14.3
+pkgver=9.14.7
 _ver=${pkgver%_p*}
 _p=${pkgver#*_p}
 _major=${pkgver%%.*}
@@ -60,6 +60,9 @@ source="
 builddir="$srcdir/$pkgname-$_ver"
 
 # secfixes:
+#   9.14.7-r0:
+#     - CVE-2019-6475
+#     - CVE-2019-6476
 #   9.14.3-r0:
 #     - CVE-2019-6471
 #   9.14.1-r0:
@@ -246,7 +249,7 @@ libs() {
 #gpg_signature_extensions="sha512.asc"
 #gpgfingerprints="good:AE3F AC79 6711 EC59 FC00  7AA4 74BB 6B9A 4CBB 3D38"
 
-sha512sums="46974be2adea512c58b82184566ea5e8a9faf67aeb78ea33356861f0a7edce37eac05c21e8fbbc7f7db4e87404fe71ed59d9eac46e6e4758d95139a21891f437  bind-9.14.3.tar.gz
+sha512sums="e1837ebfbbc60487f5f0e67fb9e935588fd6e5ffe55cdc9dc77e3ce63cd6fc4f076f4eb282cc4f51701ddda3e51e8f15255db5a3841f9fe92a4fb4207d806740  bind-9.14.7.tar.gz
 2b32d1e7f62cd1e01bb4fdd92d15460bc14761b933d5acc463a91f5ecd4773d7477c757c5dd2738e8e433693592cf3f623ffc142241861c91848f01aa84640d6  bind.plugindir.patch
 7167dccdb2833643dfdb92994373d2cc087e52ba23b51bd68bd322ff9aca6744f01fa9d8a4b9cd8c4ce471755a85c03ec956ec0d8a1d4fae02124ddbed6841f6  bind.so_bsdcompat.patch
 ca779f52a0a96d774bbc4dbb4e62d136f483ce528693ac73b844435be73500d8495bfddce34534825b5f6fa3197601e3175918a076428bab52bbc33c509a816e  named.initd


### PR DESCRIPTION
https://github.com/ventz/docker-bind/issues/28

# CVE-2019-6475
```
CVE-2019-6475: A flaw in mirror zone validity checking can allow zone data to be spoofed

Versions affected: BIND 9.14.0 -> 9.14.6  and 9.15.0 -> 9.15.4
Severity: Medium
Exploitable: Remotely

Upgrade to the patched release most closely related to your current version of BIND:
BIND 9.14.7
BIND 9.15.5
```


# CVE-2019-6476
```
CVE-2019-6476: An error in QNAME minimization code can cause BIND to exit with an assertion failure

Versions: BIND 9.14.0 -> 9.14.6 and 9.15.0 -> 9.15.4
Severity: Medium
Exploitable: Remotely

Upgrade to the patched release most closely related to your current version of BIND:
BIND 9.14.7
BIND 9.15.5
```

ping: @tcely -  re: `bind (9.14.3-r0)` in upstream alpine for docker.