### PR TITLE
[3.10] community/openjdk11: Upgrade to 11.0.5

### DIFF
--- a/community/openjdk11/APKBUILD
+++ b/community/openjdk11/APKBUILD
@@ -1,9 +1,9 @@
 # Contributor: Simon Frankenberger <simon-alpine@fraho.eu>
 # Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
 pkgname=openjdk11
-pkgver=11.0.4_p4
+pkgver=11.0.5_p10
 _pkgver=${pkgver/_p/+}
-pkgrel=1
+pkgrel=0
 pkgdesc="Oracle OpenJDK 11"
 url="https://hg.openjdk.java.net/jdk-updates/jdk11u"
 arch="all !x86 !armhf !armv7" # openjdk10 is not yet available on 32 bit arches
@@ -307,7 +307,7 @@ _jdk() {
 	mv "$_fromroot/include" "$_toroot"
 }
 
-sha512sums="3f64c8911d31214c2f07b359b57c08117597cf22e078f640b4d741b8d60c5926c6bd22f2612b54502eb14afb30e5f2012f12a69f5b77aea6273fd36fc2a5bc24  jdk-11.0.4+4.tar.bz2
+sha512sums="0d52c78e217b79756be0fc6b3f9204bae254ec7b9ae10b6c3114463a9c028143807f4422711f0c02b81a034ae6e88fa2efc6bed85022720807344230a8aa12a6  jdk-11.0.5+10.tar.bz2
 66a9f2736da87de09d7bcc136771ab760bdba7847f3a23b2aa4efbc2e55ac8b49510c6d7afdf3f8d046c6e3fe9dca0d4cb0b5a38d7a3aebaf86fa0e3cc635eac  build.patch
 8c0f1f8d2a78ebb30a8460bc0ea9cd2349cea98819df1577bf7de19a1dd82d06a593f36b4e17c282ed53d23f00163e387e3dd1f3c9e5a092726e78c3aa710370  aarch64.patch
 d2903a5b3b9f82c4888416580f0b93888bf21ae0dac0ce6e926607a82a9e53b7e10e13f07a984f65dc116e81f58cd3844d6156088534c0059be8f6ee68e19a43  arm.patch


### PR DESCRIPTION
This PR updates OpenJDK11 to the latest release.

Release-Notes: https://www.oracle.com/technetwork/java/javase/11-0-5-oracle-relnotes-5592801.html