### PR TITLE
main/gcc: Add support for the D programming language

### DIFF
--- a/main/gcc/400-dlang-phobos.patch
+++ b/main/gcc/400-dlang-phobos.patch
@@ -1,0 +1,1216 @@
+diff -Nurp a/libphobos/libdruntime/core/stdc/fenv.d b/libphobos/libdruntime/core/stdc/fenv.d
+--- a/libphobos/libdruntime/core/stdc/fenv.d	2019-10-28 06:37:30.000000000 +0900
++++ b/libphobos/libdruntime/core/stdc/fenv.d	2019-10-28 08:08:09.000000000 +0900
+@@ -375,7 +375,44 @@ else version (Solaris)
+ }
+ else version (CRuntime_Musl)
+ {
+-    version (X86_64)
++    version (AArch64)
++    {
++        struct fenv_t
++        {
++            uint __fpcr;
++            uint __fpsr;
++        }
++        alias uint fexcept_t;
++    }
++    else version (ARM)
++    {
++        import core.stdc.config : c_ulong;
++
++        struct fenv_t
++        {
++            c_ulong __cw;
++        }
++        alias c_ulong fexcept_t;
++    }
++    else version (IBMZ_Any)
++    {
++        alias uint fenv_t;
++        alias uint fexcept_t;
++    }
++    else version (MIPS_Any)
++    {
++        struct fenv_t
++        {
++            uint __cw;
++        }
++        alias ushort fexcept_t;
++    }
++    else version (PPC_Any)
++    {
++        alias double fenv_t;
++        alias uint fexcept_t;
++    }
++    else version (X86_Any)
+     {
+         struct fenv_t
+         {
+@@ -391,7 +428,8 @@ else version (CRuntime_Musl)
+             uint   __data_offset;
+             ushort __data_selector;
+             ushort __unused5;
+-            uint   __mxcsr;
++            version (X86_64)
++                uint __mxcsr;
+         }
+         alias ushort fexcept_t;
+     }
+diff -Nurp a/libphobos/libdruntime/core/sys/posix/dirent.d b/libphobos/libdruntime/core/sys/posix/dirent.d
+--- a/libphobos/libdruntime/core/sys/posix/dirent.d	2019-10-28 06:37:30.000000000 +0900
++++ b/libphobos/libdruntime/core/sys/posix/dirent.d	2019-10-28 08:08:09.000000000 +0900
+@@ -506,7 +506,7 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
+-
++    int readdir_r(DIR*, dirent*, dirent**);
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -591,6 +591,8 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
++    void   seekdir(DIR*, c_long);
++    c_long telldir(DIR*);
+ }
+ else version (CRuntime_UClibc)
+ {
+diff -Nurp a/libphobos/libdruntime/core/sys/posix/pthread.d b/libphobos/libdruntime/core/sys/posix/pthread.d
+--- a/libphobos/libdruntime/core/sys/posix/pthread.d	2019-10-28 06:37:30.000000000 +0900
++++ b/libphobos/libdruntime/core/sys/posix/pthread.d	2019-10-28 08:08:09.000000000 +0900
+@@ -854,7 +854,15 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
++    enum PTHREAD_BARRIER_SERIAL_THREAD = -1;
+
++    int pthread_barrier_destroy(pthread_barrier_t*);
++    int pthread_barrier_init(pthread_barrier_t*, in pthread_barrierattr_t*, uint);
++    int pthread_barrier_wait(pthread_barrier_t*);
++    int pthread_barrierattr_destroy(pthread_barrierattr_t*);
++    int pthread_barrierattr_getpshared(in pthread_barrierattr_t*, int*);
++    int pthread_barrierattr_init(pthread_barrierattr_t*);
++    int pthread_barrierattr_setpshared(pthread_barrierattr_t*, int);
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -880,6 +888,55 @@ else
+ int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
+ int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
+ */
++version (CRuntime_Glibc)
++{
++    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
++    int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
++}
++else version (FreeBSD)
++{
++    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
++    int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
++}
++else version (DragonFlyBSD)
++{
++    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
++    int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
++}
++else version (NetBSD)
++{
++    int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
++}
++else version (OpenBSD)
++{
++    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
++    int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
++}
++else version (Darwin)
++{
++}
++else version (Solaris)
++{
++    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
++    int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
++}
++else version (CRuntime_Bionic)
++{
++}
++else version (CRuntime_Musl)
++{
++    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
++    int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
++}
++else version (CRuntime_UClibc)
++{
++    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
++    int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
++}
++else
++{
++    static assert(false, "Unsupported platform");
++}
+
+ //
+ // Spinlock (SPI)
+@@ -948,7 +1005,11 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
+-
++    int pthread_spin_destroy(pthread_spinlock_t*);
++    int pthread_spin_init(pthread_spinlock_t*, int);
++    int pthread_spin_lock(pthread_spinlock_t*);
++    int pthread_spin_trylock(pthread_spinlock_t*);
++    int pthread_spin_unlock(pthread_spinlock_t*);
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -1187,7 +1248,7 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
+-
++    int pthread_getcpuclockid(pthread_t, clockid_t*);
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -1256,7 +1317,9 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
+-
++    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
++    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
++    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -1693,7 +1756,12 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
+-
++    int pthread_condattr_getpshared(pthread_condattr_t*, int*);
++    int pthread_condattr_setpshared(pthread_condattr_t*, int);
++    int pthread_mutexattr_getpshared(pthread_mutexattr_t*, int*);
++    int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
++    int pthread_rwlockattr_getpshared(pthread_rwlockattr_t*, int*);
++    int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
+ }
+ else version (CRuntime_UClibc)
+ {
+diff -Nurp a/libphobos/libdruntime/core/sys/posix/pwd.d b/libphobos/libdruntime/core/sys/posix/pwd.d
+--- a/libphobos/libdruntime/core/sys/posix/pwd.d	2019-10-28 06:37:30.000000000 +0900
++++ b/libphobos/libdruntime/core/sys/posix/pwd.d	2019-10-28 08:08:09.000000000 +0900
+@@ -172,7 +172,8 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
+-    struct passwd {
++    struct passwd
++    {
+         char *pw_name;
+         char *pw_passwd;
+         uid_t pw_uid;
+@@ -257,6 +258,8 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
++    int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
++    int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -325,8 +328,9 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
+-    int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+-    int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
++    void    endpwent();
++    passwd* getpwent();
++    void    setpwent();
+ }
+ else version (CRuntime_UClibc)
+ {
+diff -Nurp a/libphobos/libdruntime/core/sys/posix/signal.d b/libphobos/libdruntime/core/sys/posix/signal.d
+--- a/libphobos/libdruntime/core/sys/posix/signal.d	2019-10-28 07:12:22.000000000 +0900
++++ b/libphobos/libdruntime/core/sys/posix/signal.d	2019-10-28 08:08:09.000000000 +0900
+@@ -1136,55 +1136,57 @@ else version (NetBSD)
+     enum SIG_UNBLOCK = 2;
+     enum SIG_SETMASK = 3;
+
+-    union sigval_t {
+-        int     sival_int;
+-        void    *sival_ptr;
+-    };
+-    struct _rt{
+-        pid_t   _pid;
+-        uid_t   _uid;
+-        sigval_t        _value;
+-    };
+-    struct _child{
+-        pid_t   _pid;
+-        uid_t   _uid;
+-        int     _status;
+-        clock_t _utime;
+-        clock_t _stime;
+-    };
+-   struct _fault{
+-        void   *_addr;
+-        int     _trap;
+-        int     _trap2;
+-        int     _trap3;
+-    };
+-    struct _poll{
+-        long    _band;
+-        int     _fd;
+-    };
+-    union _reason{
+-        _rt rt;
+-        _child child;
+-        _fault fault;
+-        _poll poll;
+-    };
+-    struct _ksiginfo {
++    union sigval_t
++    {
++        int   sival_int;
++        void* sival_ptr;
++    }
++
++    struct _ksiginfo
++    {
+         int     _signo;
+         int     _code;
+         int     _errno;
+-/+#ifdef _LP64
+-        /* In _LP64 the union starts on an 8-byte boundary. */
+-        int     _pad;
+-#endif+/
+-        _reason reason;
+-    };
++        version (D_LP64)
++            int _pad;
+
++        union reason_t
++        {
++            struct rt_t
++            {
++                pid_t    _pid;
++                uid_t    _uid;
++                sigval_t _value;
++            } rt_t _rt;
++            struct child_t
++            {
++                pid_t   _pid;
++                uid_t   _uid;
++                int     _status;
++                clock_t _utime;
++                clock_t _stime;
++            } child_t _child;
++            struct fault_t
++            {
++                void* _addr;
++                int   _trap;
++                int   _trap2;
++                int   _trap3;
++            } fault_t fault;
++            struct poll_t
++            {
++                c_long _band;
++                int  _fd;
++            } poll_t _poll;
++        }
++        reason_t _reason;
++    }
+
+     union siginfo_t
+     {
+-        ubyte[128] si_pad;/* Total size; for future expansion */
++        ubyte[128] si_pad;
+         _ksiginfo _info;
+-        @property ref c_long si_band() return { return _info.reason.poll._band; }
++        @property ref c_long si_band() return { return _info._reason._poll._band; }
+     }
+
+     enum SI_USER    = 0;
+@@ -1589,27 +1591,53 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
+-    struct sigset_t {
+-        ulong[128/long.sizeof] __bits;
++    struct sigset_t
++    {
++        c_ulong[128/c_long.sizeof] __bits;
+     }
+
+-    enum SIG_BLOCK      = 0;
+-    enum SIG_UNBLOCK    = 1;
+-    enum SIG_SETMASK    = 2;
++    version (MIPS_Any)
++    {
++        enum SIG_BLOCK      = 1;
++        enum SIG_UNBLOCK    = 2;
++        enum SIG_SETMASK    = 3;
++    }
++    else
++    {
++        enum SIG_BLOCK      = 0;
++        enum SIG_UNBLOCK    = 1;
++        enum SIG_SETMASK    = 2;
++    }
+
+-    struct siginfo_t {
+-        int si_signo, si_errno, si_code;
+-        union __si_fields_t {
+-            char[128 - 2*int.sizeof - long.sizeof] __pad = 0;
+-            struct __si_common_t {
+-                union __first_t {
+-                    struct __piduid_t {
++    struct siginfo_t
++    {
++        int si_signo;
++        version (MIPS_Any)  // __SI_SWAP_ERRNO_CODE
++        {
++            int si_code;
++            int si_errno;
++        }
++        else
++        {
++            int si_errno;
++            int si_code;
++        }
++        union __si_fields_t
++        {
++            char[128 - 2*int.sizeof - c_long.sizeof] __pad = 0;
++            struct __si_common_t
++            {
++                union __first_t
++                {
++                    struct __piduid_t
++                    {
+                         pid_t si_pid;
+                         uid_t si_uid;
+                     }
+                     __piduid_t __piduid;
+
+-                    struct __timer_t {
++                    struct __timer_t
++                    {
+                         int si_timerid;
+                         int si_overrun;
+                     }
+@@ -1617,11 +1645,14 @@ else version (CRuntime_Musl)
+                 }
+                 __first_t __first;
+
+-                union __second_t {
++                union __second_t
++                {
+                     sigval si_value;
+-                    struct __sigchld_t {
++                    struct __sigchld_t
++                    {
+                         int si_status;
+-                        clock_t si_utime, si_stime;
++                        clock_t si_utime;
++                        clock_t si_stime;
+                     }
+                     __sigchld_t __sigchld;
+                 }
+@@ -1629,11 +1660,14 @@ else version (CRuntime_Musl)
+             }
+             __si_common_t __si_common;
+
+-            struct __sigfault_t {
++            struct __sigfault_t
++            {
+                 void *si_addr;
+                 short si_addr_lsb;
+-                union __first_t {
+-                    struct __addr_bnd_t {
++                union __first_t
++                {
++                    struct __addr_bnd_t
++                    {
+                         void *si_lower;
+                         void *si_upper;
+                     }
+@@ -1644,13 +1678,15 @@ else version (CRuntime_Musl)
+             }
+             __sigfault_t __sigfault;
+
+-            struct __sigpoll_t {
+-                long si_band;
++            struct __sigpoll_t
++            {
++                c_long si_band;
+                 int si_fd;
+             }
+             __sigpoll_t __sigpoll;
+
+-            struct __sigsys_t {
++            struct __sigsys_t
++            {
+                 void *si_call_addr;
+                 int si_syscall;
+                 uint si_arch;
+@@ -3030,7 +3066,177 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
+-    enum SA_RESTART     = 0x10000000;
++    version (MIPS_Any)
++    {
++        enum SIGPOLL   = 22;
++        enum SIGPROF   = 29;
++        enum SIGSYS    = 12;
++        enum SIGTRAP   = 5;
++        enum SIGVTALRM = 28;
++        enum SIGXCPU   = 30;
++        enum SIGXFSZ   = 31;
++
++        enum SA_ONSTACK   = 0x08000000;
++        enum SA_RESETHAND = 0x80000000;
++        enum SA_RESTART   = 0x10000000;
++        enum SA_SIGINFO   = 8;
++        enum SA_NOCLDWAIT = 0x10000;
++        enum SA_NODEFER   = 0x40000000;
++    }
++    else
++    {
++        enum SIGPOLL   = 29;
++        enum SIGPROF   = 27;
++        enum SIGSYS    = 31;
++        enum SIGTRAP   = 5;
++        enum SIGVTALRM = 26;
++        enum SIGXCPU   = 24;
++        enum SIGXFSZ   = 25;
++
++        enum SA_ONSTACK   = 0x08000000;
++        enum SA_RESETHAND = 0x80000000;
++        enum SA_RESTART   = 0x10000000;
++        enum SA_SIGINFO   = 4;
++        enum SA_NOCLDWAIT = 2;
++        enum SA_NODEFER   = 0x40000000;
++    }
++
++    enum SS_ONSTACK = 1;
++    enum SS_DISABLE = 2;
++
++    version (ARM)
++    {
++        enum MINSIGSTKSZ = 2048;
++        enum SIGSTKSZ    = 8192;
++    }
++    else version (AArch64)
++    {
++        enum MINSIGSTKSZ = 6144;
++        enum SIGSTKSZ    = 12288;
++    }
++    else version (IBMZ_Any)
++    {
++        enum MINSIGSTKSZ = 4096;
++        enum SIGSTKSZ    = 10240;
++    }
++    else version (MIPS_Any)
++    {
++        enum MINSIGSTKSZ = 2048;
++        enum SIGSTKSZ    = 8192;
++    }
++    else version (PPC_Any)
++    {
++        enum MINSIGSTKSZ = 4096;
++        enum SIGSTKSZ    = 10240;
++    }
++    else version (X86_Any)
++    {
++        enum MINSIGSTKSZ = 2048;
++        enum SIGSTKSZ    = 8192;
++    }
++    else
++        static assert(0, "unimplemented");
++
++    //ucontext_t (defined in core.sys.posix.ucontext)
++    //mcontext_t (defined in core.sys.posix.ucontext)
++
++    version (MIPS_Any)
++    {
++        struct stack_t
++        {
++            void*  ss_sp;
++            size_t ss_size;
++            int    ss_flags;
++        }
++    }
++    else
++    {
++        struct stack_t
++        {
++            void*  ss_sp;
++            int    ss_flags;
++            size_t ss_size;
++        }
++    }
++
++    enum
++    {
++        ILL_ILLOPC = 1,
++        ILL_ILLOPN,
++        ILL_ILLADR,
++        ILL_ILLTRP,
++        ILL_PRVOPC,
++        ILL_PRVREG,
++        ILL_COPROC,
++        ILL_BADSTK
++    }
++
++    enum
++    {
++        FPE_INTDIV = 1,
++        FPE_INTOVF,
++        FPE_FLTDIV,
++        FPE_FLTOVF,
++        FPE_FLTUND,
++        FPE_FLTRES,
++        FPE_FLTINV,
++        FPE_FLTSUB
++    }
++
++    enum
++    {
++        SEGV_MAPERR = 1,
++        SEGV_ACCERR
++    }
++
++    enum
++    {
++        BUS_ADRALN = 1,
++        BUS_ADRERR,
++        BUS_OBJERR
++    }
++
++    enum
++    {
++        TRAP_BRKPT = 1,
++        TRAP_TRACE
++    }
++
++    enum
++    {
++        CLD_EXITED = 1,
++        CLD_KILLED,
++        CLD_DUMPED,
++        CLD_TRAPPED,
++        CLD_STOPPED,
++        CLD_CONTINUED
++    }
++
++    enum
++    {
++        POLL_IN = 1,
++        POLL_OUT,
++        POLL_MSG,
++        POLL_ERR,
++        POLL_PRI,
++        POLL_HUP
++    }
++
++    sigfn_t bsd_signal(int sig, sigfn_t func);
++    sigfn_t sigset(int sig, sigfn_t func);
++
++  nothrow:
++  @nogc:
++    sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
++    sigfn_t2 sigset(int sig, sigfn_t2 func);
++
++    int killpg(pid_t, int);
++    int sigaltstack(const scope stack_t*, stack_t*);
++    int sighold(int);
++    int sigignore(int);
++    int siginterrupt(int, int);
++    int sigpause(int);
++    int sigrelse(int);
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -3483,7 +3689,7 @@ else version (CRuntime_Musl)
+         int sigev_notify;
+         void function(sigval) sigev_notify_function;
+         pthread_attr_t *sigev_notify_attributes;
+-        char[56 - 3 * long.sizeof] __pad = void;
++        char[56 - 3 * c_long.sizeof] __pad = void;
+     }
+ }
+ else version (CRuntime_UClibc)
+diff -Nurp a/libphobos/libdruntime/core/sys/posix/sys/mman.d b/libphobos/libdruntime/core/sys/posix/sys/mman.d
+--- a/libphobos/libdruntime/core/sys/posix/sys/mman.d	2019-10-28 07:12:22.000000000 +0900
++++ b/libphobos/libdruntime/core/sys/posix/sys/mman.d	2019-10-28 08:08:09.000000000 +0900
+@@ -128,6 +128,15 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
++    enum
++    {
++        POSIX_MADV_NORMAL = 0,
++        POSIX_MADV_RANDOM = 1,
++        POSIX_MADV_SEQUENTIAL = 2,
++        POSIX_MADV_WILLNEED = 3,
++        POSIX_MADV_DONTNEED = 4,
++    }
++    int posix_madvise(void *, size_t, int);
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -611,6 +620,14 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
++    enum
++    {
++        MCL_CURRENT = 1,
++        MCL_FUTURE = 2,
++    }
++
++    int mlockall(int);
++    int munlockall();
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -674,6 +691,8 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
++    int mlock(in void*, size_t);
++    int munlock(in void*, size_t);
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -776,6 +795,8 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
++    int shm_open(in char*, int, mode_t);
++    int shm_unlink(in char*);
+ }
+ else version (CRuntime_UClibc)
+ {
+diff -Nurp a/libphobos/libdruntime/core/sys/posix/sys/socket.d b/libphobos/libdruntime/core/sys/posix/sys/socket.d
+--- a/libphobos/libdruntime/core/sys/posix/sys/socket.d	2019-10-28 07:12:22.000000000 +0900
++++ b/libphobos/libdruntime/core/sys/posix/sys/socket.d	2019-10-28 08:08:09.000000000 +0900
+@@ -1755,10 +1755,10 @@ else version (CRuntime_Musl)
+         c_ulong     __ss_align;
+     }
+
+-    enum {
++    enum
++    {
+         SOCK_STREAM = 1,
+         SOCK_DGRAM = 2,
+-        SOCK_RAW = 3,
+         SOCK_RDM = 4,
+         SOCK_SEQPACKET = 5,
+         SOCK_DCCP = 6,
+@@ -2187,6 +2187,10 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
++    enum
++    {
++        SOCK_RAW    = 3
++    }
+ }
+ else version (CRuntime_UClibc)
+ {
+diff -Nurp a/libphobos/libdruntime/core/sys/posix/sys/types.d b/libphobos/libdruntime/core/sys/posix/sys/types.d
+--- a/libphobos/libdruntime/core/sys/posix/sys/types.d	2019-10-28 07:12:22.000000000 +0900
++++ b/libphobos/libdruntime/core/sys/posix/sys/types.d	2019-10-28 08:07:51.000000000 +0900
+@@ -112,20 +112,25 @@ version (CRuntime_Glibc)
+ }
+ else version (CRuntime_Musl)
+ {
+-    alias long      blksize_t;
+-    alias ulong     nlink_t;
+-    alias long      dev_t;
+-    alias long      blkcnt_t;
+-    alias ulong     ino_t;
+-    alias long      off_t;
+-    alias long      _Addr;
+-    alias int       pid_t;
+-    alias uint      uid_t;
+-    alias uint      gid_t;
+-    alias long      time_t;
+-    alias long      clock_t;
+-    alias ulong     pthread_t;
+-    alias _Addr     ssize_t;
++    alias c_long     blksize_t;
++    alias c_ulong    nlink_t;
++    alias long       dev_t;
++    alias long       blkcnt_t;
++    alias ulong      ino_t;
++    alias long       off_t;
++    alias int        pid_t;
++    alias uint       uid_t;
++    alias uint       gid_t;
++    version (D_X32)
++        alias long   time_t;
++    else
++        alias c_long time_t;
++    alias c_long     clock_t;
++    alias c_ulong    pthread_t;
++    version (D_LP64)
++        alias c_long ssize_t;
++    else
++        alias int    ssize_t;
+ }
+ else version (Darwin)
+ {
+@@ -420,7 +425,10 @@ else version (CRuntime_Musl)
+   }
+     alias uint mode_t;
+     alias uint id_t;
+-    alias long suseconds_t;
++    version (D_X32)
++        alias long susseconds_t;
++    else
++        alias c_long suseconds_t;
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -723,40 +746,77 @@ version (CRuntime_Glibc)
+ }
+ else version (CRuntime_Musl)
+ {
+-    version (X86_64) {
++    version (D_LP64)
++    {
+         union pthread_attr_t
+         {
+             int[14] __i;
+             ulong[7] __s;
+         }
++
+         union pthread_cond_t
+         {
+             int[12] __i;
+             void*[6] __p;
+         }
++
+         union pthread_mutex_t
+         {
+             int[10] __i;
+             void*[5] __p;
+         }
++
+         union pthread_rwlock_t
+         {
+             int[14] __i;
+             void*[7] __p;
+         }
+-        struct pthread_rwlockattr_t
++    }
++    else
++    {
++        union pthread_attr_t
++        {
++            int[9] __i;
++            uint[9] __s;
++        }
++
++        union pthread_cond_t
++        {
++            int[12] __i;
++            void*[12] __p;
++        }
++
++        union pthread_mutex_t
+         {
+-            uint[2] __attr;
++            int[6] __i;
++            void*[6] __p;
++        }
++
++        union pthread_rwlock_t
++        {
++            int[8] __i;
++            void*[8] __p;
+         }
+-        alias uint pthread_key_t;
+-        alias uint pthread_condattr_t;
+-        alias uint pthread_mutexattr_t;
+-        alias int pthread_once_t;
+     }
+-    else
++
++    struct pthread_rwlockattr_t
+     {
+-        static assert (false, "Architecture unsupported");
++        uint[2] __attr;
+     }
++
++    alias uint pthread_key_t;
++
++    struct pthread_condattr_t
++    {
++        uint __attr;
++    }
++
++    struct pthread_mutexattr_t
++    {
++        uint __attr;
++    }
++
++    alias int pthread_once_t;
+ }
+ else version (Darwin)
+ {
+@@ -1300,6 +1360,27 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
++    version (D_LP64)
++    {
++        union pthread_barrier_t
++        {
++            int[8] __i;
++            void*[4] __p;
++        }
++    }
++    else
++    {
++        union pthread_barrier_t
++        {
++            int[5] __i;
++            void*[5] __p;
++        }
++    }
++
++    struct pthread_barrierattr_t
++    {
++        uint __attr;
++    }
+ }
+ else version (CRuntime_UClibc)
+ {
+@@ -1351,6 +1432,10 @@ else version (CRuntime_UClibc)
+ {
+     alias int pthread_spinlock_t; // volatile
+ }
++else version (CRuntime_Musl)
++{
++    alias int pthread_spinlock_t;
++}
+
+ //
+ // Timer (TMR)
+diff -Nurp a/libphobos/libdruntime/core/sys/posix/sys/wait.d b/libphobos/libdruntime/core/sys/posix/sys/wait.d
+--- a/libphobos/libdruntime/core/sys/posix/sys/wait.d	2019-10-28 07:12:22.000000000 +0900
++++ b/libphobos/libdruntime/core/sys/posix/sys/wait.d	2019-10-28 08:08:09.000000000 +0900
+@@ -362,6 +362,19 @@ else version (CRuntime_Bionic)
+ }
+ else version (CRuntime_Musl)
+ {
++    enum WEXITED    = 4;
++    enum WSTOPPED   = 2;
++    enum WCONTINUED = 8;
++    enum WNOWAIT    = 0x01000000;
++
++    enum idtype_t
++    {
++        P_ALL,
++        P_PID,
++        P_PGID
++    }
++
++    int waitid(idtype_t, id_t, siginfo_t*, int);
+ }
+ else version (CRuntime_UClibc)
+ {
+diff -Nurp a/libphobos/libdruntime/core/sys/posix/ucontext.d b/libphobos/libdruntime/core/sys/posix/ucontext.d
+--- a/libphobos/libdruntime/core/sys/posix/ucontext.d	2019-10-28 07:12:22.000000000 +0900
++++ b/libphobos/libdruntime/core/sys/posix/ucontext.d	2019-10-28 08:08:09.000000000 +0900
+@@ -23,6 +23,10 @@ extern (C):
+ nothrow:
+ @nogc:
+
++version (MIPS32)  version = MIPS_Any;
++version (MIPS64)  version = MIPS_Any;
++version (PPC)     version = PPC_Any;
++version (PPC64)   version = PPC_Any;
+ version (RISCV32) version = RISCV_Any;
+ version (RISCV64) version = RISCV_Any;
+ version (S390)    version = IBMZ_Any;
+@@ -770,6 +774,139 @@ version (CRuntime_Glibc)
+     else
+         static assert(0, "unimplemented");
+ }
++else version (CRuntime_Musl)
++{
++    version (AArch64)
++    {
++        struct mcontext_t
++        {
++            real[18+256] __regs;
++        }
++
++        struct ucontext_t
++        {
++            c_ulong     uc_flags;
++            ucontext_t* uc_link;
++            stack_t     uc_stack;
++            sigset_t    uc_sigmask;
++            mcontext_t  uc_mcontext;
++        }
++    }
++    else version (ARM)
++    {
++        struct mcontext_t
++        {
++            c_ulong[21] __regs;
++        }
++
++        struct ucontext_t
++        {
++            c_ulong     uc_flags;
++            ucontext_t* uc_link;
++            stack_t     uc_stack;
++            mcontext_t  uc_mcontext;
++            sigset_t    uc_sigmask;
++            ulong[64]   uc_regspace;
++        }
++    }
++    else version (IBMZ_Any)
++    {
++        struct mcontext_t
++        {
++            c_ulong[18] __regs1;
++            uint[18]    __regs2;
++            double[16]  __regs3;
++        }
++
++        struct ucontext_t
++        {
++            c_ulong     uc_flags;
++            ucontext_t* uc_link;
++            stack_t     uc_stack;
++            mcontext_t  uc_mcontext;
++            sigset_t    uc_sigmask;
++        }
++    }
++    else version (MIPS_Any)
++    {
++        version (MIPS_N32)
++        {
++            struct mcontext_t
++            {
++                ulong[32]  __mc1;
++                double[32] __mc2;
++                ulong[9]   __mc3;
++                uint[4]    __mc4;
++            }
++        }
++        else version (MIPS64)
++        {
++            struct mcontext_t
++            {
++                ulong[32]  __mc1;
++                double[32] __mc2;
++                ulong[9]   __mc3;
++                uint[4]    __mc4;
++            }
++        }
++        else
++        {
++            struct mcontext_t
++            {
++                uint[2]    __mc1;
++                ulong[65]  __mc2;
++                uint[5]    __mc3;
++                ulong[2]   __mc4;
++                uint[6]    __mc5;
++            }
++        }
++
++        struct ucontext_t
++        {
++            c_ulong     uc_flags;
++            ucontext_t* uc_link;
++            stack_t     uc_stack;
++            mcontext_t  uc_mcontext;
++            sigset_t    uc_sigmask;
++        }
++    }
++    else version (X86)
++    {
++        struct mcontext_t
++        {
++            uint[22] __space;
++        }
++
++        struct ucontext_t
++        {
++            c_ulong     uc_flags;
++            ucontext_t* uc_link;
++            stack_t     uc_stack;
++            mcontext_t  uc_mcontext;
++            sigset_t    uc_sigmask;
++            c_ulong[28] __fpregs_mem;
++        }
++    }
++    else version (X86_64)
++    {
++        struct mcontext_t
++        {
++            ulong[32] __space;
++        }
++
++        struct ucontext_t
++        {
++            c_ulong     uc_flags;
++            ucontext_t* uc_link;
++            stack_t     uc_stack;
++            mcontext_t  uc_mcontext;
++            sigset_t    uc_sigmask;
++            ulong[64]   __fpregs_mem;
++        }
++    }
++    else
++        static assert(0, "unimplemented");
++}
+ else version (FreeBSD)
+ {
+     // <machine/ucontext.h>
+diff -Nurp a/libphobos/src/std/experimental/allocator/building_blocks/region.d b/libphobos/src/std/experimental/allocator/building_blocks/region.d
+--- a/libphobos/src/std/experimental/allocator/building_blocks/region.d	2019-10-28 07:23:27.000000000 +0900
++++ b/libphobos/src/std/experimental/allocator/building_blocks/region.d	2019-10-28 08:08:09.000000000 +0900
+@@ -580,6 +580,12 @@ struct InSituRegion(size_t size, size_t
+     assert(a.length == 2001);
+ }
+
++version(CRuntime_Musl)
++{
++    // sbrk and brk are disabled in Musl:
++    // https://git.musl-libc.org/cgit/musl/commit/?id=7a995fe706e519a4f55399776ef0df9596101f93
++    // https://git.musl-libc.org/cgit/musl/commit/?id=863d628d93ea341b6a32661a1654320ce69f6a07
++} else:
+ private extern(C) void* sbrk(long);
+ private extern(C) int brk(shared void*);
+
+diff -Nurp a/libphobos/src/std/socket.d b/libphobos/src/std/socket.d
+--- a/libphobos/src/std/socket.d	2019-10-28 07:23:27.000000000 +0900
++++ b/libphobos/src/std/socket.d	2019-10-28 08:08:09.000000000 +0900
+@@ -163,47 +163,7 @@ string formatSocketError(int err) @trust
+         {
+             cs = strerror_r(err, buf.ptr, buf.length);
+         }
+-        else version (OSX)
+-        {
+-            auto errs = strerror_r(err, buf.ptr, buf.length);
+-            if (errs == 0)
+-                cs = buf.ptr;
+-            else
+-                return "Socket error " ~ to!string(err);
+-        }
+-        else version (FreeBSD)
+-        {
+-            auto errs = strerror_r(err, buf.ptr, buf.length);
+-            if (errs == 0)
+-                cs = buf.ptr;
+-            else
+-                return "Socket error " ~ to!string(err);
+-        }
+-        else version (NetBSD)
+-        {
+-            auto errs = strerror_r(err, buf.ptr, buf.length);
+-            if (errs == 0)
+-                cs = buf.ptr;
+-            else
+-                return "Socket error " ~ to!string(err);
+-        }
+-        else version (DragonFlyBSD)
+-        {
+-            auto errs = strerror_r(err, buf.ptr, buf.length);
+-            if (errs == 0)
+-                cs = buf.ptr;
+-            else
+-                return "Socket error " ~ to!string(err);
+-        }
+-        else version (Solaris)
+-        {
+-            auto errs = strerror_r(err, buf.ptr, buf.length);
+-            if (errs == 0)
+-                cs = buf.ptr;
+-            else
+-                return "Socket error " ~ to!string(err);
+-        }
+-        else version (CRuntime_Bionic)
++        else
+         {
+             auto errs = strerror_r(err, buf.ptr, buf.length);
+             if (errs == 0)
+@@ -211,8 +171,6 @@ string formatSocketError(int err) @trust
+             else
+                 return "Socket error " ~ to!string(err);
+         }
+-        else
+-            static assert(0);
+
+         auto len = strlen(cs);
+
+diff -Nurp a/libphobos/src/std/stdio.d b/libphobos/src/std/stdio.d
+--- a/libphobos/src/std/stdio.d	2019-10-28 07:23:27.000000000 +0900
++++ b/libphobos/src/std/stdio.d	2019-10-28 08:08:09.000000000 +0900
+@@ -44,38 +44,38 @@ version (CRuntime_Glibc)
+     version = GCC_IO;
+     version = HAS_GETDELIM;
+ }
+-
+-version (OSX)
++else version (CRuntime_Bionic)
+ {
+     version = GENERIC_IO;
+     version = HAS_GETDELIM;
+ }
+-
+-version (FreeBSD)
++else version (CRuntime_Musl)
+ {
+     version = GENERIC_IO;
+     version = HAS_GETDELIM;
+ }
+
+-version (NetBSD)
++version (OSX)
+ {
+     version = GENERIC_IO;
+     version = HAS_GETDELIM;
+ }
+-
+-version (DragonFlyBSD)
++else version (FreeBSD)
+ {
+     version = GENERIC_IO;
+     version = HAS_GETDELIM;
+ }
+-
+-version (Solaris)
++else version (NetBSD)
+ {
+     version = GENERIC_IO;
+-    version = NO_GETDELIM;
++    version = HAS_GETDELIM;
+ }
+-
+-version (CRuntime_Bionic)
++else version (DragonFlyBSD)
++{
++    version = GENERIC_IO;
++    version = HAS_GETDELIM;
++}
++else version (Solaris)
+ {
+     version = GENERIC_IO;
+     version = NO_GETDELIM;

--- a/main/gcc/401-dlang-32bits.patch
+++ b/main/gcc/401-dlang-32bits.patch
@@ -1,0 +1,25 @@
+--- a/libphobos/libdruntime/core/sys/posix/config.d	2019-10-29 15:54:05.000000000 +0900
++++ b/libphobos/libdruntime/core/sys/posix/config.d	2019-10-29 15:54:08.000000000 +0900
+@@ -67,15 +67,21 @@ version (CRuntime_Glibc)
+ }
+ else version (CRuntime_Musl)
+ {
++    // off_t is always 64 bits on Musl
+     enum _FILE_OFFSET_BITS   = 64;
+
++    // Not present in Musl sources
+     enum __REDIRECT          = false;
+
++    // Those three are irrelevant for Musl as it always uses 64 bits off_t
+     enum __USE_FILE_OFFSET64 = _FILE_OFFSET_BITS == 64;
+     enum __USE_LARGEFILE     = __USE_FILE_OFFSET64 && !__REDIRECT;
+     enum __USE_LARGEFILE64   = __USE_FILE_OFFSET64 && !__REDIRECT;
+
+-    enum __WORDSIZE=64;
++    version (D_LP64)
++        enum __WORDSIZE = 64;
++    else
++        enum __WORDSIZE = 32;
+ }
+ else version (CRuntime_UClibc)
+ {

--- a/main/gcc/APKBUILD
+++ b/main/gcc/APKBUILD
@@ -6,7 +6,7 @@ pkgver=9.2.0
 [ "$CHOST" != "$CTARGET" ] && _target="-$CTARGET_ARCH" || _target=""
 
 pkgname="$pkgname$_target"
-pkgrel=2
+pkgrel=3
 pkgdesc="The GNU Compiler Collection"
 url="http://gcc.gnu.org"
 arch="all"
@@ -20,6 +20,7 @@ subpackages=" "
 replaces="libstdc++ binutils"
 
 : ${LANG_CXX:=true}
+: ${LANG_D:=true}
 : ${LANG_OBJC:=true}
 : ${LANG_GO:=true}
 : ${LANG_FORTRAN:=true}
@@ -33,6 +34,7 @@ LIBITM=true
 if [ "$CHOST" != "$CTARGET" ]; then
 	if [ "$BOOTSTRAP" = nolibc ]; then
 		LANG_CXX=false
+		LANG_D=false
 		LANG_ADA=false
 		LIBGCC=false
 		_builddir="$srcdir/build-cross-pass2"
@@ -86,6 +88,10 @@ else
 	_builddir="$srcdir/build"
 fi
 
+# GDC hasn't been ported to PowerPC
+# See libphobos/configure.tgt in GCC sources for supported targets
+[ "$CARCH" = ppc64le ] && LANG_D=false
+
 # Go needs {set,make,swap}context, unimplemented in musl
 [ "$CTARGET_LIBC" = musl ] && LANG_GO=false
 
@@ -116,6 +122,10 @@ _languages=c
 if $LANG_CXX; then
 	subpackages="$subpackages libstdc++:libcxx:$CTARGET_ARCH g++$_target:gpp"
 	_languages="$_languages,c++"
+fi
+if $LANG_D; then
+	subpackages="$subpackages libgphobos::$CTARGET_ARCH gcc-gdc$_target:gdc"
+	_languages="$_languages,d"
 fi
 if $LANG_OBJC; then
 	subpackages="$subpackages libobjc::$CTARGET_ARCH gcc-objc$_target:objc"
@@ -172,6 +182,9 @@ source="https://gcc.gnu.org/pub/gcc/releases/gcc-${_pkgbase:-$pkgver}/gcc-${_pkg
 
 	gcc-pure64-mips.patch
 	0016-invalid_tls_model.patch
+
+	400-dlang-phobos.patch
+	401-dlang-32bits.patch
 	"
 
 #	gcc-4.8-build-args.patch
@@ -319,6 +332,7 @@ package() {
 
 	# strip debug info from some static libs
 	${STRIP_FOR_TARGET} -g `find "$pkgdir" \( -name libgfortran.a -o -name libobjc.a -o -name libgomp.a \
+		-o -name libgphobos.a -o -name libgdruntime.a \
 		-o -name libmudflap.a -o -name libmudflapth.a \
 		-o -name libgcc.a -o -name libgcov.a -o -name libquadmath.a \
 		-o -name libitm.a -o -name libgo.a -o -name libcaf\*.a \
@@ -470,6 +484,32 @@ libgomp() {
 	mv "$pkgdir"/usr/${_target:+$CTARGET/}lib/libgomp.so.* "$subpkgdir"/usr/lib/
 }
 
+libgphobos() {
+	pkgdesc="D programming language standard library for GCC"
+	depends=
+
+	mkdir -p "$subpkgdir"/usr/lib
+	mv "$pkgdir"/usr/lib/libgdruntime.so.* "$subpkgdir"/usr/lib/
+	mv "$pkgdir"/usr/lib/libgphobos.so.*  "$subpkgdir"/usr/lib/
+}
+
+gdc() {
+	pkgdesc="GCC-based D language compiler"
+	depends="gcc=$_gccrel libgphobos=$_gccrel"
+
+	mkdir -p "$subpkgdir"/$_gcclibdir/include/d/ \
+		"$subpkgdir"/usr/lib \
+		"$subpkgdir"/usr/bin
+	# Copy: The installed `.d` files, the static lib, the binary itself
+	# The shared libs are part of `libgphobos` so one can run program
+	# without installing the compiler
+	mv "$pkgdir"/$_gcclibdir/include/d/ "$subpkgdir"/$_gcclibdir/include/d/
+	mv "$pkgdir"/usr/lib/libgdruntime.a "$subpkgdir"/usr/lib/
+	mv "$pkgdir"/usr/lib/libgphobos.a "$subpkgdir"/usr/lib/
+	mv "$pkgdir"/usr/bin/gdc "$subpkgdir"/usr/bin/
+}
+
+
 libgo() {
 	pkgdesc="Go runtime library for GCC"
 	depends=
@@ -585,4 +625,6 @@ cceeac95f47ea8664e1c16c5ebecb472b5aaa56040e943c1b97c7873b50e3a2bf972d9f743d342a2
 a1f7750bc7b8b7d916a5dee34fcc736bd4fb249c96538b547d495794e6cfd49356aa3974506a15074b4cb58edd5d7e2868607c902dd003e8c464d5066fd4a575  libgnarl-musl.patch
 f4ef08454e28c8732db69115e4998ec153399e8d229dd27f923dbdcf57b68128a65640d026cc7f45b58ba8764ab1eb575d4eb6d6dfc550a87a183f8b94e76181  320-libffi-gnulinux.patch
 86be3338cc9c33089608bc4c5e3b7918c4e500a345c338f361b18c342119a6ed69af5495d72950de7106d760f003528b46ad14795e805f8a3331e206dcb234e3  gcc-pure64-mips.patch
-17e0faeef742d32d57a070d983480367dd28cd28d47a8966ce327afdff3a38ea76803a833c90aff7d3a93aa66dae76c9be47b2408500913b40571af25b85aca7  0016-invalid_tls_model.patch"
+17e0faeef742d32d57a070d983480367dd28cd28d47a8966ce327afdff3a38ea76803a833c90aff7d3a93aa66dae76c9be47b2408500913b40571af25b85aca7  0016-invalid_tls_model.patch
+38772c5b0905455a44c43d6ef7e5f140530006e2bde9f5ffd6b569c7cf9633992515f666b486d7a78c30ab8da99b92b2775c90fde47821ae542ef1c49dc405df  400-dlang-phobos.patch
+84bdbdfcb972161765b81220ea2e80e83c32f3ab27596b77eb451d8cac4bd6312210df468581c2b0e1363f5e3b31654e369c47ae84c907f3b54a1786d7c17830  401-dlang-32bits.patch"


### PR DESCRIPTION
```
GDC, the GCC-based D compiler, is part of GCC since GCC9.
Upstream support for Musl was added progressively (D relies heavily on libc),
and some key components were missing as of GCC 9.2.0 release (2019-08-12).
A stream of patches, from which the massive patch included in this PR derives,
was submitted to the gcc-patches mailing list on the 2019-08-21.
This patch could be removed after/if GCC 9.3.0 is released.
```

This is still very much a WIP, as dealing with GCC is much more complicated than the LDC bootstrapping.
However, should this work, it would allow D to bootstrap on all platform Alpine support, which is kind of cool.