### PR TITLE
community/certbot: change version checking to Loose when using python3.8

### DIFF
--- a/community/certbot/APKBUILD
+++ b/community/certbot/APKBUILD
@@ -26,7 +26,8 @@ depends="
 checkdepends="py3-augeas"
 replaces="letsencrypt"
 subpackages="py3-acme:acme $pkgname-nginx $pkgname-apache"
-source="certbot-$pkgver.tar.gz::https://github.com/certbot/certbot/archive/v$pkgver.tar.gz"
+source="certbot-$pkgver.tar.gz::https://github.com/certbot/certbot/archive/v$pkgver.tar.gz
+	cerbot_py3_looseversion.patch"
 
 build() {
 	local i
@@ -96,4 +97,5 @@ apache() {
 	python3 setup.py install --prefix=/usr --root="$subpkgdir"
 }
 
-sha512sums="e5517a20cf26efba850728b3f81db5d6c3c5570b0a1c8eeeec9d4a4401ac04bcf44c6a2f1c248bf6e0b1be4a21b54f6168ccd11dc766304805f13b4cb16336b3  certbot-0.40.1.tar.gz"
+sha512sums="e5517a20cf26efba850728b3f81db5d6c3c5570b0a1c8eeeec9d4a4401ac04bcf44c6a2f1c248bf6e0b1be4a21b54f6168ccd11dc766304805f13b4cb16336b3  certbot-0.40.1.tar.gz
+2886130eb5c28c3af3435107f2c8fce1c2cd8e1fbf1a49c11f8ba276b5748c26913748bbc4af10dca522a55e82bbae786f9a06d7c75efe94faf9afb0597f91b7  cerbot_py3_looseversion.patch"

--- a/community/certbot/cerbot_py3_looseversion.patch
+++ b/community/certbot/cerbot_py3_looseversion.patch
@@ -1,0 +1,20 @@
+--- a/setup.py
++++ b/setup.py
+@@ -3,7 +3,7 @@
+ import re
+ import sys
+ 
+-from distutils.version import StrictVersion
++from distutils.version import LooseVersion
+ from setuptools import find_packages, setup, __version__ as setuptools_version
+ from setuptools.command.test import test as TestCommand
+ 
+@@ -60,7 +60,7 @@
+ # So this dependency is not added for old Linux distributions with old setuptools,
+ # in order to allow these systems to build certbot from sources.
+ pywin32_req = 'pywin32>=225'  # do not forget to edit pywin32 dependency accordingly in windows-installer/construct.py
+-if StrictVersion(setuptools_version) >= StrictVersion('36.2'):
++if LooseVersion(setuptools_version) >= LooseVersion('36.2'):
+     install_requires.append(pywin32_req + " ; sys_platform == 'win32'")
+ elif 'bdist_wheel' in sys.argv[1:]:
+     raise RuntimeError('Error, you are trying to build certbot wheels using an old version '


### PR DESCRIPTION
With python3.8 cerbot build fails with error:
```
Traceback (most recent call last):
  File "setup.py", line 63, in <module>
    if StrictVersion(setuptools_version) >= StrictVersion('36.2'):
  File "/usr/lib/python3.8/distutils/version.py", line 40, in __init__
    self.parse(vstring)
  File "/usr/lib/python3.8/distutils/version.py", line 137, in parse
    raise ValueError("invalid version number '%s'" % vstring)
ValueError: invalid version number '41.5.0.post20191112'
```
This is due to python3.8's implementation of StrictVersion(). Changing cerbot setup.py to use LooseVersion will fix.