### PR TITLE
main/jq: fix jq rc status

### DIFF
--- a/main/jq/APKBUILD
+++ b/main/jq/APKBUILD
@@ -16,7 +16,7 @@ source="https://github.com/stedolan/jq/archive/$pkgname-$pkgver.tar.gz"
 builddir="$srcdir/$pkgname-$pkgname-$pkgver"
 
 # secfixes:
-#   1.6_rc1-r0:
+#   1.6-r0:
 #     - CVE-2016-4074
 
 prepare() {


### PR DESCRIPTION
Prompted by https://github.com/alpinelinux/alpine-secdb/pull/2

Signed-off-by: Richard Mortier <mort@cantab.net>