### PR TITLE
main/nmap: fix pkg build error on ppc64le limit parallelism

### DIFF
--- a/main/nmap/APKBUILD
+++ b/main/nmap/APKBUILD
@@ -55,7 +55,7 @@ check() {
 
 package() {
 	cd "$builddir"
-	make DESTDIR="$pkgdir" install
+	make -j1 DESTDIR="$pkgdir" install
 	install -Dm644 COPYING \
 		"$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 


### PR DESCRIPTION
APKBUILD's package() fails on ppc64le with what appears to be a build sequencing issue. To prevent this add -j1 during the packages() make phase.