### PR TITLE
main/jq: fix typo in secfixes info

### DIFF
--- a/main/jq/APKBUILD
+++ b/main/jq/APKBUILD
@@ -17,7 +17,7 @@ source="https://github.com/stedolan/jq/archive/${pkgname}-${_pkgver}.tar.gz"
 builddir="${srcdir}/$pkgname-${pkgname}-${_pkgver}"
 
 # secfixes:
-#   1.6rc1-r0:
+#   1.6_rc1-r0:
 #     - CVE-2016-4074
 
 prepare() {


### PR DESCRIPTION
Prompted by https://github.com/alpinelinux/alpine-secdb/pull/1

Signed-off-by: Richard Mortier <mort@cantab.net>