### PR TITLE
testing/opensmtpd-extras: upgrade to 6.6.0 

### DIFF
--- a/testing/opensmtpd-extras/APKBUILD
+++ b/testing/opensmtpd-extras/APKBUILD
@@ -1,16 +1,16 @@
 # Contributor: Shiz <hi@shiz.me>
 # Maintainer: Shiz <hi@shiz.me>
 pkgname=opensmtpd-extras
-pkgver=6.4.0
-pkgrel=1
+pkgver=6.6.0
+pkgrel=2
 pkgdesc="OpenSMTPD addons"
 url="https://opensmtpd.org/"
 arch="all"
 license="ISC"
-makedepends="libevent-dev mariadb-connector-c-dev postgresql-dev
+makedepends="automake autoconf libtool libevent-dev mariadb-connector-c-dev postgresql-dev
 	hiredis-dev sqlite-dev"
 subpackages="$pkgname-doc"
-source="https://www.opensmtpd.org/archives/opensmtpd-extras-$pkgver.tar.gz
+source="$pkgname-$pkgver.tar.gz::https://github.com/OpenSMTPD/OpenSMTPD-extras/archive/$pkgver.tar.gz
 	0001-uint8_t-is-defined-in-stdint.h-at-least-on-Linux.patch
 	0002-wrap-stdint.h-in-autoconf-variables.patch
 	remove-decls.patch
@@ -18,6 +18,8 @@ source="https://www.opensmtpd.org/archives/opensmtpd-extras-$pkgver.tar.gz
 options="!check"  # upstream does not provide tests
 
 replaces="table-python" # removed in 6.4.0-r1 (python2 EOL)
+
+builddir="$srcdir"/OpenSMTPD-extras-"$pkgver"
 
 _extras="
 	table-ldap
@@ -40,6 +42,7 @@ build() {
 		with_extras="$with_extras --with-$extra"
 	done
 
+	./bootstrap
 	./configure \
 		--prefix=/usr \
 		--sysconfdir=/etc/smtpd \
@@ -66,7 +69,7 @@ _package_extra() {
 	mv "$pkgdir"/usr/lib/opensmtpd/$name "$subpkgdir"/usr/lib/opensmtpd/
 }
 
-sha512sums="097223884841ec3939d3f3d86ba9d23f9c62a37825a8e5b94c2ac5fd16584879780305685706b9bd8ed9a49dfece3ff5ed8f7f143494ca92a8c2c249aff9c28d  opensmtpd-extras-6.4.0.tar.gz
+sha512sums="0c2f89449f51df243d8933a228f7685c8262376a1c95632517c02066c7be6155ddeae71ce364d953d3571cad4a46cfdbfbb11010ee778d82f6185b49d1336003  opensmtpd-extras-6.6.0.tar.gz
 2e12845233437bef691ef92a2b4ffcc307b7cd72ec61b2063604034e28266550940ed432ef66a871fe82030df68b01cdd50ac97a255bf7724ab62a43d45ca4e5  0001-uint8_t-is-defined-in-stdint.h-at-least-on-Linux.patch
 df6f52669e1df3d2b134fa8ec99795b0cef3f6aa38ccb5f85def240370b487988d6576fb769dee7d3eba30cfb291298b1c5a22433f4e6243307c589a7bbdb538  0002-wrap-stdint.h-in-autoconf-variables.patch
 36efd3b6cf75728cc8b75b3d9d6bf464d1e949ccfbe6151ed53dbba0f9ee1e50eb61afcca05af302ab359bc9ea1136e7750a15e5f5b824899141298d3060782a  remove-decls.patch"


### PR DESCRIPTION
Upgrade opensmtpd-extras to latest release. Release archive is only hosted on github.