### PR TITLE
testing/openjfx12: New aport

### DIFF
--- a/testing/openjfx12/APKBUILD
+++ b/testing/openjfx12/APKBUILD
@@ -1,0 +1,241 @@
+# Contributor: Simon Frankenberger <simon-alpine@fraho.eu>
+# Maintainer: Simon Frankenberger <simon-alpine@fraho.eu>
+pkgname=openjfx12
+pkgver=12.0.2_p1
+_pkgver=${pkgver/_p/+}
+pkgrel=0
+pkgdesc="Open JavaFX 12"
+url="https://hg.openjdk.java.net/openjfx/12-dev/rt"
+arch="all !x86 !armhf !armv7" # openjdk11 is not yet available on 32 bit arches
+license="GPL-2.0-with-classpath-exception"
+depends="$pkgname-gtk3" # for the virtual openjfx12 package
+makedepends="binutils-gold
+	cmake
+	ninja
+	python2
+	gperf
+	openjdk11-jdk
+	alsa-lib-dev
+	ffmpeg-dev
+	freetype-dev
+	gtk+2.0-dev
+	gtk+3.0-dev
+	icu-dev
+	ruby-dev
+	sqlite-dev"
+subpackages="$pkgname-media:_media
+	$pkgname-web:_web
+	$pkgname-jmods:_jmods:noarch
+	$pkgname-src:_src:noarch
+	$pkgname-doc:_doc:noarch
+	$pkgname-gtk2:_gtk2
+	$pkgname-gtk3:_gtk3
+	$pkgname-libs:_libs
+	$pkgname-base:_base:noarch
+	$pkgname-dev:_dev:noarch"
+source="openjfx-$_pkgver.tar.bz2::http://hg.openjdk.java.net/openjfx/12-dev/rt/archive/$_pkgver.tar.bz2
+	https://archive.apache.org/dist/ant/binaries/apache-ant-1.8.2-bin.zip
+
+	configure-ant-home.patch
+	crosscompile.patch
+	disable-architecture-verification.patch
+	disable-assembler-on-unsupported-archs.patch
+	disable-jit-for-non-x86.patch
+	disable-sse2.patch
+	disable-webkit-sampling-profiler.patch
+	fix-arm32-build.patch
+	fix-arm64-build.patch
+	gcc-no-error.patch
+	use-system-icu.patch
+	webcore-linker-flags.patch
+	webkit-debug-level.patch"
+builddir="$srcdir/rt-$_pkgver"
+
+_ant_home="$srcdir/apache-ant-1.8.2/"
+_java_home="/usr/lib/java/openjfx12"
+
+sonameprefix="$pkgname:"
+ldpath="$_java_home/lib"
+
+prepare() {
+	default_prepare
+
+	# Create build properties
+	cat >gradle.properties <<EOF
+PROMOTED_BUILD_NUMBER=${_pkgver##*+}
+COMPANY_NAME=Alpine
+HUDSON_JOB_NAME=abuild
+RELEASE_SUFFIX=-alpine
+COMPILE_WEBKIT=true
+COMPILE_MEDIA=true
+# non standard, alpine patched properties
+ANT_HOME=$_ant_home
+EXTRA_CXXFLAGS=$CXXFLAGS
+EXTRA_LDFLAGS=$LDFLAGS
+PKG_CONFIG_PATH=$PKG_CONFIG_PATH
+PKG_CONFIG_SYSROOT_DIR=$PKG_CONFIG_SYSROOT_DIR
+CC=${CC:-gcc}
+CXX=${CXX:-g++}
+AR=${AR:-ar}
+EOF
+
+	# use system provided library for icu
+	rm -rf modules/javafx.web/src/main/native/Source/ThirdParty/icu
+
+	# make gradle wrapper executable
+	chmod +x ./gradlew
+}
+
+build() {
+	./gradlew publicExportsStandaloneLinux
+}
+
+check() {
+	./gradlew check -x :web:test
+}
+
+package() {
+	mkdir -p "$pkgdir/$_java_home/apps"
+	cp -r build/artifacts/javafx-sdk-12*/*                         "$pkgdir/$_java_home"
+	cp -r build/artifacts/javafx-jmods-12*/                        "$pkgdir/$_java_home/jmods"
+	cp -r build/artifacts/javafx-docs-12*/                         "$pkgdir/$_java_home/api"
+}
+
+_jmods() {
+	pkgdesc="$pkgdesc (jmods)"
+	depends=""
+	_fromroot="$pkgdir/$_java_home"
+	_toroot="$subpkgdir/$_java_home"
+
+	mkdir -p "$_toroot"
+	mv "$_fromroot/jmods" "$_toroot"
+}
+
+_src() {
+	pkgdesc="$pkgdesc (src)"
+	depends=""
+	_fromroot="$pkgdir/$_java_home"
+	_toroot="$subpkgdir/$_java_home"
+
+	mkdir -p "$_toroot/lib"
+	mv "$_fromroot/lib/src.zip" "$_toroot/lib/src.zip"
+}
+
+_doc() {
+	pkgdesc="$pkgdesc (Documentation)"
+	depends=""
+	_fromroot="$pkgdir/$_java_home"
+	_toroot="$subpkgdir/$_java_home"
+
+	mkdir -p "$_toroot"
+	mv "$_fromroot/api" "$_toroot"
+}
+
+_gtk2() {
+	pkgdesc="$pkgdesc (GTK 2)"
+	depends="$pkgname-base"
+	_fromroot="$pkgdir/$_java_home"
+	_toroot="$subpkgdir/$_java_home"
+
+	mkdir -p "$_toroot/lib"
+	mv "$_fromroot/lib/libglassgtk2.so"   "$_toroot/lib"
+}
+
+_gtk3() {
+	pkgdesc="$pkgdesc (GTK 3)"
+	depends="$pkgname-base"
+	_fromroot="$pkgdir/$_java_home"
+	_toroot="$subpkgdir/$_java_home"
+
+	mkdir -p "$_toroot/lib"
+	mv "$_fromroot/lib/libglassgtk3.so"   "$_toroot/lib"
+}
+
+_web() {
+	pkgdesc="$pkgdesc (web)"
+	depends="$pkgname-media"
+	_fromroot="$pkgdir/$_java_home"
+	_toroot="$subpkgdir/$_java_home"
+
+	mkdir -p "$_toroot/lib"
+	mkdir -p "$_toroot/jmods"
+	mkdir -p "$_toroot/legal"
+	mv \
+		"$_fromroot"/lib/libjfxwebkit.so \
+		"$_fromroot"/lib/javafx.web.jar \
+		"$_toroot/lib"
+	mv \
+		"$_fromroot"/jmods/javafx.web.jmod \
+		"$_toroot/jmods"
+	mv \
+		"$_fromroot/legal/javafx.web" \
+		"$_toroot/legal"
+}
+
+_media() {
+	pkgdesc="$pkgdesc (media)"
+	depends="$pkgname-libs"
+	_fromroot="$pkgdir/$_java_home"
+	_toroot="$subpkgdir/$_java_home"
+
+	mkdir -p "$_toroot/lib"
+	mkdir -p "$_toroot/jmods"
+	mkdir -p "$_toroot/legal"
+
+	mv \
+		"$_fromroot"/lib/libavplugin.so \
+		"$_fromroot"/lib/libgstreamer-lite.so \
+		"$_fromroot"/lib/libjfxmedia.so \
+		"$_fromroot"/lib/libfxplugins.so \
+		"$_fromroot"/lib/javafx.media.jar \
+		"$_toroot/lib"
+	mv \
+		"$_fromroot"/jmods/javafx.media.jmod \
+		"$_toroot/jmods"
+	mv \
+		"$_fromroot/legal/javafx.media" \
+		"$_toroot/legal/"
+}
+
+_libs() {
+	pkgdesc="$pkgdesc (libs)"
+	depends=""
+	_fromroot="$pkgdir/$_java_home"
+	_toroot="$subpkgdir/$_java_home"
+
+	mkdir -p "$_toroot/lib"
+	mv "$_fromroot"/lib/*.so   "$_toroot/lib"
+}
+
+_base() {
+	pkgdesc="$pkgdesc (base)"
+	depends="$pkgname-libs openjdk11-jre"
+	_fromroot="$pkgdir/$_java_home"
+	_toroot="$subpkgdir/$_java_home"
+
+	mkdir -p "$_toroot"
+	mv "$_fromroot/legal" "$_toroot"
+	mv "$_fromroot/lib"   "$_toroot"
+}
+
+_dev() {
+	pkgdesc="$pkgdesc (development)"
+	depends="$pkgname-jmods $pkgname-src $pkgname-doc $pkgname-media $pkgname-web"
+	mkdir -p "$subpkgdir"
+}
+
+sha512sums="35b45abf22922f3bea17a746ccad683f7d408ccd7e3aa27f8775d10fbeec72058c6c5828b4b587a0e8c57dbcdee3e9d465f6ecc414cf78b0b38261d8b0b93f9a  openjfx-12.0.2+1.tar.bz2
+b10a420f65dc47b609fd3b7b0fae5b0bd1ddfa6a52cad41bc729c03f7ff82a79092ec81a24cdae363b8b6ec05061267e3cc48a0e14e097d07757bc021cb5619b  apache-ant-1.8.2-bin.zip
+0c0c32bc1fcb1766c4149d16b07d5f656300a945208a1df5044c9ad2055c37ea7b348593ef88c529be0ff653daf662fc89b0b0e17acd58d95faafbf76de6b2a4  configure-ant-home.patch
+261b5c26c33030caa5350bf1833455f0b80f24a115876b95bba1490a42b9bfde43d36c0887ff15d34cd73e14b89d33633316d4baece480f4cfef2f9e147775f6  crosscompile.patch
+33a3e4067347a51f5a8dacd3827e6108aefce1dd6a8b39847b1af4652834ffc36d69622023f18cd6cad73c7a3e2e65b51cf14e57f96bf4152385838f82f99646  disable-architecture-verification.patch
+c508a813d8c21151396fd385b6807f757236d0ddb0e33db21368c61c554f845c01326c774eb515a52b098ec51c55f77d1b9c185fba8f6dd0bd4aaf2b32e09880  disable-assembler-on-unsupported-archs.patch
+b4a421f68a58d1e1f06344068fa835a07ba55e4ea73a9171fbb2a158c961ac0951ce6f29969f54ae5358f89f8f5284b78bcbf7a2c0727cda82d333d1ed4ca816  disable-jit-for-non-x86.patch
+7d8c16f132e31a2caa86391944824dfc74ffdcd689c5429310f1546e66726c800583fb5e2bface1ee663fc4576ded545f6118baac9a0c8b7c67a2d21050ff8c7  disable-sse2.patch
+3d443a7216b5f0df3eca1ceb7da9cb973f17d015707cad0203972dee8af1422c3204bd77af36571ded0827a56a21f2f355bb657c1e2ff42da2780667bc8cb995  disable-webkit-sampling-profiler.patch
+1c139f90a666638866ce3898d0cd2597f6f6ac9c93eb9cfcf0538c30c63949b9a2a1e9a737d06f6b611cf1b13aef9690c82a14fd6d0ec5f9685418190eefab37  fix-arm32-build.patch
+3f7ec35437b94e8773541b8cfbf99c2225540572b0c2ba50a954824aba9ad374085fb1b3532ff7bb53a02346b9b5ef7804acf980016815c56acdf587f6559613  fix-arm64-build.patch
+51d4cb484996d62b441ce3ee310703b4e16ad79b4574d936215cb8aea512d5f74511244f0e21d7dc0f56f30469803e3581742444da6db7261b93c60f34ffd91a  gcc-no-error.patch
+1ad39f3d53ab52696f8ec6c1039afa494949de1c261dd3c0f9f68372860da2a9c601b09c92b61c9099b399c7589f7f2e313bf93aabaabde0e294ddb7eec60b92  use-system-icu.patch
+2b8ec3bae8c93e5b6154988a5a7ac53477b7e86eea00d11cbd5ac1aaa5c87ddeaba239a65423549da29647f839c15d0f25126128f8fa619ea11ae907be646b44  webcore-linker-flags.patch
+232aebbd13e2e3291d1ae2bc0df282ade5e861e17fce9aaf378ea930655137a2f3fd6e8b43b1ffbc9c3fcc5b21ec36129bdff1070253d6642162e099b32fc171  webkit-debug-level.patch"

--- a/testing/openjfx12/configure-ant-home.patch
+++ b/testing/openjfx12/configure-ant-home.patch
@@ -1,0 +1,11 @@
+--- old/build.gradle
++++ new/build.gradle
+@@ -751,7 +751,7 @@
+          List<String>  params // parameters (usually -Dxxx=yyy)
+          ) {
+     // Try to use ANT_HOME
+-    String antHomeEnv = System.getenv("ANT_HOME")
++    String antHomeEnv = "$ANT_HOME"
+     String antHome = antHomeEnv != null ? cygpath(antHomeEnv) : null;
+     String ant = (antHome != null && !antHome.equals("")) ? "$antHome/bin/ant" : "ant";
+ 

--- a/testing/openjfx12/crosscompile.patch
+++ b/testing/openjfx12/crosscompile.patch
@@ -1,0 +1,224 @@
+--- old/build.gradle
++++ new/build.gradle
+@@ -2509,6 +2509,12 @@
+ 
+ }
+ 
++def pkgConfigEnv = [
++    PKG_CONFIG_PATH: "$PKG_CONFIG_PATH",
++    PKG_CONFIG_SYSROOT_DIR: "$PKG_CONFIG_SYSROOT_DIR"
++]
++
++
+ project(":media") {
+     configurations {
+         media
+@@ -2614,6 +2620,7 @@
+ 
+             doLast {
+                 exec {
++                    environment(pkgConfigEnv)
+                     commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/jfxmedia/projects/${projectDir}")
+                     args("JAVA_HOME=${JDK_HOME}", "GENERATED_HEADERS_DIR=${generatedHeadersDir}",
+                          "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=jfxmedia",
+@@ -2643,6 +2650,7 @@
+                 enabled = IS_COMPILE_MEDIA
+                 doLast {
+                     exec {
++                        environment(pkgConfigEnv)
+                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/gstreamer-lite")
+                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=gstreamer-lite",
+                              IS_64 ? "ARCH=x64" : "ARCH=x32", "CC=${mediaProperties.compiler}",
+@@ -2661,6 +2669,7 @@
+ 
+                 doLast {
+                     exec {
++                        environment(pkgConfigEnv)
+                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/fxplugins")
+                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=fxplugins",
+                              IS_64 ? "ARCH=x64" : "ARCH=x32",
+@@ -2789,6 +2798,7 @@
+                                 }
+                                 exec {
+                                     workingDir("$libavDir")
++                                    environment(pkgConfigEnv)
+                                     commandLine("make")
+                                 }
+                             }
+@@ -2857,6 +2867,7 @@
+                                 }
+                                 exec {
+                                     workingDir("$libavDir")
++                                    environment(pkgConfigEnv)
+                                     commandLine("make")
+                                 }
+                             }
+@@ -2928,6 +2939,7 @@
+                                 }
+                                 exec {
+                                     workingDir("$libavDir")
++                                    environment(pkgConfigEnv)
+                                     commandLine("make")
+                                 }
+                             }
+@@ -2962,6 +2974,7 @@
+                                 File dir = file(libavDir)
+                                 if (dir.exists()) {
+                                     exec {
++                                        environment(pkgConfigEnv)
+                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
+                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
+                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
+@@ -2976,6 +2989,7 @@
+                                 File dir = file(libavDir)
+                                 if (dir.exists()) {
+                                     exec {
++                                        environment(pkgConfigEnv)
+                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
+                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
+                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
+@@ -2990,6 +3004,7 @@
+                                 File dir = file(libavDir)
+                                 if (dir.exists()) {
+                                     exec {
++                                        environment(pkgConfigEnv)
+                                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
+                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
+                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
+@@ -3001,6 +3016,7 @@
+                         } else {
+                             // Building fxavcodec plugin (libav plugin)
+                             exec {
++                                environment(pkgConfigEnv)
+                                 commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
+                                 args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
+                                      "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
+@@ -3199,7 +3215,7 @@
+                 exec {
+                     workingDir("$webkitOutputDir")
+                     commandLine("perl", "$projectDir/src/main/native/Tools/Scripts/set-webkit-configuration", "--$webkitConfig")
+-                    environment(["WEBKIT_OUTPUTDIR" : webkitOutputDir])
++                    environment(["WEBKIT_OUTPUTDIR" : webkitOutputDir, "CC" : CC, "CXX" : CXX, "AR" : AR])
+                 }
+ 
+                 exec {
+@@ -3245,6 +3261,9 @@
+                         "JAVA_HOME"       : JDK_HOME,
+                         "WEBKIT_OUTPUTDIR" : webkitOutputDir,
+                         "PYTHONDONTWRITEBYTECODE" : "1",
++                        "CC" : CC,
++                        "CXX" : CXX,
++                        "AR" : AR
+                     ])
+ 
+                     def targetCpuBitDepthSwitch = ""
+--- old/buildSrc/linux.gradle
++++ new/buildSrc/linux.gradle
+@@ -54,11 +54,13 @@
+         commonFlags, "-I$JDK_HOME/include", "-I$JDK_HOME/include/linux", "-c",
+         "-ffunction-sections", "-fdata-sections",
+         IS_DEBUG_NATIVE ? ["-ggdb", "-DVERBOSE"] : ["-O2", "-DNDEBUG"]].flatten()
++ccFlags.addAll(ext.EXTRA_CXXFLAGS.split(" "))
+ def ccFlagsGTK3 = ccFlags
+ //ccFlags.addAll(["-Wnon-virtual-dtor", "-Woverloaded-virtual", "-std=c++0x"])
+ def linkFlags = ["-static-libgcc", "-static-libstdc++", "-shared", commonFlags,
+                  "-z", "relro",
+                  "-Wl,--gc-sections"].flatten()
++linkFlags.addAll(ext.EXTRA_LDFLAGS.split(" "))
+ 
+ if (IS_DEBUG_NATIVE) {
+     linkFlags += "-g"
+@@ -77,11 +79,17 @@
+ def gtk3LinkFlags = [ ];
+ LINUX.buildGTK3 = true
+ 
++def pkgConfigEnv = [
++    PKG_CONFIG_PATH: "$PKG_CONFIG_PATH",
++    PKG_CONFIG_SYSROOT_DIR: "$PKG_CONFIG_SYSROOT_DIR"
++]
++
+ // Create $buildDir/linux_tools.properties file and load props from it
+ setupTools("linux_gtk2",
+     { propFile ->
+         ByteArrayOutputStream results1 = new ByteArrayOutputStream();
+         exec {
++            environment(pkgConfigEnv)
+             commandLine("${toolchainDir}pkg-config", "--cflags", "gtk+-2.0", "gthread-2.0", "xtst")
+             setStandardOutput(results1);
+         }
+@@ -89,6 +97,7 @@
+ 
+         ByteArrayOutputStream results3 = new ByteArrayOutputStream();
+         exec {
++            environment(pkgConfigEnv)
+             commandLine("${toolchainDir}pkg-config", "--libs", "gtk+-2.0", "gthread-2.0", "xtst")
+             setStandardOutput(results3);
+         }
+@@ -110,6 +119,7 @@
+     { propFile ->
+         ByteArrayOutputStream results2 = new ByteArrayOutputStream();
+         exec {
++            environment(pkgConfigEnv)
+             commandLine("${toolchainDir}pkg-config", "--cflags", "gtk+-3.0", "gthread-2.0", "xtst")
+             setStandardOutput(results2);
+             ignoreExitValue(true)
+@@ -118,6 +128,7 @@
+ 
+         ByteArrayOutputStream results4 = new ByteArrayOutputStream();
+         exec {
++            environment(pkgConfigEnv)
+             commandLine("${toolchainDir}pkg-config", "--libs", "gtk+-3.0", "gthread-2.0", "xtst")
+             setStandardOutput(results4);
+             ignoreExitValue(true)
+@@ -144,6 +155,7 @@
+     { propFile ->
+         ByteArrayOutputStream results = new ByteArrayOutputStream();
+         exec {
++            environment(pkgConfigEnv)
+             commandLine "${toolchainDir}pkg-config", "--cflags", "pangoft2"
+             standardOutput = results
+         }
+@@ -151,6 +163,7 @@
+ 
+         results = new ByteArrayOutputStream();
+         exec {
++            environment(pkgConfigEnv)
+             commandLine "${toolchainDir}pkg-config", "--libs", "pangoft2"
+             standardOutput = results
+         }
+@@ -175,6 +188,7 @@
+     { propFile ->
+         ByteArrayOutputStream results = new ByteArrayOutputStream();
+         exec {
++            environment(pkgConfigEnv)
+             commandLine "${toolchainDir}pkg-config", "--cflags", "freetype2"
+             standardOutput = results
+         }
+@@ -182,6 +196,7 @@
+ 
+         results = new ByteArrayOutputStream();
+         exec {
++            environment(pkgConfigEnv)
+             commandLine "${toolchainDir}pkg-config", "--libs", "freetype2"
+             standardOutput = results
+         }
+@@ -199,8 +214,8 @@
+     }
+ )
+ 
+-def compiler = IS_COMPILE_PARFAIT ? "parfait-gcc" : "${toolchainDir}gcc";
+-def linker = IS_COMPILE_PARFAIT ? "parfait-g++" : "${toolchainDir}g++";
++def compiler = ext.CC;
++def linker = ext.CXX;
+ 
+ LINUX.glass = [:]
+ LINUX.glass.variants = ["glass", "glassgtk2"]
+@@ -316,7 +331,7 @@
+ LINUX.media = [:]
+ LINUX.media.compiler = compiler
+ LINUX.media.linker = linker
+-LINUX.media.ar = "${toolchainDir}ar"
++LINUX.media.ar = ext.AR
+ 
+ LINUX.webkit = [:]
+ LINUX.webkit.compiler = compiler

--- a/testing/openjfx12/disable-architecture-verification.patch
+++ b/testing/openjfx12/disable-architecture-verification.patch
@@ -1,0 +1,23 @@
+Description: Disable the architecture verification which is limited to i386 and amd64
+Author: Emmanuel Bourg <ebourg@apache.org>
+Forwarded: no
+Taken from: https://sources.debian.org/patches/openjfx/11.0.2+1-1/06-disable-architecture-verification.patch
+--- a/build.gradle
++++ b/build.gradle
+@@ -302,6 +302,7 @@
+ // at present building on PI is not supported, but we would only need to make
+ // some changes on assumptions on what should be built (like SWT / Swing) and
+ // such and we could probably make it work.
++/*
+ if (!IS_MAC && !IS_WINDOWS && !IS_LINUX) fail("Unsupported build OS ${OS_NAME}")
+ if (IS_WINDOWS && OS_ARCH != "x86" && OS_ARCH != "amd64") {
+     fail("Unknown and unsupported build architecture: $OS_ARCH")
+@@ -310,6 +311,7 @@
+ } else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64") {
+     fail("Unknown and unsupported build architecture: $OS_ARCH")
+ }
++*/
+ 
+ 
+ // Get the JDK_HOME automatically based on the version of Java used to execute gradle. Or, if specified,
+

--- a/testing/openjfx12/disable-assembler-on-unsupported-archs.patch
+++ b/testing/openjfx12/disable-assembler-on-unsupported-archs.patch
@@ -1,0 +1,19 @@
+Description: Disable assembler in WebKit on unsupported architectures
+Author: Emmanuel Bourg <ebourg@apache.org>
+Forwarded: no
+Taken from: https://sources.debian.org/patches/openjfx/11.0.2+1-1/07-disable-assembler-on-unsupported-archs.patch
+--- old/modules/javafx.web/src/main/native/Source/WTF/wtf/Platform.h
++++ new/modules/javafx.web/src/main/native/Source/WTF/wtf/Platform.h
+@@ -357,6 +357,12 @@
+ #endif
+ #endif
+ 
++#if !CPU(ARM_THUMB2) && !CPU(ARM_TRADITIONAL) && !CPU(X86) && !CPU(X86_64) && !CPU(SH4)
++#define ENABLE_ASSEMBLER 0
++#define ENABLE_JIT 0
++#define ENABLE_YARR_JIT 0
++#endif
++
+ /* ==== OS() - underlying operating system; only to be used for mandated low-level services like
+    virtual memory, not to choose a GUI toolkit ==== */
+ 

--- a/testing/openjfx12/disable-jit-for-non-x86.patch
+++ b/testing/openjfx12/disable-jit-for-non-x86.patch
@@ -1,0 +1,21 @@
+Taken from: https://sources.debian.org/patches/openjfx/11.0.2+1-1/disable-jit-for-non-x86.patch
+--- old/build.gradle
++++ new/build.gradle
+@@ -3231,11 +3231,17 @@
+                         cmakeArgs = " $cmakeArgs -DCMAKE_OSX_DEPLOYMENT_TARGET=$MACOSX_MIN_VERSION -DCMAKE_OSX_SYSROOT=$MACOSX_SDK_PATH"
+                     } else if (t.name == "linux") {
+                         cmakeArgs = " $cmakeArgs -DCMAKE_SYSTEM_NAME=Linux"
++                        /*
+                         if (IS_64) {
+                             cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=x86_64"
+                         } else {
+                             cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=i586"
+                         }
++                        */
++                        if ( OS_ARCH != "amd64" && OS_ARCH != "i386" ) {
++                            cmakeArgs = "$cmakeArgs -DENABLE_JIT=OFF"
++                        }
++                        cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=$OS_ARCH"
+                         // TODO: Use cflags and ldflags from all platforms
+                         def cFlags = webkitProperties.ccFlags?.join(' ') ?: ''
+                         def lFlags = webkitProperties.linkFlags?.join(' ') ?: ''

--- a/testing/openjfx12/disable-sse2.patch
+++ b/testing/openjfx12/disable-sse2.patch
@@ -1,0 +1,60 @@
+Description: Enable SSE2 on i386 and amd64 CPUs only
+Author: Emmanuel Bourg <ebourg@apache.org>
+Forwarded: no
+Taken from: https://sources.debian.org/patches/openjfx/11.0.2+1-1/08-disable-sse2.patch
+--- old/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
++++ new/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
+@@ -24,13 +24,16 @@
+          -fstack-protector       \
+          -Werror=implicit-function-declaration \
+          -Werror=trampolines     \
+-         -msse2                  \
+          -fbuiltin               \
+          -DHAVE_STDINT_H         \
+          -DLINUX                 \
+          -DGST_DISABLE_LOADSAVE  \
+          -DGSTREAMER_LITE \
+          -ffunction-sections -fdata-sections
++
++ifneq (,$(filter $(CARCH), x86 x86_64))
++    CFLAGS += -msse2
++endif
+ 
+ ifeq ($(BUILD_TYPE), Release)
+     CFLAGS += -Os
+--- old/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
++++ new/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
+@@ -21,7 +21,6 @@
+          -fstack-protector       \
+          -Werror=implicit-function-declaration \
+          -Werror=trampolines     \
+-         -msse2                  \
+          -fbuiltin               \
+          -DHAVE_STDINT_H         \
+          -DLINUX                 \
+@@ -32,6 +31,10 @@
+          -DGST_DISABLE_GST_DEBUG \
+          -DGSTREAMER_LITE \
+          -ffunction-sections -fdata-sections
++
++ifneq (,$(filter $(CARCH), x86 x86_64))
++    CFLAGS += -msse2
++endif
+ 
+ ifeq ($(BUILD_TYPE), Release)
+     CFLAGS += -Os
+--- old/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
++++ new/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
+@@ -43,8 +43,11 @@
+                   -fstack-protector \
+                   -Werror=implicit-function-declaration \
+                   -Werror=trampolines \
+-		  -msse2 \
+ 	          -DGSTREAMER_LITE
++
++ifneq (,$(filter $(CARCH), x86 x86_64))
++	CFLAGS += -msse2
++endif
+ 
+ 	PACKAGES_INCLUDES := $(shell pkg-config --cflags glib-2.0)
+ 	PACKAGES_LIBS := $(shell pkg-config --libs glib-2.0 gobject-2.0 gmodule-2.0 gthread-2.0)

--- a/testing/openjfx12/disable-webkit-sampling-profiler.patch
+++ b/testing/openjfx12/disable-webkit-sampling-profiler.patch
@@ -1,0 +1,15 @@
+Description: Disables the sampling profiler in WebKit (fails to build on arm64)
+Author: Emmanuel Bourg <ebourg@apache.org>
+Forwarded: not-needed
+Taken from: https://sources.debian.org/patches/openjfx/11.0.2+1-1/19-disable-webkit-sampling-profiler.patch
+--- old/modules/javafx.web/src/main/native/Source/cmake/WebKitFeatures.cmake
++++ new/modules/javafx.web/src/main/native/Source/cmake/WebKitFeatures.cmake
+@@ -163,7 +163,7 @@
+     WEBKIT_OPTION_DEFINE(ENABLE_RESOLUTION_MEDIA_QUERY "Toggle resolution media query support" PRIVATE OFF)
+     WEBKIT_OPTION_DEFINE(ENABLE_RESOURCE_USAGE "Toggle resource usage support" PRIVATE OFF)
+     WEBKIT_OPTION_DEFINE(ENABLE_RUBBER_BANDING "Toggle rubber banding support" PRIVATE OFF)
+-    WEBKIT_OPTION_DEFINE(ENABLE_SAMPLING_PROFILER "Toggle sampling profiler support" PRIVATE ON)
++    WEBKIT_OPTION_DEFINE(ENABLE_SAMPLING_PROFILER "Toggle sampling profiler support" PRIVATE OFF)
+     WEBKIT_OPTION_DEFINE(ENABLE_SERVICE_CONTROLS "Toggle service controls support" PRIVATE OFF)
+     WEBKIT_OPTION_DEFINE(ENABLE_SERVICE_WORKER "Toggle ServiceWorker support" PRIVATE OFF)
+     WEBKIT_OPTION_DEFINE(ENABLE_SMOOTH_SCROLLING "Toggle smooth scrolling" PRIVATE ON)

--- a/testing/openjfx12/fix-arm32-build.patch
+++ b/testing/openjfx12/fix-arm32-build.patch
@@ -1,0 +1,69 @@
+--- old/buildSrc/linux.gradle
++++ new/buildSrc/linux.gradle
+@@ -45,10 +45,6 @@
+         "-fstack-protector",
+         "-Wextra", "-Wall", "-Wformat-security", "-Wno-unused", "-Wno-parentheses", "-Werror=implicit-function-declaration", "-Werror=trampolines"] // warning flags
+ 
+-if (!IS_64) {
+-    commonFlags += "-m32"
+-}
+-
+ // Specify the compilation parameters and link parameters
+ def ccFlags = [
+         commonFlags, "-I$JDK_HOME/include", "-I$JDK_HOME/include/linux", "-c",
+--- old/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
++++ new/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
+@@ -64,11 +64,6 @@
+ LDFLAGS  += $(shell pkg-config --libs libavcodec libavformat)
+ endif
+ 
+-ifeq ($(ARCH), x32)
+-    CFLAGS += -m32
+-    LDFLAGS += -m32
+-endif
+-
+ SOURCES = av/fxavcodecplugin.c  \
+           av/avelement.c        \
+           av/decoder.c          \
+--- old/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
++++ new/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
+@@ -55,11 +55,6 @@
+           -z relro \
+           -static-libgcc -static-libstdc++ -Wl,--gc-sections
+ 
+-ifeq ($(ARCH), x32)
+-    CFLAGS += -m32
+-    LDFLAGS += -m32
+-endif
+-
+ SOURCES = fxplugins.c                        \
+           progressbuffer/progressbuffer.c    \
+           progressbuffer/hlsprogressbuffer.c \
+--- old/modules/javafx.media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile
++++ new/modules/javafx.media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile
+@@ -80,11 +80,6 @@
+           -z relro \
+           -static-libgcc -static-libstdc++ -Wl,--gc-sections
+ 
+-ifeq ($(ARCH), x32)
+-    CFLAGS += -m32
+-    LDFLAGS += -m32
+-endif
+-
+ SOURCES = \
+ gstreamer/gst/gst.c \
+             gstreamer/gst/gstallocator.c \
+--- old/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
++++ new/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
+@@ -75,11 +75,6 @@
+ 	CFLAGS += -g -Wall -D_DEBUG
+ endif
+ 
+-ifeq ($(ARCH), x32)
+-    CFLAGS += -m32
+-    LDFLAGS += -m32
+-endif
+-
+ CPP_SOURCES = \
+         jni/com_sun_media_jfxmedia_logging_Logger.cpp           \
+         jni/JavaBandsHolder.cpp 				\

--- a/testing/openjfx12/fix-arm64-build.patch
+++ b/testing/openjfx12/fix-arm64-build.patch
@@ -1,0 +1,21 @@
+From: Iain Lane <iain.lane@canonical.com>
+Description: Fix arm64 build
+ Add AArch64 support in Platform.h
+ Don't use COMPARE_AND_SWAP on arm64; it produces invalid asm.
+ Fix some other areas where disabling JIT doesn't work.
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=752735
+Forwarded: no
+Taken from: https://sources.debian.org/patches/openjfx/11.0.2+1-1/fix-arm64-build.patch
+--- old/modules/javafx.web/src/main/native/Source/WTF/wtf/Platform.h
++++ new/modules/javafx.web/src/main/native/Source/WTF/wtf/Platform.h
+@@ -146,7 +146,9 @@
+ #if (defined(__arm64__) && defined(__APPLE__)) || defined(__aarch64__)
+ #define WTF_CPU_ARM64 1
+ #define WTF_CPU_KNOWN 1
+-
++#if defined(__AARCH64BE__)
++#define WTF_CPU_BIG_ENDIAN 1
++#endif
+ #if defined(__arm64e__)
+ #define WTF_CPU_ARM64E 1
+ #endif

--- a/testing/openjfx12/gcc-no-error.patch
+++ b/testing/openjfx12/gcc-no-error.patch
@@ -1,0 +1,31 @@
+The compilation with GCC 8.2 produces a lot of warnings which are treated as errors by default.
+Let the warnings be warnings and pretend we don't care.
+--- old/buildSrc/linux.gradle
++++ new/buildSrc/linux.gradle
+@@ -233,7 +233,7 @@
+ LINUX.glass.glass = [:]
+ LINUX.glass.glass.nativeSource = ft_gtk_launcher.getFiles()
+ LINUX.glass.glass.compiler = compiler
+-LINUX.glass.glass.ccFlags = [ccFlags, gtk2CCFlags,  "-Werror"].flatten()
++LINUX.glass.glass.ccFlags = [ccFlags, gtk2CCFlags,  "-Wno-error"].flatten()
+ LINUX.glass.glass.linker = linker
+ LINUX.glass.glass.linkFlags = [linkFlags, "-lX11", "-ldl" ].flatten()
+ LINUX.glass.glass.lib = "glass"
+@@ -241,7 +241,7 @@
+ LINUX.glass.glassgtk2 = [:]
+ LINUX.glass.glassgtk2.nativeSource =  ft_gtk.getFiles()
+ LINUX.glass.glassgtk2.compiler = compiler
+-LINUX.glass.glassgtk2.ccFlags = [ccFlags, gtk2CCFlags, "-Werror"].flatten()
++LINUX.glass.glassgtk2.ccFlags = [ccFlags, gtk2CCFlags, "-Wno-error"].flatten()
+ LINUX.glass.glassgtk2.linker = linker
+ LINUX.glass.glassgtk2.linkFlags = [linkFlags, gtk2LinkFlags ].flatten()
+ LINUX.glass.glassgtk2.lib = "glassgtk2"
+@@ -249,7 +249,7 @@
+ LINUX.glass.glassgtk3 = [:]
+ LINUX.glass.glassgtk3.nativeSource =  ft_gtk.getFiles()
+ LINUX.glass.glassgtk3.compiler = compiler
+-LINUX.glass.glassgtk3.ccFlags = [ccFlags, gtk3CCFlags, "-Werror"].flatten()
++LINUX.glass.glassgtk3.ccFlags = [ccFlags, gtk3CCFlags, "-Wno-error"].flatten()
+ LINUX.glass.glassgtk3.linker = linker
+ LINUX.glass.glassgtk3.linkFlags = [linkFlags, gtk3LinkFlags ].flatten()
+ LINUX.glass.glassgtk3.lib = "glassgtk3"

--- a/testing/openjfx12/use-system-icu.patch
+++ b/testing/openjfx12/use-system-icu.patch
@@ -1,0 +1,39 @@
+This patch disables usage of the bundled icu library as alpine
+already has 63.1
+This saves about 30 MB on the final jfxwebkit.so
+--- old/modules/javafx.web/src/main/native/Source/PlatformJava.cmake
++++ new/modules/javafx.web/src/main/native/Source/PlatformJava.cmake
+@@ -1,4 +1,3 @@
+ add_subdirectory(ThirdParty/sqlite)
+-add_subdirectory(ThirdParty/icu)
+ add_subdirectory(ThirdParty/libxml)
+ add_subdirectory(ThirdParty/libxslt)
+--- old/modules/javafx.web/src/main/native/Source/WTF/wtf/unicode/java/UnicodeJava.h
++++ new/modules/javafx.web/src/main/native/Source/WTF/wtf/unicode/java/UnicodeJava.h
+@@ -18,7 +18,7 @@
+ #if PLATFORM(JAVA) && OS(WINDOWS)
+ typedef wchar_t UChar;
+ #else
+-typedef uint16_t UChar;
++//typedef uint16_t UChar;
+ #endif
+ 
+ // #ifdef UChar32
+@@ -26,7 +26,7 @@
+ // #endif
+ 
+ #ifndef __UMACHINE_H__ //XXX: recheck
+-typedef uint32_t UChar32;
++//typedef uint32_t UChar32;
+ #endif
+ 
+ #define U_MASK(x) ((uint32_t)1<<(x))
+--- old/modules/javafx.web/src/main/native/Tools/CMakeLists.txt
++++ new/modules/javafx.web/src/main/native/Tools/CMakeLists.txt
+@@ -48,6 +48,3 @@
+     add_subdirectory(TestWebKitAPI)
+ endif ()
+ 
+-if (PORT STREQUAL "Java")
+-    add_subdirectory(DumpRenderTree/java)
+-endif ()

--- a/testing/openjfx12/webcore-linker-flags.patch
+++ b/testing/openjfx12/webcore-linker-flags.patch
@@ -1,0 +1,16 @@
+Description: Use the gold linker with memory saving options to avoid build failures caused by lack of RAM
+Author: Emmanuel Bourg <ebourg@apache.org>
+Forwarded: no
+Bug-Debian: https://bugs.debian.org/857464
+Taken from: https://sources.debian.org/patches/openjfx/11.0.2+1-1/23-webcore-linker-flags.patch
+--- old/modules/javafx.web/src/main/native/Source/WebCore/PlatformJava.cmake
++++ new/modules/javafx.web/src/main/native/Source/WebCore/PlatformJava.cmake
+@@ -314,7 +314,7 @@
+     set_target_properties(JFXWebKit PROPERTIES LINK_FLAGS "-exported_symbols_list ${WEBCORE_DIR}/mapfile-macosx")
+     set(JFXWebKit_EXTERNAL_DEP "${WEBCORE_DIR}/mapfile-macosx")
+ elseif (UNIX)
+-    set_target_properties(JFXWebKit PROPERTIES LINK_FLAGS "-Xlinker -version-script=${WEBCORE_DIR}/mapfile-vers -Wl,--no-undefined")
++    set_target_properties(JFXWebKit PROPERTIES LINK_FLAGS "-Xlinker -version-script=${WEBCORE_DIR}/mapfile-vers -fuse-ld=gold -Wl,--no-undefined -Wl,--no-keep-memory -Wl,--no-map-whole-files -Wl,--no-keep-files-mapped")
+     set(JFXWebKit_EXTERNAL_DEP "${WEBCORE_DIR}/mapfile-vers")
+ elseif (WIN32)
+     # Adds version information to jfxwebkit.dll created by Gradle build, see JDK-8166265

--- a/testing/openjfx12/webkit-debug-level.patch
+++ b/testing/openjfx12/webkit-debug-level.patch
@@ -1,0 +1,16 @@
+Description: Use the -g1 debugging level instead of -g when compiling WebKit
+ to reduce the memory used and avoid build failures caused by lack of RAM.
+Author: Emmanuel Bourg <ebourg@apache.org>
+Forwarded: not-needed
+Taken from: https://sources.debian.org/patches/openjfx/11.0.2+1-1/25-webkit-debug-level.patch
+--- a/modules/javafx.web/src/main/native/Source/cmake/WebKitCompilerFlags.cmake
++++ b/modules/javafx.web/src/main/native/Source/cmake/WebKitCompilerFlags.cmake
+@@ -89,6 +89,7 @@
+ 
+ if (COMPILER_IS_GCC_OR_CLANG)
+     WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-fno-strict-aliasing)
++    WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-g1)
+ 
+     # clang-cl.exe impersonates cl.exe so some clang arguments like -fno-rtti are
+     # represented using cl.exe's options and should not be passed as flags, so
+


### PR DESCRIPTION
This PR add OpenJFX to alpine, the latest JavaFX release developed by the community.
Note: Builds on Drone and Travis fail because the build takes extremely long.