### PR TITLE
main/busybox: remove timestamp

### DIFF
--- a/main/busybox/APKBUILD
+++ b/main/busybox/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=busybox
 pkgver=1.31.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Size optimized toolbox of many common UNIX utilities"
 url="https://busybox.net/"
 arch="all"
@@ -76,6 +76,9 @@ build() {
 	msg "Building ssl_client"
 	${CC:-${CROSS_COMPILE}gcc} ${CPPFLAGS} ${CFLAGS} $(pkg-config --cflags libtls-standalone) \
 		"$srcdir"/ssl_client.c -o "$_dyndir"/ssl_client ${LDFLAGS} $(pkg-config --libs libtls-standalone)
+
+	# no timestamp in build
+	export KCONFIG_NOTIMESTAMP=1
 
 	# build dynamic
 	cd "$_dyndir"


### PR DESCRIPTION
before:
```
$ busybox
BusyBox v1.31.1 (2019-10-29 11:54:15 UTC) multi-call binary.
```
after:
```
$ busybox 
BusyBox v1.31.1 () multi-call binary.
```
This makes it a bit more reproducible