### PR TITLE
testing/spdlog: fix cmake packaging

### DIFF
--- a/testing/spdlog/APKBUILD
+++ b/testing/spdlog/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Leo <thinkabit.ukim@gmail.com>
 pkgname=spdlog
 pkgver=1.4.2
-pkgrel=0
+pkgrel=1
 pkgdesc="Fast C++ logging library"
 url="https://github.com/gabime/spdlog"
 arch="all"
@@ -46,8 +46,8 @@ dev() {
 	default_dev
 
 	# Fix path
-	mkdir -p "$subpkgdir"/usr/lib/cmake
-	mv "$pkgdir"/usr/lib/spdlog/cmake "$subpkgdir"/usr/lib/cmake
+	mkdir -p "$subpkgdir"/usr/lib/cmake/spdlog
+	mv "$pkgdir"/usr/lib/spdlog/cmake/* "$subpkgdir"/usr/lib/cmake/spdlog/
 	rmdir -p "$pkgdir"/usr/lib/spdlog || true
 }
 


### PR DESCRIPTION
Currently the cmake files are packed into
`/usr/lib/cmake/cmake/spdlogConfigTargets.cmake` when it needs to be `/usr/lib/cmake/spdlog/spdlogConfigTargets.cmake`