### PR TITLE
testing/moosefs: upgrade to 3.0.107

### DIFF
--- a/testing/moosefs/APKBUILD
+++ b/testing/moosefs/APKBUILD
@@ -1,8 +1,8 @@
 # Contributor: Michael Pirogov <vbnet.ru@gmail.com>
 # Maintainer: Michael Pirogov <vbnet.ru@gmail.com>
 pkgname="moosefs"
-pkgver="3.0.105"
-pkgrel=1
+pkgver="3.0.107"
+pkgrel=0
 pkgdesc="Open Source, Petabyte, Fault-Tolerant, Highly Performing, Scalable Network Distributed File System"
 url="https://moosefs.com"
 arch="all"
@@ -17,7 +17,7 @@ subpackages="$pkgname-doc $pkgname-static $pkgname-client $pkgname-master
 	$pkgname-master-openrc:master_openrc
 	$pkgname-chunkserver-openrc:chunkserver_openrc
 	$pkgname-cgiserv-openrc:cgiserv_openrc"
-source="$pkgname-$pkgver.tar.gz::https://github.com/moosefs/moosefs/archive/v$pkgver.tar.gz
+source="$pkgname-$pkgver.tar.gz::http://ppa.moosefs.com/src/moosefs-${pkgver}-1.tar.gz
 	$pkgname-cgiserv.initd
 	$pkgname-cgiserv.confd
 	$pkgname-master.initd
@@ -150,7 +150,7 @@ cgiserv_openrc() {
 	install -Dm644 "$srcdir"/moosefs-cgiserv.confd "$subpkgdir"/etc/conf.d/moosefs-cgiserv
 }
 
-sha512sums="d64bf58971a114c62bc3ae40d48fa800bec9a9ba012f51912b58ae14203b3b523f47bb2fb120759025ea1b604b6a8f74e87b0769b5888b137e7febed2d1fd24f  moosefs-3.0.105.tar.gz
+sha512sums="0e2c480621df733929ada47a77190d36033cd74894132ec66ed4d609742b91a2ee80184deb40f66c8228d0e5494a07dd3bf82ac18ac76dcfb9659ef7f778de05  moosefs-3.0.107.tar.gz
 c698aff4de9aeb76202a809e44ac8d0ec9c6348a806b1c813c2a40858339b1c139a480a9c5aff40bf2c9821883c6c0dfeabb010f3faa5746673235f0fb3c5a76  moosefs-cgiserv.initd
 b5c625f0004df33889de60ddad37e41f3acf081b37247606a1544e5f63354e121fe4cce511a6e60f4f2c0305155faf0614b8a4bce7267929fe68a1a4b546b582  moosefs-cgiserv.confd
 a041fa324d37bda098ad65e9d6507f281ed388471956ca79aa33b8b0d1c4a9d528662a2410c47f3856183d6378ac7fb417c3d7ec314f624e7e5dac7c5e4247f0  moosefs-master.initd


### PR DESCRIPTION
also changed source url to the main site.