### PR TITLE
testing/traefik: upgrade to 2.0.5

### DIFF
--- a/testing/traefik/APKBUILD
+++ b/testing/traefik/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Joe Holden <jwh@zorins.us>
 # Maintainer: Joe Holden <jwh@zorins.us>
 pkgname=traefik
-pkgver=2.0.4
+pkgver=2.0.5
 pkgrel=0
 pkgdesc="The Cloud Native Edge Router"
 url="https://traefik.io"
@@ -65,7 +65,7 @@ package() {
 		"$pkgdir"/etc/$pkgname/$pkgname.toml
 
 }
-sha512sums="56075bc283e24616f33caf7e6e103623d44311bd07807902cc24a02aecdb87a8145f55436837cf34215c770d6757bfb2858facd33ee1c6a6bc3704fd4e7dfe6d  traefik-2.0.4.tar.gz
+sha512sums="69378cd3c44962b8bc55919222487b581dfa799153ea7f031f442a9e2a5209a7a54272fc07ae683486ff9944faa524ea16624231e018da1698a9befc443cf482  traefik-2.0.5.tar.gz
 2fe42052cdb035b202c7c0a1acd5cfe9ed1800ca067f2f5588d54e6ffbdd672d7c46cfd57fcfc219cadaa24d64a0e038a20d092eb1e4c04b67b8eb83c0af74fd  traefik.initd
 1519c2f446c4bc3af8407eb367a05e5ec0491f28d56d5385b12a550c84606d84e2424aadd5d72e56e628fd1da3f0f194ab3c077e6da85ead75a256f8e8069751  traefik.confd
 7dff62db55362433fe33a69bfb556e6f285a033aaaab46ea970ae4ee1b19a4b0d6b25bf5523d4dc6b40d26922945fd1263ae8e53d295d6bf7f18ea1477a9e4d5  traefik.toml"


### PR DESCRIPTION
Ref https://github.com/containous/traefik/releases/tag/v2.0.5

next is 2.1 with consul support