### PR TITLE
community/ferrumc: new aport

### DIFF
--- a/community/ferrumc/APKBUILD
+++ b/community/ferrumc/APKBUILD
@@ -1,0 +1,20 @@
+# Contributor: Ferrum-Language <noreply@ferrum-lang.org>
+# Maintainer: Ferrum-Language <noreply@ferrum-lang.org>
+pkgname=ferrumc
+pkgver=0.3.0
+pkgrel=0
+pkgdesc="Ferrum-language compiler with compile-time memory safety"
+url="https://ferrum-language.github.io/Ferrum/"
+arch="x86_64 aarch64"
+license="GPL-3.0-only"
+options="!check"
+source_x86_64="ferrumc-$pkgver-linux-x86_64.tar.gz::https://github.com/Ferrum-Language/Ferrum/releases/download/v$pkgver/ferrumc-v$pkgver-linux-x86_64.tar.gz"
+source_aarch64="ferrumc-$pkgver-linux-aarch64.tar.gz::https://github.com/Ferrum-Language/Ferrum/releases/download/v$pkgver/ferrumc-v$pkgver-linux-aarch64.tar.gz"
+sha512sums="
+a6830626a677c7cadf3c7d20fd3183fb2c7bf2080dd180955faff86470062059af4fbfbc27d378c7b40df87ae25d300737df38dbf8cb4413ace79947790a63b8  ferrumc-$pkgver-linux-x86_64.tar.gz
+083415f97fcf1dd07a064b11f3ef631cb33ee69aa08ff90914422a5fa507d60cce08cf896a9ebb3185a1a388914748898530068962b963eb5a25e9652dded434  ferrumc-$pkgver-linux-aarch64.tar.gz
+"
+
+package() {
+	install -Dm755 "$srcdir/ferrumc" "$pkgdir/usr/bin/ferrumc"
+}


### PR DESCRIPTION
## New package: ferrumc (Ferrum-language compiler) 0.3.0

Ferrum-language is a systems programming language with C syntax and compile-time memory safety via a borrow checker and ownership model, compiled to native code through LLVM 18.

- **License:** GPL-3.0-only
- **Homepage:** https://ferrum-language.github.io/Ferrum/
- **Architectures:** x86_64, aarch64
- **Section:** community
- SHA512 verified against GitHub release