### PR TITLE
main/valgrind: enhance suppression file

### DIFF
--- a/main/valgrind/APKBUILD
+++ b/main/valgrind/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=valgrind
 pkgver=3.15.0
-pkgrel=0
+pkgrel=1
 pkgdesc="A tool to help find memory-management problems in programs"
 url="http://valgrind.org/"
 arch="all"
@@ -74,7 +74,7 @@ package() {
 }
 
 sha512sums="5695d1355226fb63b0c80809ed43bb077b6eed4d427792d9d7ed944c38b557a84fe3c783517b921e32f161228e10e4625bea0550faa4685872bb4454450cfa7f  valgrind-3.15.0.tar.bz2
-05ecb7bf5a1f5b5ec0eedea7c4f9f4ad1745ceeccf01b84057852effcd81f2ace95fd3fd8f93640756ffbcec3ed4859824f8d921dc92e7dc46526aa9bd9c3d56  musl.supp
+49df485f158a7f4d354b2ed0d46dcc691f0490f50913c83dabfdd513b47ef1045f140fd59f54b560df05e4f3a4aba63de7124553b396189fa3ac89c908831e45  musl.supp
 09a992c39e755d92894f79cd95ed2a6e84daa3ac1af1fe8907ebb2c90dca27d224aae882389c2c246aff8a6bb7d8b9c57a6ca62bd7b36f6fb43e182471186821  activate-musl-supp.patch
 d59a10db9037e120df2ee94a103402ca95a79abee9d8be63e4e1bca29c82dca775cc402a79b854ec11a2160a4d2da202c237369418e221d1925267ea2613fd5d  uclibc.patch
 9ee297d1b2b86891584443ad0caadc4977e1447979611ccf1cc55dbee61911b0b063bc4ad936d86c451cedae410cb3219b5a088b2ad0aa17df182d564fe36cfe  arm.patch"

--- a/main/valgrind/musl.supp
+++ b/main/valgrind/musl.supp
@@ -17,9 +17,30 @@
    musl-dynlink-false-positive2
    Memcheck:Leak
    fun:calloc
+   fun:load_direct_deps
+   fun:load_deps
+   fun:load_deps
+   fun:__dls3
+   fun:__dls2
+}
+
+{
+   musl-dynlink-false-positive3
+   Memcheck:Leak
+   fun:calloc
    fun:load_library
    fun:load_preload
    fun:__dls3
    fun:__dls2b
+   fun:__dls2
+}
+
+{
+   musl-dynlink-false-positive4
+   Memcheck:Leak
+   fun:calloc
+   fun:load_library
+   fun:load_preload
+   fun:__dls3
    fun:__dls2
 }


### PR DESCRIPTION
On edge the supression file added in #8779 seems to be insufficient.

Reconsider the test program from #8779:

```C
#include <stdio.h>
#include <string.h>
#include <stdlib.h>

int
main(void)
{
	char *str;

	str = strdup("foo");
	printf("%s\n", str);
	free(str);
	return 0;
}
```

Running it with `valgrind-3.15.0-r0` from edge yields the following output:

```
$ cc -o test test.c
$ valgrind --leak-check=full --show-leak-kinds=all ./test
==30586== HEAP SUMMARY:
==30586==     in use at exit: 468 bytes in 4 blocks
==30586==   total heap usage: 6 allocs, 2 frees, 512 bytes allocated
==30586==
==30586== 48 bytes in 3 blocks are still reachable in loss record 1 of 2
==30586==    at 0x48A16F0: calloc (vg_replace_malloc.c:762)
==30586==    by 0x4059056: load_direct_deps (dynlink.c:1182)
==30586==    by 0x4059056: load_deps (dynlink.c:1209)
==30586==    by 0x4059056: load_deps (dynlink.c:1205)
==30586==    by 0x4059A32: __dls3 (dynlink.c:1845)
==30586==    by 0x40593B0: __dls2 (dynlink.c:1650)
==30586==    by 0x4056FAC: ??? (in /lib/ld-musl-x86_64.so.1)
==30586==
==30586== 420 bytes in 1 blocks are still reachable in loss record 2 of 2
==30586==    at 0x48A16F0: calloc (vg_replace_malloc.c:762)
==30586==    by 0x4058E1E: load_library (dynlink.c:1122)
==30586==    by 0x4059A71: load_preload (dynlink.c:1272)
==30586==    by 0x4059A71: __dls3 (dynlink.c:1844)
==30586==    by 0x40593B0: __dls2 (dynlink.c:1650)
==30586==    by 0x4056FAC: ??? (in /lib/ld-musl-x86_64.so.1)
==30586==
==30586== LEAK SUMMARY:
==30586==    definitely lost: 0 bytes in 0 blocks
==30586==    indirectly lost: 0 bytes in 0 blocks
==30586==      possibly lost: 0 bytes in 0 blocks
==30586==    still reachable: 468 bytes in 4 blocks
==30586==         suppressed: 0 bytes in 0 blocks
==30586==
```

The current suppression file only covers the case where `__dls2` calls
`__dls2b` and `__dls2b` calls `__dls3`. Unfourtunatly, the stacktrace
from above doesn't include a call to `__dls2b`, this PR adds the calltrace
to the suppression file.