### PR TITLE
WIP testing/php7-pecl-parallel: new aport

### DIFF
--- a/testing/php7-pecl-parallel/APKBUILD
+++ b/testing/php7-pecl-parallel/APKBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Andy Postnikov <apostnikov@gmail.com>
+pkgname=php7-pecl-parallel
+_pkgreal=parallel
+pkgver=1.1.3
+pkgrel=0
+pkgdesc="A succinct parallel concurrency API for PHP7"
+url="https://pecl.php.net/package/parallel"
+arch="all"
+license="PHP-3.01"
+depends="php7-common"
+makedepends="php7-dev re2c"
+source="$pkgname-$pkgver.tgz::https://pecl.php.net/get/$_pkgreal-$pkgver.tgz"
+builddir="$srcdir/$_pkgreal-$pkgver"
+
+build() {
+	phpize7
+	./configure --prefix=/usr --with-php-config=php-config7 --enable-maintainer-zts
+	make
+}
+
+check() {
+	make NO_INTERACTION=1 REPORT_EXIT_STATUS=1 test
+}
+
+package() {
+	make INSTALL_ROOT="$pkgdir"/ install
+	install -d "$pkgdir"/etc/php7/conf.d
+	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/50_$_pkgreal.ini
+}
+
+sha512sums="12ce2d6b0c389b4842f23506338ce3458fd36360505d306cac67b271443297b466bcbfa5d7766b69a115e207e49e57dac396ba0cda1e89fb86e64be543d1654f  php7-pecl-parallel-1.1.3.tgz"


### PR DESCRIPTION
To build the extension php should be build in ZTS mode 
`checking for ZTS... configure: error: parallel requires ZTS, please use PHP with ZTS enabled`
