### PR TITLE
community/dnscrypt-proxy upgrade to 2.0.31-r1

### DIFF
--- a/community/dnscrypt-proxy/APKBUILD
+++ b/community/dnscrypt-proxy/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Ian Bashford <ianbashford@gmail.com>
 pkgname=dnscrypt-proxy
 pkgver=2.0.31
-pkgrel=0
+pkgrel=1
 pkgdesc="A tool for securing communications between a client and a DNS resolver"
 url="https://dnscrypt.info"
 arch="all"
@@ -58,4 +58,4 @@ sha512sums="500c800213b94bf8ecbea7493716de5fe41afd584c70844519f1f50827b94a28ec98
 e0a72d39d47dc24b889d08beedbd9fdf21615f42fbab79980debdfd2c3feaa83dc3f776351f7dd13533cc85905ce4e01812e4ff8a80a9ccc0b21e9db7d6cb232  dnscrypt-proxy.initd
 c001ae39da1b2db71764cab568f9ed18e4de0cea3d1a4e7bd6dd01a5668b81a888ea9eef99de6beac08857ad7f8eb1a32d730e946ac3563e4dcfa27147e35052  dnscrypt-proxy.confd
 66dd43d84117a0151ae41f34d82b716760382a5a491424bf6418228ffd21f0dfbc88e34cc5074e11f97f006335d97b85367bb9ab1d96747a48e893c022ad52d0  dnscrypt-proxy.setup
-96e46daf9487f25fcbf3513f862759c8522e5f4c842345cbbd4a25ef4e686cf05c10b539d78eff2ea6b76716e071337d6b8f3f0415ed6a8b92c6e46511411f4a  config-full-paths.patch"
+1352d05e5862a11ad7e751a188aab153e916889b8134e8c09b2e8db7e9a2e04b7f3de609b04a195ce67a9b77aedfb11feef4717af4cbc5b4d3ac61d39410922a  config-full-paths.patch"

--- a/community/dnscrypt-proxy/config-full-paths.patch
+++ b/community/dnscrypt-proxy/config-full-paths.patch
@@ -551,7 +551,7 @@ index 0000000..8455f8d
 +
 +  [sources.'relays']
 +  urls = ['https://github.com/DNSCrypt/dnscrypt-resolvers/raw/master/v2/relays.md', 'https://download.dnscrypt.info/resolvers-list/v2/relays.md']
-+  cache_file = 'relays.md'
++  cache_file = '/var/cache/dnscrypt-proxy/relays.md'
 +  minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
 +  refresh_delay = 72
 +  prefix = ''


### PR DESCRIPTION
fix file paths for new relays files