### PR TITLE
main/varnish: upgrade to 6.3.1

### DIFF
--- a/main/varnish/APKBUILD
+++ b/main/varnish/APKBUILD
@@ -3,7 +3,7 @@
 # Contributor: V.Krishn <vkrishn4@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=varnish
-pkgver=6.3.0
+pkgver=6.3.1
 pkgrel=0
 pkgdesc="High-performance HTTP accelerator"
 url="https://www.varnish-cache.org/"
@@ -99,7 +99,7 @@ geoip() {
 		"$subpkgdir"/usr/lib/varnish/plugins/maxminddb.vcl
 }
 
-sha512sums="887c27b498bdac1ddb01759569078e2394a0a754ab3842f866fd06724f154950accebe80c5412b0ba5dd70ff9f687ce4bad3161d1bd32448e0d50aa01c6f96b1  varnish-6.3.0.tgz
+sha512sums="2fee11bcd01f53464b53e8271c2aec08233af078f2e9a2600cd82efbf646b3fd48160ebb2add09e1fb4f43e18e61f21a2408e351eeb2a567179733a3efbc3ddc  varnish-6.3.1.tgz
 2123668169b055f2d88f9b5b8e0877ca8b3cbfcd61e03d91fd7d0513b3267e4ef01a4d858cc6a3298cca0a49aaea2f92ff4fd9c0baf52a6c67b452a53f7e54d0  musl-include-vpf.patch
 c51c8964880990c2b01807b2a38d886b146736a918bda9ea2e032c50085bf6745cab3cccb4ee4c561ab936a8b7cfb278cfcb758543ea6c605c15b8973c9f10ce  musl-include-vsb.patch
 5ac7867e85cbd721f903c524ed4b524423d9dada4acfeefb0e543214a208828df5cc4efe2f012991bea6b38c2b223c24b17d3890ec4ed2c57d2b441b8e5a6900  varnishd.initd


### PR DESCRIPTION
Ref https://varnish-cache.org/security/VSV00004.html