### PR TITLE
community/docker-compose: add missing dependency

### DIFF
--- a/community/docker-compose/APKBUILD
+++ b/community/docker-compose/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=docker-compose
 pkgver=1.24.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Define and run multi-container applications with Docker"
 url="https://docs.docker.com/compose/"
 arch="noarch"
@@ -17,6 +17,7 @@ depends="python3
 	py3-dockerpty>=0.4.1
 	py3-docopt>=0.6.2
 	py3-idna>=2.5
+	py3-importlib-metadata>=0.23
 	py3-ipaddress>=1.0.18
 	py3-jsonschema>=2.6.0
 	py3-paramiko


### PR DESCRIPTION
Running `docker-compose` raise an exception as a dependency is missing. Installing `py3-importlib-metadata` package solve the problem.

### Steps to reproduce bug

~~I haven't (yet) a minimal environment to reproduce this bug. It may be related to the fact I'm deploying remotely using `DOCKER_HOST` environment variable.~~

EDIT: See [comment below](https://github.com/alpinelinux/aports/pull/12111#issuecomment-554376038)

#### Expected output
```
$ docker-compose up
Pulling ...
```

#### Actual output
```
$ docker-compose up
Traceback (most recent call last):
  File "/usr/bin/docker-compose", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3252, in <module>
    def _initialize_master_working_set():
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3235, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3264, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'importlib_metadata' distribution was not found and is required by jsonschema
```

### Fix

Installing `py3-importlib-metadata` solve the problem