### PR TITLE
testing/py3-spacy: upgrade to 2.2.3

### DIFF
--- a/testing/py3-catalogue/APKBUILD
+++ b/testing/py3-catalogue/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor: Oleg Titov <oleg.titov@gmail.com>
+# Maintainer: Oleg Titov <oleg.titov@gmail.com>
+pkgname=py3-catalogue
+pkgver=0.0.8
+pkgrel=0
+pkgdesc="Super lightweight function registries for your library"
+url="https://github.com/explosion/catalogue"
+arch="noarch"
+license="MIT"
+depends="py3-importlib-metadata"
+makedepends="py3-setuptools"
+checkdepends="py3-pytest"
+subpackages="$pkgname-doc"
+source="$pkgname-$pkgver.tar.gz::https://github.com/explosion/catalogue/archive/v$pkgver.tar.gz"
+
+builddir=$srcdir/catalogue-$pkgver
+
+build() {
+	python3 setup.py build
+}
+
+check() {
+	pytest-3 test_catalogue.py
+}
+
+package() {
+	python3 setup.py install --prefix=/usr --root="$pkgdir"
+
+	install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+}
+
+sha512sums="285fab8fe2460ee6724cfe4b55422cbe8905da9ea15430b650cbaf4c20188494b00e6243dd44862553ad3122b1ca4a72c609519de50d483aca66346fe43334a5  py3-catalogue-0.0.8.tar.gz"

--- a/testing/py3-spacy/APKBUILD
+++ b/testing/py3-spacy/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Oleg Titov <oleg.titov@gmail.com>
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 pkgname=py3-spacy
-pkgver=2.2.2
+pkgver=2.2.3
 pkgrel=0
 pkgdesc="Industrial-strength Natural Language Processing (NLP)"
 url="https://spacy.io/"
@@ -18,6 +18,7 @@ depends="
 	py3-wasabi
 	py3-pyrsistent
 	py3-plac
+	py3-catalogue
 	"
 makedepends="python3-dev py3-setuptools cython py3-requests"
 checkdepends="py3-pytest py3-pytest-timeout py3-mock py3-flake8"
@@ -39,4 +40,4 @@ package() {
 	install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
 }
 
-sha512sums="b4569c29399548f15968e080d6e7569db56e7475ceb744ea35e6afb8c38bdc737b9f9aec70f6145d622bafdfef6a2961b8bb80602d3c3312fc38fe18b0e8cdf0  py3-spacy-2.2.2.tar.gz"
+sha512sums="244e4634d296e59f423c6c267534a21948dc0b9143af8e984348132ca36499ea2c2beba345cd9c92c0b7b01c2ed02570488c147433d6276772dcd93f730c66b6  py3-spacy-2.2.3.tar.gz"


### PR DESCRIPTION
Ref https://github.com/explosion/spaCy/releases/tag/v2.2.3
Add new dependency: py3-catalogue