### PR TITLE
testing/k3s: upgrade to 0.10.2

### DIFF
--- a/testing/k3s/APKBUILD
+++ b/testing/k3s/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=k3s
-pkgver=0.10.1
+pkgver=0.10.2
 pkgrel=0
 pkgdesc="Lightweigt Kubernetes. 5 less than k8s."
 url="https://k3s.io"
@@ -68,6 +68,6 @@ cleanup_srcdir() {
 	default_cleanup_srcdir
 }
 
-sha512sums="8dc48557fa6a3cfef03fd168e9f6c19551f06a4dfd8757c199bb2cf7193b36e15280b27ac29c1d86a23eda4931b8d1d360e79e429f734eaaef254ac7c5cbcece  k3s-0.10.1.tar.gz
+sha512sums="1d99506c7e82225032956ff951a08a0e0e5c1365d4e69bce09016c6527723c9be16919f0567c5b373406bd81fb87b3edddbd52ce1458f4f477c62ff55d695637  k3s-0.10.2.tar.gz
 9501422f1bf5375555116cbeedb32de32109153396699bde1300ce01156c3e57fe3fb14a57f7de1dce47c955e5e6d61de7fea181a07b407f5b452006bc58991c  k3s.initd
 dda2fc70e884ef439fece8f850d798f98d07cd431f0b8b79183f192b35f68fc7c633d3c790aae7b86ca57331212a7bb2f783131b752a4e1e71ef918469e6b944  k3s.confd"


### PR DESCRIPTION
Ref https://github.com/rancher/k3s/releases/tag/v0.10.2