### PR TITLE
testing/dtools: new aport

### DIFF
--- a/testing/dtools/APKBUILD
+++ b/testing/dtools/APKBUILD
@@ -1,0 +1,41 @@
+# Contributor: Mathias LANG <pro.mathias.lang@gmail.com>
+# Maintainer: Mathias LANG <pro.mathias.lang@gmail.com>
+pkgname=dtools
+pkgver=2.088.1
+pkgrel=0
+pkgdesc="Ancillary tools for the D programming language compiler"
+url="https://github.com/dlang/tools"
+arch="x86_64"
+license="BSL-1.0"
+makedepends="ldc ldc-static"
+subpackages="$pkgname-ddemangle $pkgname-rdmd"
+source="tools-${pkgver}.tar.gz::https://github.com/dlang/tools/archive/v${pkgver}.tar.gz"
+builddir="$srcdir/tools-$pkgver/"
+
+build() {
+	ldmd2 -O -release "$builddir/ddemangle.d" -od"$builddir" -ofddemangle
+	ldmd2 -O -release "$builddir/rdmd.d" -od"$builddir" -ofrdmd
+}
+
+check() {
+	ldmd2 -run "$builddir/rdmd_test.d" --rdmd-default-compiler=ldmd2 "$builddir/rdmd"
+}
+
+package() {
+	depends="$pkgname-ddemangle $pkgname-rdmd"
+
+	install -s -D "$builddir/ddemangle" "$pkgdir/usr/bin/ddemangle"
+	install -s -D "$builddir/rdmd" "$pkgdir/usr/bin/rdmd"
+}
+
+ddemangle() {
+	mkdir -p "$subpkgdir/usr/bin/"
+	mv "$pkgdir/usr/bin/ddemangle" "$subpkgdir/usr/bin/ddemangle"
+}
+
+rdmd() {
+	mkdir -p "$subpkgdir/usr/bin/"
+	mv "$pkgdir/usr/bin/rdmd" "$subpkgdir/usr/bin/rdmd"
+}
+
+sha512sums="288739656404e345e683e6692a6478a03af8455d3e3ad56d3ba22e1d7d9cb1e5156f70116e4444138c798bfa28cf4b38263b6cd32a8d2483417e8ae51192ea65  tools-2.088.1.tar.gz"


### PR DESCRIPTION
```
Add two very common tools: ddemangle (to demangle D symbols),
and rdmd, a simple build tool on top of the compiler.
```

CC @Cogitri 
Extracted from: https://github.com/dlang/tools