### PR TITLE
community/phpmyadmin: security upgrade to 4.9.2

### DIFF
--- a/community/phpmyadmin/APKBUILD
+++ b/community/phpmyadmin/APKBUILD
@@ -2,7 +2,7 @@
 # Contributor: Matt Smith <mcs@darkregion.net>
 # Maintainer: Andy Postnikov <apostnikov@gmail.com>
 pkgname=phpmyadmin
-pkgver=4.9.1
+pkgver=4.9.2
 pkgrel=0
 pkgdesc="A Web-based PHP tool for administering MySQL"
 url="https://www.phpmyadmin.net/"
@@ -101,5 +101,5 @@ doc() {
 	done
 }
 
-sha512sums="c2804bdb9d8501309e46d66fe4c27c3618de9cbd440928bf6335b3623a7e71608bb02fda17c5f1715b0cb32ecd68e2bbca86565f240b138c3630084225c56f83  phpMyAdmin-4.9.1-all-languages.tar.xz
+sha512sums="426689c31f963a9cbe34b2116888aa0264801aa5ef18fb0e4b89811b032d4018c770538e823bccb684fb066ed27fcf6dc6e0fb4198d1e082e7eea15595b67727  phpMyAdmin-4.9.2-all-languages.tar.xz
 ba5776800f5c7b6cbb4ae594ec77c4d3e0d0bd319d109c676bd6c969054967baef99cab1a30c2efa26487b2ec03ef9b81d035a4323003565cffb19b08fdce9f5  phpmyadmin.apache2.conf"


### PR DESCRIPTION
No CVE yet but better to backport
Ref https://www.phpmyadmin.net/news/2019/11/22/phpmyadmin-492-released/