### PR TITLE
main/cmake: upgrade to 3.16.0

### DIFF
--- a/main/cmake/APKBUILD
+++ b/main/cmake/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Valery Kartel <valery.kartel@gmail.com>
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=cmake
-pkgver=3.15.5
+pkgver=3.16.0
 pkgrel=0
 pkgdesc="Cross-platform, open-source make system"
 url="https://www.cmake.org/"
@@ -68,4 +68,4 @@ bashcomp() {
 		"$subpkgdir"/usr/share/bash-completion/
 }
 
-sha512sums="c71a50fe864772dbef16ef472c1ead88e8e322c8451bc395c454af9baa7c7eb6e1bd9abdca0745f979fbacf97f1e1ceaa84c0fcc412cf1e3bcd835aff32199b6  cmake-3.15.5.tar.gz"
+sha512sums="edbe16745cb82dc85f387ccdff37f3a89aa670a0e3b7dae53c3762c1cc44be1fa647156000a4ddcaac66822e3e537434ce2918da72a1ad208fa5378947ecec0d  cmake-3.16.0.tar.gz"


### PR DESCRIPTION
Ref https://blog.kitware.com/cmake-3-16-0-available-for-download/