### PR TITLE
testing/xmrig: upgrade to 5.1.0

### DIFF
--- a/testing/xmrig/APKBUILD
+++ b/testing/xmrig/APKBUILD
@@ -2,11 +2,11 @@
 # Maintainer: Oleg Titov <oleg.titov@gmail.com>
 
 pkgname=xmrig
-pkgver=5.0.1
+pkgver=5.1.0
 pkgrel=0
 pkgdesc="XMRig is a high performance Monero (XMR) miner"
 url="https://github.com/xmrig/xmrig"
-arch="all !s390x !ppc64le !aarch64" # disable aarch64 as Drone CI get stalled
+arch="all !s390x !ppc64le"
 license="GPL-3.0-or-later"
 options="!check" # No test suite from upstream
 makedepends="cmake libmicrohttpd-dev libuv-dev openssl-dev hwloc-dev"
@@ -32,4 +32,4 @@ package() {
 	install -Dm 644 -t "$pkgdir"/usr/share/doc/$pkgname/ README.md
 }
 
-sha512sums="c03508bb643ec20bb70da5ed277c275183ff90c849a24609a14b08af6224f5b84454378e144b254eb8d60879c3af55ae36697ca83f445e910bfbf6b85a1f1ca9  xmrig-5.0.1.tar.gz"
+sha512sums="816583be8e7331a7c10afed35e661f5085d920fd77413fca98a198df008f2cc0155e732ee2f3c3a976970775ffa17e1e781f0281ef4c83871024c5cf8668e297  xmrig-5.1.0.tar.gz"


### PR DESCRIPTION
- Ref https://github.com/xmrig/xmrig/blob/master/CHANGELOG.md
- Enable aarch64

<!-- Attention Required

Dear Contributor,

Alpine Linux has moved its development to its own GitLab instance located at
https://gitlab.alpinelinux.org/alpine. To submit your code changes for aports
please create an account on our GitLab instance by registering or logging in
with your GitHub account and submit it as a Merge Request (also known as a MR).
This GitHub repository will be kept operational as a git mirror. Pull request
made in this repository will automatically be closed by our GitHub bot.

Sorry for the inconvenience and happy hacking!

-->

