### PR TITLE
community/go: upgrade top 1.13.4

### DIFF
--- a/community/go/APKBUILD
+++ b/community/go/APKBUILD
@@ -3,8 +3,8 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=go
 # go binaries are statically linked, security updates require rebuilds
-pkgver=1.13.3
-pkgrel=1
+pkgver=1.13.4
+pkgrel=0
 pkgdesc="Go programming language compiler"
 url="https://golang.org/"
 arch="all"
@@ -136,7 +136,7 @@ package() {
 		-exec rm -rf \{\} \+
 }
 
-sha512sums="0999876f995a3d9189640ce15b496ab72a6273649d27acdc190c1d50b88ab8b7facaabfc832334911d178f0b9a645ea4169716ed5c593a7540b075e6901d51f2  go1.13.3.src.tar.gz
+sha512sums="e8155cdceca2ebefd386feef98223bbdc92d9316f7188d4ba701cf43a723b75a9bf67a1eb92ac80987b7a113a2fb6981ef235292bec7dd3964805b7c33abdbb1  go1.13.4.src.tar.gz
 f0c07d9979fc3165fc78158406de8440624b3f2c6f6542c9889c71efbf3d2f02a7ffee27ccba8c2630489895d331b7b9d3a606162134dcb3e8e0b9fc06b529dc  default-buildmode-pie.patch
 faf8de430df185842902322f064254f3e9ecee0884b3075b5550c85da15ff61ea6c2bb8d0fb7cf3887abc0e40974bd73ee8f8c14da7f914dde7e9220177c4e2a  set-external-linker.patch
 6ce14ca43fd35520e667530af91cfcad8902d635e6dd8c04d19428299b9e29ba049120f5eebbb00717a895f052d1cc40d3f522c090786625cce726715a8218ec  disable-flaky-sync-test.patch"


### PR DESCRIPTION
Ref https://golang.org/doc/devel/release.html#go1.13.minor