### PR TITLE
main/monit: fix init script

### DIFF
--- a/main/monit/APKBUILD
+++ b/main/monit/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=monit
 pkgver=5.26.0
-pkgrel=0
+pkgrel=1
 pkgdesc="Managing and monitoring on a UNIX system"
 url="https://mmonit.com/monit/"
 arch="all"
@@ -49,4 +49,4 @@ package() {
 }
 
 sha512sums="ae5bfc9f2e8cf2d2efa7a121f3bb865dc5b66b647e23e005349799f3f4384dfa1534ed88d0767ca41dac4cea2674fb82cfb51098129d350b470143df548c6900  monit-5.26.0.tar.gz
-688711432aa072bf9a6fe55cec0202d54a5fac9a421efd41ebe3974e843f41a076945e65b3b53f968926e037ecb54049f42d99dc7a1a9f35a7e6d19ca5a4f019  monit.initd"
+cf2b417a73766ff568f1df904f1ccdee1289037994c8ba1743cf1d04cb1ea8945f66d6cb2c9bab868f600a7c7ae57436d1f49cccbe22745b41282034e169ef25  monit.initd"

--- a/main/monit/monit.initd
+++ b/main/monit/monit.initd
@@ -8,8 +8,10 @@ supervisor=supervise-daemon
 name="monit"
 description="Monit service supervisor"
 
+: ${monit_config:=${CONF:-/etc/monitrc}}
+
 command=/usr/bin/monit
-command_args="-c ${CONF:-/etc/monitrc}"
+command_args="-c ${monit_config}"
 command_args_foreground="-I"
 
 extra_commands="configtest"
@@ -20,17 +22,18 @@ depend() {
 }
 
 configtest() {
-        /usr/bin/monit -t -c "$CONF" 1>/dev/null 2>&1
+        /usr/bin/monit -t -c "${monit_config}" 1>/dev/null 2>&1
         ret=$?
         if [ $ret -ne 0 ]; then
                 eerror "${RC_SVCNAME} has detected an error in your setup:"
-                /usr/bin/monit -t "$CONF"
+                /usr/bin/monit -t "${monit_config}"
         fi
         return $ret
 }
 
 reload() {
 	ebegin "Reloading monit"
-	$command -c "$CONF" reload >/dev/null 2>&1
+	$command -c "${monit_config}" reload >/dev/null 2>&1
 	eend $?
 }
+


### PR DESCRIPTION
$CONF variable was not properly assigned. Therefore reload and configtest always returns exit code 1.