### PR TITLE
community/roundcubemail: security upgrade to 1.3.10 - CVE-2019-10740

### DIFF
--- a/community/roundcubemail/APKBUILD
+++ b/community/roundcubemail/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Jakub Jirutka <jakub@jirutka.cz>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=roundcubemail
-pkgver=1.3.9
+pkgver=1.3.10
 pkgrel=0
 pkgdesc="A PHP web-based mail client"
 url="https://www.roundcube.net/"
@@ -57,6 +57,8 @@ source="https://github.com/roundcube/$pkgname/releases/download/$pkgver/$pkgname
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   1.3.10-r0:
+#     - CVE-2019-10740
 #   1.3.8-r0:
 #     - CVE-2018-19206
 #   1.3.6-r0:
@@ -211,7 +213,7 @@ _mv() {
 	mv $@
 }
 
-sha512sums="42ae9b772272b3e82476beeeb0fc5a909fb07ed0bfbdb655627b1e31da1c292f67f5a305452de31b2d60fe5905bcacabd6874dea394a9b0fd66b7921d73500ac  roundcubemail-1.3.9-complete.tar.gz
+sha512sums="8fffa16abda87d29081d1afedbf1d9e4862b8b1864785101d422e62048ca7f365c3708e8a76b4a37f716109230943bb9f03a5faa0cf3c3963fa5454207e00c49  roundcubemail-1.3.10-complete.tar.gz
 d205ba8442870b26f93fb287e7fe2bd1a452ea534823869b7ef299e2dca52d64c8a3fdc9a44bd3bc731c1e400efcf745c1866974e3b908e4e54d05b47b835f3e  fix-dirs.patch
 7c4b88da4d2baa53d247dcb7b130d564954a04611c13f2770f45924fafab2a0e98f8dd078cabc87f3eddd0ab03f3ca48a48f27a462676354af22566cb19d220b  config-session_key.patch
 e46cdded33114ee7dae671d936cc41551168df29778dbf18f848a4f0eb0738a54c0751a5689716ba126ac256f2a50284afdcde542a42827003d6ba89af94f064  config-disable-remote-spellcheck.patch


### PR DESCRIPTION
Ref https://github.com/roundcube/roundcubemail/releases/tag/1.3.10