### PR TITLE
community/php7-pecl-protobuf: upgrade to 3.11.0

### DIFF
--- a/community/php7-pecl-protobuf/APKBUILD
+++ b/community/php7-pecl-protobuf/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: TBK <alpine@jjtc.eu>
 pkgname=php7-pecl-protobuf
 _pkgreal=protobuf
-pkgver=3.10.0
+pkgver=3.11.0
 pkgrel=0
 pkgdesc="PHP7 extension: Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data."
 url="https://pecl.php.net/package/protobuf"
@@ -32,4 +32,4 @@ package() {
 	echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/$_pkgreal.ini
 }
 
-sha512sums="c996baf95db4908bbd06a533d5ded5e1d9ed700e99604a5609de54dc5b0624235c7776afbb32ae652d182635ada1b80fdb04e0480eb4c6525f53b6b978f9c0e3  protobuf-3.10.0.tgz"
+sha512sums="97eb5f42f44650833bade62b9df46bbdefa9563577fb5b0e45657442f298a3ef414b276d391d19af979fd9a119b849ea986d3dbf761ec0677f52d9a36bbe3db8  protobuf-3.11.0.tgz"


### PR DESCRIPTION
Ref https://pecl.php.net/package-changelog.php?package=protobuf&release=3.11.0

PHP has no dependency on protobuf which needs update separate https://github.com/protocolbuffers/protobuf/releases/tag/v3.11.0