### PR TITLE
main/file: Fix CVE ID for security patch

### DIFF
--- a/main/file/APKBUILD
+++ b/main/file/APKBUILD
@@ -16,7 +16,7 @@ builddir="$srcdir/$pkgname-FILE${pkgver/./_}"
 
 # secfixes:
 #   5.37-r1:
-#     - CVE-2019-19218
+#     - CVE-2019-18218
 #   5.36-r0:
 #     - CVE-2019-1543
 #     - CVE-2019-8904


### PR DESCRIPTION
The secfixes block references `CVE-2019-19218` when it should state `CVE-2019-18218`:

The erroneous CVE ID has been merged into:
* edge (5.37-r1)
* 3.10 (5.37-r1)
* 3.9 (5.36-r1)
* 3.8 (5.32-r2)
* 3.7 (5.32-r2)

So this commit will need porting to those stable releases.