### PR TITLE
testing/assimp: upgrade to 5.0.0

### DIFF
--- a/testing/assimp/01-rm-revision-test.patch
+++ b/testing/assimp/01-rm-revision-test.patch
@@ -1,12 +1,14 @@
---- src/test/unit/utVersion.cpp.orig
-+++ src/test/unit/utVersion.cpp
-@@ -65,7 +65,6 @@
+--- assimp-5.0.0/test/unit/utVersion.cpp.orig	2019-10-27 02:51:11.128925442 +0000
++++ assimp-5.0.0/test/unit/utVersion.cpp	2019-10-27 02:54:22.554333936 +0000
+@@ -66,9 +66,9 @@
      EXPECT_NE( aiGetCompileFlags(), 0U );
  }
-
+ 
 -TEST_F( utVersion, aiGetVersionRevisionTest ) {
 +/*TEST_F( utVersion, aiGetVersionRevisionTest ) {
      EXPECT_NE( aiGetVersionRevision(), 0U );
 -}
--
 +}*/
+ 
+ TEST_F( utVersion, aiGetBranchNameTest ) {
+     EXPECT_NE( nullptr, aiGetBranchName() );

--- a/testing/assimp/02-fix-ssize-32bit.patch
+++ b/testing/assimp/02-fix-ssize-32bit.patch
@@ -1,0 +1,40 @@
+From 0fb68863ffb226044200e5ed1c70eb882be60f78 Mon Sep 17 00:00:00 2001
+From: kuba-- <kuba@sourced.tech>
+Date: Mon, 11 Nov 2019 20:37:48 +0100
+Subject: [PATCH] Add __DEFINED_ssize_t for alpine gcc
+
+---
+ src/zip.h | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/src/zip.h b/src/zip.h
+index c9463a1..a48d64d 100644
+--- a/contrib/zip/src/zip.h
++++ b/contrib/zip/src/zip.h
+@@ -20,8 +20,9 @@ extern "C" {
+ #endif
+ 
+ #if !defined(_SSIZE_T_DEFINED) && !defined(_SSIZE_T_DEFINED_) &&               \
+-    !defined(_SSIZE_T) && !defined(_SSIZE_T_) && !defined(__ssize_t_defined)
+-#define _SSIZE_T
++    !defined(__DEFINED_ssize_t) && !defined(__ssize_t_defined) &&              \
++    !defined(_SSIZE_T) && !defined(_SSIZE_T_)
++
+ // 64-bit Windows is the only mainstream platform
+ // where sizeof(long) != sizeof(void*)
+ #ifdef _WIN64
+@@ -29,6 +30,14 @@ typedef long long ssize_t; /* byte count or error */
+ #else
+ typedef long ssize_t; /* byte count or error */
+ #endif
++
++#define _SSIZE_T_DEFINED
++#define _SSIZE_T_DEFINED_
++#define __DEFINED_ssize_t
++#define __ssize_t_defined
++#define _SSIZE_T
++#define _SSIZE_T_
++
+ #endif
+ 
+ #ifndef MAX_PATH

--- a/testing/assimp/APKBUILD
+++ b/testing/assimp/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Russ Webber <russ@rw.id.au>
 # Maintainer: Russ Webber <russ@rw.id.au>
 pkgname=assimp
-pkgver=4.1.0
+pkgver=5.0.0
 pkgrel=0
 pkgdesc="Open Asset Import Library imports and exports 3D model formats."
 url="http://www.assimp.org/"
@@ -10,7 +10,8 @@ license="BSD-3-Clause"
 makedepends="cmake zlib-dev minizip-dev"
 subpackages="$pkgname-dev"
 source="assimp-$pkgver.tar.gz::https://github.com/assimp/assimp/archive/v$pkgver.tar.gz
-        01-rm-revision-test.patch"
+        01-rm-revision-test.patch
+        02-fix-ssize-32bit.patch"
 
 build() {
   if [ "$CBUILD" != "$CHOST" ]; then
@@ -39,5 +40,6 @@ package() {
   rm -vf "$pkgdir"/usr/lib/libIrrXML.a
 }
 
-sha512sums="5f1292de873ae16c9921d1d44f2871474d74c0ddfd76cc928a7d9b3e03aa6eca4cc72af0513da20a86d09c55d48646e610fd4a4f2b05364f08ad09cf27cbc67a  assimp-4.1.0.tar.gz
-4cbcf0d8c91a5d727de25af2444f9a997e111b8cc3cfb951ec7f1ad4f4d0a1bce5300a853a3788a3da787245fd373bfbf9a0f767ec902343e47c366c070b28f3  01-rm-revision-test.patch"
+sha512sums="0f73b6e961cd8455d6b6c8c10ed8b99485d846c96377b5d4fcc3b83f737647207c1306aa3dd51dad9654fbfa61bfe1119b34646f90288ae7ecab45efa6fa418a  assimp-5.0.0.tar.gz
+535a80c5899a2994735e7b17b4e3fdb3ff2b53e64c09ec8fcab1dbcea2ad696fed50aeb1667a3c4e00a8a3ddf411d33ec1d36fcb256e26f02cf951f0e2c83a73  01-rm-revision-test.patch
+19a52d40887de945b74efe0f7e105a02eab306e6295d2d9b32f76bed9596c93ab954118df6e7afdafd2488e0e1feb666c734a8eb56e0edc34510efe3f8f99374  02-fix-ssize-32bit.patch"


### PR DESCRIPTION
Patched issue was reported last version, but it wasn't actually fixed. https://github.com/assimp/assimp/issues/2732