### PR TITLE
testing/php7-pecl-xlswriter: upgrade to 1.3.3.2

### DIFF
--- a/testing/php7-pecl-xlswriter/APKBUILD
+++ b/testing/php7-pecl-xlswriter/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: viest <dev@service.viest.me>
 pkgname="php7-pecl-xlswriter"
 _pkgreal=xlswriter
-pkgver="1.3.1"
+pkgver="1.3.3.2"
 pkgrel=0
 pkgdesc="A PHP Extension for creating and reader XLSX files. "
 url="https://pecl.php.net/package/xlswriter"
@@ -32,4 +32,4 @@ package() {
     echo "extension=$_pkgreal.so" > "$pkgdir"/etc/php7/conf.d/$_pkgreal.ini
 }
 
-sha512sums="9d14c9ae0d7a757fba9de4a4d241914778ce106d82f5349c239e2954bc95744714c5e7e87cfc87e28a733dbf917384e3b1afe1bfedf46ec94f5ce5dad963a5f7  php7-pecl-xlswriter-1.3.1.tar.gz"
+sha512sums="a04606fac1419d7180aa7e05d9587bedfb9ac08ead907113d2e6023e6121855c98a0b991cb7cebc4493e004ca44fcc650cb593058dd39860beed5797d73b88d4  php7-pecl-xlswriter-1.3.3.2.tar.gz"


### PR DESCRIPTION
https://pecl.php.net/package/xlswriter
xlswriter is a PHP C Extension that can be used to write text, numbers, formulas and hyperlinks to multiple worksheets in an Excel 2007+ XLSX file.

<!-- Attention Required

Dear Contributor,

Alpine Linux has moved its development to its own GitLab instance located at
https://gitlab.alpinelinux.org/alpine. To submit your code changes for aports
please create an account on our GitLab instance by registering or logging in
with your GitHub account and submit it as a Merge Request (also known as a MR).
This GitHub repository will be kept operational as a git mirror. Pull request
made in this repository will automatically be closed by our GitHub bot.

Sorry for the inconvenience and happy hacking!

-->

