### PR TITLE
main/samba: security upgrade to 4.11.2

### DIFF
--- a/main/samba/APKBUILD
+++ b/main/samba/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=samba
-pkgver=4.11.1
+pkgver=4.11.2
 pkgrel=0
 pkgdesc="Tools to access a server's filespace and printers via SMB"
 url="https://www.samba.org/"
@@ -90,6 +90,10 @@ pkggroups="winbind"
 builddir="$srcdir/$pkgname-$pkgver"
 
 # secfixes:
+#   4.11.2-r0:
+#     - CVE-2019-10218
+#     - CVE-2019-14833
+#     - CVE-2019-14847
 #   4.10.8-r0:
 #     - CVE-2019-10197
 #   4.10.5-r0:
@@ -567,7 +571,7 @@ libs() {
 		"$pkgdir"/usr
 }
 
-sha512sums="3a711b11254cff4c0d74f883d8bc6e454094ba2c6a10fb0d08e85cbed11a1326bb39f0e47600380a5f293a14a6463dbd09be7404305923ac579b6f85072309c8  samba-4.11.1.tar.gz
+sha512sums="f91053f019c9f979d7e29af00ea9b03a79c6f8efe91413ac2d6dca823f45ca9c30686264fdc0545dddabc687ad369a80c9ec78ebe75d1787dfc9b834233e12c1  samba-4.11.2.tar.gz
 c48f4533a9612c8534ddcf8531a50a31cc39da0b55a42fa5a4e2a36aa964a79a594215cd0edabd0bea837d493eca3f53341987d5aa4f10d370bf10123b957d1e  bind-9.14.patch
 0d4fd9862191554dc9c724cec0b94fd19afbfd0c4ed619e4c620c075e849cb3f3d44db1e5f119d890da23a3dd0068d9873703f3d86c47b91310521f37356208b  getpwent_r.patch
 a99e771f28d787dc22e832b97aa48a1c5e13ddc0c030c501a3c12819ff6e62800ef084b62930abe88c6767d785d5c37e2e9f18a4f9a24f2ee1f5d9650320c556  musl_uintptr.patch


### PR DESCRIPTION
https://www.samba.org/samba/history/samba-4.11.2.html