### PR TITLE
community/gtk-vnc fixes gvncviewer not being installed in latest apk

### DIFF
--- a/community/gtk-vnc/APKBUILD
+++ b/community/gtk-vnc/APKBUILD
@@ -43,8 +43,9 @@ package() {
 
 gvncviewer() {
 	pkgdesc="Demo application for gtk-vnc"
-	mkdir -p "$subpkgdir"/usr
-	mv "$pkgdir"/usr/bin "$subpkgdir"/usr/
+	cd $builddir
+	mkdir -p "$subpkgdir"/usr/bin
+	mv output/examples/gvncviewer "$subpkgdir"/usr/bin
 }
 
 sha512sums="63a40b9b284c4e46a92d5375ab3660b324ff27bfc572559d3b34d29fe4f7d24e976396b6688b8f3e3109d49dc5527075d128c43bb997507e68ddc0880b0ad148  gtk-vnc-1.0.0.tar.xz"


### PR DESCRIPTION
i guess the source has changed and does not automatically install gvncviewer anymore, it looks like it is only considered an example and not a production-ready program?