### PR TITLE
community/py3-hypothesis: build requiers py3-packaging makedepedns

### DIFF
--- a/community/py3-hypothesis/APKBUILD
+++ b/community/py3-hypothesis/APKBUILD
@@ -8,7 +8,7 @@ url="https://hypothesis.works/"
 arch="noarch"
 license="MPL-2.0"
 depends="py3-attrs"
-makedepends="py3-setuptools"
+makedepends="py3-setuptools py3-packaging"
 checkdepends="py3-pytest py3-coverage py3-tz py3-numpy py3-dateutil py3-pexpect"
 source="py-hypothesis-$pkgver.tar.gz::https://github.com/HypothesisWorks/hypothesis-python/archive/hypothesis-python-$pkgver.tar.gz
 	attrs.patch


### PR DESCRIPTION
on ppc64le build fails with error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 192, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/lib/python3.8/site-packages/pytest.py", line 6, in <module>
    from _pytest.assertion import register_assert_rewrite
  File "/usr/lib/python3.8/site-packages/_pytest/assertion/__init__.py", line 7, in <module>
    from _pytest.assertion import rewrite
  File "/usr/lib/python3.8/site-packages/_pytest/assertion/rewrite.py", line 26, in <module>
    from _pytest.assertion import util
  File "/usr/lib/python3.8/site-packages/_pytest/assertion/util.py", line 9, in <module>
    from _pytest import outcomes
  File "/usr/lib/python3.8/site-packages/_pytest/outcomes.py", line 9, in <module>
    from packaging.version import Version
ModuleNotFoundError: No module named 'packaging'
```
py3-packaging needs to be added as makedepends to fix build error.