### PR TITLE
community/libindicator: remove Werror option for gcc 9.2

### DIFF
--- a/community/libindicator/APKBUILD
+++ b/community/libindicator/APKBUILD
@@ -15,8 +15,8 @@ builddir="$srcdir/$pkgname-$pkgver"
 prepare() {	
 	default_prepare
 	cd "$builddir"
-	sed '/-Werror/s/$/ -Wno-deprecated-declarations/' -i libindicator/Makefile.am
-	sed '/-Werror/s/$/ -Wno-deprecated-declarations/' -i libindicator/Makefile.in
+	sed '/-Werror/s// -Wno-deprecated-declarations/' -i libindicator/Makefile.am
+	sed '/-Werror/s// -Wno-deprecated-declarations/' -i libindicator/Makefile.in
 	update_config_sub
 }
 


### PR DESCRIPTION
With gcc 9.2.0 build fails with error:
```
indicator-desktop-shortcuts.c: In function 'indicator_desktop_shortcuts_init':
indicator-desktop-shortcuts.c:112:13: error: G_ADD_PRIVATE [-Werror]
  112 |  IndicatorDesktopShortcutsPrivate * priv = INDICATOR_DESKTOP_SHORTCUTS_GET_PRIVATE(self);
      |             ^~~~~~~~~~~~~~~
```
Updating sed statement in APKBUILD to remove building with Werror option for current source to fix.