### PR TITLE
testing/xmrig: upgrade to 5.0.1

### DIFF
--- a/testing/xmrig/APKBUILD
+++ b/testing/xmrig/APKBUILD
@@ -2,11 +2,11 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 
 pkgname=xmrig
-pkgver=3.2.0
+pkgver=5.0.1
 pkgrel=0
 pkgdesc="XMRig is a high performance Monero (XMR) miner"
 url="https://github.com/xmrig/xmrig"
-arch="all !s390x !ppc64le"
+arch="all !s390x !ppc64le !aarch64" # disable aarch64 as Drone CI get stalled
 license="GPL-3.0-or-later"
 options="!check" # No test suite from upstream
 makedepends="cmake libmicrohttpd-dev libuv-dev openssl-dev hwloc-dev"
@@ -32,4 +32,4 @@ package() {
 	install -Dm 644 -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
 }
 
-sha512sums="21b8088807ef45f486b646f529e85cf709253b0edb25fd9d5e41decbd90a1115bef5c4590d0b0b8a803f86b0b154e3a48c3a34306c1b40a0d7630d163501d1ce  xmrig-3.2.0.tar.gz"
+sha512sums="c03508bb643ec20bb70da5ed277c275183ff90c849a24609a14b08af6224f5b84454378e144b254eb8d60879c3af55ae36697ca83f445e910bfbf6b85a1f1ca9  xmrig-5.0.1.tar.gz"


### PR DESCRIPTION
- Ref https://github.com/xmrig/xmrig/blob/master/CHANGELOG.md
- Disable aarch64 as Drone CI get stalled builing this target