### PR TITLE
testing/ldc: Install ldc-static alongside compiler

### DIFF
--- a/testing/ldc/APKBUILD
+++ b/testing/ldc/APKBUILD
@@ -11,7 +11,7 @@ url="https://github.com/ldc-developers/ldc"
 arch="x86_64"
 license="BSD-3-Clause AND BSL-1.0 AND (Artistic-1.0 OR GPL-2.0-or-later) AND NCSA AND MIT"
 depends="libexecinfo tzdata"
-makedepends="bash chrpath cmake curl-dev diffutils dlang-compiler gdb grep llvm9-dev llvm9-static libedit-dev libexecinfo-static py-pip zlib-dev"
+makedepends="bash chrpath cmake curl-dev diffutils dlang-compiler ldc-static gdb grep llvm9-dev llvm9-static libedit-dev libexecinfo-static py-pip zlib-dev"
 # A user might want to install the '-runtime' subpackage when they have
 # a dynamically-linked D program.
 subpackages="$pkgname-runtime $pkgname-static"
@@ -37,7 +37,6 @@ build() {
 
 	# CMake added the rpaths to the shared libs - strip them
 	chrpath -d "$builddir"/lib/*.so*
-	:
 }
 
 check() {
@@ -58,6 +57,7 @@ check() {
 }
 
 package() {
+	depends="$depends $pkgname-static"
 	make DESTDIR="$pkgdir" install
 }
 
@@ -73,7 +73,6 @@ runtime() {
 	mv "$pkgdir"/usr/lib/libldc-jit.so* "$subpkgdir/usr/lib"
 
 	mv "$pkgdir"/usr/lib/*.so* "$subpkgdir/usr/lib/"
-	:
 }
 
 static() {


### PR DESCRIPTION
```
The previous dependency means that 'ldc' would not work out of the box.
One had to install ldc and ldc-static, or ldc and ldc-runtime and compile with flags.
This makes sure that ldc-static is installed so basic compilation works out of the box.
People wanting to compile with shared libraries will still need
to install the 'runtime' package explicitly.
```

CC @Cogitri 


EDIT: Hum, `abuild` ignore `ldc-static` in makedepends, probably because it is a subpackage. One way to solve it would be to merge `ldc-static` with `ldc`. The `static` package was originally here because `abuild` outputs a warning when a static library is present without a `-static` package, but I don't think that makes much sense for compilers (and, in fact, GCC outputs plenty of those warnings).

Another way is to just wait on #12006, given it's a much better bootstrapping solution long term (and the package currently works, just not out of the box).