### PR TITLE
community/wireguard-go: new aport

### DIFF
--- a/community/wireguard-go/APKBUILD
+++ b/community/wireguard-go/APKBUILD
@@ -1,0 +1,26 @@
+# Contributor: Stefan Reiff <kroko87@hotmail.com>
+# Maintainer: Stefan Reiff <kroko87@hotmail.com>
+pkgname=wireguard-go
+pkgver=0.0.20191012
+pkgrel=0
+pkgdesc="Next generation secure network tunnel: userspace implementation in go"
+arch="all"
+url="https://www.wireguard.com"
+license="GPL-2.0-only"
+makedepends="go"
+depends="wireguard-tools-wg wireguard-tools-wg-quick"
+subpackages="$pkgname-doc"
+options="!check"
+source="https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-$pkgver.tar.xz"
+
+build() {
+	make
+}
+
+package() {
+	make DESTDIR="$pkgdir" install
+	install -Dm644 README.md "$pkgdir"/usr/share/doc/$pkgname/README.md
+	install -Dm644 COPYING "$pkgdir"/usr/share/licenses/$pkgname/COPYING
+}
+
+sha512sums="244cf4cdfaf3bae29d789af302cecfe7018e303db3340e1a68c4df0d557af28d535323e7f6aa66310abbf4e9627c405fbf95d79b2a909c6d8b6f2c057070f10c  wireguard-go-0.0.20191012.tar.xz"


### PR DESCRIPTION
I know, we should use the kernel module on linux systems.
But I think it's useful, when you only have a hosted container somewhere.