### PR TITLE
community/py3-jsonschema: Add dependency 'py3-importlib-metadata'

### DIFF
--- a/community/py3-jsonschema/APKBUILD
+++ b/community/py3-jsonschema/APKBUILD
@@ -3,12 +3,12 @@
 pkgname=py3-jsonschema
 _pkgname=jsonschema
 pkgver=3.1.1
-pkgrel=0
+pkgrel=1
 pkgdesc="An implementation of JSON Schema validation for Python"
 url="https://github.com/Julian/jsonschema"
 arch="noarch"
 license="MIT"
-depends="python3 py3-pyrsistent py3-attrs py3-setuptools py3-six"
+depends="python3 py3-pyrsistent py3-attrs py3-setuptools py3-six py3-importlib-metadata"
 checkdepends="py3-twisted py3-pytest"
 source="https://files.pythonhosted.org/packages/source/${_pkgname:0:1}/$_pkgname/$_pkgname-$pkgver.tar.gz"
 builddir="$srcdir"/$_pkgname-$pkgver


### PR DESCRIPTION
jsonschema require ```importlib_metadata```. See following commit: https://github.com/Julian/jsonschema/commit/6a7155a854d57e3f13f9dec15f2ade0820dbca2a

```
$ docker run alpine:edge sh -c 'apk add py3-jsonschema; python3 -m jsonschema'
fetch http://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
(1/16) Installing libbz2 (1.0.8-r1)
(2/16) Installing expat (2.2.9-r0)
(3/16) Installing libffi (3.2.1-r6)
(4/16) Installing gdbm (1.13-r1)
(5/16) Installing xz-libs (5.2.4-r0)
(6/16) Installing ncurses-terminfo-base (6.1_p20191019-r0)
(7/16) Installing ncurses-terminfo (6.1_p20191019-r0)
(8/16) Installing ncurses-libs (6.1_p20191019-r0)
(9/16) Installing readline (8.0.1-r0)
(10/16) Installing sqlite-libs (3.30.1-r0)
(11/16) Installing python3 (3.8.0-r0)
(12/16) Installing py3-six (1.12.0-r2)
(13/16) Installing py3-pyrsistent (0.15.5-r1)
(14/16) Installing py3-attrs (18.2.0-r2)
(15/16) Installing py3-setuptools (41.5.0-r0)
(16/16) Installing py3-jsonschema (3.1.1-r0)
Executing busybox-1.31.1-r0.trigger
OK: 76 MiB in 30 packages
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 183, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.8/runpy.py", line 142, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/usr/lib/python3.8/runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "/usr/lib/python3.8/site-packages/jsonschema/__init__.py", line 31, in <module>
    import importlib_metadata
ModuleNotFoundError: No module named 'importlib_metadata'
```