### PR TITLE
testing/py3-cymem: upgrade to 2.0.3

### DIFF
--- a/testing/py3-cymem/APKBUILD
+++ b/testing/py3-cymem/APKBUILD
@@ -1,10 +1,9 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=py3-cymem
-pkgver=2.0.2
+pkgver=2.0.3
 pkgrel=0
 pkgdesc="Cython memory pool for RAll-style memory management"
-options="!check" # Requires older version of pytest
 url="https://github.com/explosion/cymem"
 arch="all"
 license="MIT"
@@ -26,7 +25,7 @@ check() {
 package() {
 	python3 setup.py install --prefix=/usr --root="$pkgdir"
 
-	install -Dm644 README.rst "$pkgdir/usr/share/doc/$pkgname/README.rst"
+	install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
 }
 
-sha512sums="6ea5f6cc55027a4c706f02b16d2e1d658fd0f8b629f4e9871d518dbdf2f0c97735ecd7d10b14cd04c6c09930b1726199537263080cd6ff88a5e0bed8a6feb68f  cymem-2.0.2.tar.gz"
+sha512sums="e80f1af0be0399c93e9dbddb9c132513ca3e17b14337662097cb36edf606fb7fd0a490d348d44d3f905aa274a9c8f6a5a8008099d0814c0a462775d357bdae26  cymem-2.0.3.tar.gz"

--- a/testing/py3-cymem/tox.ini
+++ b/testing/py3-cymem/tox.ini
@@ -1,6 +1,0 @@
-[tox]
-envlist = py37
-
-[testenv]
-deps = pytest
-commands = pytest {posargs}


### PR DESCRIPTION
- Ref https://github.com/explosion/cymem/releases/tag/v2.0.3
- Enable check()
- Delete tox.ini as tox is not used any more for testing