### PR TITLE
testing/lzbench: upgrade to v1.8

### DIFF
--- a/testing/lzbench/APKBUILD
+++ b/testing/lzbench/APKBUILD
@@ -1,12 +1,13 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=lzbench
-pkgver=1.7.4
+pkgver=1.8
 pkgrel=0
 pkgdesc="lzbench is an in-memory benchmark of open-source LZ77/LZSS/LZMA compressors"
 url="https://github.com/inikep/lzbench"
 arch="all !x86 !s390x"
 license="GPL zlib MIT Unlicense BSD Apache-2.0 CDDL CC0 custom"
+options="!check" # No test suite from upstream
 subpackages="$pkgname-doc"
 source="$pkgname-$pkgver.tar.gz::https://github.com/inikep/lzbench/archive/v$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgver/"
@@ -15,14 +16,10 @@ build() {
 	make
 }
 
-check() {
-	./lzbench
-}
-
 package() {
 	install -Dm 755 lzbench "$pkgdir"/usr/bin/lzbench
 
 	install -Dm 644 -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
 }
 
-sha512sums="79f53ade2c1d28d3b1aa8dcb13e81bb6d48364d6d670478002cb90d6a49b5c25dec78b497bf86d32b5d84cb38f45385f54f96c5ec25811ebe2c04e956c4b4d81  lzbench-1.7.4.tar.gz"
+sha512sums="3fbbc95159aa99844039ccf45fecf7a1637bb049a87542eb942a849234d753907c1f78f7fe3776855a282bc0cb1f363d26ca6dae4bc0d16592adc0853c977d16  lzbench-1.8.tar.gz"


### PR DESCRIPTION
- Ref https://github.com/inikep/lzbench/blob/v1.8/NEWS
- Removed check() as there is no test suite from upstream