### PR TITLE
WIP: community/php7-pecl-event: bump for libevent_core-2.1.so.7

### DIFF
--- a/community/php7-pecl-event/APKBUILD
+++ b/community/php7-pecl-event/APKBUILD
@@ -3,7 +3,7 @@
 pkgname=php7-pecl-event
 _pkgname=event
 pkgver=2.5.3
-pkgrel=0
+pkgrel=1
 pkgdesc="PHP extension that provides interface to libevent library - PECL"
 url="https://pecl.php.net/package/event"
 arch="all"

--- a/community/php7/APKBUILD
+++ b/community/php7/APKBUILD
@@ -27,7 +27,7 @@
 pkgname=php7
 _pkgreal=php
 pkgver=7.3.12
-pkgrel=0
+pkgrel=1
 _apiver=20180731
 _suffix=${pkgname#php}
 # Is this package the default (latest) PHP version?
@@ -176,6 +176,7 @@ for _ext in $_extensions; do
 done
 subpackages="$subpackages $pkgname-common::noarch"
 
+options="$options !check" # to test building dependencies
 # FIXME: tests fails on s390x and x86_64
 case "$CARCH" in
 	x86_64) options="$options !check";;


### PR DESCRIPTION
https://abi-laboratory.pro/?view=timeline&l=libevent

```
apk add php7-event
ERROR: unsatisfiable constraints:
  so:libevent_core-2.1.so.6 (missing):
    required by: php7-pecl-event-2.5.3-r0[so:libevent_core-2.1.so.6]
  so:libevent_extra-2.1.so.6 (missing):
    required by: php7-pecl-event-2.5.3-r0[so:libevent_extra-2.1.so.6]
  so:libevent_openssl-2.1.so.6 (missing):
    required by: php7-pecl-event-2.5.3-r0[so:libevent_openssl-2.1.so.6]
```

After 1b30601be9354df41a443a94ecfbf8dfe8f9448f