### PR TITLE
main/mesa: fix PIPE_ARCH_LITTLE_ENDIAN define for ppc64le

### DIFF
--- a/main/mesa/APKBUILD
+++ b/main/mesa/APKBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=mesa
 pkgver=19.2.5
-pkgrel=0
+pkgrel=1
 pkgdesc="Mesa DRI OpenGL library"
 url="https://www.mesa3d.org"
 arch="all"
@@ -59,6 +59,7 @@ source="
 	adjust-cache-deflate-buffer.patch
 	musl-fix-includes.patch
 	add-use-elf-tls.patch
+	update-endian-define.patch
 	"
 replaces="mesa-dricore"
 
@@ -320,4 +321,5 @@ _vulkan() {
 sha512sums="881735c4fec07fb6557d01c2d5bb7971e2d4b2bedbb52fd1025dfb0222f8b1cbca080b6f849efe19ff514da8e6310fc6f0cde5b59fcc1c6a10e593876bcd6a38  mesa-19.2.5.tar.xz
 cdf22d2da3328e116c379264886bd01fd3ad5cc45fe03dc6fd97bdc4794502598ee195c0b9d975fa264d6ac31c6fa108c0535c91800ecf4fcabfd308e53074cc  adjust-cache-deflate-buffer.patch
 cf849044d6cc7d2af4ff015208fb09d70bf9660538699797da21bda2ecb7c1892d312af83d05116afd826708d9caafb1d05a13f09139c558aea6fee931e3eee7  musl-fix-includes.patch
-6793388662ed98ae2a6bd964573d9ae380195f078386f0402957a1c9ac61b691b48a82ed41045c7172533f25b44f249af10f17f7ac68c8e03847594962cd4b04  add-use-elf-tls.patch"
+6793388662ed98ae2a6bd964573d9ae380195f078386f0402957a1c9ac61b691b48a82ed41045c7172533f25b44f249af10f17f7ac68c8e03847594962cd4b04  add-use-elf-tls.patch
+6e449b62f1f1f02792f0098960b6ab4d2c098a05c7986d30bc63434fc2ae4736bc1871518978fe299349176e7f8afc2a10873fdad5f38c270abed721f2b77e24  update-endian-define.patch"

--- a/main/mesa/update-endian-define.patch
+++ b/main/mesa/update-endian-define.patch
@@ -1,0 +1,11 @@
+--- a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
++++ b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
+@@ -705,7 +705,7 @@
+     */
+    builder.setCodeModel(CodeModel::Large);
+ 
+-#if PIPE_ARCH_LITTLE_ENDIAN
++#if defined(PIPE_ARCH_LITTLE_ENDIAN)
+    /*
+     * Versions of LLVM prior to 4.0 lacked a table entry for "POWER8NVL",
+     * resulting in (big-endian) "generic" being returned on


### PR DESCRIPTION
with update to mesa 19.2.5 building on ppc64le fails with error:
```
../src/gallium/auxiliary/gallivm/lp_bld_misc.cpp:708:28: error: #if with no expression
  708 | #if PIPE_ARCH_LITTLE_ENDIAN
```
This patch will fix the issue