### PR TITLE
testing/dub: new aport

### DIFF
--- a/testing/dub/APKBUILD
+++ b/testing/dub/APKBUILD
@@ -1,0 +1,26 @@
+# Contributor: Mathias LANG <pro.mathias.lang@gmail.com>
+# Maintainer: Mathias LANG <pro.mathias.lang@gmail.com>
+pkgname=dub
+pkgver=1.18.0
+pkgrel=0
+pkgdesc="Package and build management system for D"
+url="http://code.dlang.org/"
+arch="x86_64"
+license="MIT"
+depends="libcurl"
+makedepends="ldc ldc-static bash curl-dev"
+source="$pkgname-$pkgver.zip::https://github.com/dlang/dub/archive/v$pkgver.zip"
+
+build() {
+	DMD=ldmd2 GITVER="v$pkgver" ./build.sh
+}
+
+check() {
+	bin/dub test
+}
+
+package() {
+	install -s -D "$builddir/bin/dub" "$pkgdir/usr/bin/dub"
+}
+
+sha512sums="454479867cce89d6a555505bb6b51b11192c18ae622239c01b0b9914d0c007cc6aa9b68274e80baa2eea068ae4c41c6838eef516c7ed57a947759cb37452dfa8  dub-1.18.0.zip"


### PR DESCRIPTION
Add dub v1.18.0, the D package manager.