### PR TITLE
community/imagemagick: security upgrade to 7.1.2.29

### DIFF
--- a/community/imagemagick/APKBUILD
+++ b/community/imagemagick/APKBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Natanael Copa <ncopa@alpinelinux.org>
 pkgname=imagemagick
 _pkgname=ImageMagick
-pkgver=7.1.2.24
+pkgver=7.1.2.29
 pkgrel=0
 _pkgver=${pkgver%.*}-${pkgver##*.}
 _abiver=7
@@ -61,11 +61,44 @@ subpackages="
 	$pkgname-tiff
 	$pkgname-webp
 	"
-source="https://imagemagick.org/archive/releases/ImageMagick-$_pkgver.tar.xz"
+source="https://download.imagemagick.org/archive/releases/ImageMagick-$_pkgver.tar.xz"
 builddir="$srcdir/$_pkgname-$_pkgver"
 
 # secfixes:
-#   7.1.2.23-r0:
+#   7.1.2.29-r0:
+#     - CVE-2026-61857
+#     - CVE-2026-61859
+#     - CVE-2026-61860
+#     - CVE-2026-61861
+#     - CVE-2026-61862
+#     - CVE-2026-61863
+#     - CVE-2026-61864
+#     - CVE-2026-61866
+#     - CVE-2026-61869
+#     - CVE-2026-61870
+#   7.1.2.27-r0:
+#     - CVE-2026-53466
+#     - CVE-2026-53467
+#     - CVE-2026-55510
+#     - CVE-2026-55577
+#     - CVE-2026-55594
+#     - CVE-2026-55595
+#     - CVE-2026-55597
+#     - CVE-2026-55628
+#   7.1.2.25-r0:
+#     - CVE-2026-53460
+#     - CVE-2026-53461
+#     - CVE-2026-53462
+#     - CVE-2026-53463
+#     - CVE-2026-53464
+#     - CVE-2026-53465
+#   7.1.2.24-r0:
+#     - CVE-2026-48724
+#     - CVE-2026-48733
+#     - CVE-2026-48734
+#     - CVE-2026-48994
+#     - CVE-2026-49218
+#     - CVE-2026-49219
 #     - CVE-2026-46520
 #     - CVE-2026-46521
 #     - CVE-2026-46522
@@ -421,5 +454,5 @@ _perlmagick_doc() {
 }
 
 sha512sums="
-678be1e1c1941baabd34b4565e6c0f1a02ad0de08662957cdca3e3df826f5fa15c563f9a22d4b739ecc28279ed4d5efd701bbc0a4ef40f69fbcd61696528bafc  ImageMagick-7.1.2-24.tar.xz
+77332c0e76904e6b6738359d7feae882b181e205e8ec8d91e9853afae7bb12dc34721a942d5c4e7aeaf96a4fab65e11f434028ab73d3304ebd38ebadcd5cd81b  ImageMagick-7.1.2-29.tar.xz
 "


### PR DESCRIPTION
Security upgrade of imagemagick from 7.1.2.24 to 7.1.2.29 for 3.23-stable.

This fixes multiple CVEs that are marked "fixAvailable" but have no
patched package in the v3.23 repository:

- CVE-2026-61857, CVE-2026-61859, CVE-2026-61860, CVE-2026-61861
- CVE-2026-61862, CVE-2026-61863, CVE-2026-61864, CVE-2026-61866
- CVE-2026-61869, CVE-2026-61870
- CVE-2026-53460 through CVE-2026-53467
- CVE-2026-55510, CVE-2026-55577, CVE-2026-55594-55628

This mirrors the upgrade already done on 3.24-stable (7.1.2.27)
and master (7.1.2.29), following the same pattern used in commit
96098d76ef7 on 3.24-stable.

Also updates the source URL from imagemagick.org to
download.imagemagick.org as done in master (ae1b3d82ece).