### PR TITLE
community/ocaml: update pkgrel for binutils update

### DIFF
--- a/community/ocaml/APKBUILD
+++ b/community/ocaml/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=ocaml
 pkgver=4.08.1
-pkgrel=0
+pkgrel=1
 pkgdesc="Main implementation of the Caml programming language"
 url="http://ocaml.org/"
 arch="aarch64 ppc64le x86_64"
@@ -20,7 +20,7 @@ subpackages="
 	"
 source="http://caml.inria.fr/pub/distrib/ocaml-${pkgver%.*}/$pkgname-$pkgver.tar.gz
 	compile-without-debug-info.patch
-        fix-mcontext-fields.patch
+	fix-mcontext-fields.patch
 	fix-segfault-in-ppc64le.patch
 	fix-check-parser-uptodate-or-warn.sh.patch
 	"
@@ -35,7 +35,7 @@ build() {
 		--mandir /usr/share/man \
 		CC="${CC:-gcc}" \
 		AS="${CC:-gcc} -c" \
-		ASPP="${CC:-gcc} -c" 
+		ASPP="${CC:-gcc} -c"
 	make world.opt
 }
 


### PR DESCRIPTION
The package requires rebuilding to match the upgrade of binutils

Fixing this bug: https://gitlab.alpinelinux.org/alpine/aports/issues/10888:
```
ERROR: unsatisfiable constraints:
  so:libbfd-2.32.so (missing):
    required by: ocaml-4.08.1-r0[so:libbfd-2.32.so]
```