### PR TITLE
community/openjdk7: fix typo in secfixes info

### DIFF
--- a/community/openjdk7/APKBUILD
+++ b/community/openjdk7/APKBUILD
@@ -90,7 +90,7 @@ source="https://icedtea.classpath.org/download/source/icedtea-$_icedteaversrc.ta
 #   7.211.2.6.17-r0:
 #   - CVE-2018-11212
 #   - CVE-2019-2422
-#   - CVE_2019-2426
+#   - CVE-2019-2426
 #   7.201.2.6.16-r0:
 #   - CVE-2018-3136
 #   - CVE-2018-3139


### PR DESCRIPTION
Prompted by https://github.com/alpinelinux/alpine-secdb/pull/3

Signed-off-by: Richard Mortier <mort@cantab.net>