### PR TITLE
testing/conmon: new aports

### DIFF
--- a/testing/conmon/APKBUILD
+++ b/testing/conmon/APKBUILD
@@ -1,0 +1,32 @@
+# Contributor:
+# Maintainer:
+pkgname="conmon"
+pkgver="2.0.7"
+pkgrel=0
+pkgdesc="An OCI container runtime monitor."
+url="https://github.com/containers/conmon"
+arch="all"
+license="Apache-2.0"
+makedepends="glib-dev"
+source="${pkgname}-${pkgver}.tar.gz::https://github.com/containers/${pkgname}/archive/v${pkgver}.tar.gz"
+builddir="$srcdir/${pkgname}-${pkgver}"
+subpackages="$pkgname-doc"
+
+build() {
+        make
+        :
+}
+
+check() {
+        ./bin/conmon --version
+}
+
+package() {
+        cd "$builddir"
+        install -Dm644  LICENSE "$pkgdir"/usr/share/licenses/"$pkgname"/LICENSE
+        make install PREFIX=/usr DESTDIR="$pkgdir"
+        :
+}
+
+sha512sums="700297016bb3471a7dc5ed243df69bf21d459d612ee23ba325ff0c8ff8842f77d2601e155326c80ebe86cc8e6fb0a45603fac401bfcdbea184d39358cedeafac  conmon-2.0.7.tar.gz"
+


### PR DESCRIPTION
Add conmon as a preparation for adding podman to alpine testing repository.