### PR TITLE
main/haproxy: upgrade to 2.0.8

### DIFF
--- a/main/haproxy/APKBUILD
+++ b/main/haproxy/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Jeff Bilyk <jbilyk@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=haproxy
-pkgver=2.0.7
+pkgver=2.0.8
 _pkgmajorver=${pkgver%.*}
 pkgrel=0
 pkgdesc="A TCP/HTTP reverse proxy for high availability environments"
@@ -49,6 +49,6 @@ package() {
 	        "$pkgdir"/etc/haproxy/haproxy.cfg
 }
 
-sha512sums="3257bb90555cb7ccf1b5ef71815f8258598aa87239ec46a24d250929811bd49fef21e4c2d0a12ee9f7aca2cca33367f972e4e62e9b01274b8c644a97e4353574  haproxy-2.0.7.tar.gz
+sha512sums="61cb7274d96bde1c542e9f0cd5c9dc8f7ee5fa710eb8867bd70040718ce696505d533713f867199d6f0780fe0f8c7e989bf25ee93e806c0e3fe6f593382814a6  haproxy-2.0.8.tar.gz
 3ab277bf77fe864ec6c927118dcd70bdec0eb3c54535812d1c3c0995fa66a3ea91a73c342edeb8944caeb097d2dd1a7761099182df44af5e3ef42de6e2176d26  haproxy.initd
 26bc8f8ac504fcbaec113ecbb9bb59b9da47dc8834779ebbb2870a8cadf2ee7561b3a811f01e619358a98c6c7768e8fdd90ab447098c05b82e788c8212c4c41f  haproxy.cfg"


### PR DESCRIPTION
Refs
- http://git.haproxy.org/?p=haproxy-2.0.git;a=commit;h=60e6020c8f2c9efc5f67208efaeafd09c719a29b
- https://www.mail-archive.com/haproxy@formilux.org/msg35168.html