### PR TITLE
testing/mailutils: security upgrade to 3.8

### DIFF
--- a/testing/mailutils/APKBUILD
+++ b/testing/mailutils/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Shiz <hi@shiz.me>
 # Maintainer: Shiz <hi@shiz.me>
 pkgname=mailutils
-pkgver=3.7
+pkgver=3.8
 pkgrel=0
 pkgdesc="GNU swiss army knife of electronic mail handling"
 url="https://mailutils.org/"
@@ -37,7 +37,7 @@ package() {
 	cd "$pkgdir"
 	rm usr/lib/charset.alias
 	# No need for these to be suid/sgid root.
-	chmod u-s usr/sbin/maidag
+	chmod u-s usr/sbin/mda
 	chmod g-s usr/bin/dotlock
 }
 
@@ -68,5 +68,5 @@ mh() {
 	rmdir -p "$pkgdir"/usr/share/$pkgname || true
 }
 
-sha512sums="9a1dbcc2f93504a2b9fe60fabcb9429a36b90b55931935b03988af00d26128e18eb3c92fc6f32d5ebfa488fc81ae5c3e354a4b24612faa7aa46da4f7862c2795  mailutils-3.7.tar.gz
+sha512sums="5f10c669a01212e582f9a558bf446e601e9f27d9d819b1f741921c4547a69b580eac9ee904ee1719d81300935625369fc3769f8cbac0ea0842502df4c69d1119  mailutils-3.8.tar.gz
 d0d78bba10d3ce039bb00657a570fb9411fabf448548994860285701939ae52afd15c007daa85bb18662a67153dda86069afe240b430fbe1b28a45755108f477  disable-koi8-r-test.patch"


### PR DESCRIPTION
No CVE available: https://lists.gnu.org/archive/html/bug-mailutils/2019-11/msg00000.html