### PR TITLE
main/nodejs: upgrade to 12.13.1

### DIFF
--- a/main/nodejs/APKBUILD
+++ b/main/nodejs/APKBUILD
@@ -44,8 +44,8 @@
 pkgname=nodejs
 # Note: Update only to even-numbered versions (e.g. 6.y.z, 8.y.z)!
 # Odd-numbered versions are supported only for 9 months by upstream.
-pkgver=12.13.0
-pkgrel=1
+pkgver=12.13.1
+pkgrel=0
 pkgdesc="JavaScript runtime built on V8 engine - LTS version"
 url="https://nodejs.org/"
 arch="all !mips64 !mips64el"
@@ -136,6 +136,6 @@ npm() {
 	mv "$pkgdir"/usr/lib/node_modules/npm "$subpkgdir"/usr/lib/node_modules/
 }
 
-sha512sums="0c1b8f9163ee5cb274666814eff1e2acc0ec286b5383a1e879fa8e587751a8fd11e891730dd099c1702b00c624bd172a683be7ceec3cc38981559dd19462d9c5  node-v12.13.0.tar.gz
+sha512sums="6da5aad8df117ed5eda566610919f0c5b77a03093182d52e049577777ed5c7adca9459eda28cb074015525d126d3e7e33156cf54756f9dc46369f3895f48908e  node-v12.13.1.tar.gz
 3c536776e2ecb5dc677bf711a09418085b3c5e931a6eaf647f47c28e194d5c6dec354d4e7a039a5805b30fc7e83140594851e18d9120f523eec2f93539eac4db  dont-run-gyp-files-for-bundled-deps.patch
 9f60928b53447f9590c7065bcdbdd4065d10a06e8451531615791a3bd7d14f9114807e5446e0ec00e2cb7a11a277050345e34636b199db2979d7f022b31ffde4  link-with-libatomic-on-mips32.patch"


### PR DESCRIPTION
This updates Node.js to v12.13.1 (see https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.13.1).

~I've also switched to Python3 - given the fact that the changelog states that the building process is improved. Finger crossed 🤞~
Nope. `./configure: exec: line 4: python: not found`