### PR TITLE
community/wireguard: update to 20191226

### DIFF
--- a/community/wireguard-lts/APKBUILD
+++ b/community/wireguard-lts/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 # wireguard version
-_ver=0.0.20191219
+_ver=0.0.20191226
 _rel=0
 
 # kernel version
@@ -37,10 +37,10 @@ makedepends="
 	linux-$_flavor-dev=$_kpkgver
 	linux-firmware-none
 	"
-install_if="wireguard-tools-wg=$_ver-r$_rel linux-$_flavor=$_kpkgver"
+install_if="wireguard-tools-wg linux-$_flavor=$_kpkgver"
 options="!check"
-source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$_ver.tar.xz"
-builddir="$srcdir"/WireGuard-$_ver
+source="https://git.zx2c4.com/wireguard-linux-compat/snapshot/wireguard-linux-compat-$_ver.tar.xz"
+builddir="$srcdir"/wireguard-linux-compat-$_ver
 
 for f in $_extra_flavors; do
 	makedepends="$makedepends linux-$f-dev=$_kpkgver"
@@ -81,11 +81,11 @@ package() {
 _extra() {
 	flavor=${subpkgname##*-}
 	depends="linux-$flavor=$_kpkgver"
-	install_if="wireguard-tools-wg=$_ver-r$_rel linux-$flavor=$_kpkgver"
+	install_if="wireguard-tools-wg linux-$flavor=$_kpkgver"
 	pkgdesc="Next generation secure network tunnel: kernel modules for $flavor"
 	local kabi="$_kver-$_krel-$flavor"
 	install -Dm644 "$srcdir"/virt/src/wireguard.ko \
 		"$subpkgdir/lib/modules/$kabi/extra/wireguard.ko"
 }
 
-sha512sums="0ff9f50e36378b2444f1cd670138e58676cee04f82dcc637d47aea69268034c950103609f7e35af14d7d1b0b579535000330737c2071f61b2d56147c95ef8e71  WireGuard-0.0.20191219.tar.xz"
+sha512sums="7eba183128555ca5fd8b171179fe8ec7b9a67c618ad000bc9c5475ff74097e0e2c220a1f1dd82393fbde6dbbba5c1114bfd725e733a5f4acfbb23248538f6afb  wireguard-linux-compat-0.0.20191226.tar.xz"

--- a/community/wireguard-rpi/APKBUILD
+++ b/community/wireguard-rpi/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 
 # wireguard version
-_ver=0.0.20191219
+_ver=0.0.20191226
 _rel=0
 
 # kernel version
@@ -37,10 +37,10 @@ makedepends="
 	linux-$_flavor-dev=$_kpkgver
 	linux-firmware-none
 	"
-install_if="wireguard-tools-wg=$_ver-r$_rel linux-$_flavor=$_kpkgver"
+install_if="wireguard-tools-wg linux-$_flavor=$_kpkgver"
 options="!check"
-source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$_ver.tar.xz"
-builddir="$srcdir"/WireGuard-$_ver
+source="https://git.zx2c4.com/wireguard-linux-compat/snapshot/wireguard-linux-compat-$_ver.tar.xz"
+builddir="$srcdir"/wireguard-linux-compat-$_ver
 
 for f in $_extra_flavors; do
 	makedepends="$makedepends linux-$f-dev=$_kpkgver"
@@ -81,11 +81,11 @@ package() {
 _extra() {
 	flavor=${subpkgname##*-}
 	depends="linux-$flavor=$_kpkgver"
-	install_if="wireguard-tools-wg=$_ver-r$_rel linux-$flavor=$_kpkgver"
+	install_if="wireguard-tools-wg linux-$flavor=$_kpkgver"
 	pkgdesc="Next generation secure network tunnel: kernel modules for $flavor"
 	local kabi="$_kver-$_krel-$flavor"
 	install -Dm644 "$srcdir"/$flavor/src/wireguard.ko \
 		"$subpkgdir/lib/modules/$kabi/extra/wireguard.ko"
 }
 
-sha512sums="0ff9f50e36378b2444f1cd670138e58676cee04f82dcc637d47aea69268034c950103609f7e35af14d7d1b0b579535000330737c2071f61b2d56147c95ef8e71  WireGuard-0.0.20191219.tar.xz"
+sha512sums="7eba183128555ca5fd8b171179fe8ec7b9a67c618ad000bc9c5475ff74097e0e2c220a1f1dd82393fbde6dbbba5c1114bfd725e733a5f4acfbb23248538f6afb  wireguard-linux-compat-0.0.20191226.tar.xz"

--- a/community/wireguard-tools/APKBUILD
+++ b/community/wireguard-tools/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Stuart Cardall <developer@it-offshore.co.uk>
 # Maintainer: Stuart Cardall <developer@it-offshore.co.uk>
 pkgname=wireguard-tools
-pkgver=0.0.20191219
+pkgver=1.0.20200102
 pkgrel=0
 pkgdesc="Next generation secure network tunnel: userspace tools"
 arch="all"
@@ -19,25 +19,25 @@ subpackages="
 	$pkgname-wg-quick:_split:noarch
 	"
 options="!check"
-source="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-$pkgver.tar.xz"
-builddir="$srcdir"/WireGuard-$pkgver
+source="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-$pkgver.tar.xz"
+builddir="$srcdir"/wireguard-tools-$pkgver
 
 build() {
-	make -C src/tools
+	make -C src
 }
 
 package() {
 	mkdir -p "$pkgdir/usr/share/doc/$pkgname"
 
-	make -C src/tools \
+	make -C src \
 		DESTDIR="$pkgdir" \
 		WITH_BASHCOMPLETION=yes \
 		WITH_WGQUICK=yes \
 		WITH_SYSTEMDUNITS=no \
 		install
 
-	find "$builddir"/contrib/examples -name '.gitignore' -delete
-	cp -rf "$builddir"/contrib/examples "$pkgdir/usr/share/doc/$pkgname/"
+	find "$builddir"/contrib -name '.gitignore' -delete
+	cp -rf "$builddir"/contrib "$pkgdir/usr/share/doc/$pkgname/"
 }
 
 _split() {
@@ -59,4 +59,4 @@ bashcomp() {
 	mv "$pkgdir"/usr/share "$subpkgdir"/usr
 }
 
-sha512sums="0ff9f50e36378b2444f1cd670138e58676cee04f82dcc637d47aea69268034c950103609f7e35af14d7d1b0b579535000330737c2071f61b2d56147c95ef8e71  WireGuard-0.0.20191219.tar.xz"
+sha512sums="a4275eefc55b2a7ed3935a46a2098f9b0acdfaf0e1ed33ca42b51a186b388b53425ded5887e2cfc5be2802d6a453b8ebbf0294800ec1307a2dc21f46bd040da6  wireguard-tools-1.0.20200102.tar.xz"


### PR DESCRIPTION
This follows a reorganzation of WireGuard repos and tarballs after being merged to net-next.