### PR TITLE
community/pidgin-sipe: with gcc 9.2.0 disable Werror to fix build

### DIFF
--- a/community/pidgin-sipe/APKBUILD
+++ b/community/pidgin-sipe/APKBUILD
@@ -14,6 +14,12 @@ checkdepends="appstream"
 subpackages="$pkgname-lang"
 source="https://downloads.sourceforge.net/project/sipe/sipe/pidgin-sipe-$pkgver/pidgin-sipe-$pkgver.tar.bz2"
 
+prepare() {
+	default_prepare
+	cd "$builddir"
+	sed 's/-Werror -Wall/-Wall/' -i configure
+}
+
 build() {
 	./configure \
 		--build=$CBUILD \


### PR DESCRIPTION
With gcc 9.2.0 pidgin-sipe fails to build with errors:
```
sipe-utils.c:293:3: error: 'GTimeVal' is deprecated: Use 'GDateTime' instead [-Werror=deprecated-declarations]
  293 |   GTimeVal currtime;
      |   ^~~~~~~~
In file included from /usr/include/glib-2.0/glib/galloca.h:32,
                 from /usr/include/glib-2.0/glib.h:30,
                 from sipe-utils.c:29:
/usr/include/glib-2.0/glib/gtypes.h:551:8: note: declared here
  551 | struct _GTimeVal
      |        ^~~~~~~~~
sipe-utils.c:297:3: error: 'g_get_current_time' is deprecated: Use 'g_get_real_time' instead [-Werror=deprecated-declarations]
  297 |   g_get_current_time(&currtime);
      |   ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/glib/giochannel.h:33,
                 from /usr/include/glib-2.0/glib.h:54,
                 from sipe-utils.c:29:
/usr/include/glib-2.0/glib/gmain.h:575:8: note: declared here
  575 | void   g_get_current_time                 (GTimeVal       *result);
      |        ^~~~~~~~~~~~~~~~~~
```

On pidgin-sipe 1.24.0 disable Werror to allow successful building.