### PR TITLE
[3.10] community/intel-ucode: upgrade to 20191113

### DIFF
--- a/community/intel-ucode/APKBUILD
+++ b/community/intel-ucode/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
 pkgname=intel-ucode
-pkgver=20191112
+pkgver=20191113
 pkgrel=0
 pkgdesc="Microcode update files for Intel CPUs"
 arch="x86 x86_64"
@@ -25,4 +25,4 @@ package() {
 	install -Dm644 license "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }
 
-sha512sums="34cebf266f9d6cc38b0dd87f8c7fcf42f3c8d9e434560328b0811b4c4834d0f253d834f53bfaf5b4c561bb153b4bcf509620131046bf0afd6038d02bf9a25a13  microcode-20191112.tar.gz"
+sha512sums="6675d517d407887d8a8acc6f3ea0b0df170326ba90cea8970990052c1aa2d96e7f64c0f4c13006d4614e545ed92f11cf3a9f8b34719b18dd8c4c83760656c1f1  microcode-20191113.tar.gz"


### PR DESCRIPTION
(cherry picked from commit 88a35e92705cabc827109285493ab6ecb93b7c5b)