### PR TITLE
community/imagemagick6: security upgrade to 6.9.10.70

### DIFF
--- a/community/imagemagick6/APKBUILD
+++ b/community/imagemagick6/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Jakub Jirutka <jakub@jirutka.cz>
 pkgname=imagemagick6
 _pkgname=ImageMagick6
-pkgver=6.9.10.69
+pkgver=6.9.10.70
 _pkgver=${pkgver%.*}-${pkgver##*.}
 _abiver=${pkgname#imagemagick}
 pkgrel=0
@@ -49,6 +49,8 @@ builddir="$srcdir/$_pkgname-$_pkgver"
 #     - CVE-2019-13134
 #     - CVE-2019-13133
 #   6.9.10.43-r0:
+#     - CVE-2019-14981
+#     - CVE-2019-14980
 #     - CVE-2019-11598
 #     - CVE-2019-11597
 #     - CVE-2019-11472
@@ -186,4 +188,4 @@ _cxx() {
 	mv "$pkgdir"/usr/lib/libMagick++*.so.* "$subpkgdir"/usr/lib/
 }
 
-sha512sums="89e548c76106f0417ac392e93866497dc41c478b5812e3dbcbb4950b27f8f85573411394c7cf41658968aa770085e8be6624a45aedbed0bf71a0f3437b8e1113  ImageMagick6-6.9.10-69.tar.gz"
+sha512sums="196460d7c61623249718cfe090d9fe1edd2ca0c59dead02a5f75b975379592993d4e8fc2490389ef2d3d3b8af38d8803e96e04e64a6ab8a457bc3b33ba60e598  ImageMagick6-6.9.10-70.tar.gz"


### PR DESCRIPTION
CVEs have not yet been assigned